### PR TITLE
fix: replace "math/rand" with "crypto/rand" in padding generation

### DIFF
--- a/common/crypto/auth.go
+++ b/common/crypto/auth.go
@@ -2,8 +2,8 @@ package crypto
 
 import (
 	"crypto/cipher"
+	"crypto/rand"
 	"io"
-	"math/rand"
 
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/buf"
@@ -265,7 +265,8 @@ func (w *AuthenticationWriter) seal(b []byte) (*buf.Buffer, error) {
 		return nil, err
 	}
 	if paddingSize > 0 {
-		// With size of the chunk and padding length encrypted, the content of padding doesn't matter much.
+		// These paddings will send in clear text.
+		// To avoid leakage of PRNG internal state, a cryptographically secure PRNG should be used.
 		paddingBytes := eb.Extend(paddingSize)
 		common.Must2(rand.Read(paddingBytes))
 	}


### PR DESCRIPTION
Copied from https://github.com/v2fly/v2ray-core/pull/2032

Thanks to @nlzy

Close #1255