### PR TITLE
Added utls to http2 transport

### DIFF
--- a/transport/internet/tls/tls.go
+++ b/transport/internet/tls/tls.go
@@ -34,6 +34,11 @@ func (c *Conn) HandshakeAddress() net.Address {
 	return net.ParseAddress(state.ServerName)
 }
 
+func (c *Conn) NegotiatedProtocol() (name string, mutual bool) {
+	state := c.ConnectionState()
+	return state.NegotiatedProtocol, state.NegotiatedProtocolIsMutual
+}
+
 // Client initiates a TLS client handshake on the given connection.
 func Client(c net.Conn, config *tls.Config) net.Conn {
 	tlsConn := tls.Client(c, config)
@@ -61,6 +66,11 @@ func (c *UConn) HandshakeAddress() net.Address {
 	return net.ParseAddress(state.ServerName)
 }
 
+func (c *UConn) NegotiatedProtocol() (name string, mutual bool) {
+	state := c.ConnectionState()
+	return state.NegotiatedProtocol, state.NegotiatedProtocolIsMutual
+}
+
 func UClient(c net.Conn, config *tls.Config, fingerprint *utls.ClientHelloID) net.Conn {
 	utlsConn := utls.UClient(c, copyConfig(config), *fingerprint)
 	return &UConn{UConn: utlsConn}
@@ -79,4 +89,11 @@ var Fingerprints = map[string]*utls.ClientHelloID{
 	"firefox":    &utls.HelloFirefox_Auto,
 	"safari":     &utls.HelloIOS_Auto,
 	"randomized": &utls.HelloRandomized,
+}
+
+type Interface interface {
+	net.Conn
+	Handshake() error
+	VerifyHostname(host string) error
+	NegotiatedProtocol() (name string, mutual bool)
 }


### PR DESCRIPTION
Hello
I was messing around with xray settings and realized that [utls](https://github.com/refraction-networking/utls) integration only works with raw tcp + tls configuration. So I thought maybe there is a way to bring utls to websocket/gRPC and http2!
Turns out, websocket and gRPC are not really handy to use utls in them. But http is really easy because we simply set DialTLS function and do it ourselves. So I added the ability to choose between `gotls.Client` and `utls.Client` and stablish the TLS with them.

To achieve a clean code, I added an interface to tls package which provides methods needed to initiate the tls connection. Unfortunately, `ConnectionState` method returns two different structs in gotls and utls so I had to create a method called `NegotiatedProtocol` to return the `NegotiatedProtocol` and `NegotiatedProtocolIsMutual`.

At last, I tested it with my own server. I set up my server just like [this](https://github.com/XTLS/Xray-examples/tree/main/VLESS-H2C-Caddy2) example and it is working fine! Next I checked the fingerprints which they also lead to fingerprints used by Firefox and Chrome. I used wireshark to capture the packets and test them.
[Firefox Fingerprint](https://tlsfingerprint.io/id/b250617dca0ac79f)
[Chrome Fingerprint](https://tlsfingerprint.io/id/e47eae8f8c4887b6)