### PR TITLE
Added utls to websocket

### DIFF
--- a/transport/internet/tls/tls.go
+++ b/transport/internet/tls/tls.go
@@ -76,10 +76,10 @@ func (c *UConn) WebsocketHandshake() error {
 	}
 	// Iterate over extensions and check for utls.ALPNExtension
 	hasALPNExtension := false
-	for i, extension := range c.Extensions {
-		if _, ok := extension.(*utls.ALPNExtension); ok {
+	for _, extension := range c.Extensions {
+		if alpn, ok := extension.(*utls.ALPNExtension); ok {
 			hasALPNExtension = true
-			c.Extensions[i] = &utls.ALPNExtension{AlpnProtocols: []string{"http/1.1"}}
+			alpn.AlpnProtocols = []string{"http/1.1"}
 			break
 		}
 	}

--- a/transport/internet/tls/tls.go
+++ b/transport/internet/tls/tls.go
@@ -66,6 +66,33 @@ func (c *UConn) HandshakeAddress() net.Address {
 	return net.ParseAddress(state.ServerName)
 }
 
+// WebsocketHandshake basically calls UConn.Handshake inside it but it will only send
+// http/1.1 in its ALPN.
+func (c *UConn) WebsocketHandshake() error {
+	// Build the handshake state. This will apply every variable of the TLS of the
+	// fingerprint in the UConn
+	if err := c.BuildHandshakeState(); err != nil {
+		return err
+	}
+	// Iterate over extensions and check for utls.ALPNExtension
+	hasALPNExtension := false
+	for i, extension := range c.Extensions {
+		if _, ok := extension.(*utls.ALPNExtension); ok {
+			hasALPNExtension = true
+			c.Extensions[i] = &utls.ALPNExtension{AlpnProtocols: []string{"http/1.1"}}
+			break
+		}
+	}
+	if !hasALPNExtension { // Append extension if doesn't exists
+		c.Extensions = append(c.Extensions, &utls.ALPNExtension{AlpnProtocols: []string{"http/1.1"}})
+	}
+	// Rebuild the client hello and do the handshake
+	if err := c.BuildHandshakeState(); err != nil {
+		return err
+	}
+	return c.Handshake()
+}
+
 func (c *UConn) NegotiatedProtocol() (name string, mutual bool) {
 	state := c.ConnectionState()
 	return state.NegotiatedProtocol, state.NegotiatedProtocolIsMutual


### PR DESCRIPTION
Hello again
Well; I added utls this time to websocket which is far more popular than http2 and will be probably more used.

So lemme explain it a little because this pull request contains only additions and some of them are not really obvious. At first, I added a method called `WebsocketHandshake` to `UConn`. Why another method is needed? Because both Chrome and Firefox fingerprints have a very small difference depending on if the request is a websocket connection or a simple HTTP request.
[Chrome Fingerprint Difference](https://tlsfingerprint.io/compare/b8ddad74f1546398/e47eae8f8c4887b6)
[Firefox Fingerprint Difference](https://tlsfingerprint.io/compare/ad5407dfc7213726/b250617dca0ac79f)
As you can see, the only difference is in ALPN which for websocket, it only contains `http/1.1`. Apparently, when stablishing a WSS connection, you need to only send `http/1.1` in ALPN. But unfortunately, `utls` library only has normal TLS fingerprints (which is used by HTTP methods). Also, [`utlsIdToSpec`](https://github.com/refraction-networking/utls/blob/35e5b05fc4b6f8c4351d755f2570bc293f30aaf6/u_parrots.go#L17) is an unexported function so we cannot use it to get the `ClientHelloSpec` of browsers. But, there is a function which builds the client hello which is called [`BuildHandshakeState`](https://github.com/refraction-networking/utls/blob/35e5b05fc4b6f8c4351d755f2570bc293f30aaf6/u_conn.go#L67). Calling this function for the first time results in client hello be built with normal browsers fingerprint; This results in `UConn.Extensions` to be populated. Next, I iterate over `UConn.Extensions` to find the `ALPNExtension` which is used to define the ALPNs and override it with `http/1.1` only. If there is no `ALPNExtension` found (which happens in randomized fingerprint) add one and fill it with `http/1.1` as well. At last, I will rebuild the client hello and do the handshake.

For the websocket part itself, I just defined `websocket.Dialer.NetDialTLSContext` to do something like the one in the `websocket.Dialer.NetDial` and the one in http package (which I updated in my last pull request). I simply dials the endpoint like the one defined [here](https://github.com/XTLS/Xray-core/blob/93c7ebe38245a44fb8d7f029677a16e9def1187c/transport/internet/websocket/dialer.go#L74-L76) and then establishes a `utls` connection with the peer using the new `WebsocketHandshake` method.

I tested the executable myself and it works fine. Firefox generates [this fingerprint](https://tlsfingerprint.io/id/ad5407dfc7213726) and Chrome generates [this one](https://tlsfingerprint.io/id/b8ddad74f1546398). I also tested it with ArvanCloud CDN and my own server and it proxied my traffic.

As a side note, I also like to note that if you don't set the `fingerprint` key in `tlsSettings` in config, the old code flow will be executed which means that `websocket.Dialer.NetDialTLSContext` won't be set and go's normal fingerprint will be used.

Edit: Here is the commit which sets chrome ALPN to `http1.1` only: https://github.com/chromium/chromium/commit/db8295539257cd84f400aef5d4709f701b830ebb