### PR TITLE
Fix available mux picker

### DIFF
--- a/app/reverse/portal.go
+++ b/app/reverse/portal.go
@@ -157,6 +157,9 @@ func (p *StaticMuxPicker) PickAvailable() (*mux.ClientWorker, error) {
 		if w.draining {
 			continue
 		}
+		if w.client.Closed() {
+			continue
+		}
 		if w.client.ActiveConnections() < minConn {
 			minConn = w.client.ActiveConnections()
 			minIdx = i


### PR DESCRIPTION
至少检查了一下连接是否还可用，原先当同一个portal处理两个以上的bridges的时候，先连接的bridge掉线了还会被pick到，直到它被间隔30秒执行一次的cleanup清理掉。