### PR TITLE
Adding `security risks` flag for `Hiddify` in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - Web Panel
   - [X-UI](https://github.com/FranzKafkaYu/x-ui), [X-UI-English](https://github.com/NidukaAkalanka/x-ui-english), [3X-UI](https://github.com/MHSanaei/3x-ui), [X-UI](https://github.com/alireza0/x-ui), [X-UI](https://github.com/diditra/x-ui)
   - [Xray-UI](https://github.com/qist/xray-ui), [X-UI](https://github.com/sing-web/x-ui)
-  - [Hiddify](https://github.com/hiddify/hiddify-config)
+  - [Hiddify](https://github.com/hiddify/hiddify-config) \[Half open Source, Containing binary packages, Security Risks [#2132](https://github.com/XTLS/Xray-core/issues/2132)]
   - [Marzban](https://github.com/Gozargah/Marzban)
   - [Libertea](https://github.com/VZiChoushaDui/Libertea)
 - One Click
@@ -63,11 +63,11 @@
   - [luci-app-xray](https://github.com/yichya/luci-app-xray) ([openwrt-xray](https://github.com/yichya/openwrt-xray))
 - Windows
   - [v2rayN](https://github.com/2dust/v2rayN)
-  - [HiddifyN](https://github.com/hiddify/HiddifyN)
+  - [HiddifyN](https://github.com/hiddify/HiddifyN) \[Half open Source, Containing binary packages, Security Risks [#2132](https://github.com/XTLS/Xray-core/issues/2132)]
   - [Invisible Man - Xray](https://github.com/InvisibleManVPN/InvisibleMan-XRayClient)
 - Android
   - [v2rayNG](https://github.com/2dust/v2rayNG)
-  - [HiddifyNG](https://github.com/hiddify/HiddifyNG)
+  - [HiddifyNG](https://github.com/hiddify/HiddifyNG) \[Half open Source, Containing binary packages, Security Risks [#2132](https://github.com/XTLS/Xray-core/issues/2132)]
   - [X-flutter](https://github.com/XTLS/X-flutter)
 - iOS & macOS arm64
   - [Mango](https://github.com/arror/Mango)


### PR DESCRIPTION
* 3f0a9b776da1d558d7ca060f79f20517dfb88331 Add security risks tag to [Hiddify](https://github.com/hiddify) projects due to #2132

@tavallaie Found some security risks in Hiddify and asked for change reverts of this Pull request: #2028, which described why in https://github.com/XTLS/Xray-core/pull/2028#issuecomment-1559530044, However, I think it's better not to revert changes of this commit, I'd rather have this security notices for their project until the Hiddify team, describe the reason of having binary, non-secure, packages in their open source and free project. 

Also, meanwhile, Hiddify started advertising their project with the slogan: `Verified by Xray-core`, because their name is in the Xray-Core readme file. So that's why we have become more suspicious of it.

_**This PR can be reverted after the closing of #2132, when Hiddify team made the desired considerations.**_