### PR TITLE
add restrictedIPsPath flag for limit restricted IPs

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -280,6 +280,9 @@ func initRestrictedIPs(){
 	ticker := time.NewTicker(intvalSecond)
 	quit := make(chan struct{})
 	restrictedIPsPath := getOsArgValue(os.Args,"-restrictedIPsPath","-rip")
+	if restrictedIPsPath == "" {
+		return
+	}
 	go func() {
 		intvalSecond = 30 * time.Second
 		for {
@@ -297,7 +300,9 @@ func initRestrictedIPs(){
 	}()
 }
 func dropRestrictedConnections(ctx context.Context,outboundLink *transport.Link,inboundLink *transport.Link){
-	
+	if restrictedIPs == ""{
+		return
+	}
 	// Drop Restricted Connections
 	sessionInbounds := session.InboundFromContext(ctx)
 	userIP := sessionInbounds.Source.Address.String()

--- a/main/run.go
+++ b/main/run.go
@@ -33,6 +33,10 @@ The -confdir=dir flag sets a dir with multiple json config
 The -format=json flag sets the format of config files. 
 Default "auto".
 
+The -restrictedIPsPath=file, -rip=file flags set the restricted IPs file path
+The IPs should split by "," in file. EX : 1.1.1.1,2.2.2.2 
+Default "".
+
 The -test flag tells Xray to test config files only, 
 without launching the server
 	`,
@@ -45,6 +49,7 @@ func init() {
 var (
 	configFiles cmdarg.Arg // "Config file for Xray.", the option is customed type, parse in main
 	configDir   string
+	restrictedIPsPath  string
 	test        = cmdRun.Flag.Bool("test", false, "Test config file only, without launching Xray server.")
 	format      = cmdRun.Flag.String("format", "auto", "Format of input file.")
 
@@ -55,6 +60,8 @@ var (
 		cmdRun.Flag.Var(&configFiles, "config", "Config path for Xray.")
 		cmdRun.Flag.Var(&configFiles, "c", "Short alias of -config")
 		cmdRun.Flag.StringVar(&configDir, "confdir", "", "A dir with multiple json config")
+		cmdRun.Flag.StringVar(&restrictedIPsPath, "restrictedIPsPath", "", "disAllowed IPs file path")
+		cmdRun.Flag.StringVar(&restrictedIPsPath, "rip", "", "Short alias of -restrictedIPsPath")
 
 		return true
 	}()


### PR DESCRIPTION
add `-restrictedIPsPath blockedIPs.txt` OR `-rip blockedIPs.txt`  to Xray for drop connection from limited IPs.
stored IPs should be split by ","  in the text file. 
**EX blockedIPs.txt content** : 
`1.2.3.4,1.1.1.2,5.6.7.8`
it's useful for limiting connected Different IPs to inbound at the same time.
like implemented for x-ui [here](https://github.com/hossinasaadi/x-ui)