### PR TITLE
Update the Qv2ray URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
   - [luci-app-xray](https://github.com/yichya/luci-app-xray) ([openwrt-xray](https://github.com/yichya/openwrt-xray))
 - Windows
   - [v2rayN](https://github.com/2dust/v2rayN)
-  - [Qv2ray](https://github.com/Qv2ray/Qv2ray)
+  - [Qv2ray](https://github.com/Shadowsocks-NET/Qv2ray)
   - [Netch (NetFilter & TUN/TAP)](https://github.com/NetchX/Netch)
 - Android
   - [v2rayNG](https://github.com/2dust/v2rayNG)


### PR DESCRIPTION
https://github.com/Shadowsocks-NET/Qv2ray/issues/4