### PR TITLE
fixed XTLS#104 and apply routing for non-local DoH requests

### DIFF
--- a/app/dns/dohdns.go
+++ b/app/dns/dohdns.go
@@ -29,6 +29,7 @@ import (
 // which is compatible with traditional dns over udp(RFC1035),
 // thus most of the DOH implementation is copied from udpns.go
 type DoHNameServer struct {
+	dispatcher routing.Dispatcher
 	sync.RWMutex
 	ips        map[string]record
 	pub        *pubsub.Service
@@ -45,40 +46,8 @@ func NewDoHNameServer(url *url.URL, dispatcher routing.Dispatcher, clientIP net.
 	newError("DNS: created Remote DOH client for ", url.String()).AtInfo().WriteToLog()
 	s := baseDOHNameServer(url, "DOH", clientIP)
 
-	// Dispatched connection will be closed (interrupted) after each request
-	// This makes DOH inefficient without a keep-alived connection
-	// See: core/app/proxyman/outbound/handler.go:113
-	// Using mux (https request wrapped in a stream layer) improves the situation.
-	// Recommend to use NewDoHLocalNameServer (DOHL:) if xray instance is running on
-	//  a normal network eg. the server side of xray
-	tr := &http.Transport{
-		MaxIdleConns:        30,
-		IdleConnTimeout:     90 * time.Second,
-		TLSHandshakeTimeout: 30 * time.Second,
-		ForceAttemptHTTP2:   true,
-		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			dest, err := net.ParseDestination(network + ":" + addr)
-			if err != nil {
-				return nil, err
-			}
+	s.dispatcher = dispatcher
 
-			link, err := dispatcher.Dispatch(ctx, dest)
-			if err != nil {
-				return nil, err
-			}
-			return cnc.NewConnection(
-				cnc.ConnectionInputMulti(link.Writer),
-				cnc.ConnectionOutputMulti(link.Reader),
-			), nil
-		},
-	}
-
-	dispatchedClient := &http.Client{
-		Transport: tr,
-		Timeout:   60 * time.Second,
-	}
-
-	s.httpClient = dispatchedClient
 	return s, nil
 }
 
@@ -237,7 +206,7 @@ func (s *DoHNameServer) sendQuery(ctx context.Context, domain string, option IPO
 			})
 
 			// forced to use mux for DOH
-			dnsCtx = session.ContextWithMuxPrefered(dnsCtx, true)
+			// dnsCtx = session.ContextWithMuxPrefered(dnsCtx, true)
 
 			var cancel context.CancelFunc
 			dnsCtx, cancel = context.WithDeadline(dnsCtx, deadline)
