### PR TITLE
Fix: new cert issuing is incorrectly delayed

### DIFF
--- a/transport/internet/tls/config.go
+++ b/transport/internet/tls/config.go
@@ -121,7 +121,7 @@ func isCertificateExpired(c *tls.Certificate) bool {
 	}
 
 	// If leaf is not there, the certificate is probably not used yet. We trust user to provide a valid certificate.
-	return c.Leaf != nil && c.Leaf.NotAfter.Before(time.Now().Add(-time.Minute))
+	return c.Leaf != nil && c.Leaf.NotAfter.Before(time.Now().Add(time.Minute*2))
 }
 
 func issueCertificate(rawCA *Certificate, domain string) (*tls.Certificate, error) {
@@ -173,6 +173,9 @@ func getGetCertificateFunc(c *tls.Config, ca []*Certificate) func(hello *tls.Cli
 			for _, certificate := range c.Certificates {
 				if !isCertificateExpired(&certificate) {
 					newCerts = append(newCerts, certificate)
+				} else if certificate.Leaf != nil {
+					expTime := certificate.Leaf.NotAfter.Format(time.RFC3339)
+					newError("old certificate for ", domain, " (expire on ", expTime, ") discarded").AtInfo().WriteToLog()
 				}
 			}
 
@@ -189,6 +192,14 @@ func getGetCertificateFunc(c *tls.Config, ca []*Certificate) func(hello *tls.Cli
 				if err != nil {
 					newError("failed to issue new certificate for ", domain).Base(err).WriteToLog()
 					continue
+				}
+				parsed, err := x509.ParseCertificate(newCert.Certificate[0])
+				if err == nil {
+					newCert.Leaf = parsed
+					expTime := parsed.NotAfter.Format(time.RFC3339)
+					newError("new certificate for ", domain, " (expire on ", expTime, ") issued").AtInfo().WriteToLog()
+				} else {
+					newError("failed to parse new certificate for ", domain).Base(err).WriteToLog()
 				}
 
 				access.Lock()


### PR DESCRIPTION
the same fix with https://github.com/v2fly/v2ray-core/pull/998

由于上述pr内做了很多讨论和修改，所以为了清晰，这里简单总结一下：
1. 此PR修复https://github.com/v2fly/v2ray-core/issues/997 （此bug在Xray中同样存在）
2. 修复bug的同时，将生成证书的提前时间从1分钟增加为2分钟。为的是在VMess协议允许的C/S两端时间误差（90s）内，保证生成的证书依旧可用
3. 在生成证书和丢弃证书时，输出相应日志信息，便于排查相关问题