### PR TITLE
Fix: Trojan fallback (TLS mode)

### DIFF
--- a/proxy/trojan/server.go
+++ b/proxy/trojan/server.go
@@ -2,7 +2,6 @@ package trojan
 
 import (
 	"context"
-	"crypto/tls"
 	"io"
 	"strconv"
 	"strings"
@@ -28,6 +27,7 @@ import (
 	"github.com/xtls/xray-core/features/routing"
 	"github.com/xtls/xray-core/features/stats"
 	"github.com/xtls/xray-core/transport/internet/udp"
+	"github.com/xtls/xray-core/transport/internet/tls"
 	"github.com/xtls/xray-core/transport/internet/xtls"
 )
 


### PR DESCRIPTION
参考AkinoKaede大PR： [Trojan fallback cannot get ALPN](https://github.com/v2fly/v2ray-core/pull/1286)，修复从v2ray继承下来的bug：[TLS模式，trojan fallbacks 中"alpn"无效问题](https://github.com/v2fly/v2ray-core/issues/1282)。