### PR TITLE
Config: handle errors correctly 

### DIFF
--- a/main/jsonem/jsonem.go
+++ b/main/jsonem/jsonem.go
@@ -22,9 +22,13 @@ func init() {
 				for i, arg := range v {
 					newError("Reading config: ", arg).AtInfo().WriteToLog()
 					r, err := confloader.LoadConfig(arg)
-					common.Must(err)
+					if err != nil {
+						return nil, newError("failed to read config: ", arg).Base(err)
+					}
 					c, err := serial.DecodeJSONConfig(r)
-					common.Must(err)
+					if err != nil {
+						return nil, newError("failed to decode config: ", arg).Base(err)
+					}
 					if i == 0 {
 						// This ensure even if the muti-json parser do not support a setting,
 						// It is still respected automatically for the first configure file

--- a/main/run.go
+++ b/main/run.go
@@ -164,7 +164,7 @@ func startXray() (core.Server, error) {
 
 	config, err := core.LoadConfig(getConfigFormat(), configFiles[0], configFiles)
 	if err != nil {
-		return nil, newError("failed to read config files: [", configFiles.String(), "]").Base(err)
+		return nil, newError("failed to load config files: [", configFiles.String(), "]").Base(err)
 	}
 
 	server, err := core.New(config)


### PR DESCRIPTION
返回读取/解码配置文件时发生的错误，而不是`panic`。