### PR TITLE
fix udp encode error when shadowsocks  cipher none

### DIFF
--- a/proxy/shadowsocks/protocol.go
+++ b/proxy/shadowsocks/protocol.go
@@ -237,9 +237,9 @@ func EncodeUDPPacket(request *protocol.RequestHeader, payload []byte) (*buf.Buff
 
 func DecodeUDPPacket(validator *Validator, payload *buf.Buffer) (*protocol.RequestHeader, *buf.Buffer, error) {
 	bs := payload.Bytes()
-	if len(bs) <= 32 {
-		return nil, nil, newError("len(bs) <= 32")
-	}
+	// if len(bs) <= 32 {
+	// 	return nil, nil, newError("len(bs) <= 32")
+	// }
 
 	user, _, d, _, err := validator.Get(bs, protocol.RequestCommandUDP)
 	switch err {


### PR DESCRIPTION
when shadowsocks cipher is none，panic below
proxy/shadowsocks: dropping invalid UDP packet from: udp:127.0.0.1:43893 > proxy/shadowsocks: len(bs) <= 32