### PR TITLE
feat: shouldSniffDomain for (FakeDNS) Sniffer

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -268,7 +268,7 @@ func sniffer(ctx context.Context, cReader *cachedReader, metadataOnly bool) (Sni
 
 	metaresult, metadataErr := sniffer.SniffMetadata(ctx)
 
-	if metadataOnly || metaresult != nil {
+	if metadataOnly {
 		return metaresult, metadataErr
 	}
 
@@ -286,7 +286,7 @@ func sniffer(ctx context.Context, cReader *cachedReader, metadataOnly bool) (Sni
 
 				cReader.Cache(payload)
 				if !payload.IsEmpty() {
-					result, err := sniffer.Sniff(ctx, payload.Bytes())
+					result, err := sniffer.Sniff(ctx, payload.Bytes(), metadataErr != nil)
 					if err != common.ErrNoClue {
 						return result, err
 					}

--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -268,7 +268,7 @@ func sniffer(ctx context.Context, cReader *cachedReader, metadataOnly bool) (Sni
 
 	metaresult, metadataErr := sniffer.SniffMetadata(ctx)
 
-	if metadataOnly {
+	if metadataOnly || metaresult != nil {
 		return metaresult, metadataErr
 	}
 

--- a/app/dispatcher/fakednssniffer.go
+++ b/app/dispatcher/fakednssniffer.go
@@ -23,7 +23,7 @@ func newFakeDNSSniffer(ctx context.Context) (protocolSnifferWithMetadata, error)
 		errNotInit := newError("FakeDNSEngine is not initialized, but such a sniffer is used").AtError()
 		return protocolSnifferWithMetadata{}, errNotInit
 	}
-	return protocolSnifferWithMetadata{protocolSniffer: func(ctx context.Context, bytes []byte) (SniffResult, error) {
+	return protocolSnifferWithMetadata{protocolSniffer: func(ctx context.Context, bytes []byte, shouldSniffDomain bool) (SniffResult, error) {
 		Target := session.OutboundFromContext(ctx).Target
 		if Target.Network == net.Network_TCP || Target.Network == net.Network_UDP {
 			domainFromFakeDNS := fakeDNSEngine.GetDomainFromFakeDNS(Target.Address)

--- a/app/dispatcher/sniffer.go
+++ b/app/dispatcher/sniffer.go
@@ -14,9 +14,12 @@ type SniffResult interface {
 	Domain() string
 }
 
-type protocolSniffer func(context.Context, []byte, bool) (SniffResult, error)
+type domainSniffer func(context.Context, []byte) (SniffResult, error)
 
-type protocolSnifferWithMetadata struct {
+type protocolSniffer func(context.Context, []byte) (SniffResult, error)
+
+type snifferWithMetadata struct {
+	domainSniffer   domainSniffer
 	protocolSniffer protocolSniffer
 	// A Metadata sniffer will be invoked on connection establishment only, with nil body,
 	// for both TCP and UDP connections
@@ -25,15 +28,15 @@ type protocolSnifferWithMetadata struct {
 }
 
 type Sniffer struct {
-	sniffer []protocolSnifferWithMetadata
+	sniffer []snifferWithMetadata
 }
 
 func NewSniffer(ctx context.Context) *Sniffer {
 	ret := &Sniffer{
-		sniffer: []protocolSnifferWithMetadata{
-			{func(c context.Context, b []byte, s bool) (SniffResult, error) { return http.SniffHTTP(b, s) }, false},
-			{func(c context.Context, b []byte, s bool) (SniffResult, error) { return tls.SniffTLS(b, s) }, false},
-			{func(c context.Context, b []byte, s bool) (SniffResult, error) { return bittorrent.SniffBittorrent(b, s) }, false},
+		sniffer: []snifferWithMetadata{
+			{func(c context.Context, b []byte) (SniffResult, error) { return http.SniffDomainHTTP(b) }, func(c context.Context, b []byte) (SniffResult, error) { return http.SniffProtocolHTTP(b) }, false},
+			{func(c context.Context, b []byte) (SniffResult, error) { return tls.SniffDomainTLS(b) }, func(c context.Context, b []byte) (SniffResult, error) { return tls.SniffProtocolTLS(b) }, false},
+			{func(c context.Context, b []byte) (SniffResult, error) { return bittorrent.SniffDomainBittorrent(b) }, func(c context.Context, b []byte) (SniffResult, error) { return bittorrent.SniffProtocolBittorrent(b) }, false},
 		},
 	}
 	if sniffer, err := newFakeDNSSniffer(ctx); err == nil {
@@ -45,13 +48,22 @@ func NewSniffer(ctx context.Context) *Sniffer {
 var errUnknownContent = newError("unknown content")
 
 func (s *Sniffer) Sniff(c context.Context, payload []byte, shouldSniffDomain bool) (SniffResult, error) {
-	var pendingSniffer []protocolSnifferWithMetadata
+	var pendingSniffer []snifferWithMetadata
 	for _, si := range s.sniffer {
-		s := si.protocolSniffer
+		sd := si.domainSniffer
+		sp := si.protocolSniffer
+
 		if si.metadataSniffer {
 			continue
 		}
-		result, err := s(c, payload, shouldSniffDomain)
+
+		var result SniffResult
+		var err error
+		if shouldSniffDomain {
+			result, err = sd(c, payload)
+		} else {
+			result, err = sp(c, payload)
+		}
 		if err == common.ErrNoClue {
 			pendingSniffer = append(pendingSniffer, si)
 			continue
@@ -71,14 +83,16 @@ func (s *Sniffer) Sniff(c context.Context, payload []byte, shouldSniffDomain boo
 }
 
 func (s *Sniffer) SniffMetadata(c context.Context) (SniffResult, error) {
-	var pendingSniffer []protocolSnifferWithMetadata
+	var pendingSniffer []snifferWithMetadata
 	for _, si := range s.sniffer {
-		s := si.protocolSniffer
+		sd := si.domainSniffer
+
 		if !si.metadataSniffer {
 			pendingSniffer = append(pendingSniffer, si)
 			continue
 		}
-		result, err := s(c, nil, true)
+
+		result, err := sd(c, nil)
 		if err == common.ErrNoClue {
 			pendingSniffer = append(pendingSniffer, si)
 			continue

--- a/common/protocol/bittorrent/bittorrent.go
+++ b/common/protocol/bittorrent/bittorrent.go
@@ -19,7 +19,7 @@ func (h *SniffHeader) Domain() string {
 
 var errNotBittorrent = errors.New("not bittorrent header")
 
-func SniffBittorrent(b []byte, shouldSniffDomain bool) (*SniffHeader, error) {
+func SniffProtocolBittorrent(b []byte) (*SniffHeader, error) {
 	h := &SniffHeader{}
 
 	if len(b) < 20 {
@@ -31,4 +31,8 @@ func SniffBittorrent(b []byte, shouldSniffDomain bool) (*SniffHeader, error) {
 	}
 
 	return nil, errNotBittorrent
+}
+
+func SniffDomainBittorrent(b []byte) (*SniffHeader, error) {
+	return SniffProtocolBittorrent(b)
 }

--- a/common/protocol/bittorrent/bittorrent.go
+++ b/common/protocol/bittorrent/bittorrent.go
@@ -19,7 +19,7 @@ func (h *SniffHeader) Domain() string {
 
 var errNotBittorrent = errors.New("not bittorrent header")
 
-func SniffBittorrent(b []byte) (*SniffHeader, error) {
+func SniffBittorrent(b []byte, shouldSniffDomain bool) (*SniffHeader, error) {
 	if len(b) < 20 {
 		return nil, common.ErrNoClue
 	}

--- a/common/protocol/bittorrent/bittorrent.go
+++ b/common/protocol/bittorrent/bittorrent.go
@@ -22,10 +22,6 @@ var errNotBittorrent = errors.New("not bittorrent header")
 func SniffBittorrent(b []byte, shouldSniffDomain bool) (*SniffHeader, error) {
 	h := &SniffHeader{}
 
-	if !shouldSniffDomain {
-		return h, nil
-	}
-
 	if len(b) < 20 {
 		return nil, common.ErrNoClue
 	}

--- a/common/protocol/bittorrent/bittorrent.go
+++ b/common/protocol/bittorrent/bittorrent.go
@@ -20,12 +20,18 @@ func (h *SniffHeader) Domain() string {
 var errNotBittorrent = errors.New("not bittorrent header")
 
 func SniffBittorrent(b []byte, shouldSniffDomain bool) (*SniffHeader, error) {
+	h := &SniffHeader{}
+
+	if !shouldSniffDomain {
+		return h, nil
+	}
+
 	if len(b) < 20 {
 		return nil, common.ErrNoClue
 	}
 
 	if b[0] == 19 && string(b[1:20]) == "BitTorrent protocol" {
-		return &SniffHeader{}, nil
+		return h, nil
 	}
 
 	return nil, errNotBittorrent

--- a/common/protocol/http/sniff.go
+++ b/common/protocol/http/sniff.go
@@ -56,7 +56,7 @@ func beginWithHTTPMethod(b []byte) error {
 	return errNotHTTPMethod
 }
 
-func SniffHTTP(b []byte, shouldSniffDomain bool) (*SniffHeader, error) {
+func SniffProtocolHTTP(b []byte) (*SniffHeader, error) {
 	if err := beginWithHTTPMethod(b); err != nil {
 		return nil, err
 	}
@@ -65,8 +65,13 @@ func SniffHTTP(b []byte, shouldSniffDomain bool) (*SniffHeader, error) {
 		version: HTTP1,
 	}
 
-	if !shouldSniffDomain {
-		return sh, nil
+	return sh, nil
+}
+
+func SniffDomainHTTP(b []byte) (*SniffHeader, error) {
+	sh, err := SniffProtocolHTTP(b)
+	if err != nil {
+		return nil, err
 	}
 
 	headers := bytes.Split(b, []byte{'\n'})

--- a/common/protocol/http/sniff_test.go
+++ b/common/protocol/http/sniff_test.go
@@ -88,7 +88,7 @@ first_name=John&last_name=Doe&action=Submit`,
 	}
 
 	for _, test := range cases {
-		header, err := SniffHTTP([]byte(test.input))
+		header, err := SniffDomainHTTP([]byte(test.input))
 		if test.err {
 			if err == nil {
 				t.Errorf("Expect error but nil, in test: %v", test)

--- a/common/protocol/tls/sniff.go
+++ b/common/protocol/tls/sniff.go
@@ -29,7 +29,7 @@ func IsValidTLSVersion(major, minor byte) bool {
 
 // ReadClientHello returns server name (if any) from TLS client hello message.
 // https://github.com/golang/go/blob/master/src/crypto/tls/handshake_messages.go#L300
-func ReadClientHello(shouldSniffDomain bool, data []byte, h *SniffHeader) error {
+func ReadClientHello(data []byte, h *SniffHeader) error {
 	if len(data) < 42 {
 		return common.ErrNoClue
 	}
@@ -142,7 +142,12 @@ func SniffTLS(b []byte, shouldSniffDomain bool) (*SniffHeader, error) {
 	}
 
 	h := &SniffHeader{}
-	err := ReadClientHello(shouldSniffDomain, b[5:5+headerLen], h)
+
+	if !shouldSniffDomain {
+		return h, nil
+	}
+
+	err := ReadClientHello(b[5:5+headerLen], h)
 	if err == nil {
 		return h, nil
 	}

--- a/common/protocol/tls/sniff.go
+++ b/common/protocol/tls/sniff.go
@@ -121,7 +121,7 @@ func ReadClientHello(data []byte, h *SniffHeader) error {
 	return errNotTLS
 }
 
-func SniffTLS(b []byte, shouldSniffDomain bool) (*SniffHeader, error) {
+func SniffProtocolTLS(b []byte) (*SniffHeader, error) {
 	if len(b) < 5 {
 		return nil, common.ErrNoClue
 	}
@@ -139,13 +139,18 @@ func SniffTLS(b []byte, shouldSniffDomain bool) (*SniffHeader, error) {
 
 	h := &SniffHeader{}
 
-	if !shouldSniffDomain {
-		return h, nil
+	return h, nil
+}
+
+func SniffDomainTLS(b []byte) (*SniffHeader, error) {
+	h, err := SniffProtocolTLS(b)
+	if err != nil {
+		return nil, err
 	}
 
-	err := ReadClientHello(b[5:5+headerLen], h)
-	if err == nil {
-		return h, nil
+	err = ReadClientHello(b[5:5+headerLen], h)
+	if err != nil {
+		return nil, err
 	}
-	return nil, err
+	return h, nil
 }

--- a/common/protocol/tls/sniff.go
+++ b/common/protocol/tls/sniff.go
@@ -148,6 +148,7 @@ func SniffDomainTLS(b []byte) (*SniffHeader, error) {
 		return nil, err
 	}
 
+	headerLen := int(binary.BigEndian.Uint16(b[3:5]))
 	err = ReadClientHello(b[5:5+headerLen], h)
 	if err != nil {
 		return nil, err

--- a/common/protocol/tls/sniff.go
+++ b/common/protocol/tls/sniff.go
@@ -70,10 +70,6 @@ func ReadClientHello(data []byte, h *SniffHeader) error {
 		return errNotClientHello
 	}
 
-	if !shouldSniffDomain {
-		return nil
-	}
-
 	for len(data) != 0 {
 		if len(data) < 4 {
 			return errNotClientHello

--- a/common/protocol/tls/sniff.go
+++ b/common/protocol/tls/sniff.go
@@ -29,7 +29,7 @@ func IsValidTLSVersion(major, minor byte) bool {
 
 // ReadClientHello returns server name (if any) from TLS client hello message.
 // https://github.com/golang/go/blob/master/src/crypto/tls/handshake_messages.go#L300
-func ReadClientHello(data []byte, h *SniffHeader) error {
+func ReadClientHello(shouldSniffDomain bool, data []byte, h *SniffHeader) error {
 	if len(data) < 42 {
 		return common.ErrNoClue
 	}
@@ -68,6 +68,10 @@ func ReadClientHello(data []byte, h *SniffHeader) error {
 	data = data[2:]
 	if extensionsLength != len(data) {
 		return errNotClientHello
+	}
+
+	if !shouldSniffDomain {
+		return nil
 	}
 
 	for len(data) != 0 {
@@ -121,7 +125,7 @@ func ReadClientHello(data []byte, h *SniffHeader) error {
 	return errNotTLS
 }
 
-func SniffTLS(b []byte) (*SniffHeader, error) {
+func SniffTLS(b []byte, shouldSniffDomain bool) (*SniffHeader, error) {
 	if len(b) < 5 {
 		return nil, common.ErrNoClue
 	}
@@ -138,7 +142,7 @@ func SniffTLS(b []byte) (*SniffHeader, error) {
 	}
 
 	h := &SniffHeader{}
-	err := ReadClientHello(b[5:5+headerLen], h)
+	err := ReadClientHello(shouldSniffDomain, b[5:5+headerLen], h)
 	if err == nil {
 		return h, nil
 	}

--- a/common/protocol/tls/sniff_test.go
+++ b/common/protocol/tls/sniff_test.go
@@ -144,7 +144,7 @@ func TestTLSHeaders(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		header, err := SniffTLS(test.input)
+		header, err := SniffDomainTLS(test.input)
 		if test.err {
 			if err == nil {
 				t.Errorf("Exepct error but nil in test %v", test)


### PR DESCRIPTION
to ensure uses FakeDNSSniffer only (not do pendingSniffers to do domain sniff unnecessarily) when if it succeed.