### PR TITLE
REALITY protocol: Add ChaCha20-Poly1305 auth mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/seiflotfy/cuckoofilter v0.0.0-20220411075957-e3b120b3f5fb
 	github.com/stretchr/testify v1.8.4
 	github.com/v2fly/ss-bloomring v0.0.0-20210312155135-28617310f63e
-	github.com/xtls/reality v0.0.0-20230331223127-176a94313eda
+	github.com/xtls/reality v0.0.0-20230613075828-e07c3b04b983
 	golang.org/x/crypto v0.10.0
 	golang.org/x/net v0.11.0
 	golang.org/x/sync v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/v2fly/ss-bloomring v0.0.0-20210312155135-28617310f63e h1:5QefA066A1tF
 github.com/v2fly/ss-bloomring v0.0.0-20210312155135-28617310f63e/go.mod h1:5t19P9LBIrNamL6AcMQOncg/r10y3Pc01AbHeMhwlpU=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
-github.com/xtls/reality v0.0.0-20230331223127-176a94313eda h1:psRJD2RrZbnI0OWyHvXfgYCPqlRM5q5SPDcjDoDBWhE=
-github.com/xtls/reality v0.0.0-20230331223127-176a94313eda/go.mod h1:rkuAY1S9F8eI8gDiPDYvACE8e2uwkyg8qoOTuwWov7Y=
+github.com/xtls/reality v0.0.0-20230613075828-e07c3b04b983 h1:AMyzgjkh54WocjQSlCnT1LhDc/BKiUqtNOv40AkpURs=
+github.com/xtls/reality v0.0.0-20230613075828-e07c3b04b983/go.mod h1:rkuAY1S9F8eI8gDiPDYvACE8e2uwkyg8qoOTuwWov7Y=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=

--- a/transport/internet/reality/linkname.go
+++ b/transport/internet/reality/linkname.go
@@ -1,0 +1,10 @@
+package reality
+
+import (
+	_ "unsafe"
+
+	_ "github.com/xtls/reality"
+)
+
+//go:linkname aesgcmPreferred github.com/xtls/reality.aesgcmPreferred
+func aesgcmPreferred(ciphers []uint16) bool

--- a/transport/internet/reality/reality.go
+++ b/transport/internet/reality/reality.go
@@ -126,16 +126,17 @@ func UClient(c net.Conn, config *Config, ctx context.Context, dest net.Destinati
 	{
 		uConn.BuildHandshakeState()
 		hello := uConn.HandshakeState.Hello
-		rawSessionID := hello.Raw[39 : 39+32] // the location of session ID
-		for i := range rawSessionID {         // https://github.com/golang/go/issues/5373
-			rawSessionID[i] = 0
+		hello.Random = hello.Raw[39 : 39+32] // the fixed location of `Session ID`
+		for i := range hello.Random {        // https://github.com/golang/go/issues/5373
+			hello.Random[i] = 0
 		}
-		copy(hello.SessionId[8:], config.ShortId)
-		binary.BigEndian.PutUint32(hello.SessionId[4:], uint32(time.Now().Unix()))
+		hello.Random = hello.Raw[6 : 6+32] // the fixed location of `Random`
 		hello.SessionId[0] = core.Version_x
 		hello.SessionId[1] = core.Version_y
 		hello.SessionId[2] = core.Version_z
 		hello.SessionId[3] = 0 // reserved
+		binary.BigEndian.PutUint32(hello.SessionId[4:], uint32(time.Now().Unix()))
+		copy(hello.SessionId[8:], config.ShortId)
 		if config.Show {
 			fmt.Printf("REALITY localAddr: %v\thello.SessionId[:16]: %v\n", localAddr, hello.SessionId[:16])
 		}


### PR DESCRIPTION
This comes with other optimizations with current REALITY client implementation:
1. Reuse existing sessionId slice instead of allocating a new one.
2. Adjust sessionId processing order to eliminate bounds checks.
3. Cache the offset of `peerCertificates` to avoid reflection overhead.