### PR TITLE
Added uTLS to gRPC

### DIFF
--- a/transport/internet/tls/grpc.go
+++ b/transport/internet/tls/grpc.go
@@ -1,0 +1,107 @@
+package tls
+
+import (
+	"context"
+	gotls "crypto/tls"
+	utls "github.com/refraction-networking/utls"
+	"google.golang.org/grpc/credentials"
+	"net"
+	"net/url"
+	"strconv"
+)
+
+// grpcUtlsInfo contains the auth information for a TLS authenticated connection.
+// It implements the AuthInfo interface.
+type grpcUtlsInfo struct {
+	State utls.ConnectionState
+	credentials.CommonAuthInfo
+	// This API is experimental.
+	SPIFFEID *url.URL
+}
+
+// AuthType returns the type of TLSInfo as a string.
+func (t grpcUtlsInfo) AuthType() string {
+	return "utls"
+}
+
+// GetSecurityValue returns security info requested by channelz.
+func (t grpcUtlsInfo) GetSecurityValue() credentials.ChannelzSecurityValue {
+	v := &credentials.TLSChannelzSecurityValue{
+		StandardName: strconv.FormatUint(uint64(t.State.CipherSuite), 10),
+	}
+	// Currently there's no way to get LocalCertificate info from tls package.
+	if len(t.State.PeerCertificates) > 0 {
+		v.RemoteCertificate = t.State.PeerCertificates[0].Raw
+	}
+	return v
+}
+
+// grpcUtls is the credentials required for authenticating a connection using TLS.
+type grpcUtls struct {
+	config      *gotls.Config
+	fingerprint *utls.ClientHelloID
+}
+
+func (c grpcUtls) Info() credentials.ProtocolInfo {
+	return credentials.ProtocolInfo{
+		SecurityProtocol: "tls",
+		SecurityVersion:  "1.2",
+		ServerName:       c.config.ServerName,
+	}
+}
+
+func (c *grpcUtls) ClientHandshake(ctx context.Context, authority string, rawConn net.Conn) (_ net.Conn, _ credentials.AuthInfo, err error) {
+	// use local cfg to avoid clobbering ServerName if using multiple endpoints
+	cfg := c.config.Clone()
+	if cfg.ServerName == "" {
+		serverName, _, err := net.SplitHostPort(authority)
+		if err != nil {
+			// If the authority had no host port or if the authority cannot be parsed, use it as-is.
+			serverName = authority
+		}
+		cfg.ServerName = serverName
+	}
+	conn := UClient(rawConn, cfg, c.fingerprint).(*UConn)
+	errChannel := make(chan error, 1)
+	go func() {
+		errChannel <- conn.Handshake()
+		close(errChannel)
+	}()
+	select {
+	case err := <-errChannel:
+		if err != nil {
+			conn.Close()
+			return nil, nil, err
+		}
+	case <-ctx.Done():
+		conn.Close()
+		return nil, nil, ctx.Err()
+	}
+	tlsInfo := grpcUtlsInfo{
+		State: conn.ConnectionState(),
+		CommonAuthInfo: credentials.CommonAuthInfo{
+			SecurityLevel: credentials.PrivacyAndIntegrity,
+		},
+	}
+	return conn, tlsInfo, nil
+}
+
+// ServerHandshake will always panic. We don't support running uTLS as server.
+func (c *grpcUtls) ServerHandshake(net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	panic("not available!")
+}
+
+func (c *grpcUtls) Clone() credentials.TransportCredentials {
+	return NewGrpcUtls(c.config, c.fingerprint)
+}
+
+func (c *grpcUtls) OverrideServerName(serverNameOverride string) error {
+	c.config.ServerName = serverNameOverride
+	return nil
+}
+
+// NewGrpcUtls uses c to construct a TransportCredentials based on uTLS.
+func NewGrpcUtls(c *gotls.Config, fingerprint *utls.ClientHelloID) credentials.TransportCredentials {
+	tc := &grpcUtls{c.Clone(), fingerprint}
+	return tc
+}

--- a/transport/internet/tls/grpc.go
+++ b/transport/internet/tls/grpc.go
@@ -27,7 +27,7 @@ func (t grpcUtlsInfo) AuthType() string {
 // GetSecurityValue returns security info requested by channelz.
 func (t grpcUtlsInfo) GetSecurityValue() credentials.ChannelzSecurityValue {
 	v := &credentials.TLSChannelzSecurityValue{
-		StandardName: strconv.FormatUint(uint64(t.State.CipherSuite), 10),
+		StandardName: "0x" + strconv.FormatUint(uint64(t.State.CipherSuite), 16),
 	}
 	// Currently there's no way to get LocalCertificate info from tls package.
 	if len(t.State.PeerCertificates) > 0 {


### PR DESCRIPTION
Hello again
At the very end, I added uTLS to gRPC transport.

What I did to implement this, was that I copy and pasted [this lines of code](https://github.com/grpc/grpc-go/blob/v1.50.1/credentials/tls.go#L33-L146) from gRPC's library into `tls` package of xray. Then, I changed the go's TLS package with uTLS. I also made the `ServerHandshake` method to always panic because it's never called (because this is client's code!) and, well, we don't want uTLS to act as server. I can change this and simply copy and paste the `ServerHandshake` [code](https://github.com/grpc/grpc-go/blob/v1.50.1/credentials/tls.go#L113-L130) from gRPC's library to xray's code; But as I said, I think it's better to keep it this way.
One small change which I also done is this line:
https://github.com/XTLS/Xray-core/pull/1264/files#diff-79f0d50c97be933687e099e60e722cbb9376197d0edde3ba554d23f526a112ebR30
In gRPC's library it uses a map between cipher suites and their string name to get this value. But in this pull request I only use the base 10 representation of the cipher suite which is sent in binary in client hello.
I also re-defined `TLSInfo` as `grpcUtlsInfo` but changed the `State` to be `utls.ConnectionState` instead of `tls.ConnectionState`.

Just like other pull requests I made, if fingerprint is not defined it simply falls back to standard gRPC tls. This ensures maximum backward compatibility.
Also, I tested this pull request with my own server which is behind Cloudflare and Caddy and I can tell you it's working fine!
As well as, I tested the fingerprints with https://tlsfingerprint.io/pcap and wireshark.