### PR TITLE
fix: email inconsistent

### DIFF
--- a/proxy/shadowsocks_2022/inbound_multi.go
+++ b/proxy/shadowsocks_2022/inbound_multi.go
@@ -97,7 +97,7 @@ func (i *MultiUserInbound) AddUser(ctx context.Context, u *protocol.MemoryUser) 
 	}
 	i.users = append(i.users, &User{
 		Key:   account.Key,
-		Email: strings.ToLower(account.Email),
+		Email: account.Email,
 		Level: account.Level,
 	})
 
@@ -120,7 +120,6 @@ func (i *MultiUserInbound) RemoveUser(ctx context.Context, email string) error {
 	i.Lock()
 	defer i.Unlock()
 
-	email = strings.ToLower(email)
 	idx := -1
 	for ii, u := range i.users {
 		if strings.EqualFold(u.Email, email) {


### PR DESCRIPTION
@thank243 strings.ToLower will cause the email inconsistent, which makes XrayR unable to limit the speed and device. But I am not sure whether remove it would cause other issues in adding/deleting Shadowsocks2022 users.