### PR TITLE
为 Dockerfile 设置 `ENTRYPOINT`

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -18,4 +18,5 @@ RUN set -ex \
 
 VOLUME /etc/xray
 ENV TZ=Asia/Shanghai
-CMD [ "/usr/bin/xray", "-config", "/etc/xray/config.json" ]
+ENTRYPOINT [ "/usr/bin/xray" ]
+CMD [ "-config", "/etc/xray/config.json" ]


### PR DESCRIPTION
在需要自定义参数时可以省略输入 `/usr/bin/xray`，例如：

```bash
# before
docker run --rm ghcr.io/xtls/xray-core /usr/bin/xray x25519
# after
docker run --rm ghcr.io/xtls/xray-core x25519
```