### PR TITLE
调整tcp通讯超时时长，解决长链接600秒自动断开问题

### DIFF
--- a/features/policy/policy.go
+++ b/features/policy/policy.go
@@ -120,7 +120,7 @@ func SessionDefault() Session {
 			// Align Handshake timeout with nginx client_header_timeout
 			// So that this value will not indicate server identity
 			Handshake:      time.Second * 60,
-			ConnectionIdle: time.Second * 300,
+			ConnectionIdle: time.Second * 72000,
 			UplinkOnly:     time.Second * 1,
 			DownlinkOnly:   time.Second * 1,
 		},

--- a/proxy/socks/client.go
+++ b/proxy/socks/client.go
@@ -116,7 +116,8 @@ func (c *Client) Process(ctx context.Context, link *transport.Link, dialer inter
 		newError("failed to clear deadline after handshake").Base(err).WriteToLog(session.ExportIDToError(ctx))
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
+	//ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithTimeout(ctx, p.Timeouts.ConnectionIdle)
 	timer := signal.CancelAfterInactivity(ctx, cancel, p.Timeouts.ConnectionIdle)
 
 	var requestFunc func() error

--- a/proxy/socks/server.go
+++ b/proxy/socks/server.go
@@ -147,7 +147,8 @@ func (*Server) handleUDP(c io.Reader) error {
 }
 
 func (s *Server) transport(ctx context.Context, reader io.Reader, writer io.Writer, dest net.Destination, dispatcher routing.Dispatcher, inbound *session.Inbound) error {
-	ctx, cancel := context.WithCancel(ctx)
+	//ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithTimeout(ctx, s.policy().Timeouts.ConnectionIdle)
 	timer := signal.CancelAfterInactivity(ctx, cancel, s.policy().Timeouts.ConnectionIdle)
 
 	if inbound != nil {

--- a/proxy/vless/inbound/inbound.go
+++ b/proxy/vless/inbound/inbound.go
@@ -312,7 +312,8 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection i
 				return newError(`failed to find the default "path" config`).AtWarning()
 			}
 
-			ctx, cancel := context.WithCancel(ctx)
+			//ctx, cancel := context.WithCancel(ctx)
+			ctx, cancel := context.WithTimeout(ctx, sessionPolicy.Timeouts.ConnectionIdle)
 			timer := signal.CancelAfterInactivity(ctx, cancel, sessionPolicy.Timeouts.ConnectionIdle)
 			ctx = policy.ContextWithBufferPolicy(ctx, sessionPolicy.Buffer)
 
@@ -485,7 +486,8 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection i
 	}
 
 	sessionPolicy = h.policyManager.ForLevel(request.User.Level)
-	ctx, cancel := context.WithCancel(ctx)
+	//ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithTimeout(ctx, sessionPolicy.Timeouts.ConnectionIdle)
 	timer := signal.CancelAfterInactivity(ctx, cancel, sessionPolicy.Timeouts.ConnectionIdle)
 	ctx = policy.ContextWithBufferPolicy(ctx, sessionPolicy.Buffer)
 

--- a/proxy/vless/outbound/outbound.go
+++ b/proxy/vless/outbound/outbound.go
@@ -172,7 +172,8 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 	}
 
 	sessionPolicy := h.policyManager.ForLevel(request.User.Level)
-	ctx, cancel := context.WithCancel(ctx)
+	//ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithTimeout(ctx, sessionPolicy.Timeouts.ConnectionIdle)
 	timer := signal.CancelAfterInactivity(ctx, cancel, sessionPolicy.Timeouts.ConnectionIdle)
 
 	clientReader := link.Reader // .(*pipe.Reader)


### PR DESCRIPTION
1.调整ConnectionIdle默认值为72000秒
2.修改context.Context的调用，将context.WithCancel改为context.WithTimeout，解决长链接超过600秒调用会被自动切断问题。