### PR TITLE
Fix some tests to use udp.PickPort()

### DIFF
--- a/testing/scenarios/dokodemo_test.go
+++ b/testing/scenarios/dokodemo_test.go
@@ -156,7 +156,7 @@ func TestDokodemoUDP(t *testing.T) {
 		},
 	}
 
-	clientPort := uint32(tcp.PickPort())
+	clientPort := uint32(udp.PickPort())
 	clientPortRange := uint32(5)
 	clientConfig := &core.Config{
 		Inbound: []*core.InboundHandlerConfig{

--- a/testing/scenarios/feature_test.go
+++ b/testing/scenarios/feature_test.go
@@ -512,7 +512,7 @@ func TestUDPConnection(t *testing.T) {
 	common.Must(err)
 	defer udpServer.Close()
 
-	clientPort := tcp.PickPort()
+	clientPort := udp.PickPort()
 	clientConfig := &core.Config{
 		Inbound: []*core.InboundHandlerConfig{
 			{

--- a/testing/scenarios/shadowsocks_test.go
+++ b/testing/scenarios/shadowsocks_test.go
@@ -215,7 +215,7 @@ func TestShadowsocksAES128GCMUDP(t *testing.T) {
 		CipherType: shadowsocks.CipherType_AES_128_GCM,
 	})
 
-	serverPort := tcp.PickPort()
+	serverPort := udp.PickPort()
 	serverConfig := &core.Config{
 		App: []*serial.TypedMessage{
 			serial.ToTypedMessage(&log.Config{
@@ -245,7 +245,7 @@ func TestShadowsocksAES128GCMUDP(t *testing.T) {
 		},
 	}
 
-	clientPort := tcp.PickPort()
+	clientPort := udp.PickPort()
 	clientConfig := &core.Config{
 		App: []*serial.TypedMessage{
 			serial.ToTypedMessage(&log.Config{
@@ -341,7 +341,7 @@ func TestShadowsocksAES128GCMUDPMux(t *testing.T) {
 		},
 	}
 
-	clientPort := tcp.PickPort()
+	clientPort := udp.PickPort()
 	clientConfig := &core.Config{
 		App: []*serial.TypedMessage{
 			serial.ToTypedMessage(&log.Config{

--- a/testing/scenarios/transport_test.go
+++ b/testing/scenarios/transport_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/xtls/xray-core/proxy/vmess/inbound"
 	"github.com/xtls/xray-core/proxy/vmess/outbound"
 	"github.com/xtls/xray-core/testing/servers/tcp"
+	"github.com/xtls/xray-core/testing/servers/udp"
 	"github.com/xtls/xray-core/transport/internet"
 	"github.com/xtls/xray-core/transport/internet/domainsocket"
 	"github.com/xtls/xray-core/transport/internet/headers/http"
@@ -257,7 +258,7 @@ func TestVMessQuic(t *testing.T) {
 	defer tcpServer.Close()
 
 	userID := protocol.NewID(uuid.New())
-	serverPort := tcp.PickPort()
+	serverPort := udp.PickPort()
 	serverConfig := &core.Config{
 		App: []*serial.TypedMessage{
 			serial.ToTypedMessage(&log.Config{

--- a/testing/scenarios/vmess_test.go
+++ b/testing/scenarios/vmess_test.go
@@ -446,7 +446,7 @@ func TestVMessGCMUDP(t *testing.T) {
 		},
 	}
 
-	clientPort := tcp.PickPort()
+	clientPort := udp.PickPort()
 	clientConfig := &core.Config{
 		App: []*serial.TypedMessage{
 			serial.ToTypedMessage(&log.Config{


### PR DESCRIPTION
https://github.com/XTLS/Xray-core/pull/731/checks?check_run_id=3713499282
Some tests try to listen udp port, but the port maybe not available.