### PR TITLE
Add a client that supports Reality protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 - iOS & macOS arm64
   - [Shadowrocket](https://apps.apple.com/app/shadowrocket/id932747118)
   - [Stash](https://apps.apple.com/app/stash/id1596063349)
+  - [Pharos Pro](https://apps.apple.com/app/pharos-pro/id1456610173)
 - API Wrapper
   - [xtlsapi](https://github.com/hiddify/xtlsapi)
 - [XrayR](https://github.com/XrayR-project/XrayR)


### PR DESCRIPTION
This is my one-click build reality script (https://github.com/BoxXt/installReality), the script outputs a clash.meta configuration about Reality that works fine on Pharos Pro, so I came to add it to the client list.