### PR TITLE
workflows: add check-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ^1.17.7
+          check-latest: true
 
       - name: Get project dependencies
         run: go mod download

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ^1.17.7
+          check-latest: true
       - name: Checkout codebase
         uses: actions/checkout@v2
 


### PR DESCRIPTION
check-latest can make sure actions will always use the latest minor version of golang to build.
No manually update needed anymore.