### PR TITLE
fix: fix format flag not working

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -84,10 +84,19 @@ func LoadConfig(formatName string, input interface{}) (*Config, error) {
 		formats := make([]string, len(v))
 		hasProtobuf := false
 		for i, file := range v {
-			f := getFormat(file)
+			var f string
+
+			if formatName == "auto" {
+				f = getFormat(file)
+				if f == "" {
+					return nil, newError("Unable to get format of", formatName).AtWarning()
+				}
+			}
+
 			if f == "" {
 				f = formatName
 			}
+
 			if f == "protobuf" {
 				hasProtobuf = true
 			}

--- a/main/run.go
+++ b/main/run.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"runtime"
 	"runtime/debug"
+	"strings"
 	"syscall"
 
 	"github.com/xtls/xray-core/common/cmdarg"
@@ -112,7 +113,7 @@ func dirExists(file string) bool {
 }
 
 func getRegepxByFormat() string {
-	switch *format {
+	switch strings.ToLower(*format) {
 	case "json":
 		return `^.+\.(json)$`
 	case "toml":

--- a/main/run.go
+++ b/main/run.go
@@ -115,9 +115,9 @@ func dirExists(file string) bool {
 func getRegepxByFormat() string {
 	switch strings.ToLower(*format) {
 	case "json":
-		return `^.+\.(json)$`
+		return `^.+\.json$`
 	case "toml":
-		return `^.+\.(toml)$`
+		return `^.+\.toml$`
 	case "yaml", "yml":
 		return `^.+\.(yaml|yml)$`
 	default:

--- a/main/run.go
+++ b/main/run.go
@@ -31,7 +31,7 @@ Xray. Multiple assign is accepted.
 The -confdir=dir flag sets a dir with multiple json config
 
 The -format=json flag sets the format of config files. 
-Default "json".
+Default "auto".
 
 The -test flag tells Xray to test config files only, 
 without launching the server
@@ -46,7 +46,7 @@ var (
 	configFiles cmdarg.Arg // "Config file for Xray.", the option is customed type, parse in main
 	configDir   string
 	test        = cmdRun.Flag.Bool("test", false, "Test config file only, without launching Xray server.")
-	format      = cmdRun.Flag.String("format", "json", "Format of input file.")
+	format      = cmdRun.Flag.String("format", "auto", "Format of input file.")
 
 	/* We have to do this here because Golang's Test will also need to parse flag, before
 	 * main func in this file is run.
@@ -111,13 +111,26 @@ func dirExists(file string) bool {
 	return err == nil && info.IsDir()
 }
 
+func getRegepxByFormat() string {
+	switch *format {
+	case "json":
+		return `^.+\.(json)$`
+	case "toml":
+		return `^.+\.(toml)$`
+	case "yaml", "yml":
+		return `^.+\.(yaml|yml)$`
+	default:
+		return `^.+\.(json|toml|yaml|yml)$`
+	}
+}
+
 func readConfDir(dirPath string) {
 	confs, err := ioutil.ReadDir(dirPath)
 	if err != nil {
 		log.Fatalln(err)
 	}
 	for _, f := range confs {
-		matched, err := regexp.MatchString(`^.+\.(json|toml|yaml|yml)$`, f.Name())
+		matched, err := regexp.MatchString(getRegepxByFormat(), f.Name())
 		if err != nil {
 			log.Fatalln(err)
 		}
@@ -160,7 +173,7 @@ func getConfigFilePath() cmdarg.Arg {
 func getConfigFormat() string {
 	f := core.GetFormatByExtension(*format)
 	if f == "" {
-		f = "json"
+		f = "auto"
 	}
 	return f
 }


### PR DESCRIPTION
修复了 1b87264c532b8e250e5098b15fc0b29d7f551e6e 导致文件读取不遵守 format 参数的问题