### PR TITLE
fix: handle error raised by dispatcher

### DIFF
--- a/transport/internet/udp/dispatcher.go
+++ b/transport/internet/udp/dispatcher.go
@@ -51,12 +51,12 @@ func (v *Dispatcher) RemoveRay(dest net.Destination) {
 	}
 }
 
-func (v *Dispatcher) getInboundRay(ctx context.Context, dest net.Destination) *connEntry {
+func (v *Dispatcher) getInboundRay(ctx context.Context, dest net.Destination) (*connEntry, error) {
 	v.Lock()
 	defer v.Unlock()
 
 	if entry, found := v.conns[dest]; found {
-		return entry
+		return entry, nil
 	}
 
 	newError("establishing new connection for ", dest).WriteToLog()
@@ -67,7 +67,12 @@ func (v *Dispatcher) getInboundRay(ctx context.Context, dest net.Destination) *c
 		v.RemoveRay(dest)
 	}
 	timer := signal.CancelAfterInactivity(ctx, removeRay, time.Minute)
-	link, _ := v.dispatcher.Dispatch(ctx, dest)
+
+	link, err := v.dispatcher.Dispatch(ctx, dest)
+	if err != nil {
+		return nil, newError("failed to dispatch request to ", dest).Base(err)
+	}
+
 	entry := &connEntry{
 		link:   link,
 		timer:  timer,
@@ -75,14 +80,18 @@ func (v *Dispatcher) getInboundRay(ctx context.Context, dest net.Destination) *c
 	}
 	v.conns[dest] = entry
 	go handleInput(ctx, entry, dest, v.callback)
-	return entry
+	return entry, nil
 }
 
 func (v *Dispatcher) Dispatch(ctx context.Context, destination net.Destination, payload *buf.Buffer) {
 	// TODO: Add user to destString
 	newError("dispatch request to: ", destination).AtDebug().WriteToLog(session.ExportIDToError(ctx))
 
-	conn := v.getInboundRay(ctx, destination)
+	conn, err := v.getInboundRay(ctx, destination)
+	if err != nil {
+		newError("failed to get inbound").Base(err).WriteToLog(session.ExportIDToError(ctx))
+		return
+	}
 	outputStream := conn.link.Writer
 	if outputStream != nil {
 		if err := outputStream.WriteMultiBuffer(buf.MultiBuffer{payload}); err != nil {


### PR DESCRIPTION
UDP dispatcher fails to handle the error raised by routing.Dispatcher, which could cause unexpected errors XrayR-project/XrayR#204.