### PR TITLE
Fix sockopt.TcpKeepAliveInterval

### DIFF
--- a/transport/internet/system_dialer.go
+++ b/transport/internet/system_dialer.go
@@ -70,7 +70,7 @@ func (d *DefaultSystemDialer) Dial(ctx context.Context, src net.Address, dest ne
 		}, nil
 	}
 	goStdKeepAlive := time.Duration(0)
-	if sockopt != nil && sockopt.TcpKeepAliveIdle != 0 {
+	if sockopt != nil && (sockopt.TcpKeepAliveInterval != 0 || sockopt.TcpKeepAliveIdle != 0) {
 		goStdKeepAlive = time.Duration(-1)
 	}
 	dialer := &net.Dialer{

--- a/transport/internet/system_listener.go
+++ b/transport/internet/system_listener.go
@@ -51,7 +51,7 @@ func (dl *DefaultListener) Listen(ctx context.Context, addr net.Addr, sockopt *S
 		network = addr.Network()
 		address = addr.String()
 		lc.Control = getControlFunc(ctx, sockopt, dl.controllers)
-		if sockopt != nil && sockopt.TcpKeepAliveIdle != 0 {
+		if sockopt != nil && (sockopt.TcpKeepAliveInterval != 0 || sockopt.TcpKeepAliveIdle != 0) {
 			lc.KeepAlive = time.Duration(-1)
 		}
 	case *net.UnixAddr:


### PR DESCRIPTION
如果配置中只设置了`"tcpKeepAliveInterval": -1`，而没有设置`"tcpKeepAliveIdle": -1`，xray不会设置goStdKeepAlive，导致后面dial或者accept的时候，keepalive配置被golang官方默认的覆盖。