@@ -245,17 +214,17 @@ func (s *DoHNameServer) sendQuery(ctx context.Context, domain string, option IPO
 
 			b, err := dns.PackMessage(r.msg)
 			if err != nil {
-				newError("failed to pack dns query").Base(err).AtError().WriteToLog()
+				newError("failed to pack dns query for ", domain).Base(err).AtError().WriteToLog()
 				return
 			}
 			resp, err := s.dohHTTPSContext(dnsCtx, b.Bytes())
 			if err != nil {
-				newError("failed to retrieve response").Base(err).AtError().WriteToLog()
+				newError("failed to retrieve response for ", domain).Base(err).AtError().WriteToLog()
 				return
 			}
 			rec, err := parseResponse(resp)
 			if err != nil {
-				newError("failed to handle DOH response").Base(err).AtError().WriteToLog()
+				newError("failed to handle DOH response for ", domain).Base(err).AtError().WriteToLog()
 				return
 			}
 			s.updateIP(r, rec)
@@ -273,7 +242,44 @@ func (s *DoHNameServer) dohHTTPSContext(ctx context.Context, b []byte) ([]byte, 
 	req.Header.Add("Accept", "application/dns-message")
 	req.Header.Add("Content-Type", "application/dns-message")
 
-	resp, err := s.httpClient.Do(req.WithContext(ctx))
+	hc := s.httpClient
+
+	// Dispatched connection will be closed (interrupted) after each request
+	// This makes DOH inefficient without a keep-alived connection
+	// See: core/app/proxyman/outbound/handler.go:113
+	// Using mux (https request wrapped in a stream layer) improves the situation.
+	// Recommend to use NewDoHLocalNameServer (DOHL:) if xray instance is running on
+	//  a normal network eg. the server side of xray
+
+	if s.dispatcher != nil {
+		tr := &http.Transport{
+			MaxIdleConns:        30,
+			IdleConnTimeout:     90 * time.Second,
+			TLSHandshakeTimeout: 30 * time.Second,
+			ForceAttemptHTTP2:   true,
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				dest, err := net.ParseDestination(network + ":" + addr)
+				if err != nil {
+					return nil, err
+				}
+
+				link, err := s.dispatcher.Dispatch(ctx, dest)
+				if err != nil {
+					return nil, err
+				}
+				return cnc.NewConnection(
+					cnc.ConnectionInputMulti(link.Writer),
+					cnc.ConnectionOutputMulti(link.Reader),
+				), nil
+			},
+		}
+		hc = &http.Client{
+			Timeout:   time.Second * 180,
+			Transport: tr,
+		}
+	}
+
+	resp, err := hc.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/app/dns/dohdns.go
+++ b/app/dns/dohdns.go
@@ -180,6 +180,11 @@ func (s *DoHNameServer) newReqID() uint16 {
 func (s *DoHNameServer) sendQuery(ctx context.Context, domain string, option IPOption) {
 	newError(s.name, " querying: ", domain).AtInfo().WriteToLog(session.ExportIDToError(ctx))
 
+	if s.name+"." == "DOH//"+domain {
+		newError(s.name, " tries to resolve itself! Use IP or set \"hosts\" instead.").AtError().WriteToLog(session.ExportIDToError(ctx))
+		return
+	}
+
 	reqs := buildReqMsgs(domain, option, s.newReqID, genEDNS0Options(s.clientIP))
 
 	var deadline time.Time
@@ -201,8 +206,8 @@ func (s *DoHNameServer) sendQuery(ctx context.Context, domain string, option IPO
 			}
 
 			dnsCtx = session.ContextWithContent(dnsCtx, &session.Content{
-				Protocol:      "https",
-				SkipRoutePick: true,
+				Protocol: "https",
+				//SkipRoutePick: true,
 			})
 
 			// forced to use mux for DOH


### PR DESCRIPTION
1. fixed XTLS#104

因为 'Dispatched connection will be closed (interrupted) after each request'.
所以原来的远程DOH方式在高并发时,第一个DNS请求返回后连接关闭,后续使用同一个连接的请求失败.出现'app/dns: failed to retrieve response > Post "https://1.0.0.1/dns-query": io: read/write on closed pipe'的错误.

这个修改仅针对 non-local DOH(即远程DOH).
**其余模式(如local DOH)行为和以前一致.**


2. apply routing for non-local DoH requests

在很久前 v2ray 的一次 commit 中,将 non-local DoH 修改成直接使用第一个outbound, 而不经过路由. 
本意是为了防止某些不当配置时,陷入DNS解析的死循环,但这是很不合理的,会导致远程DOH请求发往的都是第一个 outbound 进行解析,得到的未必是最合适IP,甚至可能并未发往代理(比如第一个outbound为freedom时)

这个修改使远程DoH 请求和其他DNS(如最常用UDP模式)请求一样, 目标DNS服务器会经过路由模块分流,并且选择你期望的outbound

即可以同样通过类似
```
      {
        "type": "field",
        "domain": [
          "dns.google"
        ],
        "outboundTag": "proxy"
      },
      {
        "type": "field",
        "ip": [
          "8.8.8.8"
        ],
        "outboundTag": "proxy"
      },
```
进行路由分流.
**其余模式(如local DOH 仍然是直接发起连接)行为和以前一致.**

如欲避免不当配置导致的死循环(自己企图解析自己), 最方便的模式是 host 中直接加入 DNS 服务器的IP)
比如:
```
  "dns": {
    "hosts": {
      "dns.google": "8.8.8.8"
    },
    "servers": [
      {
        "address": "https://dns.google/dns-query"
      },
   "https+local://1.1.1.1/dns-query",
   "8.8.8.8"
   ]
}
```