### PR TITLE
add balance optimal strategy

### DIFF
--- a/app/router/balancing.go
+++ b/app/router/balancing.go
@@ -6,13 +6,14 @@ import (
 )
 
 type BalancingStrategy interface {
-	PickOutbound([]string) string
+	PickOutbound(outbound.Manager, []string) string
 }
 
 type RandomStrategy struct {
 }
 
-func (s *RandomStrategy) PickOutbound(tags []string) string {
+// PickOutbound implement BalancingStrategy interface
+func (s *RandomStrategy) PickOutbound(_ outbound.Manager, tags []string) string {
 	n := len(tags)
 	if n == 0 {
 		panic("0 tags")
@@ -36,7 +37,7 @@ func (b *Balancer) PickOutbound() (string, error) {
 	if len(tags) == 0 {
 		return "", newError("no available outbounds selected")
 	}
-	tag := b.strategy.PickOutbound(tags)
+	tag := b.strategy.PickOutbound(b.ohm, tags)
 	if tag == "" {
 		return "", newError("balancing strategy returns empty tag")
 	}

--- a/app/router/balancing_optimal_strategy.go
+++ b/app/router/balancing_optimal_strategy.go
@@ -1,0 +1,246 @@
+// +build !confonly
+
+package router
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math"
+	"net/http"
+	"net/url"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/net/cnc"
+	"github.com/xtls/xray-core/common/session"
+	"github.com/xtls/xray-core/transport"
+	"github.com/xtls/xray-core/transport/pipe"
+
+	"github.com/xtls/xray-core/common/task"
+	"github.com/xtls/xray-core/features/outbound"
+)
+
+type TagWeight struct {
+	tag    string
+	weight float64
+}
+
+// OptimalStrategy pick outbound by net speed
+type OptimalStrategy struct {
+	timeout       time.Duration
+	interval      time.Duration
+	url           *url.URL
+	count         uint32
+	obm           outbound.Manager
+	tag           string
+	tags          []string
+	weights       map[string]uint32
+	periodic      *task.Periodic
+	periodicMutex sync.Mutex
+}
+
+// NewOptimalStrategy create new strategy
+func NewOptimalStrategy(config *BalancingOptimalStrategyConfig) *OptimalStrategy {
+	s := &OptimalStrategy{}
+	if config.Timeout == 0 {
+		s.timeout = time.Second * 5
+	} else {
+		s.timeout = time.Millisecond * time.Duration(config.Timeout)
+	}
+	if config.Interval == 0 {
+		s.interval = time.Second * 60 * 10
+	} else {
+		s.interval = time.Millisecond * time.Duration(config.Interval)
+	}
+	if config.Url == "" {
+		s.url, _ = url.Parse("https://www.google.com")
+	} else {
+		var err error
+		s.url, err = url.Parse(config.Url)
+		if err != nil {
+			panic(err)
+		}
+		if s.url.Scheme != "http" && s.url.Scheme != "https" {
+			panic("Only http/https url support")
+		}
+	}
+	if config.Count == 0 {
+		s.count = 1
+	} else {
+		s.count = config.Count
+	}
+	s.weights = make(map[string]uint32)
+	if config.Weights != nil {
+		for _, w := range config.Weights {
+			s.weights[w.Tag] = w.Weight
+		}
+	}
+	return s
+}
+
+// PickOutbound implement BalancingStrategy interface
+func (s *OptimalStrategy) PickOutbound(obm outbound.Manager, tags []string) string {
+	if len(tags) == 0 {
+		panic("0 tags")
+	} else if len(tags) == 1 {
+		return s.tag
+	}
+
+	s.obm = obm
+	s.tags = tags
+
+	if s.periodic == nil {
+		s.periodicMutex.Lock()
+		if s.periodic == nil {
+			s.tag = s.tags[0]
+			s.periodic = &task.Periodic{
+				Interval: s.interval,
+				Execute:  s.run,
+			}
+			go s.periodic.Start()
+		}
+		s.periodicMutex.Unlock()
+	}
+
+	return s.tag
+}
+
+type optimalStrategyTestResult struct {
+	tag   string
+	score float64
+}
+
+// periodic execute function
+func (s *OptimalStrategy) run() error {
+	tags := s.tags
+	count := s.count
+
+	results := make([]optimalStrategyTestResult, len(tags))
+
+	var wg sync.WaitGroup
+	wg.Add(len(tags))
+	for i, tag := range tags {
+		result := &results[i]
+		result.tag = tag
+		go s.testOutboud(tag, result, count, &wg)
+	}
+	wg.Wait()
+
+	sort.Slice(results, func(i, j int) bool {
+		// score scores in desc order
+		return results[i].score > results[j].score
+	})
+
+	if results[0].tag != s.tag {
+		newError(fmt.Sprintf("The balanced optimal strategy changes the outbound from [%s] to [%s] in %s", s.tag, results[0].tag, s.tags)).AtWarning().WriteToLog()
+		s.tag = results[0].tag
+	}
+	return nil
+}
+
+// Test outbound's network state with multi-round
+func (s *OptimalStrategy) testOutboud(tag string, result *optimalStrategyTestResult, count uint32, wg *sync.WaitGroup) {
+	// test outbound by fetch url
+	defer wg.Done()
+	newError(fmt.Sprintf("s.obm.GetHandler %s", tag)).AtDebug().WriteToLog()
+	oh := s.obm.GetHandler(tag)
+	if oh == nil {
+		newError("Wrong OptimalStrategy tag").AtError().WriteToLog()
+		return
+	}
+
+	scores := make([]float64, count)
+	for i := uint32(0); i < count; i++ {
+		client := s.buildClient(oh)
+		// send http request though this outbound
+		req, _ := http.NewRequest("GET", s.url.String(), nil)
+		startAt := time.Now()
+		resp, err := client.Do(req)
+		// use http response speed or time(no http content) as score
+		score := 0.0
+		if err != nil {
+			newError(fmt.Sprintf("Balance OptimalStrategy tag %s error: %s", tag, err)).AtInfo().WriteToLog()
+		} else {
+			defer resp.Body.Close()
+			bodybuff := new(bytes.Buffer)
+			contentSize, err := bodybuff.ReadFrom(resp.Body)
+			if err != nil {
+				newError(fmt.Sprintf("Balance OptimalStrategy tag %s error: %s", tag, err)).AtInfo().WriteToLog()
+			} else {
+				finishAt := time.Now()
+				usetime := float64(finishAt.UnixNano()-startAt.UnixNano()) / float64(time.Second)
+				newError(fmt.Sprintf("Balance OptimalStrategy tag %s get contentSize: %d", tag, contentSize)).AtDebug().WriteToLog()
+				newError(fmt.Sprintf("Balance OptimalStrategy tag %s usetime: %f", tag, usetime)).AtDebug().WriteToLog()
+				var weight uint32 = 100.00
+				if _, ok := s.weights[tag]; ok {
+					weight = s.weights[tag]
+				}
+				if contentSize != 0 {
+					score = float64(weight) * float64(contentSize) / usetime
+				} else {
+					// assert http header's Byte size is 100B
+					score = float64(weight) * 100 / usetime
+				}
+			}
+		}
+		scores[i] = score
+		// next test round
+		client.CloseIdleConnections()
+	}
+
+	// calculate average score and end test round
+	var minScore float64 = float64(math.MaxInt64)
+	var maxScore float64 = float64(math.MinInt64)
+	var sumScore float64
+	var score float64
+
+	for _, score := range scores {
+		if score < minScore {
+			minScore = score
+		}
+		if score > maxScore {
+			maxScore = score
+		}
+		sumScore += score
+	}
+	if len(scores) < 3 {
+		score = sumScore / float64(len(scores))
+	} else {
+		score = (sumScore - minScore - maxScore) / float64(s.count-2)
+	}
+	newError(fmt.Sprintf("Balance OptimalStrategy get %s's score: %.2f", tag, score)).AtDebug().WriteToLog()
+	result.score = score
+}
+
+func (s *OptimalStrategy) buildClient(oh outbound.Handler) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				netDestination, err := net.ParseDestination(fmt.Sprintf("%s:%s", network, addr))
+				if err != nil {
+					return nil, err
+				}
+
+				uplinkReader, uplinkWriter := pipe.New()
+				downlinkReader, downlinkWriter := pipe.New()
+				ctx = session.ContextWithOutbound(
+					ctx,
+					&session.Outbound{
+						Target: netDestination,
+					})
+				go oh.Dispatch(ctx, &transport.Link{Reader: uplinkReader, Writer: downlinkWriter})
+
+				return cnc.NewConnection(cnc.ConnectionInputMulti(uplinkWriter), cnc.ConnectionOutputMulti(downlinkReader)), nil
+			},
+			MaxConnsPerHost:    1,
+			MaxIdleConns:       1,
+			DisableCompression: true,
+			DisableKeepAlives:  true,
+			ForceAttemptHTTP2:  true,
+		},
+		Timeout: s.timeout,
+	}
+}

