### PR TITLE
Fix when there are multiple certs, after refresh from file all will b…

### DIFF
--- a/transport/internet/tls/config.go
+++ b/transport/internet/tls/config.go
@@ -43,7 +43,7 @@ func (c *Config) loadSelfCertPool() (*x509.CertPool, error) {
 // BuildCertificates builds a list of TLS certificates from proto definition.
 func (c *Config) BuildCertificates() []*tls.Certificate {
 	certs := make([]*tls.Certificate, 0, len(c.Certificate))
-	for _, entry := range c.Certificate {
+	for index, entry := range c.Certificate {
 		if entry.Usage != Certificate_ENCIPHERMENT {
 			continue
 		}
@@ -65,8 +65,7 @@ func (c *Config) BuildCertificates() []*tls.Certificate {
 				hotReloadCertInterval = entry.OcspStapling
 				isOcspstapling = true
 			}
-			index := len(certs) - 1
-			go func(cert *tls.Certificate, index int) {
+			go func(entry *Certificate, cert *tls.Certificate, index int) {
 				t := time.NewTicker(time.Duration(hotReloadCertInterval) * time.Second)
 				for {
 					if entry.CertificatePath != "" && entry.KeyPath != "" {
@@ -107,7 +106,7 @@ func (c *Config) BuildCertificates() []*tls.Certificate {
 					certs[index] = cert
 					<-t.C
 				}
-			}(certs[len(certs)-1], index)
+			}(entry, certs[index], index)
 		}
 	}
 	return certs

--- a/transport/internet/tls/config.go
+++ b/transport/internet/tls/config.go
@@ -43,7 +43,7 @@ func (c *Config) loadSelfCertPool() (*x509.CertPool, error) {
 // BuildCertificates builds a list of TLS certificates from proto definition.
 func (c *Config) BuildCertificates() []*tls.Certificate {
 	certs := make([]*tls.Certificate, 0, len(c.Certificate))
-	for index, entry := range c.Certificate {
+	for _, entry := range c.Certificate {
 		if entry.Usage != Certificate_ENCIPHERMENT {
 			continue
 		}
@@ -65,6 +65,7 @@ func (c *Config) BuildCertificates() []*tls.Certificate {
 				hotReloadCertInterval = entry.OcspStapling
 				isOcspstapling = true
 			}
+			index := len(certs) - 1
 			go func(entry *Certificate, cert *tls.Certificate, index int) {
 				t := time.NewTicker(time.Duration(hotReloadCertInterval) * time.Second)
 				for {

--- a/transport/internet/xtls/config.go
+++ b/transport/internet/xtls/config.go
@@ -44,7 +44,7 @@ func (c *Config) loadSelfCertPool() (*x509.CertPool, error) {
 // BuildCertificates builds a list of TLS certificates from proto definition.
 func (c *Config) BuildCertificates() []*xtls.Certificate {
 	certs := make([]*xtls.Certificate, 0, len(c.Certificate))
-	for _, entry := range c.Certificate {
+	for index, entry := range c.Certificate {
 		if entry.Usage != Certificate_ENCIPHERMENT {
 			continue
 		}
@@ -66,8 +66,7 @@ func (c *Config) BuildCertificates() []*xtls.Certificate {
 				hotRelodaInterval = entry.OcspStapling
 				isOcspstapling = true
 			}
-			index := len(certs) - 1
-			go func(cert *xtls.Certificate, index int) {
+			go func(entry *Certificate, cert *xtls.Certificate, index int) {
 				t := time.NewTicker(time.Duration(hotRelodaInterval) * time.Second)
 				for {
 					if entry.CertificatePath != "" && entry.KeyPath != "" {
@@ -108,7 +107,7 @@ func (c *Config) BuildCertificates() []*xtls.Certificate {
 					certs[index] = cert
 					<-t.C
 				}
-			}(certs[len(certs)-1], index)
+			}(entry, certs[index], index)
 		}
 	}
 	return certs

--- a/transport/internet/xtls/config.go
+++ b/transport/internet/xtls/config.go
@@ -44,7 +44,7 @@ func (c *Config) loadSelfCertPool() (*x509.CertPool, error) {
 // BuildCertificates builds a list of TLS certificates from proto definition.
 func (c *Config) BuildCertificates() []*xtls.Certificate {
 	certs := make([]*xtls.Certificate, 0, len(c.Certificate))
-	for index, entry := range c.Certificate {
+	for _, entry := range c.Certificate {
 		if entry.Usage != Certificate_ENCIPHERMENT {
 			continue
 		}
@@ -66,6 +66,7 @@ func (c *Config) BuildCertificates() []*xtls.Certificate {
 				hotRelodaInterval = entry.OcspStapling
 				isOcspstapling = true
 			}
+			index := len(certs) - 1
 			go func(entry *Certificate, cert *xtls.Certificate, index int) {
 				t := time.NewTicker(time.Duration(hotRelodaInterval) * time.Second)
 				for {


### PR DESCRIPTION
…e the same as the last. Removed unnecessary index calculation.

[常见错误中提到](https://github.com/golang/go/wiki/CommonMistakes)

当Certificates中定义多个Certificate对象时，随着证书的更新，会更新为数组中最后一项的证书，导致使用其他域名tls握手会失败。

index变量可以使用for range中的，因为已经作为一个参数传给go func了。