### PR TITLE
Fix go generate core/format.go

### DIFF
--- a/core/format.go
+++ b/core/format.go
@@ -1,4 +1,4 @@
 package core
 
 //go:generate go install -v golang.org/x/tools/cmd/goimports@latest
-//go:generate go run ../infra/vformat/
+//go:generate go run ../infra/vformat/main.go -pwd ./..


### PR DESCRIPTION
Found an issue in format.go. It currently only work with `go run infra/vformat/main.go`
Fix by porting logic from vprotogen.