--- a/app/router/config.go
+++ b/app/router/config.go
@@ -146,9 +146,17 @@ func (rr *RoutingRule) BuildCondition() (Condition, error) {
 }
 
 func (br *BalancingRule) Build(ohm outbound.Manager) (*Balancer, error) {
+	var strategy BalancingStrategy
+
+	if br.Strategy == "optimal" {
+		strategy = NewOptimalStrategy(br.OptimalStrategyConfig)
+	} else if br.Strategy == "" || br.Strategy == "random" {
+		strategy = &RandomStrategy{}
+	}
+
 	return &Balancer{
 		selectors: br.OutboundSelector,
-		strategy:  &RandomStrategy{},
+		strategy:  strategy,
 		ohm:       ohm,
 	}, nil
 }

--- a/app/router/config.pb.go
+++ b/app/router/config.pb.go
@@ -136,7 +136,7 @@ func (x Config_DomainStrategy) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Config_DomainStrategy.Descriptor instead.
 func (Config_DomainStrategy) EnumDescriptor() ([]byte, []int) {
-	return file_app_router_config_proto_rawDescGZIP(), []int{8, 0}
+	return file_app_router_config_proto_rawDescGZIP(), []int{10, 0}
 }
 
 // Domain for routing decision.
@@ -690,19 +690,155 @@ func (*RoutingRule_Tag) isRoutingRule_TargetTag() {}
 
 func (*RoutingRule_BalancingTag) isRoutingRule_TargetTag() {}
 
