### PR TITLE
Move from deprecated ioutil to os and io packages

### DIFF
--- a/app/dns/dohdns.go
+++ b/app/dns/dohdns.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"sync"
@@ -315,11 +314,11 @@ func (s *DoHNameServer) dohHTTPSContext(ctx context.Context, b []byte) ([]byte, 
 
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		io.Copy(ioutil.Discard, resp.Body) // flush resp.Body so that the conn is reusable
+		io.Copy(io.Discard, resp.Body) // flush resp.Body so that the conn is reusable
 		return nil, fmt.Errorf("DOH server returned code %d", resp.StatusCode)
 	}
 
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func (s *DoHNameServer) findIPsForDomain(domain string, option dns_feature.IPOption) ([]net.IP, error) {

--- a/common/buf/multi_buffer_test.go
+++ b/common/buf/multi_buffer_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/rand"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -120,7 +119,7 @@ func TestMultiBufferReadAllToByte(t *testing.T) {
 		common.Must(err)
 		f.Close()
 
-		cnt, err := ioutil.ReadFile(dat)
+		cnt, err := os.ReadFile(dat)
 		common.Must(err)
 
 		if d := cmp.Diff(buf2, cnt); d != "" {

--- a/common/common.go
+++ b/common/common.go
@@ -5,7 +5,6 @@ package common
 import (
 	"fmt"
 	"go/build"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -69,7 +68,7 @@ func GetRuntimeEnv(key string) (string, error) {
 	}
 	var data []byte
 	var runtimeEnv string
-	data, readErr := ioutil.ReadFile(file)
+	data, readErr := os.ReadFile(file)
 	if readErr != nil {
 		return "", readErr
 	}
@@ -131,7 +130,7 @@ func GetModuleName(pathToProjectRoot string) (string, error) {
 	for {
 		if idx := strings.LastIndex(loopPath, string(filepath.Separator)); idx >= 0 {
 			gomodPath := filepath.Join(loopPath, "go.mod")
-			gomodBytes, err := ioutil.ReadFile(gomodPath)
+			gomodBytes, err := os.ReadFile(gomodPath)
 			if err != nil {
 				loopPath = loopPath[:idx]
 				continue

--- a/common/log/logger_test.go
+++ b/common/log/logger_test.go
@@ -1,7 +1,6 @@
 package log_test
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -13,7 +12,7 @@ import (
 )
 
 func TestFileLogger(t *testing.T) {
-	f, err := ioutil.TempFile("", "vtest")
+	f, err := os.CreateTemp("", "vtest")
 	common.Must(err)
 	path := f.Name()
 	common.Must(f.Close())

--- a/common/ocsp/ocsp.go
+++ b/common/ocsp/ocsp.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 
@@ -74,7 +74,7 @@ func GetOCSPForCert(cert [][]byte) ([]byte, error) {
 		}
 		defer resp.Body.Close()
 
-		issuerBytes, errC := ioutil.ReadAll(resp.Body)
+		issuerBytes, errC := io.ReadAll(resp.Body)
 		if errC != nil {
 			return nil, newError(errC)
 		}
@@ -98,7 +98,7 @@ func GetOCSPForCert(cert [][]byte) ([]byte, error) {
 		return nil, newError(err)
 	}
 	defer req.Body.Close()
-	ocspResBytes, err := ioutil.ReadAll(req.Body)
+	ocspResBytes, err := io.ReadAll(req.Body)
 
 	if err != nil {
 		return nil, newError(err)

--- a/infra/conf/serial/loader.go
+++ b/infra/conf/serial/loader.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 
 	"github.com/ghodss/yaml"
 	"github.com/pelletier/go-toml"
@@ -88,7 +87,7 @@ func LoadJSONConfig(reader io.Reader) (*core.Config, error) {
 // DecodeTOMLConfig reads from reader and decode the config into *conf.Config
 // using github.com/pelletier/go-toml and map to convert toml to json.
 func DecodeTOMLConfig(reader io.Reader) (*conf.Config, error) {
-	tomlFile, err := ioutil.ReadAll(reader)
+	tomlFile, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, newError("failed to read config file").Base(err)
 	}
@@ -123,7 +122,7 @@ func LoadTOMLConfig(reader io.Reader) (*core.Config, error) {
 // DecodeYAMLConfig reads from reader and decode the config into *conf.Config
 // using github.com/ghodss/yaml to convert yaml to json.
 func DecodeYAMLConfig(reader io.Reader) (*conf.Config, error) {
-	yamlFile, err := ioutil.ReadAll(reader)
+	yamlFile, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, newError("failed to read config file").Base(err)
 	}

--- a/infra/vformat/main.go
+++ b/infra/vformat/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"go/build"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -45,7 +44,7 @@ func GetRuntimeEnv(key string) (string, error) {
 	}
 	var data []byte
 	var runtimeEnv string
-	data, readErr := ioutil.ReadFile(file)
+	data, readErr := os.ReadFile(file)
 	if readErr != nil {
 		return "", readErr
 	}

--- a/infra/vprotogen/main.go
+++ b/infra/vprotogen/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"go/build"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -49,7 +48,7 @@ func GetRuntimeEnv(key string) (string, error) {
 	}
 	var data []byte
 	var runtimeEnv string
-	data, readErr := ioutil.ReadFile(file)
+	data, readErr := os.ReadFile(file)
 	if readErr != nil {
 		return "", readErr
 	}

--- a/main/commands/all/api/shared.go
+++ b/main/commands/all/api/shared.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -56,10 +55,10 @@ func loadArg(arg string) (out io.Reader, err error) {
 		data, err = fetchHTTPContent(arg)
 
 	case arg == "stdin:":
-		data, err = ioutil.ReadAll(os.Stdin)
+		data, err = io.ReadAll(os.Stdin)
 
 	default:
-		data, err = ioutil.ReadFile(arg)
+		data, err = os.ReadFile(arg)
 	}
 
 	if err != nil {

--- a/main/commands/all/convert.go
+++ b/main/commands/all/convert.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -77,10 +76,10 @@ func loadArg(arg string) (out io.Reader, err error) {
 		data, err = FetchHTTPContent(arg)
 
 	case arg == "stdin:":
-		data, err = ioutil.ReadAll(os.Stdin)
+		data, err = io.ReadAll(os.Stdin)
 
 	default:
-		data, err = ioutil.ReadFile(arg)
+		data, err = os.ReadFile(arg)
 	}
 
 	if err != nil {

--- a/main/confloader/external/external.go
+++ b/main/confloader/external/external.go
@@ -5,7 +5,6 @@ package external
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -24,10 +23,10 @@ func ConfigLoader(arg string) (out io.Reader, err error) {
 		data, err = FetchHTTPContent(arg)
 
 	case arg == "stdin:":
-		data, err = ioutil.ReadAll(os.Stdin)
+		data, err = io.ReadAll(os.Stdin)
 
 	default:
-		data, err = ioutil.ReadFile(arg)
+		data, err = os.ReadFile(arg)
 	}
 
 	if err != nil {

--- a/main/run.go
+++ b/main/run.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -126,7 +125,7 @@ func getRegepxByFormat() string {
 }
 
 func readConfDir(dirPath string) {
-	confs, err := ioutil.ReadDir(dirPath)
+	confs, err := os.ReadDir(dirPath)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/proxy/shadowsocks/protocol.go
+++ b/proxy/shadowsocks/protocol.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha256"
 	"hash/crc32"
 	"io"
-	"io/ioutil"
 
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/buf"
@@ -160,7 +159,7 @@ func ReadTCPSession(validator *Validator, reader io.Reader) (*protocol.RequestHe
 }
 
 func DrainConnN(reader io.Reader, n int) error {
-	_, err := io.CopyN(ioutil.Discard, reader, int64(n))
+	_, err := io.CopyN(io.Discard, reader, int64(n))
 	return err
 }
 

--- a/proxy/vmess/encoding/server.go
+++ b/proxy/vmess/encoding/server.go
@@ -9,7 +9,6 @@ import (
 	"encoding/binary"
 	"hash/fnv"
 	"io"
-	"io/ioutil"
 	"sync"
 	"time"
 
@@ -499,6 +498,6 @@ func (s *ServerSession) EncodeResponseBody(request *protocol.RequestHeader, writ
 }
 
 func (s *ServerSession) DrainConnN(reader io.Reader, n int) error {
-	_, err := io.CopyN(ioutil.Discard, reader, int64(n))
+	_, err := io.CopyN(io.Discard, reader, int64(n))
 	return err
 }

--- a/testing/scenarios/common.go
+++ b/testing/scenarios/common.go
@@ -5,7 +5,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -102,7 +102,7 @@ func genTestBinaryPath() {
 	testBinaryPathGen.Do(func() {
 		var tempDir string
 		common.Must(retry.Timed(5, 100).On(func() error {
-			dir, err := ioutil.TempDir("", "xray")
+			dir, err := os.MkdirTemp("", "xray")
 			if err != nil {
 				return err
 			}

--- a/testing/scenarios/feature_test.go
+++ b/testing/scenarios/feature_test.go
@@ -2,7 +2,7 @@ package scenarios
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -642,7 +642,7 @@ func TestDomainSniffing(t *testing.T) {
 		if resp.StatusCode != 200 {
 			t.Error("unexpected status code: ", resp.StatusCode)
 		}
-		common.Must(resp.Write(ioutil.Discard))
+		common.Must(resp.Write(io.Discard))
 	}
 }
 

--- a/testing/scenarios/http_test.go
+++ b/testing/scenarios/http_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/rand"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"testing"
@@ -74,7 +73,7 @@ func TestHttpConformance(t *testing.T) {
 			t.Fatal("status: ", resp.StatusCode)
 		}
 
-		content, err := ioutil.ReadAll(resp.Body)
+		content, err := io.ReadAll(resp.Body)
 		common.Must(err)
 		if string(content) != "Home" {
 			t.Fatal("body: ", string(content))
@@ -267,7 +266,7 @@ func TestHttpPost(t *testing.T) {
 			t.Fatal("status: ", resp.StatusCode)
 		}
 
-		content, err := ioutil.ReadAll(resp.Body)
+		content, err := io.ReadAll(resp.Body)
 		common.Must(err)
 		if r := cmp.Diff(content, xor(payload)); r != "" {
 			t.Fatal(r)
@@ -361,7 +360,7 @@ func TestHttpBasicAuth(t *testing.T) {
 				t.Fatal("status: ", resp.StatusCode)
 			}
 
-			content, err := ioutil.ReadAll(resp.Body)
+			content, err := io.ReadAll(resp.Body)
 			common.Must(err)
 			if string(content) != "Home" {
 				t.Fatal("body: ", string(content))


### PR DESCRIPTION
XTLS is currently based on Go 1.17, so it is safe to remove deprecated ioutil package, ref v2fly/v2ray-core#1298 and https://golang.org/doc/go1.16#ioutil.

