### PR TITLE
support memory check for socks inbound

### DIFF
--- a/common/memory/errors.generated.go
+++ b/common/memory/errors.generated.go
@@ -1,0 +1,9 @@
+package memory
+
+import "github.com/xtls/xray-core/common/errors"
+
+type errPathObjHolder struct{}
+
+func newError(values ...interface{}) *errors.Error {
+	return errors.New(values...).WithPathObj(errPathObjHolder{})
+}

--- a/common/memory/memory.go
+++ b/common/memory/memory.go
@@ -1,0 +1,56 @@
+package memory
+
+import (
+	"runtime"
+	"runtime/debug"
+	"time"
+
+	"github.com/xtls/xray-core/common/platform"
+)
+
+var (
+	memoryMaxValue      int64
+	memoryCheckInterval time.Duration
+	memoryLastCheck     time.Time
+)
+
+func MemoryCheck() error {
+	if memoryMaxValue <= 0 {
+		return nil
+	}
+	now := time.Now()
+	if now.Sub(memoryLastCheck) < memoryCheckInterval {
+		return nil
+	}
+	memoryLastCheck = now
+	var memStats runtime.MemStats
+	runtime.ReadMemStats(&memStats)
+	usedMemory := int64(memStats.StackInuse + memStats.HeapInuse + memStats.HeapIdle - memStats.HeapReleased)
+	if usedMemory > memoryMaxValue {
+		go func() {
+			debug.FreeOSMemory()
+		}()
+		return newError("out of memory")
+	}
+	return nil
+}
+
+func MemoryCheckEnabled() bool {
+	const key = "xray.inbound.memory.check"
+	const defaultValue = 0
+	checkValue := platform.EnvFlag{
+		Name:    key,
+		AltName: platform.NormalizeEnvName(key),
+	}.GetValueAsInt(defaultValue)
+	return checkValue != 0
+}
+
+func InitMemoryCheck(maxMemory int64, checkInterval time.Duration) {
+	if maxMemory > 0 {
+		debug.SetGCPercent(10)
+		debug.SetMemoryLimit(maxMemory)
+		memoryMaxValue = maxMemory
+		memoryCheckInterval = checkInterval
+		memoryLastCheck = time.Now()
+	}
+}

--- a/proxy/socks/server.go
+++ b/proxy/socks/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/buf"
 	"github.com/xtls/xray-core/common/log"
+	"github.com/xtls/xray-core/common/memory"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/protocol"
 	udp_proto "github.com/xtls/xray-core/common/protocol/udp"
@@ -27,6 +28,7 @@ type Server struct {
 	config        *ServerConfig
 	policyManager policy.Manager
 	cone          bool
+	memoryCheck   bool
 }
 
 // NewServer creates a new Server object.
@@ -36,6 +38,7 @@ func NewServer(ctx context.Context, config *ServerConfig) (*Server, error) {
 		config:        config,
 		policyManager: v.GetFeature(policy.ManagerType()).(policy.Manager),
 		cone:          ctx.Value("cone").(bool),
+		memoryCheck:   memory.MemoryCheckEnabled(),
 	}
 	return s, nil
 }
@@ -63,6 +66,12 @@ func (s *Server) Network() []net.Network {
 
 // Process implements proxy.Inbound.
 func (s *Server) Process(ctx context.Context, network net.Network, conn stat.Connection, dispatcher routing.Dispatcher) error {
+	if s.memoryCheck {
+		if err := memory.MemoryCheck(); err != nil {
+			return err
+		}
+	}
+
 	if inbound := session.InboundFromContext(ctx); inbound != nil {
 		inbound.Name = "socks"
 		inbound.User = &protocol.MemoryUser{


### PR DESCRIPTION
This PR gives socks inbound ability to check memory usage and try GC when out of memory.
It is highly similar to [conntrack killer](https://github.com/SagerNet/sing-box/blob/dev-next/common/dialer/conntrack/killer.go) of [sing-box](https://github.com/SagerNet/sing-box). ~~Maybe this PR will violate its GPL license?~~
Because most clients use tun2socks as the tun of Xray, I think only supporting socks is enough.
Memory usage still needs more improvements. This is the first step.