+type Weights struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Tag    string `protobuf:"bytes,1,opt,name=tag,proto3" json:"tag,omitempty"`
+	Weight uint32 `protobuf:"varint,2,opt,name=weight,proto3" json:"weight,omitempty"`
+}
+
+func (x *Weights) Reset() {
+	*x = Weights{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_app_router_config_proto_msgTypes[7]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *Weights) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Weights) ProtoMessage() {}
+
+func (x *Weights) ProtoReflect() protoreflect.Message {
+	mi := &file_app_router_config_proto_msgTypes[7]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Weights.ProtoReflect.Descriptor instead.
+func (*Weights) Descriptor() ([]byte, []int) {
+	return file_app_router_config_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *Weights) GetTag() string {
+	if x != nil {
+		return x.Tag
+	}
+	return ""
+}
+
+func (x *Weights) GetWeight() uint32 {
+	if x != nil {
+		return x.Weight
+	}
+	return 0
+}
+
+type BalancingOptimalStrategyConfig struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Timeout  uint32     `protobuf:"varint,1,opt,name=timeout,proto3" json:"timeout,omitempty"`
+	Interval uint32     `protobuf:"varint,2,opt,name=interval,proto3" json:"interval,omitempty"`
+	Url      string     `protobuf:"bytes,3,opt,name=url,proto3" json:"url,omitempty"`
+	Count    uint32     `protobuf:"varint,4,opt,name=count,proto3" json:"count,omitempty"`
+	Weights  []*Weights `protobuf:"bytes,5,rep,name=weights,proto3" json:"weights,omitempty"`
+}
+
+func (x *BalancingOptimalStrategyConfig) Reset() {
+	*x = BalancingOptimalStrategyConfig{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_app_router_config_proto_msgTypes[8]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *BalancingOptimalStrategyConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BalancingOptimalStrategyConfig) ProtoMessage() {}
+
+func (x *BalancingOptimalStrategyConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_app_router_config_proto_msgTypes[8]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BalancingOptimalStrategyConfig.ProtoReflect.Descriptor instead.
+func (*BalancingOptimalStrategyConfig) Descriptor() ([]byte, []int) {
+	return file_app_router_config_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *BalancingOptimalStrategyConfig) GetTimeout() uint32 {
+	if x != nil {
+		return x.Timeout
+	}
+	return 0
+}
+
+func (x *BalancingOptimalStrategyConfig) GetInterval() uint32 {
+	if x != nil {
+		return x.Interval
+	}
+	return 0
+}
+
+func (x *BalancingOptimalStrategyConfig) GetUrl() string {
+	if x != nil {
+		return x.Url
+	}
+	return ""
+}
+
+func (x *BalancingOptimalStrategyConfig) GetCount() uint32 {
+	if x != nil {
+		return x.Count
+	}
+	return 0
+}
+
+func (x *BalancingOptimalStrategyConfig) GetWeights() []*Weights {
+	if x != nil {
+		return x.Weights
+	}
+	return nil
+}
+
 type BalancingRule struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Tag              string   `protobuf:"bytes,1,opt,name=tag,proto3" json:"tag,omitempty"`
-	OutboundSelector []string `protobuf:"bytes,2,rep,name=outbound_selector,json=outboundSelector,proto3" json:"outbound_selector,omitempty"`
+	Tag                   string                          `protobuf:"bytes,1,opt,name=tag,proto3" json:"tag,omitempty"`
+	OutboundSelector      []string                        `protobuf:"bytes,2,rep,name=outbound_selector,json=outboundSelector,proto3" json:"outbound_selector,omitempty"`
+	Strategy              string                          `protobuf:"bytes,3,opt,name=strategy,proto3" json:"strategy,omitempty"`
+	OptimalStrategyConfig *BalancingOptimalStrategyConfig `protobuf:"bytes,4,opt,name=optimal_strategy_config,json=optimalStrategyConfig,proto3" json:"optimal_strategy_config,omitempty"`
 }
 
 func (x *BalancingRule) Reset() {
 	*x = BalancingRule{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_app_router_config_proto_msgTypes[7]
+		mi := &file_app_router_config_proto_msgTypes[9]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -715,7 +851,7 @@ func (x *BalancingRule) String() string {
 func (*BalancingRule) ProtoMessage() {}
 
 func (x *BalancingRule) ProtoReflect() protoreflect.Message {
-	mi := &file_app_router_config_proto_msgTypes[7]
+	mi := &file_app_router_config_proto_msgTypes[9]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -728,7 +864,7 @@ func (x *BalancingRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BalancingRule.ProtoReflect.Descriptor instead.
 func (*BalancingRule) Descriptor() ([]byte, []int) {
-	return file_app_router_config_proto_rawDescGZIP(), []int{7}
+	return file_app_router_config_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *BalancingRule) GetTag() string {
@@ -741,6 +877,20 @@ func (x *BalancingRule) GetTag() string {
 func (x *BalancingRule) GetOutboundSelector() []string {
 	if x != nil {
 		return x.OutboundSelector
+	}
+	return nil
+}
+
+func (x *BalancingRule) GetStrategy() string {
+	if x != nil {
+		return x.Strategy
+	}
+	return ""
+}
+
+func (x *BalancingRule) GetOptimalStrategyConfig() *BalancingOptimalStrategyConfig {
+	if x != nil {
+		return x.OptimalStrategyConfig
 	}
 	return nil
 }
@@ -758,7 +908,7 @@ type Config struct {
 func (x *Config) Reset() {
 	*x = Config{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_app_router_config_proto_msgTypes[8]
+		mi := &file_app_router_config_proto_msgTypes[10]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -771,7 +921,7 @@ func (x *Config) String() string {
 func (*Config) ProtoMessage() {}
 
 func (x *Config) ProtoReflect() protoreflect.Message {
-	mi := &file_app_router_config_proto_msgTypes[8]
+	mi := &file_app_router_config_proto_msgTypes[10]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -784,7 +934,7 @@ func (x *Config) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Config.ProtoReflect.Descriptor instead.
 func (*Config) Descriptor() ([]byte, []int) {
-	return file_app_router_config_proto_rawDescGZIP(), []int{8}
+	return file_app_router_config_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *Config) GetDomainStrategy() Config_DomainStrategy {
@@ -823,7 +973,7 @@ type Domain_Attribute struct {
 func (x *Domain_Attribute) Reset() {
 	*x = Domain_Attribute{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_app_router_config_proto_msgTypes[9]
+		mi := &file_app_router_config_proto_msgTypes[11]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -836,7 +986,7 @@ func (x *Domain_Attribute) String() string {
 func (*Domain_Attribute) ProtoMessage() {}
 
 func (x *Domain_Attribute) ProtoReflect() protoreflect.Message {
-	mi := &file_app_router_config_proto_msgTypes[9]
+	mi := &file_app_router_config_proto_msgTypes[11]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -995,12 +1145,35 @@ var file_app_router_config_proto_rawDesc = []byte{
 	0x6f, 0x63, 0x6f, 0x6c, 0x12, 0x1e, 0x0a, 0x0a, 0x61, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74,
 	0x65, 0x73, 0x18, 0x0f, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0a, 0x61, 0x74, 0x74, 0x72, 0x69, 0x62,
 	0x75, 0x74, 0x65, 0x73, 0x42, 0x0c, 0x0a, 0x0a, 0x74, 0x61, 0x72, 0x67, 0x65, 0x74, 0x5f, 0x74,
-	0x61, 0x67, 0x22, 0x4e, 0x0a, 0x0d, 0x42, 0x61, 0x6c, 0x61, 0x6e, 0x63, 0x69, 0x6e, 0x67, 0x52,
-	0x75, 0x6c, 0x65, 0x12, 0x10, 0x0a, 0x03, 0x74, 0x61, 0x67, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09,
-	0x52, 0x03, 0x74, 0x61, 0x67, 0x12, 0x2b, 0x0a, 0x11, 0x6f, 0x75, 0x74, 0x62, 0x6f, 0x75, 0x6e,
-	0x64, 0x5f, 0x73, 0x65, 0x6c, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x18, 0x02, 0x20, 0x03, 0x28, 0x09,
-	0x52, 0x10, 0x6f, 0x75, 0x74, 0x62, 0x6f, 0x75, 0x6e, 0x64, 0x53, 0x65, 0x6c, 0x65, 0x63, 0x74,
-	0x6f, 0x72, 0x22, 0x9b, 0x02, 0x0a, 0x06, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x12, 0x4f, 0x0a,
+	0x61, 0x67, 0x22, 0x33, 0x0a, 0x07, 0x57, 0x65, 0x69, 0x67, 0x68, 0x74, 0x73, 0x12, 0x10, 0x0a,
+	0x03, 0x74, 0x61, 0x67, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x74, 0x61, 0x67, 0x12,
+	0x16, 0x0a, 0x06, 0x77, 0x65, 0x69, 0x67, 0x68, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0d, 0x52,
+	0x06, 0x77, 0x65, 0x69, 0x67, 0x68, 0x74, 0x22, 0xb2, 0x01, 0x0a, 0x1e, 0x42, 0x61, 0x6c, 0x61,
+	0x6e, 0x63, 0x69, 0x6e, 0x67, 0x4f, 0x70, 0x74, 0x69, 0x6d, 0x61, 0x6c, 0x53, 0x74, 0x72, 0x61,
+	0x74, 0x65, 0x67, 0x79, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x12, 0x18, 0x0a, 0x07, 0x74, 0x69,
+	0x6d, 0x65, 0x6f, 0x75, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x07, 0x74, 0x69, 0x6d,
+	0x65, 0x6f, 0x75, 0x74, 0x12, 0x1a, 0x0a, 0x08, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x76, 0x61, 0x6c,
+	0x18, 0x02, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x08, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x76, 0x61, 0x6c,
+	0x12, 0x10, 0x0a, 0x03, 0x75, 0x72, 0x6c, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x75,
+	0x72, 0x6c, 0x12, 0x14, 0x0a, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x18, 0x04, 0x20, 0x01, 0x28,
+	0x0d, 0x52, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x12, 0x32, 0x0a, 0x07, 0x77, 0x65, 0x69, 0x67,
+	0x68, 0x74, 0x73, 0x18, 0x05, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x18, 0x2e, 0x78, 0x72, 0x61, 0x79,
+	0x2e, 0x61, 0x70, 0x70, 0x2e, 0x72, 0x6f, 0x75, 0x74, 0x65, 0x72, 0x2e, 0x57, 0x65, 0x69, 0x67,
+	0x68, 0x74, 0x73, 0x52, 0x07, 0x77, 0x65, 0x69, 0x67, 0x68, 0x74, 0x73, 0x22, 0xd3, 0x01, 0x0a,
+	0x0d, 0x42, 0x61, 0x6c, 0x61, 0x6e, 0x63, 0x69, 0x6e, 0x67, 0x52, 0x75, 0x6c, 0x65, 0x12, 0x10,
+	0x0a, 0x03, 0x74, 0x61, 0x67, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x74, 0x61, 0x67,
+	0x12, 0x2b, 0x0a, 0x11, 0x6f, 0x75, 0x74, 0x62, 0x6f, 0x75, 0x6e, 0x64, 0x5f, 0x73, 0x65, 0x6c,
+	0x65, 0x63, 0x74, 0x6f, 0x72, 0x18, 0x02, 0x20, 0x03, 0x28, 0x09, 0x52, 0x10, 0x6f, 0x75, 0x74,
+	0x62, 0x6f, 0x75, 0x6e, 0x64, 0x53, 0x65, 0x6c, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x12, 0x1a, 0x0a,
+	0x08, 0x73, 0x74, 0x72, 0x61, 0x74, 0x65, 0x67, 0x79, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52,
+	0x08, 0x73, 0x74, 0x72, 0x61, 0x74, 0x65, 0x67, 0x79, 0x12, 0x67, 0x0a, 0x17, 0x6f, 0x70, 0x74,
+	0x69, 0x6d, 0x61, 0x6c, 0x5f, 0x73, 0x74, 0x72, 0x61, 0x74, 0x65, 0x67, 0x79, 0x5f, 0x63, 0x6f,
+	0x6e, 0x66, 0x69, 0x67, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x2f, 0x2e, 0x78, 0x72, 0x61,
+	0x79, 0x2e, 0x61, 0x70, 0x70, 0x2e, 0x72, 0x6f, 0x75, 0x74, 0x65, 0x72, 0x2e, 0x42, 0x61, 0x6c,
+	0x61, 0x6e, 0x63, 0x69, 0x6e, 0x67, 0x4f, 0x70, 0x74, 0x69, 0x6d, 0x61, 0x6c, 0x53, 0x74, 0x72,
+	0x61, 0x74, 0x65, 0x67, 0x79, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x52, 0x15, 0x6f, 0x70, 0x74,
+	0x69, 0x6d, 0x61, 0x6c, 0x53, 0x74, 0x72, 0x61, 0x74, 0x65, 0x67, 0x79, 0x43, 0x6f, 0x6e, 0x66,
+	0x69, 0x67, 0x22, 0x9b, 0x02, 0x0a, 0x06, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x12, 0x4f, 0x0a,
 	0x0f, 0x64, 0x6f, 0x6d, 0x61, 0x69, 0x6e, 0x5f, 0x73, 0x74, 0x72, 0x61, 0x74, 0x65, 0x67, 0x79,
 	0x18, 0x01, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x26, 0x2e, 0x78, 0x72, 0x61, 0x79, 0x2e, 0x61, 0x70,
 	0x70, 0x2e, 0x72, 0x6f, 0x75, 0x74, 0x65, 0x72, 0x2e, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x2e,
@@ -1039,28 +1212,30 @@ func file_app_router_config_proto_rawDescGZIP() []byte {
 }
 
 var file_app_router_config_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_app_router_config_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_app_router_config_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_app_router_config_proto_goTypes = []interface{}{
-	(Domain_Type)(0),           // 0: xray.app.router.Domain.Type
-	(Config_DomainStrategy)(0), // 1: xray.app.router.Config.DomainStrategy
-	(*Domain)(nil),             // 2: xray.app.router.Domain
-	(*CIDR)(nil),               // 3: xray.app.router.CIDR
-	(*GeoIP)(nil),              // 4: xray.app.router.GeoIP
-	(*GeoIPList)(nil),          // 5: xray.app.router.GeoIPList
-	(*GeoSite)(nil),            // 6: xray.app.router.GeoSite
-	(*GeoSiteList)(nil),        // 7: xray.app.router.GeoSiteList
-	(*RoutingRule)(nil),        // 8: xray.app.router.RoutingRule
-	(*BalancingRule)(nil),      // 9: xray.app.router.BalancingRule
-	(*Config)(nil),             // 10: xray.app.router.Config
-	(*Domain_Attribute)(nil),   // 11: xray.app.router.Domain.Attribute
-	(*net.PortRange)(nil),      // 12: xray.common.net.PortRange
-	(*net.PortList)(nil),       // 13: xray.common.net.PortList
-	(*net.NetworkList)(nil),    // 14: xray.common.net.NetworkList
-	(net.Network)(0),           // 15: xray.common.net.Network
+	(Domain_Type)(0),                       // 0: xray.app.router.Domain.Type
+	(Config_DomainStrategy)(0),             // 1: xray.app.router.Config.DomainStrategy
+	(*Domain)(nil),                         // 2: xray.app.router.Domain
+	(*CIDR)(nil),                           // 3: xray.app.router.CIDR
+	(*GeoIP)(nil),                          // 4: xray.app.router.GeoIP
+	(*GeoIPList)(nil),                      // 5: xray.app.router.GeoIPList
+	(*GeoSite)(nil),                        // 6: xray.app.router.GeoSite
+	(*GeoSiteList)(nil),                    // 7: xray.app.router.GeoSiteList
+	(*RoutingRule)(nil),                    // 8: xray.app.router.RoutingRule
+	(*Weights)(nil),                        // 9: xray.app.router.Weights
+	(*BalancingOptimalStrategyConfig)(nil), // 10: xray.app.router.BalancingOptimalStrategyConfig
+	(*BalancingRule)(nil),                  // 11: xray.app.router.BalancingRule
+	(*Config)(nil),                         // 12: xray.app.router.Config
+	(*Domain_Attribute)(nil),               // 13: xray.app.router.Domain.Attribute
+	(*net.PortRange)(nil),                  // 14: xray.common.net.PortRange
+	(*net.PortList)(nil),                   // 15: xray.common.net.PortList
+	(*net.NetworkList)(nil),                // 16: xray.common.net.NetworkList
+	(net.Network)(0),                       // 17: xray.common.net.Network
 }
 var file_app_router_config_proto_depIdxs = []int32{
 	0,  // 0: xray.app.router.Domain.type:type_name -> xray.app.router.Domain.Type
-	11, // 1: xray.app.router.Domain.attribute:type_name -> xray.app.router.Domain.Attribute
+	13, // 1: xray.app.router.Domain.attribute:type_name -> xray.app.router.Domain.Attribute
 	3,  // 2: xray.app.router.GeoIP.cidr:type_name -> xray.app.router.CIDR
 	4,  // 3: xray.app.router.GeoIPList.entry:type_name -> xray.app.router.GeoIP
 	2,  // 4: xray.app.router.GeoSite.domain:type_name -> xray.app.router.Domain
@@ -1068,21 +1243,23 @@ var file_app_router_config_proto_depIdxs = []int32{
 	2,  // 6: xray.app.router.RoutingRule.domain:type_name -> xray.app.router.Domain
 	3,  // 7: xray.app.router.RoutingRule.cidr:type_name -> xray.app.router.CIDR
 	4,  // 8: xray.app.router.RoutingRule.geoip:type_name -> xray.app.router.GeoIP
-	12, // 9: xray.app.router.RoutingRule.port_range:type_name -> xray.common.net.PortRange
-	13, // 10: xray.app.router.RoutingRule.port_list:type_name -> xray.common.net.PortList
-	14, // 11: xray.app.router.RoutingRule.network_list:type_name -> xray.common.net.NetworkList
-	15, // 12: xray.app.router.RoutingRule.networks:type_name -> xray.common.net.Network
+	14, // 9: xray.app.router.RoutingRule.port_range:type_name -> xray.common.net.PortRange
+	15, // 10: xray.app.router.RoutingRule.port_list:type_name -> xray.common.net.PortList
+	16, // 11: xray.app.router.RoutingRule.network_list:type_name -> xray.common.net.NetworkList
+	17, // 12: xray.app.router.RoutingRule.networks:type_name -> xray.common.net.Network
 	3,  // 13: xray.app.router.RoutingRule.source_cidr:type_name -> xray.app.router.CIDR
 	4,  // 14: xray.app.router.RoutingRule.source_geoip:type_name -> xray.app.router.GeoIP
-	13, // 15: xray.app.router.RoutingRule.source_port_list:type_name -> xray.common.net.PortList
-	1,  // 16: xray.app.router.Config.domain_strategy:type_name -> xray.app.router.Config.DomainStrategy
-	8,  // 17: xray.app.router.Config.rule:type_name -> xray.app.router.RoutingRule
-	9,  // 18: xray.app.router.Config.balancing_rule:type_name -> xray.app.router.BalancingRule
-	19, // [19:19] is the sub-list for method output_type
-	19, // [19:19] is the sub-list for method input_type
-	19, // [19:19] is the sub-list for extension type_name
-	19, // [19:19] is the sub-list for extension extendee
-	0,  // [0:19] is the sub-list for field type_name
+	15, // 15: xray.app.router.RoutingRule.source_port_list:type_name -> xray.common.net.PortList
+	9,  // 16: xray.app.router.BalancingOptimalStrategyConfig.weights:type_name -> xray.app.router.Weights
+	10, // 17: xray.app.router.BalancingRule.optimal_strategy_config:type_name -> xray.app.router.BalancingOptimalStrategyConfig
+	1,  // 18: xray.app.router.Config.domain_strategy:type_name -> xray.app.router.Config.DomainStrategy
+	8,  // 19: xray.app.router.Config.rule:type_name -> xray.app.router.RoutingRule
+	11, // 20: xray.app.router.Config.balancing_rule:type_name -> xray.app.router.BalancingRule
+	21, // [21:21] is the sub-list for method output_type
+	21, // [21:21] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_app_router_config_proto_init() }
@@ -1176,7 +1353,7 @@ func file_app_router_config_proto_init() {
 			}
 		}
 		file_app_router_config_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*BalancingRule); i {
+			switch v := v.(*Weights); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1188,7 +1365,7 @@ func file_app_router_config_proto_init() {
 			}
 		}
 		file_app_router_config_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*Config); i {
+			switch v := v.(*BalancingOptimalStrategyConfig); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1200,6 +1377,30 @@ func file_app_router_config_proto_init() {
 			}
 		}
 		file_app_router_config_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*BalancingRule); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_app_router_config_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*Config); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_app_router_config_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Domain_Attribute); i {
 			case 0:
 				return &v.state
@@ -1216,7 +1417,7 @@ func file_app_router_config_proto_init() {
 		(*RoutingRule_Tag)(nil),
 		(*RoutingRule_BalancingTag)(nil),
 	}
-	file_app_router_config_proto_msgTypes[9].OneofWrappers = []interface{}{
+	file_app_router_config_proto_msgTypes[11].OneofWrappers = []interface{}{
 		(*Domain_Attribute_BoolValue)(nil),
 		(*Domain_Attribute_IntValue)(nil),
 	}
@@ -1226,7 +1427,7 @@ func file_app_router_config_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_app_router_config_proto_rawDesc,
 			NumEnums:      2,
-			NumMessages:   10,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/app/router/config.proto
+++ b/app/router/config.proto
@@ -121,9 +121,24 @@ message RoutingRule {
   string attributes = 15;
 }
 
+message Weights {
+  string tag = 1;
+  uint32 weight = 2;
+}
+
+message BalancingOptimalStrategyConfig {
+  uint32 timeout = 1;
+  uint32 interval = 2;
+  string url = 3;
+  uint32 count = 4;
+  repeated Weights weights = 5;
+}
+
 message BalancingRule {
   string tag = 1;
   repeated string outbound_selector = 2;
+  string strategy = 3;
+  BalancingOptimalStrategyConfig optimal_strategy_config = 4;
 }
 
 message Config {

--- a/infra/conf/router.go
+++ b/infra/conf/router.go
@@ -18,9 +18,20 @@ type RouterRulesConfig struct {
 	DomainStrategy string            `json:"domainStrategy"`
 }
 
+// BalancingOptimalStrategyConfig store BalancingOptimalStrategy config
+type BalancingOptimalStrategyConfig struct {
+	Timeout  uint32            `json:"timeout,omitempty"`
+	Interval uint32            `json:"interval,omitempty"`
+	URL      string            `json:"url,omitempty"`
+	Count    uint32            `json:"count,omitempty"`
+	Weights  []*router.Weights `json:"weights,omitempty"`
+}
+
 type BalancingRule struct {
-	Tag       string     `json:"tag"`
-	Selectors StringList `json:"selector"`
+	Tag                   string                          `json:"tag"`
+	Selectors             StringList                      `json:"selector"`
+	Strategy              string                          `json:"strategy"`
+	OptimalStrategyConfig *BalancingOptimalStrategyConfig `json:"optimalSettings"`
 }
 
 func (r *BalancingRule) Build() (*router.BalancingRule, error) {
@@ -31,9 +42,20 @@ func (r *BalancingRule) Build() (*router.BalancingRule, error) {
 		return nil, newError("empty selector list")
 	}
 
+	optimalStrategyConfig := &router.BalancingOptimalStrategyConfig{}
+	if r.OptimalStrategyConfig != nil {
+		optimalStrategyConfig.Timeout = r.OptimalStrategyConfig.Timeout
+		optimalStrategyConfig.Interval = r.OptimalStrategyConfig.Interval
+		optimalStrategyConfig.Url = r.OptimalStrategyConfig.URL
+		optimalStrategyConfig.Count = r.OptimalStrategyConfig.Count
+		optimalStrategyConfig.Weights = r.OptimalStrategyConfig.Weights
+	}
+
 	return &router.BalancingRule{
-		Tag:              r.Tag,
-		OutboundSelector: []string(r.Selectors),
+		Tag:                   r.Tag,
+		OutboundSelector:      []string(r.Selectors),
+		Strategy:              r.Strategy,
+		OptimalStrategyConfig: optimalStrategyConfig,
 	}, nil
 }
 


### PR DESCRIPTION
_原来的 balancer 只有一种策略,即随机策略, balancer 在配置的一组 outbound 中每次随机选择一个作为实际的outbound, 比较鸡肋._

这里增加了一种新的策略, 且以后还可以增加不同的策略模式.
如果不指定使用策略, 不会有任何影响。

**此策略包含自动择优选择,故障转移**
**即可以择优选择一组 outbound 中最佳的一个作为实际outbound, 因此在当前 outbound 故障/不稳定时,也自然会进行故障转移.**
**并且可以自行配置权重及其他参数进行控制**

## 策略原理
此策略的原理是, 为 balancer 配置一组 outbound 后, balancer 按时间间隔 (可配置)使用每个 outbound 向指定的目标URL(可配置)进行N次(次数可配置)访问进行测速. 策略计算测速的速率(多次测速则取平均值), 乘以此 outbound 的权重(可配置), 计算得到最终得分.
所有outbound同时开始,并且在指定时间(可配置)内必须结束(在指定时间内未能完成测试的得分为0). 
结束所有测试后, 策略将选择得分最高的 outbound 作为此 balancer 后续处理连接请求时实际使用的outbound, 持续到下一轮测试.

## 配置方式
首先假设有3个outbound,名称为 proxy1,proxy2,proxy3
原配置方式为
```
"balancers": [
    {
        "tag": "balancer",
        "selector": ["proxy1","proxy2","proxy3"]
    }
]
```
_如果还是用随机策略, 仍用此配置即可,对于每个新连接 balancer 将在 ["proxy1","proxy2","proxy3"] 中随机选择一个作为 outbound._

新的 balancer 配置如下
```
"balancers": [
    {
        "tag": "balancer",
        "selector": ["proxy1","proxy2","proxy3"]
        "strategy": "optimal",
        "optimalSettings": {
              "timeout": 10000,
              "interval": 20000,
              "url": "https://about.google",
              "count": 1,
              "weights": [
                {
                  "tag": "proxy1",
                  "weight": 150
                },
                {
                  "tag": "proxy2",
                  "weight": 150
                }
              ]
            }
     }
]
```
配置简要说明: 
strategy: 指示使用哪一种策略, 填"optimal"为使用最优策略, 不填或者填"random"即为以前的随机策略,
 **以后可以增加更多的 strategy .**

optimalSettings是使用"optimal"时的具体配置.
- timeout: 超时时间,单位毫秒,10000为10秒, 默认5秒.即测试需要在多长时间内结束,超过时间不能完成测试的得分为0
- interval:  测试间隔,单位毫秒,默认10分钟. 
- url: 测试使用的URL, 默认为"https://www.google.com",可以指定任意你喜欢的地址,比如一个小文件.
- count: 测试次数,默认为1. 多次将取平均值.
- weights:是一个数组,用于配置每个outbound的权重,如果没指定权重,默认为100.

## 实例说明
### 实例1
最简单的情况, 用户有2个服务器, 于是在客户端配置了两个 outbound "proxy1"和 "proxy2" 指向两个服务器.
其中 "proxy1"为较快常用线路,"proxy2"为备用线路。
希望在proxy1不稳定,或服务器down掉以后可以自动切换到"proxy2",常用场景是普通正常上网场景.
则可以这样配置.
```
{
  "routing": {
    "domainStrategy": "AsIs",
    "rules": [
      {
        "type": "field",
        "inboundTag": [
          "http-in",
          "socks-in"
        ],
        "balancerTag": "balancer"
      }
    ],
    "balancers": [
      {
        "tag": "balancer",
        "selector": [
          "proxy1",
          "proxy2"
        ],
        "strategy": "optimal",
        "optimalSettings": {
          "timeout": 2000,
          "interval": 30000,
          "url": "https://about.google",
          "count": 1,
          "weights": [
            {
              "tag": "proxy1",
              "weight": 200
            },
            {
              "tag": "proxy2",
              "weight": 100
            }
          ]
        }
      }
    ]
  }
}
```
路由配置此处将http和socks的outbound指向balancer仅为示范, (路由配置可以非常多样化,此处不展开),
关键是使用 "balancerTag": "balancer" 来指定 balancer

以上配置, 每隔30秒,proxy1和proxy2,都会访问 "https://about.google" ,进行测速. 测试需要在2秒内完成,否则认为超时.(一次完整 "https://about.google" 访问大小约80k,一般0.x秒即可完成测试), 测试次数1次.
通常情况下,因为proxy1权重为proxy2两倍,且已经假设理论上常用线路proxy1即使不加权也应快于proxy2.
因此每一轮测试后, 会有以下情况:
- 正常情况下,proxy1 得分超过 proxy2, balancer 将一直保持使用 proxy1 作为实际 outbound.
- 当proxy1网络不稳定 ,proxy1得分低于 proxy2. balancer会选择此时更优的 proxy2 作为实际 outbound 来增强体验
- 当proxy1发生故障,此时 proxy1 得分为0, balancer 将使用 proxy2 作为实际 outbound, 可视为故障转移。
- 当proxy1网络稳定后或从故障中恢复, 下一轮的测试 proxy1得分又将高于 proxy2, 此时 balancer 又会重新选择, 从proxy2 切换回 proxy1 作为实际outbound.
即 每隔30秒, balancer都会再次尝试选择当前最优的线路作为出口, 并且在接下去30秒保持使用此线路作为outbound,然后再次进行测试和选择.

根据实际的线路情况和需求, 可以通过控制测速的间隔 和 设计合理权重值 来获取最佳体验.
- 测速的间隔越短, 对网络和服务器状态的响应越灵敏, 但也可能带来一些其他问题
- 权重则可以比较精确的自行根据需求来控制选择的优先度

### 实例2

较复杂的情况, 假设用户有6个服务器, 
其中 1-3线路类似,4-5线路类似,6线路类似.用户希望可以按3条线路择优选择,并且每条线路中的各个服务器轮询进行负载
可以如下配置,**注意:下面的配置为不完整配置, 旨在说明模式**

<details>
<summary>配置较长, 请点击此处展开查看</summary>

```
{
  "outbounds": [
    {
      "protocol": "vless",
      "settings": {
        "vnext": [
          {
            "address": "IP1",
            "port": 443,
            "users": [
              {
                "id": "",
                "flow": "xtls-rprx-splice",
                "encryption": "none"
              }
            ]
          },
          {
            "address": "IP2",
            "port": 443,
            "users": [
              {
                "id": "",
                "flow": "xtls-rprx-splice",
                "encryption": "none"
              }
            ]
          },
          {
            "address": "IP3",
            "port": 443,
            "users": [
              {
                "id": "",
                "flow": "xtls-rprx-splice",
                "encryption": "none"
              }
            ]
          }
        ]
      },
      "tag": "proxy1",
      "streamSettings": {
        "network": "tcp",
        "security": "xtls",
        "xtlsSettings": {
          "serverName": "test1.com"
        }
      }
    },
    {
      "protocol": "vless",
      "settings": {
        "vnext": [
          {
            "address": "IP4",
            "port": 443,
            "users": [
              {
                "id": "",
                "flow": "xtls-rprx-splice",
                "encryption": "none"
              }
            ]
          },
          {
            "address": "IP5",
            "port": 443,
            "users": [
              {
                "id": "",
                "flow": "xtls-rprx-splice",
                "encryption": "none"
              }
            ]
          }
        ]
      },
      "tag": "proxy2",
      "streamSettings": {
        "network": "tcp",
        "security": "xtls",
        "xtlsSettings": {
          "serverName": "test2.com"
        }
      }
    },
    {
      "protocol": "vless",
      "settings": {
        "vnext": [
          {
            "address": "IP6",
            "port": 443,
            "users": [
              {
                "id": "",
                "flow": "xtls-rprx-splice",
                "encryption": "none"
              }
            ]
          }
        ]
      },
      "tag": "proxy3",
      "streamSettings": {
        "network": "tcp",
        "security": "xtls",
        "xtlsSettings": {
          "serverName": "test3.com"
        }
      }
    }
  ],
  "routing": {
    "domainStrategy": "IPOnDemand",
    "rules": [
      {
        "type": "field",
        "inboundTag": [
          "http-in",
          "socks-in"
        ],
        "balancerTag": "balancer"
      }
    ],
    "balancers": [
      {
        "tag": "balancer",
        "selector": [
          "proxy1",
          "proxy2",
          "proxy3"
        ],
        "strategy": "optimal",
        "optimalSettings": {
          "timeout": 5000,
          "interval": 30000,
          "url": "https://about.google",
          "count": 1,
          "weights": [
            {
              "tag": "proxy1",
              "weight": 300
            },
            {
              "tag": "proxy2",
              "weight": 200
            },
            {
              "tag": "proxy3",
              "weight": 100
            }
          ]
        }
      }
    ]
  }
}
```
</details>

其中 "vnext": 中的服务器组是轮询的.
balancer 和 实例1 类似 , 每30秒进行一次测试, 选择当时最好的 proxy 作为 outbound,
如果此 proxy 内有多个服务器,则轮询进行负载.
权重指定了300:200:100,即主要倾向选择proxy1,其次倾向选择proxy2,当proxy1,proxy2均不稳定或者故障,倾向于使用proxy3.

## 其他用法技巧和注意点
- 权重是个很有用的东西, 根据实际情况各不相同, 可以通过控制权重, 实现各种目的。
  - 比如可以将两个outbound权值设置为proxy1远比proxy2大,从而实现仅仅是故障转移的效果.
  - 可以打开debug级别的log,观察测试输出的每个outbound的score,仔细进行权重调整，来获得最想要的效果。(实际用例很多，比如B的质量可能不如A, 但因为B的可用流量较大, 希望大部分情况下优先选择B, 此时可以适当提高权重,提高B的score大多数情况下超过A, 来优先选择使用B)
- 实际的使用场景不同, 可以通过指定不同的URL使得测试更接近实际场景, 比如设置URL为 "https://about.google" 和较短的timeout ,则接近网页浏览为主的场景. 而指定一个文件下载和较长的timeout,则接近以大流量为主的场景.
- 测试间隔决定了对网络状态,服务器状态响应的敏感度, 但同时也会多耗费流量(视URL不同而不同),以及可能下面这个问题.
- 某些站点或软件对IP有比较严格的限制, 如果balancer中不同的proxy质量较平均,权重也指定相近, 测试间隔指定较短，那么频繁进行测试可能会导致频繁切换proxy, 即频繁切换最终的出口IP访问这些站点, 可能并不合适, 此时请小心配置分流固定出口或者指定合理的权重, 避免频繁切换.
- 但上述情况中, 如果proxy指向的是的不同的中转,中转均转发到同一落地机,即可避免上述切换最终出口IP的情况,并且可以在多个中转服务器中进行最佳的proxy选择中转.
-  即 可以通过各种参数的配合, 灵活实现各种目的. 其他技巧想到再补充吧.




