### PR TITLE
修复mux子连接无法正常断开的问题

### DIFF
--- a/common/mux/client.go
+++ b/common/mux/client.go
@@ -355,6 +355,7 @@ func (m *ClientWorker) handleStatusEnd(meta *FrameMetadata, reader *buf.Buffered
 			common.Interrupt(s.input)
 			common.Interrupt(s.output)
 		}
+		common.Interrupt(s.input)
 		s.Close()
 	}
 	if meta.Option.Has(OptionData) {

--- a/common/mux/server.go
+++ b/common/mux/server.go
@@ -202,6 +202,7 @@ func (w *ServerWorker) handleStatusEnd(meta *FrameMetadata, reader *buf.Buffered
 			common.Interrupt(s.input)
 			common.Interrupt(s.output)
 		}
+		common.Interrupt(s.input)
 		s.Close()
 	}
 	if meta.Option.Has(OptionData) {


### PR DESCRIPTION
ray系的mux一直有一个老毛病，取消下载文件后流量还会继续跑，比如#232。
排查后发现问题出在`commom/mux/server.go`文件下的`handleStatusEnd`函数。
具体而言，`mux`客户端向服务端发送`End`状态请求结束对应的`mux.Session`时，服务端接受到该请求，并最终进入`handleStatusEnd`函数：
```
func (w *ServerWorker) handleStatusEnd(meta *FrameMetadata, reader *buf.BufferedReader) error {
	if s, found := w.sessionManager.Get(meta.SessionID); found {
		...
		s.Close()
	}
	...
	return nil
}
```
上述`if`语句中的`s.Close`函数：
```
func (s *Session) Close() error {
	common.Close(s.output)
	common.Close(s.input)
	s.parent.Remove(s.ID)
	return nil
}
```
分别调用`s.input`和`s.output`的`Close`方法，然后将该`session`的`ID`从`sessionmanager`中移除。
问题出现在，`s.input`是一个`pipe.Reader`，在xray中`pipe.Reader`没有实现`Close`方法，导致子连接无法正常断开，远程服务器会持续通过该`pipe.Reader`传输数据。
解决方法很简单，在`s.Close()`前手动中止`pipe.Reader`即可：
```
func (w *ServerWorker) handleStatusEnd(meta *FrameMetadata, reader *buf.BufferedReader) error {
	if s, found := w.sessionManager.Get(meta.SessionID); found {
		...
		common.Interrupt(s.input)
		s.Close()
	}
	...
	return nil
}
```
相应的，`commom/mux/client.go`文件下的`handleStatusEnd`函数也需要做出对应的修改。
使用修改后版本的mux已经不存在上述问题，取消下载不再偷跑流量，子连接能够正常断开。