### PR TITLE
fix trim package name error

### DIFF
--- a/common/errors/errors.go
+++ b/common/errors/errors.go
@@ -36,10 +36,12 @@ func (err *Error) WithPathObj(obj interface{}) *Error {
 }
 
 func (err *Error) pkgPath() string {
-	if err.pathObj == nil {
-		return ""
+	if err.pathObj != nil {
+		if p := reflect.TypeOf(err.pathObj).PkgPath(); !strings.HasPrefix(p, "main") {
+			return p[trim:]
+		}
 	}
-	return reflect.TypeOf(err.pathObj).PkgPath()[trim:]
+	return ""
 }
 
 // Error implements error.Error().

--- a/main/run.go
+++ b/main/run.go
@@ -64,7 +64,7 @@ func executeRun(cmd *base.Command, args []string) {
 	printVersion()
 	server, err := startXray()
 	if err != nil {
-		base.Fatalf("Filed to start: %s", err)
+		base.Fatalf("Failed to start: %s", err)
 	}
 
 	if *test {
@@ -74,7 +74,7 @@ func executeRun(cmd *base.Command, args []string) {
 	}
 
 	if err := server.Start(); err != nil {
-		base.Fatalf("Filed to start: %s", err)
+		base.Fatalf("Failed to start: %s", err)
 	}
 	defer server.Close()
 


### PR DESCRIPTION
修正main包反射后包路径为main,不需要修剪的问题.

这个问题导致在启动时,如有无法读取证书等错误,会出现
%!s(PANIC=Error method: runtime error: slice bounds out of range [26:4])
