### PR TITLE
support memory check for socks inbound

### DIFF
--- a/common/memory/errors.generated.go
+++ b/common/memory/errors.generated.go
@@ -1,0 +1,9 @@
+package memory
+
+import "github.com/xtls/xray-core/common/errors"
+
+type errPathObjHolder struct{}
+
+func newError(values ...interface{}) *errors.Error {
+	return errors.New(values...).WithPathObj(errPathObjHolder{})
+}

--- a/common/memory/memory.go
+++ b/common/memory/memory.go
@@ -1,0 +1,54 @@
+package memory
+
+import (
+	"runtime"
+	"runtime/debug"
+	"time"
+
+	"github.com/xtls/xray-core/common/platform"
+)
+
+var (
+	memoryMaxValue  int64
+	memoryLastCheck time.Time
+)
+
+func MemoryCheck() error {
+	if memoryMaxValue <= 0 {
+		return nil
+	}
+	now := time.Now()
+	if now.Sub(memoryLastCheck) < 2*time.Second {
+		return nil
+	}
+	memoryLastCheck = now
+	var memStats runtime.MemStats
+	runtime.ReadMemStats(&memStats)
+	usedMemory := int64(memStats.StackInuse + memStats.HeapInuse + memStats.HeapIdle - memStats.HeapReleased)
+	if usedMemory > memoryMaxValue {
+		go func() {
+			debug.FreeOSMemory()
+		}()
+		return newError("out of memory")
+	}
+	return nil
+}
+
+func MemoryCheckEnabled() bool {
+	const key = "xray.inbound.memory.check"
+	const defaultValue = 0
+	checkValue := platform.EnvFlag{
+		Name:    key,
+		AltName: platform.NormalizeEnvName(key),
+	}.GetValueAsInt(defaultValue)
+	return checkValue != 0
+}
+
+func InitMemoryCheck(maxMemory int64) {
+	if maxMemory > 0 {
+		debug.SetGCPercent(10)
+		debug.SetMemoryLimit(maxMemory)
+		memoryMaxValue = maxMemory
+		memoryLastCheck = time.Now()
+	}
+}

--- a/common/memory/memory.go
+++ b/common/memory/memory.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	memoryMaxValue  int64
-	memoryLastCheck time.Time
+	memoryMaxValue      int64
+	memoryCheckInterval time.Duration
+	memoryLastCheck     time.Time
 )
 
 func MemoryCheck() error {
@@ -18,7 +19,7 @@ func MemoryCheck() error {
 		return nil
 	}
 	now := time.Now()
-	if now.Sub(memoryLastCheck) < 2*time.Second {
+	if now.Sub(memoryLastCheck) < memoryCheckInterval {
 		return nil
 	}
 	memoryLastCheck = now
@@ -44,11 +45,12 @@ func MemoryCheckEnabled() bool {
 	return checkValue != 0
 }
 
-func InitMemoryCheck(maxMemory int64) {
+func InitMemoryCheck(maxMemory int64, checkInterval time.Duration) {
 	if maxMemory > 0 {
 		debug.SetGCPercent(10)
 		debug.SetMemoryLimit(maxMemory)
 		memoryMaxValue = maxMemory
+		memoryCheckInterval = checkInterval
 		memoryLastCheck = time.Now()
 	}
 }


### PR DESCRIPTION
This PR gives socks inbound ability to kill connections when out of memory. It is highly similar to [conntrack killer](https://github.com/SagerNet/sing-box/blob/dev-next/common/dialer/conntrack/killer.go) of [sing-box](https://github.com/SagerNet/sing-box). ~~Maybe this PR will violate its GPL license?~~
Because most clients use tun2socks as the tun of Xray, I think only supporting socks is enough.