### PR TITLE
fix: compiling on older versions of go

### DIFF
--- a/common/protocol/quic/qtls_go119.go
+++ b/common/protocol/quic/qtls_go119.go
@@ -1,11 +1,11 @@
-//go:build go1.18 && !go1.19
+//go:build go1.19 && !go1.20
 
 package quic
 
 import (
 	"crypto/cipher"
 
-	"github.com/quic-go/qtls-go1-18"
+	"github.com/quic-go/qtls-go1-19"
 )
 
 type (

--- a/common/protocol/quic/qtls_go120.go
+++ b/common/protocol/quic/qtls_go120.go
@@ -1,11 +1,11 @@
-//go:build go1.18 && !go1.19
+//go:build go1.20
 
 package quic
 
 import (
 	"crypto/cipher"
 
-	"github.com/quic-go/qtls-go1-18"
+	"github.com/quic-go/qtls-go1-20"
 )
 
 type (

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/miekg/dns v1.1.50
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pires/go-proxyproto v0.6.2
+	github.com/quic-go/qtls-go1-18 v0.2.0
+	github.com/quic-go/qtls-go1-19 v0.2.0
 	github.com/quic-go/qtls-go1-20 v0.1.0
 	github.com/quic-go/quic-go v0.32.0
 	github.com/refraction-networking/utls v1.2.0
@@ -44,8 +46,6 @@ require (
 	github.com/klauspost/cpuid/v2 v2.2.3 // indirect
 	github.com/onsi/ginkgo/v2 v2.8.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/quic-go/qtls-go1-18 v0.2.0 // indirect
-	github.com/quic-go/qtls-go1-19 v0.2.0 // indirect
 	github.com/riobard/go-bloom v0.0.0-20200614022211-cdc8013cb5b3 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	golang.org/x/exp v0.0.0-20230131160201-f062dba9d201 // indirect


### PR DESCRIPTION
Uses a similar approach of [https://github.com/quic-go/quic-go/blob/master/internal/qtls/go118.go](https://github.com/quic-go/quic-go/blob/master/internal/qtls/go118.go)

Compiled on go1.19.5 (linux/amd64) and go1.20 (linux/amd64). Should be working on go1.18.x as well.