### PR TITLE
Fakedns fix xUDP destination override

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -4,13 +4,13 @@ package dispatcher
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/buf"
-	"github.com/xtls/xray-core/common/dice"
 	"github.com/xtls/xray-core/common/log"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/protocol"
@@ -139,71 +139,70 @@ func (d *DefaultDispatcher) getLink(ctx context.Context, network net.Network, sn
 	downOpt := pipe.OptionsFromContext(ctx)
 	upOpt := downOpt
 
-	if fkr0, ok := d.fdns.(dns.FakeDNSEngineRev0); ok {
-		IP2Fake := new(sync.Map) // net.IP.String() => net.IP
-		if network == net.Network_UDP {
-			upOpt = append(upOpt, pipe.OnTransmission(func(mb buf.MultiBuffer) buf.MultiBuffer {
-				mb2 := make(buf.MultiBuffer, 0, len(mb))
-				for _, buffer := range mb {
-					if buffer.UDP == nil {
-						mb2 = append(mb2, buffer)
-						continue
-					}
-					addr := buffer.UDP.Address
-					var originIP net.IP
-					if sniffing.Enabled && addr.Family().IsIP() {
-						if !fkr0.IsIPInIPPool(addr) {
-							mb2 = append(mb2, buffer)
-							continue
-						}
-						originIP = addr.IP()
+	if network == net.Network_UDP {
+		var ip2domain *sync.Map // net.IP.String() => domain, this map is used by server side when client turn on fakedns
+		// Client will send domain address in the buffer.UDP.Address, server record all possible target IP addrs.
+		// When target replies, server will restore the domain and send back to client.
+		// Note: this map is not global but per connection context
+		upOpt = append(upOpt, pipe.OnTransmission(func(mb buf.MultiBuffer) buf.MultiBuffer {
+			for i, buffer := range mb {
+				if buffer.UDP == nil {
+					continue
+				}
+				addr := buffer.UDP.Address
+				if addr.Family().IsIP() {
+					if fkr0, ok := d.fdns.(dns.FakeDNSEngineRev0); ok && fkr0.IsIPInIPPool(addr) && sniffing.Enabled {
 						domain := fkr0.GetDomainFromFakeDNS(addr)
 						if len(domain) > 0 {
-							newError("override buffer.UDP: " + domain).WriteToLog(session.ExportIDToError(ctx))
-							addr = net.DomainAddress(domain)
+							buffer.UDP.Address = net.DomainAddress(domain)
+							newError("[fakedns client] override with domain: ", domain, " for xUDP buffer at ", i).WriteToLog(session.ExportIDToError(ctx))
 						} else {
-							// drop buffer without a valid Fake IP
-							continue
+							newError("[fakedns client] failed to find domain! :", addr.String(), " for xUDP buffer at ", i).AtWarning().WriteToLog(session.ExportIDToError(ctx))
 						}
 					}
-	
-					// addr is DomainAddress
+				} else {
+					if (ip2domain == nil) {
+						ip2domain = new(sync.Map)
+						newError("[fakedns client] create a new map").WriteToLog(session.ExportIDToError(ctx))
+					}
 					domain := addr.Domain()
-					if len(domain) > 0 {
-						ips, err := d.dns.LookupIP(domain, dns.IPOption{true, true, false})
-						if err != nil {
-							newError("failed to look up IP for " + domain).Base(err).WriteToLog(session.ExportIDToError(ctx))
-							continue
+					ips, err := d.dns.LookupIP(domain, dns.IPOption{true, true, false})
+					if err == nil {
+						for _, ip := range ips {
+							ip2domain.Store(ip.String(), domain)
 						}
-						overrideIP := ips[dice.Roll(len(ips))]
-						buffer.UDP.Address = net.IPAddress(overrideIP)
-						newError("override buffer.UDP: " + buffer.UDP.Address.String()).WriteToLog(session.ExportIDToError(ctx))
-	
-						if originIP != nil {
-							IP2Fake.Store(overrideIP.String(), originIP)
-						}
-						mb2 = append(mb2, buffer)
+						newError("[fakedns client] candidate ip: " + fmt.Sprintf("%v", ips), " for xUDP buffer at ", i).WriteToLog(session.ExportIDToError(ctx))
+					} else {
+						newError("[fakedns client] failed to look up IP for ", domain, " for xUDP buffer at ", i).Base(err).WriteToLog(session.ExportIDToError(ctx))
 					}
 				}
-	
-				return mb2
-			}))
-		}
-	
-		if network == net.Network_UDP && sniffing.Enabled {
-			downOpt = append(downOpt, pipe.OnTransmission(func(mb buf.MultiBuffer) buf.MultiBuffer {
-				for _, buffer := range mb {
-					if buffer.UDP != nil &&
-						buffer.UDP.Address.Family().IsIP() {
-						if originIP, found := IP2Fake.Load(buffer.UDP.Address.IP().String()); found {
-							buffer.UDP.Address = net.IPAddress(originIP.(net.IP))
-							newError("restore FakeIP: " + originIP.(net.IP).String()).WriteToLog(session.ExportIDToError(ctx))
-						}
+			}
+			return mb
+		}))
+		downOpt = append(downOpt, pipe.OnTransmission(func(mb buf.MultiBuffer) buf.MultiBuffer {
+			for i, buffer := range mb {
+				if buffer.UDP == nil {
+					continue
+				}
+				addr := buffer.UDP.Address
+				if addr.Family().IsIP() {
+					if ip2domain == nil {
+						continue
+					}
+					if domain, found := ip2domain.Load(addr.IP().String()); found {
+						buffer.UDP.Address = net.DomainAddress(domain.(string))
+						newError("[fakedns client] restore domain: ", domain.(string), " for xUDP buffer at ", i).WriteToLog(session.ExportIDToError(ctx))
+					}
+				} else {
+					if fkr0, ok := d.fdns.(dns.FakeDNSEngineRev0); ok {
+						fakeIp := fkr0.GetFakeIPForDomain(addr.Domain())
+						buffer.UDP.Address = fakeIp[0]
+						newError("[fakedns client] restore FakeIP: ", buffer.UDP, fmt.Sprintf("%v", fakeIp), " for xUDP buffer at ", i).WriteToLog(session.ExportIDToError(ctx))
 					}
 				}
-				return mb
-			}))
-		}
+			}
+			return mb
+		}))
 	}
 	uplinkReader, uplinkWriter := pipe.New(upOpt...)
 	downlinkReader, downlinkWriter := pipe.New(downOpt...)

--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -4,15 +4,13 @@ package dispatcher
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/xtls/xray-core/common/dice"
-
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/buf"
+	"github.com/xtls/xray-core/common/dice"
 	"github.com/xtls/xray-core/common/log"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/protocol"
@@ -168,7 +166,6 @@ func (d *DefaultDispatcher) getLink(ctx context.Context, network net.Network, sn
 
 				// addr is DomainAddress
 				domain := addr.Domain()
-				fmt.Println(domain)
 				if len(domain) > 0 {
 					ips, err := d.dns.LookupIP(domain, dns.IPOption{true, true, false})
 					if err != nil {

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -632,7 +632,7 @@ func (c *Config) Build() (*core.Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		config.App = append(config.App, serial.ToTypedMessage(r))
+		config.App = append([]*serial.TypedMessage{serial.ToTypedMessage(r)}, config.App...)
 	}
 
 	if c.Observatory != nil {

--- a/transport/pipe/impl.go
+++ b/transport/pipe/impl.go
@@ -24,6 +24,7 @@ const (
 type pipeOption struct {
 	limit           int32 // maximum buffer size in bytes
 	discardOverflow bool
+	onTransmission  func(buffer buf.MultiBuffer) buf.MultiBuffer
 }
 
 func (o *pipeOption) isFull(curSize int32) bool {
@@ -135,6 +136,10 @@ func (p *pipe) writeMultiBufferInternal(mb buf.MultiBuffer) error {
 func (p *pipe) WriteMultiBuffer(mb buf.MultiBuffer) error {
 	if mb.IsEmpty() {
 		return nil
+	}
+
+	if p.option.onTransmission != nil {
+		mb = p.option.onTransmission(mb)
 	}
 
 	for {

--- a/transport/pipe/pipe.go
+++ b/transport/pipe/pipe.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/xtls/xray-core/common/buf"
-
 	"github.com/xtls/xray-core/common/signal"
 	"github.com/xtls/xray-core/common/signal/done"
 	"github.com/xtls/xray-core/features/policy"

--- a/transport/pipe/pipe.go
+++ b/transport/pipe/pipe.go
@@ -3,6 +3,8 @@ package pipe
 import (
 	"context"
 
+	"github.com/xtls/xray-core/common/buf"
+
 	"github.com/xtls/xray-core/common/signal"
 	"github.com/xtls/xray-core/common/signal/done"
 	"github.com/xtls/xray-core/features/policy"
@@ -22,6 +24,12 @@ func WithoutSizeLimit() Option {
 func WithSizeLimit(limit int32) Option {
 	return func(opt *pipeOption) {
 		opt.limit = limit
+	}
+}
+
+func OnTransmission(hook func(mb buf.MultiBuffer) buf.MultiBuffer) Option {
+	return func(option *pipeOption) {
+		option.onTransmission = hook
 	}
 }
 


### PR DESCRIPTION
An updated version of @hmol233's original
https://github.com/XTLS/Xray-core/tree/fix/udp-sniffing

A map is used by server side when client turn on fakedns
Client will send domain address in the buffer.UDP.Address, server record all possible target IP addrs.
When target replies, server will restore the domain and send back to client.

CC  @nekohasekai  @badO1a5A90 