### PR TITLE
fix: dns empty response

### DIFF
--- a/app/dns/dns.go
+++ b/app/dns/dns.go
@@ -215,7 +215,7 @@ func (s *DNS) LookupIP(domain string, option dns.IPOption) ([]net.IP, error) {
 			newError("failed to lookup ip for domain ", domain, " at server ", client.Name()).Base(err).WriteToLog()
 			errs = append(errs, err)
 		}
-		if err != context.Canceled && err != context.DeadlineExceeded && err != errExpectedIPNonMatch {
+		if err != context.Canceled && err != context.DeadlineExceeded && err != errExpectedIPNonMatch && err != dns.ErrEmptyResponse {
 			return nil, err
 		}
 	}

--- a/app/dns/dns_test.go
+++ b/app/dns/dns_test.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/xtls/xray-core/app/proxyman/outbound"
 	"github.com/xtls/xray-core/app/router"
 	"github.com/xtls/xray-core/common"
+	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/serial"
 	"github.com/xtls/xray-core/core"
@@ -260,7 +261,7 @@ func TestUDPServer(t *testing.T) {
 			IPv6Enable: true,
 			FakeEnable: false,
 		})
-		if err != feature_dns.ErrEmptyResponse {
+		if !errors.AllEqual(feature_dns.ErrEmptyResponse, errors.Cause(err)) {
 			t.Fatal("error: ", err)
 		}
 		if len(ips) != 0 {

--- a/common/errors/multi_error.go
+++ b/common/errors/multi_error.go
@@ -28,3 +28,20 @@ func Combine(maybeError ...error) error {
 	}
 	return errs
 }
+
+func AllEqual(expected error, actual error) bool {
+	switch errs := actual.(type) {
+	case multiError:
+		if len(errs) == 0 {
+			return false
+		}
+		for _, err := range errs {
+			if err != expected {
+				return false
+			}
+		}
+		return true
+	default:
+		return errs == expected
+	}
+}

--- a/proxy/dns/dns.go
+++ b/proxy/dns/dns.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/buf"
+	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/net"
 	dns_proto "github.com/xtls/xray-core/common/protocol/dns"
 	"github.com/xtls/xray-core/common/session"
@@ -232,7 +233,7 @@ func (h *Handler) handleIPQuery(id uint16, qType dnsmessage.Type, domain string,
 	}
 
 	rcode := dns.RCodeFromError(err)
-	if rcode == 0 && len(ips) == 0 && err != dns.ErrEmptyResponse {
+	if rcode == 0 && len(ips) == 0 && !errors.AllEqual(dns.ErrEmptyResponse, errors.Cause(err)) {
 		newError("ip query").Base(err).WriteToLog()
 		return
 	}


### PR DESCRIPTION
Sometimes previous DNS responds empty records.

This especially happens when a province/city level DNS respond with a 0.0.0.0

```
$ drill @202.101.224.68 www.binance.com
;; ->>HEADER<<- opcode: QUERY, rcode: NOERROR, id: 39119
;; flags: qr rd ra ; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
;; QUESTION SECTION:
;; www.binance.com.	IN	A

;; ANSWER SECTION:
www.binance.com.	30	IN	A	0.0.0.0

;; AUTHORITY SECTION:

;; ADDITIONAL SECTION:

;; Query time: 12 msec
;; SERVER: 202.101.224.68
;; WHEN: Wed Apr 26 22:56:42 2023
;; MSG SIZE  rcvd: 49
```

And it later got filtered by a downstream DNS server.

```
$ drill @192.168.9.1 www.binance.com
;; ->>HEADER<<- opcode: QUERY, rcode: NOERROR, id: 5425
;; flags: qr rd ra ; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0
;; QUESTION SECTION:
;; www.binance.com.	IN	A

;; ANSWER SECTION:

;; AUTHORITY SECTION:

;; ADDITIONAL SECTION:

;; Query time: 14 msec
;; SERVER: 192.168.9.1
;; WHEN: Wed Apr 26 22:59:01 2023
;; MSG SIZE  rcvd: 33
```

(Took binance as example because I can repeat it at the moment. But it sometimes happen to raw.githubusercontent.com as well.)

The target line on this pull request previously broke the query loop, which led to after DNS servers not able to participate in.

Related logs:

```
journalctl -fu xray | rg www.binance.com
```

```
Apr 26 23:09:34 t8 xray[324997]: 2023/04/26 23:09:34 [Info] app/dns: UDP:127.0.0.1:53 got answer: www.binance.com. TypeA -> [] 5.571354ms
Apr 26 23:09:34 t8 xray[324997]: 2023/04/26 23:09:34 [Info] app/dns: failed to lookup ip for domain www.binance.com at server UDP:127.0.0.1:53 > empty response
```

No more dns query log even there are more DNS servers configured.