### PR TITLE
Remove third party homebrew tap support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@
   - [Xray_For_Magisk](https://github.com/E7KMbb/Xray_For_Magisk)
 - Homebrew
   - `brew install xray`
-  - [(Tap) Repository 0](https://github.com/N4FA/homebrew-xray)
-  - [(Tap) Repository 1](https://github.com/xiruizhao/homebrew-xray)
+  - [(Tap) Repository 0](https://github.com/xiruizhao/homebrew-xray)
 
 ## Usage
 


### PR DESCRIPTION
Remove third party tap support since the xray has entered into the official homebrew/core