### PR TITLE
gRPC: Use `PathEscape` encoded service name

### DIFF
--- a/transport/internet/grpc/config.go
+++ b/transport/internet/grpc/config.go
@@ -1,6 +1,8 @@
 package grpc
 
 import (
+	"net/url"
+
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/transport/internet"
 )
@@ -11,4 +13,8 @@ func init() {
 	common.Must(internet.RegisterProtocolConfigCreator(protocolName, func() interface{} {
 		return new(Config)
 	}))
+}
+
+func (c *Config) getNormalizedName() string {
+	return url.PathEscape(c.ServiceName)
 }

--- a/transport/internet/grpc/dial.go
+++ b/transport/internet/grpc/dial.go
@@ -57,14 +57,14 @@ func dialgRPC(ctx context.Context, dest net.Destination, streamSettings *interne
 	client := encoding.NewGRPCServiceClient(conn)
 	if grpcSettings.MultiMode {
 		newError("using gRPC multi mode").AtDebug().WriteToLog()
-		grpcService, err := client.(encoding.GRPCServiceClientX).TunMultiCustomName(ctx, grpcSettings.ServiceName)
+		grpcService, err := client.(encoding.GRPCServiceClientX).TunMultiCustomName(ctx, grpcSettings.getNormalizedName())
 		if err != nil {
 			return nil, newError("Cannot dial gRPC").Base(err)
 		}
 		return encoding.NewMultiHunkConn(grpcService, nil), nil
 	}
 
-	grpcService, err := client.(encoding.GRPCServiceClientX).TunCustomName(ctx, grpcSettings.ServiceName)
+	grpcService, err := client.(encoding.GRPCServiceClientX).TunCustomName(ctx, grpcSettings.getNormalizedName())
 	if err != nil {
 		return nil, newError("Cannot dial gRPC").Base(err)
 	}

--- a/transport/internet/grpc/encoding/customSeviceName.go
+++ b/transport/internet/grpc/encoding/customSeviceName.go
@@ -39,7 +39,7 @@ func (c *gRPCServiceClient) TunCustomName(ctx context.Context, name string, opts
 }
 
 func (c *gRPCServiceClient) TunMultiCustomName(ctx context.Context, name string, opts ...grpc.CallOption) (GRPCService_TunMultiClient, error) {
-	stream, err := c.cc.NewStream(ctx, &ServerDesc(name).Streams[0], "/"+name+"/TunMulti", opts...)
+	stream, err := c.cc.NewStream(ctx, &ServerDesc(name).Streams[1], "/"+name+"/TunMulti", opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/transport/internet/grpc/hub.go
+++ b/transport/internet/grpc/hub.go
@@ -114,7 +114,7 @@ func Listen(ctx context.Context, address net.Address, port net.Port, settings *i
 			}
 		}
 
-		encoding.RegisterGRPCServiceServerX(s, listener, grpcSettings.ServiceName)
+		encoding.RegisterGRPCServiceServerX(s, listener, grpcSettings.getNormalizedName())
 
 		if err = s.Serve(streamListener); err != nil {
 			newError("Listener for gRPC ended").Base(err).WriteToLog()


### PR DESCRIPTION
- 解决一些奇妙的 emoji 兼容问题