### PR TITLE
WSS Browser Dialer

### DIFF
--- a/transport/internet/websocket/dialer.go
+++ b/transport/internet/websocket/dialer.go
@@ -25,7 +25,7 @@ var conns chan *websocket.Conn
 
 func init() {
 	if addr := os.Getenv("XRAY_BROWSER_DIALER"); addr != "" {
-		conns = make(chan *websocket.Conn, 1024)
+		conns = make(chan *websocket.Conn, 256)
 		go http.ListenAndServe(addr, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/websocket" {
 				if conn, err := upgrader.Upgrade(w, r, nil); err == nil {

--- a/transport/internet/websocket/dialer.go
+++ b/transport/internet/websocket/dialer.go
@@ -2,8 +2,12 @@ package websocket
 
 import (
 	"context"
+	_ "embed"
 	"encoding/base64"
+	"fmt"
 	"io"
+	"net/http"
+	"os"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -14,6 +18,27 @@ import (
 	"github.com/xtls/xray-core/transport/internet"
 	"github.com/xtls/xray-core/transport/internet/tls"
 )
+
+//go:embed dialer.html
+var webpage []byte
+var conns chan *websocket.Conn
+
+func init() {
+	if addr := os.Getenv("XRAY_BROWSER_DIALER"); addr != "" {
+		conns = make(chan *websocket.Conn, 1024)
+		go http.ListenAndServe(addr, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/websocket" {
+				if conn, err := upgrader.Upgrade(w, r, nil); err == nil {
+					conns <- conn
+				} else {
+					fmt.Println("unexpected error")
+				}
+			} else {
+				w.Write(webpage)
+			}
+		}))
+	}
+}
 
 // Dial dials a WebSocket connection to the given destination.
 func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.MemoryStreamConfig) (internet.Connection, error) {
@@ -65,6 +90,30 @@ func dialWebSocket(ctx context.Context, dest net.Destination, streamSettings *in
 		host = dest.Address.String()
 	}
 	uri := protocol + "://" + host + wsSettings.GetNormalizedPath()
+
+	if conns != nil {
+		data := []byte(uri)
+		if ed != nil {
+			data = append(data, " "+base64.RawURLEncoding.EncodeToString(ed)...)
+		}
+		var conn *websocket.Conn
+		for {
+			conn = <-conns
+			if conn.WriteMessage(websocket.TextMessage, data) != nil {
+				conn.Close()
+			} else {
+				break
+			}
+		}
+		if _, p, err := conn.ReadMessage(); err != nil {
+			conn.Close()
+			return nil, err
+		} else if s := string(p); s != "ok" {
+			conn.Close()
+			return nil, newError(s)
+		}
+		return newConnection(conn, conn.RemoteAddr(), nil), nil
+	}
 
 	header := wsSettings.GetRequestHeader()
 	if ed != nil {

--- a/transport/internet/websocket/dialer.html
+++ b/transport/internet/websocket/dialer.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Browser Dialer</title>
+</head>
+<body></body>
+<script>
+	// Copyright (c) 2021 XRAY. Mozilla Public License 2.0.
+	var url = "ws://" + window.location.host + "/websocket"
+	var count = 0
+	setInterval(check, 1000)
+	function check() {
+		if (count <= 0) {
+			count += 1
+			console.log("Prepare", url)
+			var ws = new WebSocket(url)
+			var wss = undefined
+			var first = true
+			ws.onmessage = function (event) {
+				if (first) {
+					first = false
+					count -= 1
+					var arr = event.data.split(" ")
+					console.log("Dial", arr[0], arr[1])
+					wss = new WebSocket(arr[0], arr[1])
+					var opened = false
+					wss.onopen = function (event) {
+						opened = true
+						ws.send("ok")
+					}
+					wss.onmessage = function (event) {
+						ws.send(event.data)
+					}
+					wss.onclose = function (event) {
+						ws.close()
+					}
+					wss.onerror = function (event) {
+						!opened && ws.send("fail")
+						wss.close()
+					}
+					check()
+				} else wss.send(event.data)
+			}
+			ws.onclose = function (event) {
+				if (first) count -= 1
+				else wss.close()
+			}
+			ws.onerror = function (event) {
+				ws.close()
+			}
+		}
+	}
+</script>
+</body>
+</html>


### PR DESCRIPTION
### Background

https://github.com/v2ray/discussion/issues/754#issuecomment-647934994 基于一年前的想法，原生 JS 实现了简洁的 WSS Browser Dialer，真实浏览器的 TLS 指纹

不过 WSS 仍存在 ALPN 明显的问题，所以下一步是浏览器转发 gRPC、QUIC

### Xray & JS

创造了一个非常简单、巧妙的通信机制：

1. Xray 监听地址端口 A，作为 HTTP 服务，浏览器访问 A，加载网页中的 JS
2. JS 主动向 A 建立 WebSocket 连接，成功后，Xray 将 conn 发给 `channel`
3. 需要 dial 时，Xray 从 `channel` 接收一个可用的 conn，并发送目标 URL 和可选的 early data
4. JS 成功 dial 目标后告知 Xray，并继续用这个 conn 全双工双向转发数据，连接关闭行为同步
5. 注意这个 conn 用过了就会被关闭，但 JS 会确保始终有新空闲连接可用

### Early data

根据浏览器的需求，对 early data 机制进行了如下调整：

1. 服务端响应的 header 会带有请求的 `Sec-WebSocket-Protocol`，这也初步混淆了 WSS 握手响应的长度特征
2. 用于浏览器的 early data 编码是 `base64.RawURLEncoding` 而不是 `StdEncoding`，服务端做了兼容

此外，由于 https://github.com/XTLS/Xray-core/pull/375 推荐 `?ed=2048`，这个 PR 顺便将服务端一处 MaxHeaderBytes 扩至了 4096（虽然好像不改也没问题）

### Configuration

这是一个探索的过程，目前两边都是 Xray-core v1.4.1 时的配置方式：

1. 准备一份可用的 WSS 配置，注意 address 必须填域名，若需要指定 IP，请配置 DNS 或系统 hosts
2. 若浏览器的流量也会经过 Xray-core，务必将这个域名设为直连，否则会造成流量回环
3. 设置环境变量指定要监听的地址端口，比如 `XRAY_BROWSER_DIALER = 127.0.0.1:8080`
4. 先运行 Xray-core，再用任一浏览器访问上面指定的地址端口，还可以 F12 看 Console 和 Network

浏览器会限制 WebSocket 连接数，所以建议开启 Xray-core 的 Mux，之后我会修一些 Mux、WS 的历史遗留问题