### PR TITLE
gRPC Custom Path

### DIFF
--- a/transport/internet/grpc/config.go
+++ b/transport/internet/grpc/config.go
@@ -22,7 +22,12 @@ func (c *Config) getServiceName() string {
 		return url.PathEscape(c.ServiceName)
 	}
 	// Otherwise new custom paths
-	return c.ServiceName[1:strings.LastIndex(c.ServiceName, "/")] // trim from first to last '/'
+	rawServiceName := c.ServiceName[1:strings.LastIndex(c.ServiceName, "/")] // trim from first to last '/'
+	serviceNameParts := strings.Split(rawServiceName, "/")
+	for i := range serviceNameParts {
+		serviceNameParts[i] = url.PathEscape(serviceNameParts[i])
+	}
+	return strings.Join(serviceNameParts, "/")
 }
 
 func (c *Config) getTunStreamName() string {
@@ -32,7 +37,7 @@ func (c *Config) getTunStreamName() string {
 	}
 	// Otherwise new custom paths
 	endingPath := c.ServiceName[strings.LastIndex(c.ServiceName, "/")+1:] // from the last '/' to end of string
-	return strings.Split(endingPath, "|")[0]
+	return url.PathEscape(strings.Split(endingPath, "|")[0])
 }
 
 func (c *Config) getMultiTunStreamName() string {
@@ -44,8 +49,8 @@ func (c *Config) getMultiTunStreamName() string {
 	endingPath := c.ServiceName[strings.LastIndex(c.ServiceName, "/")+1:] // from the last '/' to end of string
 	streamNames := strings.Split(endingPath, "|")
 	if len(streamNames) == 1 { // client side. Service name is the full path to multi tun
-		return streamNames[0]
+		return url.PathEscape(streamNames[0])
 	} else { // server side. The second part is the path to multi tun
-		return streamNames[1]
+		return url.PathEscape(streamNames[1])
 	}
 }

--- a/transport/internet/grpc/config.go
+++ b/transport/internet/grpc/config.go
@@ -40,7 +40,7 @@ func (c *Config) getTunStreamName() string {
 	return url.PathEscape(strings.Split(endingPath, "|")[0])
 }
 
-func (c *Config) getMultiTunStreamName() string {
+func (c *Config) getTunMultiStreamName() string {
 	// Normal old school config
 	if !strings.HasPrefix(c.ServiceName, "/") {
 		return "TunMulti"

--- a/transport/internet/grpc/config.go
+++ b/transport/internet/grpc/config.go
@@ -22,8 +22,7 @@ func (c *Config) getServiceName() string {
 		return url.PathEscape(c.ServiceName)
 	}
 	// Otherwise new custom paths
-	tunListen := strings.Split(c.ServiceName, ",")[0]
-	return tunListen[1:strings.LastIndex(tunListen, "/")] // trim from first to last '/'
+	return c.ServiceName[1:strings.LastIndex(c.ServiceName, "/")] // trim from first to last '/'
 }
 
 func (c *Config) getTunStreamName() string {
@@ -32,8 +31,8 @@ func (c *Config) getTunStreamName() string {
 		return "Tun"
 	}
 	// Otherwise new custom paths
-	tunListen := strings.Split(c.ServiceName, ",")[0]
-	return tunListen[strings.LastIndex(tunListen, "/")+1:] // from the last '/' to the end
+	endingPath := c.ServiceName[strings.LastIndex(c.ServiceName, "/")+1:] // from the last '/' to end of string
+	return strings.Split(endingPath, "|")[0]
 }
 
 func (c *Config) getMultiTunStreamName() string {
@@ -42,12 +41,11 @@ func (c *Config) getMultiTunStreamName() string {
 		return "TunMulti"
 	}
 	// Otherwise new custom paths
-	splitServiceName := strings.Split(c.ServiceName, ",")
-	var fullPath string
-	if len(splitServiceName) == 1 { // client side. Service name is the full path to multi tun
-		fullPath = splitServiceName[0]
+	endingPath := c.ServiceName[strings.LastIndex(c.ServiceName, "/")+1:] // from the last '/' to end of string
+	streamNames := strings.Split(endingPath, "|")
+	if len(streamNames) == 1 { // client side. Service name is the full path to multi tun
+		return streamNames[0]
 	} else { // server side. The second part is the path to multi tun
-		fullPath = splitServiceName[1]
+		return streamNames[1]
 	}
-	return fullPath[strings.LastIndex(fullPath, "/")+1:] // from the last '/' to the end
 }

--- a/transport/internet/grpc/config.go
+++ b/transport/internet/grpc/config.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"net/url"
+	"strings"
 
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/transport/internet"
@@ -15,6 +16,38 @@ func init() {
 	}))
 }
 
-func (c *Config) getNormalizedName() string {
-	return url.PathEscape(c.ServiceName)
+func (c *Config) getServiceName() string {
+	// Normal old school config
+	if !strings.HasPrefix(c.ServiceName, "/") {
+		return url.PathEscape(c.ServiceName)
+	}
+	// Otherwise new custom paths
+	tunListen := strings.Split(c.ServiceName, ",")[0]
+	return tunListen[1:strings.LastIndex(tunListen, "/")] // trim from first to last '/'
+}
+
+func (c *Config) getTunStreamName() string {
+	// Normal old school config
+	if !strings.HasPrefix(c.ServiceName, "/") {
+		return "Tun"
+	}
+	// Otherwise new custom paths
+	tunListen := strings.Split(c.ServiceName, ",")[0]
+	return tunListen[strings.LastIndex(tunListen, "/")+1:] // from the last '/' to the end
+}
+
+func (c *Config) getMultiTunStreamName() string {
+	// Normal old school config
+	if !strings.HasPrefix(c.ServiceName, "/") {
+		return "TunMulti"
+	}
+	// Otherwise new custom paths
+	splitServiceName := strings.Split(c.ServiceName, ",")
+	var fullPath string
+	if len(splitServiceName) == 1 { // client side. Service name is the full path to multi tun
+		fullPath = splitServiceName[0]
+	} else { // server side. The second part is the path to multi tun
+		fullPath = splitServiceName[1]
+	}
+	return fullPath[strings.LastIndex(fullPath, "/")+1:] // from the last '/' to the end
 }

--- a/transport/internet/grpc/config_test.go
+++ b/transport/internet/grpc/config_test.go
@@ -1,0 +1,96 @@
+package grpc
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestConfig_GetServiceName(t *testing.T) {
+	tests := []struct {
+		TestName    string
+		ServiceName string
+		Expected    string
+	}{
+		{
+			TestName:    "simple no absolute path",
+			ServiceName: "hello",
+			Expected:    "hello",
+		},
+		{
+			TestName:    "escape no absolute path",
+			ServiceName: "hello/world!",
+			Expected:    "hello%2Fworld%21",
+		},
+		{
+			TestName:    "absolute path",
+			ServiceName: "/my/sample/path/a|b",
+			Expected:    "my/sample/path",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.TestName, func(t *testing.T) {
+			config := Config{ServiceName: test.ServiceName}
+			assert.Equal(t, test.Expected, config.getServiceName())
+		})
+	}
+}
+
+func TestConfig_GetTunStreamName(t *testing.T) {
+	tests := []struct {
+		TestName    string
+		ServiceName string
+		Expected    string
+	}{
+		{
+			TestName:    "no absolute path",
+			ServiceName: "hello",
+			Expected:    "Tun",
+		},
+		{
+			TestName:    "absolute path server",
+			ServiceName: "/my/sample/path/tun_service|multi_service",
+			Expected:    "tun_service",
+		},
+		{
+			TestName:    "absolute path client",
+			ServiceName: "/my/sample/path/tun_service",
+			Expected:    "tun_service",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.TestName, func(t *testing.T) {
+			config := Config{ServiceName: test.ServiceName}
+			assert.Equal(t, test.Expected, config.getTunStreamName())
+		})
+	}
+}
+
+func TestConfig_GetMultiTunStreamName(t *testing.T) {
+	tests := []struct {
+		TestName    string
+		ServiceName string
+		Expected    string
+	}{
+		{
+			TestName:    "no absolute path",
+			ServiceName: "hello",
+			Expected:    "TunMulti",
+		},
+		{
+			TestName:    "absolute path server",
+			ServiceName: "/my/sample/path/tun_service|multi_service",
+			Expected:    "multi_service",
+		},
+		{
+			TestName:    "absolute path client",
+			ServiceName: "/my/sample/path/multi_service",
+			Expected:    "multi_service",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.TestName, func(t *testing.T) {
+			config := Config{ServiceName: test.ServiceName}
+			assert.Equal(t, test.Expected, config.getMultiTunStreamName())
+		})
+	}
+}

--- a/transport/internet/grpc/config_test.go
+++ b/transport/internet/grpc/config_test.go
@@ -26,6 +26,11 @@ func TestConfig_GetServiceName(t *testing.T) {
 			ServiceName: "/my/sample/path/a|b",
 			Expected:    "my/sample/path",
 		},
+		{
+			TestName:    "escape absolute path",
+			ServiceName: "/hello /world!/a|b",
+			Expected:    "hello%20/world%21",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.TestName, func(t *testing.T) {
@@ -56,6 +61,11 @@ func TestConfig_GetTunStreamName(t *testing.T) {
 			ServiceName: "/my/sample/path/tun_service",
 			Expected:    "tun_service",
 		},
+		{
+			TestName:    "escape absolute path client",
+			ServiceName: "/m y/sa !mple/pa\\th/tun\\_serv!ice",
+			Expected:    "tun%5C_serv%21ice",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.TestName, func(t *testing.T) {
@@ -85,6 +95,11 @@ func TestConfig_GetMultiTunStreamName(t *testing.T) {
 			TestName:    "absolute path client",
 			ServiceName: "/my/sample/path/multi_service",
 			Expected:    "multi_service",
+		},
+		{
+			TestName:    "escape absolute path client",
+			ServiceName: "/m y/sa !mple/pa\\th/mu%lti\\_serv!ice",
+			Expected:    "mu%25lti%5C_serv%21ice",
 		},
 	}
 	for _, test := range tests {

--- a/transport/internet/grpc/config_test.go
+++ b/transport/internet/grpc/config_test.go
@@ -75,7 +75,7 @@ func TestConfig_GetTunStreamName(t *testing.T) {
 	}
 }
 
-func TestConfig_GetMultiTunStreamName(t *testing.T) {
+func TestConfig_GetTunMultiStreamName(t *testing.T) {
 	tests := []struct {
 		TestName    string
 		ServiceName string
@@ -105,7 +105,7 @@ func TestConfig_GetMultiTunStreamName(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.TestName, func(t *testing.T) {
 			config := Config{ServiceName: test.ServiceName}
-			assert.Equal(t, test.Expected, config.getMultiTunStreamName())
+			assert.Equal(t, test.Expected, config.getTunMultiStreamName())
 		})
 	}
 }

--- a/transport/internet/grpc/dial.go
+++ b/transport/internet/grpc/dial.go
@@ -54,15 +54,16 @@ func dialgRPC(ctx context.Context, dest net.Destination, streamSettings *interne
 	}
 	client := encoding.NewGRPCServiceClient(conn)
 	if grpcSettings.MultiMode {
-		newError("using gRPC multi mode").AtDebug().WriteToLog()
-		grpcService, err := client.(encoding.GRPCServiceClientX).TunMultiCustomName(ctx, grpcSettings.getNormalizedName())
+		newError("using gRPC multi mode service name: `" + grpcSettings.getServiceName() + "` stream name: `" + grpcSettings.getMultiTunStreamName() + "`").AtDebug().WriteToLog()
+		grpcService, err := client.(encoding.GRPCServiceClientX).TunMultiCustomName(ctx, grpcSettings.getServiceName(), grpcSettings.getMultiTunStreamName())
 		if err != nil {
 			return nil, newError("Cannot dial gRPC").Base(err)
 		}
 		return encoding.NewMultiHunkConn(grpcService, nil), nil
 	}
 
-	grpcService, err := client.(encoding.GRPCServiceClientX).TunCustomName(ctx, grpcSettings.getNormalizedName())
+	newError("using gRPC tun mode service name: `" + grpcSettings.getServiceName() + "` stream name: `" + grpcSettings.getTunStreamName() + "`").AtDebug().WriteToLog()
+	grpcService, err := client.(encoding.GRPCServiceClientX).TunCustomName(ctx, grpcSettings.getServiceName(), grpcSettings.getTunStreamName())
 	if err != nil {
 		return nil, newError("Cannot dial gRPC").Base(err)
 	}

--- a/transport/internet/grpc/dial.go
+++ b/transport/internet/grpc/dial.go
@@ -54,8 +54,8 @@ func dialgRPC(ctx context.Context, dest net.Destination, streamSettings *interne
 	}
 	client := encoding.NewGRPCServiceClient(conn)
 	if grpcSettings.MultiMode {
-		newError("using gRPC multi mode service name: `" + grpcSettings.getServiceName() + "` stream name: `" + grpcSettings.getMultiTunStreamName() + "`").AtDebug().WriteToLog()
-		grpcService, err := client.(encoding.GRPCServiceClientX).TunMultiCustomName(ctx, grpcSettings.getServiceName(), grpcSettings.getMultiTunStreamName())
+		newError("using gRPC multi mode service name: `" + grpcSettings.getServiceName() + "` stream name: `" + grpcSettings.getTunMultiStreamName() + "`").AtDebug().WriteToLog()
+		grpcService, err := client.(encoding.GRPCServiceClientX).TunMultiCustomName(ctx, grpcSettings.getServiceName(), grpcSettings.getTunMultiStreamName())
 		if err != nil {
 			return nil, newError("Cannot dial gRPC").Base(err)
 		}

--- a/transport/internet/grpc/encoding/customSeviceName.go
+++ b/transport/internet/grpc/encoding/customSeviceName.go
@@ -6,20 +6,20 @@ import (
 	"google.golang.org/grpc"
 )
 
-func ServerDesc(name string) grpc.ServiceDesc {
+func ServerDesc(name, tun, tunMulti string) grpc.ServiceDesc {
 	return grpc.ServiceDesc{
 		ServiceName: name,
 		HandlerType: (*GRPCServiceServer)(nil),
 		Methods:     []grpc.MethodDesc{},
 		Streams: []grpc.StreamDesc{
 			{
-				StreamName:    "Tun",
+				StreamName:    tun,
 				Handler:       _GRPCService_Tun_Handler,
 				ServerStreams: true,
 				ClientStreams: true,
 			},
 			{
-				StreamName:    "TunMulti",
+				StreamName:    tunMulti,
 				Handler:       _GRPCService_TunMulti_Handler,
 				ServerStreams: true,
 				ClientStreams: true,
@@ -29,8 +29,8 @@ func ServerDesc(name string) grpc.ServiceDesc {
 	}
 }
 
-func (c *gRPCServiceClient) TunCustomName(ctx context.Context, name string, opts ...grpc.CallOption) (GRPCService_TunClient, error) {
-	stream, err := c.cc.NewStream(ctx, &ServerDesc(name).Streams[0], "/"+name+"/Tun", opts...)
+func (c *gRPCServiceClient) TunCustomName(ctx context.Context, name, tun string, opts ...grpc.CallOption) (GRPCService_TunClient, error) {
+	stream, err := c.cc.NewStream(ctx, &ServerDesc(name, tun, "").Streams[0], "/"+name+"/"+tun, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -38,8 +38,8 @@ func (c *gRPCServiceClient) TunCustomName(ctx context.Context, name string, opts
 	return x, nil
 }
 
-func (c *gRPCServiceClient) TunMultiCustomName(ctx context.Context, name string, opts ...grpc.CallOption) (GRPCService_TunMultiClient, error) {
-	stream, err := c.cc.NewStream(ctx, &ServerDesc(name).Streams[1], "/"+name+"/TunMulti", opts...)
+func (c *gRPCServiceClient) TunMultiCustomName(ctx context.Context, name, tunMulti string, opts ...grpc.CallOption) (GRPCService_TunMultiClient, error) {
+	stream, err := c.cc.NewStream(ctx, &ServerDesc(name, "", tunMulti).Streams[1], "/"+name+"/"+tunMulti, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -48,13 +48,13 @@ func (c *gRPCServiceClient) TunMultiCustomName(ctx context.Context, name string,
 }
 
 type GRPCServiceClientX interface {
-	TunCustomName(ctx context.Context, name string, opts ...grpc.CallOption) (GRPCService_TunClient, error)
-	TunMultiCustomName(ctx context.Context, name string, opts ...grpc.CallOption) (GRPCService_TunMultiClient, error)
+	TunCustomName(ctx context.Context, name, tun string, opts ...grpc.CallOption) (GRPCService_TunClient, error)
+	TunMultiCustomName(ctx context.Context, name, tunMulti string, opts ...grpc.CallOption) (GRPCService_TunMultiClient, error)
 	Tun(ctx context.Context, opts ...grpc.CallOption) (GRPCService_TunClient, error)
 	TunMulti(ctx context.Context, opts ...grpc.CallOption) (GRPCService_TunMultiClient, error)
 }
 
-func RegisterGRPCServiceServerX(s *grpc.Server, srv GRPCServiceServer, name string) {
-	desc := ServerDesc(name)
+func RegisterGRPCServiceServerX(s *grpc.Server, srv GRPCServiceServer, name, tun, tunMulti string) {
+	desc := ServerDesc(name, tun, tunMulti)
 	s.RegisterService(&desc, srv)
 }

--- a/transport/internet/grpc/hub.go
+++ b/transport/internet/grpc/hub.go
@@ -125,8 +125,8 @@ func Listen(ctx context.Context, address net.Address, port net.Port, settings *i
 			}
 		}
 
-		newError("gRPC listen for service name `" + grpcSettings.getServiceName() + "` tun `" + grpcSettings.getTunStreamName() + "` multi tun `" + grpcSettings.getMultiTunStreamName() + "`").AtDebug().WriteToLog()
-		encoding.RegisterGRPCServiceServerX(s, listener, grpcSettings.getServiceName(), grpcSettings.getTunStreamName(), grpcSettings.getMultiTunStreamName())
+		newError("gRPC listen for service name `" + grpcSettings.getServiceName() + "` tun `" + grpcSettings.getTunStreamName() + "` multi tun `" + grpcSettings.getTunMultiStreamName() + "`").AtDebug().WriteToLog()
+		encoding.RegisterGRPCServiceServerX(s, listener, grpcSettings.getServiceName(), grpcSettings.getTunStreamName(), grpcSettings.getTunMultiStreamName())
 
 		if config := reality.ConfigFromStreamSettings(settings); config != nil {
 			streamListener = goreality.NewListener(streamListener, config.GetREALITYConfig())

--- a/transport/internet/grpc/hub.go
+++ b/transport/internet/grpc/hub.go
@@ -125,7 +125,8 @@ func Listen(ctx context.Context, address net.Address, port net.Port, settings *i
 			}
 		}
 
-		encoding.RegisterGRPCServiceServerX(s, listener, grpcSettings.getNormalizedName())
+		newError("gRPC listen for service name `" + grpcSettings.getServiceName() + "` tun `" + grpcSettings.getTunStreamName() + "` multi tun `" + grpcSettings.getMultiTunStreamName() + "`").AtDebug().WriteToLog()
+		encoding.RegisterGRPCServiceServerX(s, listener, grpcSettings.getServiceName(), grpcSettings.getTunStreamName(), grpcSettings.getMultiTunStreamName())
 
 		if config := reality.ConfigFromStreamSettings(settings); config != nil {
 			streamListener = goreality.NewListener(streamListener, config.GetREALITYConfig())


### PR DESCRIPTION
In this PR, I added the ability to define custom full paths for gRPC as discussed in #1793. I added some tests as well just for the sake of it.
Here are two example configs:
Server:
```json
{
    "log": {
        "loglevel": "debug"
    },
    "inbounds": [{
            "listen": "127.0.0.1",
            "port": 12345,
            "protocol": "trojan",
            "settings": {
                "clients": [{
                        "password": "123456"
                    }
                ]
            },
            "streamSettings": {
                "network": "gun",
                "security": "none",
                "grpcSettings": {
                    "serviceName": "/my/sample/path/customTun|customTunMulti"
                }
            }
        }
    ],
    "outbounds": [{
            "protocol": "freedom"
        }
    ]
}
```
Client Tun:
```json
{
    "log": {
        "loglevel": "debug"
    },
    "inbounds": [{
            "listen": "127.0.0.1",
            "port": "10818",
            "protocol": "socks"
        }
    ],
    "outbounds": [{
            "protocol": "trojan",
            "settings": {
                "servers": [{
                        "address": "127.0.0.1",
                        "port": 12345,
                        "password": "123456"
                    }
                ]
            },
            "streamSettings": {
                "network": "gun",
                "security": "none",
                "grpcSettings": {
                    "serviceName": "/my/sample/path/customTun",
                    "multiMode": false
                }
            }
        }
    ]
}
```
Client Multi Tun:
```json
{
    "log": {
        "loglevel": "debug"
    },
    "inbounds": [{
            "listen": "127.0.0.1",
            "port": "10818",
            "protocol": "socks"
        }
    ],
    "outbounds": [{
            "protocol": "trojan",
            "settings": {
                "servers": [{
                        "address": "127.0.0.1",
                        "port": 12345,
                        "password": "123456"
                    }
                ]
            },
            "streamSettings": {
                "network": "gun",
                "security": "none",
                "grpcSettings": {
                    "serviceName": "/my/sample/path/customTunMulti",
                    "multiMode": true
                }
            }
        }
    ]
}
```

As you can see, we have the limitation that both `Tun` and `Tun Multi` endpoints must have the same sub-route. There is a very small problem with this implementation: Service names like `/` will crash the app. We need to make sure that if the service name starts with `/`, it has at least two `/` in it. We should probably somehow validate the config file.
This PR will close #1793 