### PR TITLE
fix: expvar error when observatory is not enabled & various typos

### DIFF
--- a/app/metrics/metrics.go
+++ b/app/metrics/metrics.go
@@ -64,6 +64,9 @@ func NewMetricsHandler(ctx context.Context, config *Config) (*MetricsHandler, er
 				c.observatory = observatory
 				return nil
 			}))
+			if c.observatory == nil {
+				return nil
+			}
 		}
 		var resp = map[string]*observatory.OutboundStatus{}
 		if o, err := c.observatory.GetObservation(context.Background()); err != nil {

--- a/app/metrics/outbound.go
+++ b/app/metrics/outbound.go
@@ -11,7 +11,7 @@ import (
 	"github.com/xtls/xray-core/transport"
 )
 
-// OutboundListener is a net.Listener for listening pprof http connections.
+// OutboundListener is a net.Listener for listening metrics http connections.
 type OutboundListener struct {
 	buffer chan net.Conn
 	done   *done.Instance
@@ -60,7 +60,7 @@ func (l *OutboundListener) Addr() net.Addr {
 	}
 }
 
-// Outbound is a outbound.Handler that handles pprof http connections.
+// Outbound is an outbound.Handler that handles metrics http connections.
 type Outbound struct {
 	tag      string
 	listener *OutboundListener

--- a/features/stats/stats.go
+++ b/features/stats/stats.go
@@ -25,11 +25,11 @@ type Counter interface {
 //
 // xray:api:stable
 type Channel interface {
-	// Channel is a runnable unit.
+	// Runnable implies that Channel is a runnable unit.
 	common.Runnable
 	// Publish broadcasts a message through the channel with a controlling context.
 	Publish(context.Context, interface{})
-	// SubscriberCount returns the number of the subscribers.
+	// Subscribers returns all subscribers.
 	Subscribers() []chan interface{}
 	// Subscribe registers for listening to channel stream and returns a new listener channel.
 	Subscribe() (chan interface{}, error)
@@ -47,7 +47,7 @@ func SubscribeRunnableChannel(c Channel) (chan interface{}, error) {
 	return c.Subscribe()
 }
 
-// UnsubscribeClosableChannel unsubcribes the channel and close it if there is no more subscriber.
+// UnsubscribeClosableChannel unsubscribes the channel and close it if there is no more subscriber.
 func UnsubscribeClosableChannel(c Channel, sub chan interface{}) error {
 	if err := c.Unsubscribe(sub); err != nil {
 		return err
@@ -73,7 +73,7 @@ type Manager interface {
 
 	// RegisterChannel registers a new channel to the manager. The identifier string must not be empty, and unique among other channels.
 	RegisterChannel(string) (Channel, error)
-	// UnregisterCounter unregisters a channel from the manager by its identifier.
+	// UnregisterChannel unregisters a channel from the manager by its identifier.
 	UnregisterChannel(string) error
 	// GetChannel returns a channel by its identifier.
 	GetChannel(string) Channel

--- a/testing/scenarios/metrics_test.go
+++ b/testing/scenarios/metrics_test.go
@@ -1,6 +1,7 @@
 package scenarios
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -99,7 +100,8 @@ func TestMetrics(t *testing.T) {
 	if err2 != nil {
 		t.Fatal(err2)
 	}
-	if string(body2)[0] != '{' {
+	var json2 map[string]interface{}
+	if json.Unmarshal(body2, &json2) != nil {
 		t.Error("unexpected response body from expvars handler")
 	}
 }


### PR DESCRIPTION
This commit fixes an error in metrics handler when observatory is not enabled.

At the same time changes some typos found in stats.
