### PR TITLE
Fix flaky TestVMessDynamicPort

### DIFF
--- a/testing/scenarios/common.go
+++ b/testing/scenarios/common.go
@@ -142,6 +142,23 @@ func CloseAllServers(servers []*exec.Cmd) {
 	})
 }
 
+func CloseServer(server *exec.Cmd) {
+	log.Record(&log.GeneralMessage{
+		Severity: log.Severity_Info,
+		Content:  "Closing server.",
+	})
+	if runtime.GOOS == "windows" {
+		server.Process.Kill()
+	} else {
+		server.Process.Signal(syscall.SIGTERM)
+	}
+	server.Process.Wait()
+	log.Record(&log.GeneralMessage{
+		Severity: log.Severity_Info,
+		Content:  "Server closed.",
+	})
+}
+
 func withDefaultApps(config *core.Config) *core.Config {
 	config.App = append(config.App, serial.ToTypedMessage(&dispatcher.Config{}))
 	config.App = append(config.App, serial.ToTypedMessage(&proxyman.InboundConfig{}))

--- a/testing/scenarios/vmess_test.go
+++ b/testing/scenarios/vmess_test.go
@@ -35,59 +35,87 @@ func TestVMessDynamicPort(t *testing.T) {
 	defer tcpServer.Close()
 
 	userID := protocol.NewID(uuid.New())
+
+	retry := 1
 	serverPort := tcp.PickPort()
-	serverConfig := &core.Config{
-		App: []*serial.TypedMessage{
-			serial.ToTypedMessage(&log.Config{
-				ErrorLogLevel: clog.Severity_Debug,
-				ErrorLogType:  log.LogType_Console,
-			}),
-		},
-		Inbound: []*core.InboundHandlerConfig{
-			{
-				ReceiverSettings: serial.ToTypedMessage(&proxyman.ReceiverConfig{
-					PortRange: net.SinglePortRange(serverPort),
-					Listen:    net.NewIPOrDomain(net.LocalHostIP),
-				}),
-				ProxySettings: serial.ToTypedMessage(&inbound.Config{
-					User: []*protocol.User{
-						{
-							Account: serial.ToTypedMessage(&vmess.Account{
-								Id: userID.String(),
-							}),
-						},
-					},
-					Detour: &inbound.DetourConfig{
-						To: "detour",
-					},
+	for {
+		serverConfig := &core.Config{
+			App: []*serial.TypedMessage{
+				serial.ToTypedMessage(&log.Config{
+					ErrorLogLevel: clog.Severity_Debug,
+					ErrorLogType:  log.LogType_Console,
 				}),
 			},
-			{
-				ReceiverSettings: serial.ToTypedMessage(&proxyman.ReceiverConfig{
-					PortRange: &net.PortRange{
-						From: uint32(serverPort + 1),
-						To:   uint32(serverPort + 100),
-					},
-					Listen: net.NewIPOrDomain(net.LocalHostIP),
-					AllocationStrategy: &proxyman.AllocationStrategy{
-						Type: proxyman.AllocationStrategy_Random,
-						Concurrency: &proxyman.AllocationStrategy_AllocationStrategyConcurrency{
-							Value: 2,
+			Inbound: []*core.InboundHandlerConfig{
+				{
+					ReceiverSettings: serial.ToTypedMessage(&proxyman.ReceiverConfig{
+						PortRange: net.SinglePortRange(serverPort),
+						Listen:    net.NewIPOrDomain(net.LocalHostIP),
+					}),
+					ProxySettings: serial.ToTypedMessage(&inbound.Config{
+						User: []*protocol.User{
+							{
+								Account: serial.ToTypedMessage(&vmess.Account{
+									Id: userID.String(),
+								}),
+							},
 						},
-						Refresh: &proxyman.AllocationStrategy_AllocationStrategyRefresh{
-							Value: 5,
+						Detour: &inbound.DetourConfig{
+							To: "detour",
 						},
-					},
-				}),
-				ProxySettings: serial.ToTypedMessage(&inbound.Config{}),
-				Tag:           "detour",
+					}),
+				},
+				{
+					ReceiverSettings: serial.ToTypedMessage(&proxyman.ReceiverConfig{
+						PortRange: net.SinglePortRange(serverPort + 100),
+						Listen:    net.NewIPOrDomain(net.LocalHostIP),
+					}),
+					ProxySettings: serial.ToTypedMessage(&dokodemo.Config{
+						Address: net.NewIPOrDomain(dest.Address),
+						Port:    uint32(dest.Port),
+						NetworkList: &net.NetworkList{
+							Network: []net.Network{net.Network_TCP},
+						},
+					}),
+				},
+				{
+					ReceiverSettings: serial.ToTypedMessage(&proxyman.ReceiverConfig{
+						PortRange: &net.PortRange{
+							From: uint32(serverPort + 1),
+							To:   uint32(serverPort + 99),
+						},
+						Listen: net.NewIPOrDomain(net.LocalHostIP),
+						AllocationStrategy: &proxyman.AllocationStrategy{
+							Type: proxyman.AllocationStrategy_Random,
+							Concurrency: &proxyman.AllocationStrategy_AllocationStrategyConcurrency{
+								Value: 2,
+							},
+							Refresh: &proxyman.AllocationStrategy_AllocationStrategyRefresh{
+								Value: 5,
+							},
+						},
+					}),
+					ProxySettings: serial.ToTypedMessage(&inbound.Config{}),
+					Tag:           "detour",
+				},
 			},
-		},
-		Outbound: []*core.OutboundHandlerConfig{
-			{
-				ProxySettings: serial.ToTypedMessage(&freedom.Config{}),
+			Outbound: []*core.OutboundHandlerConfig{
+				{
+					ProxySettings: serial.ToTypedMessage(&freedom.Config{}),
+				},
 			},
-		},
+		}
+
+		server, _ := InitializeServerConfig(serverConfig)
+		if server != nil && tcpConnAvailableAtPort(t, serverPort + 100) {
+			defer CloseServer(server)
+			break
+		}
+		retry += 1
+		if (retry > 5) {
+			t.Fatal("All attempts failed to start server")
+		}
+		serverPort = tcp.PickPort()
 	}
 
 	clientPort := tcp.PickPort()
@@ -134,15 +162,30 @@ func TestVMessDynamicPort(t *testing.T) {
 		},
 	}
 
-	servers, err := InitializeServerConfigs(serverConfig, clientConfig)
+	server, err := InitializeServerConfig(clientConfig)
 	common.Must(err)
-	defer CloseAllServers(servers)
+	defer CloseServer(server)
 
-	for i := 0; i < 10; i++ {
-		if err := testTCPConn(clientPort, 1024, time.Second*2)(); err != nil {
-			t.Error(err)
+	if !tcpConnAvailableAtPort(t, clientPort) {
+		t.Fail()
+	}
+}
+
+func tcpConnAvailableAtPort(t *testing.T, port net.Port) bool {
+	for i := 1; ; i++ {
+		if (i > 10) {
+			t.Log("All attempts failed to test tcp conn")
+			return false
+		}
+		time.Sleep(time.Millisecond * 10)
+		if err := testTCPConn(port, 1024, time.Second*2)(); err != nil {
+			t.Log("err ", err)
+		} else {
+			t.Log("success with", i, "attempts")
+			break
 		}
 	}
+	return true
 }
 
 func TestVMessGCM(t *testing.T) {


### PR DESCRIPTION
I will try fixing some flaky tests, start with https://github.com/XTLS/Xray-core/runs/3605024544?check_suite_focus=true
This test can fail randomly for two reasons:

1. The server core and client core could try to listen on the same port, cause one core fail
2. The server listen for three ports, some might not be available

To fix first problem, I change it so that server will run first. I open another dokodemo inbound and test it is available before creating the client core.
For 2, I added a loop for server core to try pickPort() for 5 times if it failed.
I also fix the tcpConnAvailableAtPort() method and it is running much faster.