### PR TITLE
Add XTLS RPRX's Vision

### DIFF
--- a/common/buf/multi_buffer.go
+++ b/common/buf/multi_buffer.go
@@ -203,6 +203,19 @@ func SplitSize(mb MultiBuffer, size int32) (MultiBuffer, MultiBuffer) {
 	return mb, r
 }
 
+// SplitMulti splits the beginning of the MultiBuffer into first one, the index i and after into second one
+func SplitMulti(mb MultiBuffer, i int) (MultiBuffer, MultiBuffer) {
+	mb2 := make(MultiBuffer, 0, len(mb))
+	if i < len(mb) && i >= 0 {
+		mb2 = append(mb2, mb[i:]...)
+		for j := i; j < len(mb); j++ {
+			mb[j] = nil
+		}
+		mb = mb[:i]
+	}
+	return mb, mb2
+}
+
 // WriteMultiBuffer writes all buffers from the MultiBuffer to the Writer one by one, and return error if any, with leftover MultiBuffer.
 func WriteMultiBuffer(writer io.Writer, mb MultiBuffer) (MultiBuffer, error) {
 	for {

--- a/infra/conf/vless.go
+++ b/infra/conf/vless.go
@@ -53,8 +53,8 @@ func (c *VLessInboundConfig) Build() (proto.Message, error) {
 		account.Id = u.String()
 
 		switch account.Flow {
-		case "", "xtls-rprx-origin", "xtls-rprx-direct":
-		case "xtls-rprx-splice":
+		case "", vless.XRO, vless.XRD, vless.XRV:
+		case vless.XRS:
 			return nil, newError(`VLESS clients: inbound doesn't support "xtls-rprx-splice" in this version, please use "xtls-rprx-direct" instead`)
 		default:
 			return nil, newError(`VLESS clients: "flow" doesn't support "` + account.Flow + `" in this version`)
@@ -182,8 +182,8 @@ func (c *VLessOutboundConfig) Build() (proto.Message, error) {
 			account.Id = u.String()
 
 			switch account.Flow {
-			case "", "xtls-rprx-origin", "xtls-rprx-origin-udp443", "xtls-rprx-direct", "xtls-rprx-direct-udp443":
-			case "xtls-rprx-splice", "xtls-rprx-splice-udp443":
+			case "", vless.XRO, vless.XRO + "-udp443", vless.XRD, vless.XRD + "-udp443", vless.XRV, vless.XRV + "-udp443":
+			case vless.XRS, vless.XRS + "-udp443":
 				if runtime.GOOS != "linux" && runtime.GOOS != "android" {
 					return nil, newError(`VLESS users: "` + account.Flow + `" only support linux in this version`)
 				}

--- a/proxy/vless/encoding/addons.go
+++ b/proxy/vless/encoding/addons.go
@@ -11,7 +11,7 @@ import (
 
 func EncodeHeaderAddons(buffer *buf.Buffer, addons *Addons) error {
 	switch addons.Flow {
-	case vless.XRO, vless.XRD:
+	case vless.XRO, vless.XRD, vless.XRV:
 		bytes, err := proto.Marshal(addons)
 		if err != nil {
 			return newError("failed to marshal addons protobuf value").Base(err)

--- a/proxy/vless/outbound/outbound.go
+++ b/proxy/vless/outbound/outbound.go
@@ -25,6 +25,7 @@ import (
 	"github.com/xtls/xray-core/transport"
 	"github.com/xtls/xray-core/transport/internet"
 	"github.com/xtls/xray-core/transport/internet/stat"
+	"github.com/xtls/xray-core/transport/internet/tls"
 	"github.com/xtls/xray-core/transport/internet/xtls"
 )
 
@@ -132,11 +133,11 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 
 	allowUDP443 := false
 	switch requestAddons.Flow {
-	case vless.XRO + "-udp443", vless.XRD + "-udp443", vless.XRS + "-udp443":
+	case vless.XRO + "-udp443", vless.XRD + "-udp443", vless.XRS + "-udp443", vless.XRV + "-udp443":
 		allowUDP443 = true
 		requestAddons.Flow = requestAddons.Flow[:16]
 		fallthrough
-	case vless.XRO, vless.XRD, vless.XRS:
+	case vless.XRO, vless.XRD, vless.XRS, vless.XRV:
 		switch request.Command {
 		case protocol.RequestCommandMux:
 			return newError(requestAddons.Flow + " doesn't support Mux").AtWarning()
@@ -160,6 +161,11 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 						rawConn, _ = sc.SyscallConn()
 					}
 				}
+			} else if requestAddons.Flow == vless.XRV {
+				sctx = ctx
+				if sc, ok := iConn.(*tls.Conn).NetConn().(syscall.Conn); ok {
+					rawConn, _ = sc.SyscallConn()
+				}
 			} else {
 				return newError(`failed to use ` + requestAddons.Flow + `, maybe "security" is not "xtls"`).AtWarning()
 			}
@@ -176,6 +182,7 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 
 	clientReader := link.Reader // .(*pipe.Reader)
 	clientWriter := link.Writer // .(*pipe.Writer)
+	isTLS13Connection := false
 
 	if request.Command == protocol.RequestCommandUDP && h.cone && request.Port != 53 && request.Port != 443 {
 		request.Command = protocol.RequestCommandMux
@@ -205,8 +212,18 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 			return newError("failed to write A request payload").Base(err).AtWarning()
 		}
 
-		// from clientReader.ReadMultiBuffer to serverWriter.WriteMultiBufer
-		if err := buf.Copy(clientReader, serverWriter, buf.UpdateActivity(timer)); err != nil {
+		var err error
+		if rawConn != nil && requestAddons.Flow == vless.XRV {
+			var counter stats.Counter
+			if statConn != nil {
+				counter = statConn.WriteCounter
+			}
+			err = encoding.XtlsWrite(clientReader, serverWriter, timer, iConn.(*tls.Conn), counter, account.ID.Bytes(), false, &isTLS13Connection)
+		} else {
+			// from clientReader.ReadMultiBuffer to serverWriter.WriteMultiBufer
+			err = buf.Copy(clientReader, serverWriter, buf.UpdateActivity(timer))
+		}
+		if err != nil {
 			return newError("failed to transfer request payload").Base(err).AtInfo()
 		}
 
@@ -236,7 +253,11 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 			if statConn != nil {
 				counter = statConn.ReadCounter
 			}
-			err = encoding.ReadV(serverReader, clientWriter, timer, iConn.(*xtls.Conn), rawConn, counter, sctx)
+			if requestAddons.Flow == vless.XRV {
+				err = encoding.XtlsRead(serverReader, clientWriter, timer, iConn.(*tls.Conn), rawConn, counter, sctx, account.ID.Bytes(), true, &isTLS13Connection)
+			} else {
+				err = encoding.ReadV(serverReader, clientWriter, timer, iConn.(*xtls.Conn), rawConn, counter, sctx)
+			}
 		} else {
 			// from serverReader.ReadMultiBuffer to clientWriter.WriteMultiBufer
 			err = buf.Copy(serverReader, clientWriter, buf.UpdateActivity(timer))

--- a/proxy/vless/vless.go
+++ b/proxy/vless/vless.go
@@ -11,4 +11,5 @@ const (
 	XRO = "xtls-rprx-origin"
 	XRD = "xtls-rprx-direct"
 	XRS = "xtls-rprx-splice"
+	XRV = "xtls-rprx-vision"
 )


### PR DESCRIPTION
新流控实验选项：xtls-rprx-vision
- 解决已知漏洞
- 针对 tls1.3 开启 xtls (直接拷贝) 模式
- 增加 tls 握手长度混淆
- 简化代码

注意："streamSettings" "security" 必须使用 “tls” "tlsSettings" 不能使用 “xtls” “xtlsSettings”