### PR TITLE
Add Fair VPN for iOS and macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@
 - iOS & macOS (with M1 chip)
   - [Shadowrocket](https://apps.apple.com/app/shadowrocket/id932747118)
   - [Stash](https://apps.apple.com/app/stash/id1596063349)
+  - [Fair VPN](https://apps.apple.com/app/fair-vpn/id1533873488)
 - macOS (Intel chip & M1 chip)
   - [Qv2ray](https://github.com/Qv2ray/Qv2ray) (This project had been archived and currently inactive)
   - [V2RayXS](https://github.com/tzmax/V2RayXS)
+  - [Fair VPN](https://apps.apple.com/app/fair-vpn/id1533873488)
 
 ## Credits
 


### PR DESCRIPTION
Tested vless+xtls on both iOS(15.7.2) and macOS (13.2.1). The latest update supports the protocols without crashing.
<img width="766" alt="image" src="https://user-images.githubusercontent.com/30291162/219936415-73fa9077-323b-436b-a411-73638caa5e01.png">
![image](https://user-images.githubusercontent.com/30291162/219936440-356629a6-6d99-4a94-abd6-645ba79c1398.png)
