### PR TITLE
WebSocket Early Data Protocol Harmonization with V2Ray/V2Fly

### DIFF
--- a/transport/internet/websocket/dialer.go
+++ b/transport/internet/websocket/dialer.go
@@ -117,6 +117,7 @@ func dialWebSocket(ctx context.Context, dest net.Destination, streamSettings *in
 
 	header := wsSettings.GetRequestHeader()
 	if ed != nil {
+		// RawURLEncoding is support by both V2Ray/V2Fly and XRay.
 		header.Set("Sec-WebSocket-Protocol", base64.RawURLEncoding.EncodeToString(ed))
 	}
 

--- a/transport/internet/websocket/dialer.go
+++ b/transport/internet/websocket/dialer.go
@@ -117,7 +117,7 @@ func dialWebSocket(ctx context.Context, dest net.Destination, streamSettings *in
 
 	header := wsSettings.GetRequestHeader()
 	if ed != nil {
-		header.Set("Sec-WebSocket-Protocol", base64.StdEncoding.EncodeToString(ed))
+		header.Set("Sec-WebSocket-Protocol", base64.RawURLEncoding.EncodeToString(ed))
 	}
 
 	conn, resp, err := dialer.Dial(uri, header)


### PR DESCRIPTION
V2Ray and XRay's WebSocket Early Data Protocol is currently not compatible with each other.

This Pull Request is intended to create a common standard between these two projects and allow correctly configures instance to connect to each other.  

Currently, XRay clients with WebSocket Early Data enabled cannot connect to V2Ray/V2Fly sever. This is because base64.StdEncoding is used to encode WebSocket Early Data, which is not used by V2Ray/V2Fly.

XRay already uses RawURLEncoding for browser forwarding request and accepting this Pull Request will allow it to connect to both V2Ray/V2Fly and XRay.