### PR TITLE
add comment for gRPC TLS silent failure behavior

### DIFF
--- a/transport/internet/grpc/hub.go
+++ b/transport/internet/grpc/hub.go
@@ -80,6 +80,7 @@ func Listen(ctx context.Context, address net.Address, port net.Port, settings *i
 	var options []grpc.ServerOption
 	var s *grpc.Server
 	if config != nil {
+		// gRPC server may silently ignore TLS errors
 		options = append(options, grpc.Creds(credentials.NewTLS(config.GetTLSConfig(tls.WithNextProto("h2")))))
 	}
 	if grpcSettings.IdleTimeout > 0 || grpcSettings.HealthCheckTimeout > 0 {


### PR DESCRIPTION
When gRPC transport have been configured to use TLS, it may silently ignore TLS failure. This may make it harder to diagnose TLS setting issues when gRPC transport is used. This comment is added to help other developers be aware of this caveat.
Thanks @xiaokangwang 