### PR TITLE
Fix null pointer exception for observatory

### DIFF
--- a/app/router/strategy_leastping.go
+++ b/app/router/strategy_leastping.go
@@ -15,14 +15,17 @@ type LeastPingStrategy struct {
 }
 
 func (l *LeastPingStrategy) InjectContext(ctx context.Context) {
-	common.Must(core.RequireFeatures(ctx, func(observatory extension.Observatory) error {
-		l.observatory = observatory
-		return nil
-	}))
 	l.ctx = ctx
 }
 
 func (l *LeastPingStrategy) PickOutbound(strings []string) string {
+	if l.observatory == nil {
+		common.Must(core.RequireFeatures(l.ctx, func(observatory extension.Observatory) error {
+			l.observatory = observatory
+			return nil
+		}))
+	}
+
 	observeReport, err := l.observatory.GetObservation(l.ctx)
 	if err != nil {
 		newError("cannot get observe report").Base(err).WriteToLog()


### PR DESCRIPTION
Core setup router object first, when InjectContext() is called, observatory object is still null,
so observatory need to be injected after InjectContext()