### PR TITLE
#2174: fix: Patch potential nil pointer deference

### DIFF
--- a/proxy/http/client.go
+++ b/proxy/http/client.go
@@ -172,6 +172,10 @@ func fillRequestHeader(ctx context.Context, header []*Header) ([]*Header, error)
 	inbound := session.InboundFromContext(ctx)
 	outbound := session.OutboundFromContext(ctx)
 
+	if inbound == nil || outbound == nil {
+		return nil, newError("missing inbound or outbound metadata from context")
+	}
+
 	data := struct {
 		Source net.Destination
 		Target net.Destination


### PR DESCRIPTION
#2174 Patch potential nil pointer deference.

Inside ```proxy::http::client::fillRequestHeader()``` function, inbound and outbound metadata are extracted from the context object,

```go
inbound := session.InboundFromContext(ctx)
outbound := session.OutboundFromContext(ctx)

data := struct {
	Source net.Destination
	Target net.Destination
}{
	Source: inbound.Source,
	Target: outbound.Target,
}
```

However, both ```InboundFromContext``` and ```OutboundFromContext``` can return nil value, 

```go
func InboundFromContext(ctx context.Context) *Inbound {
	if inbound, ok := ctx.Value(inboundSessionKey).(*Inbound); ok {
		return inbound
	}
	return nil
}
```

and de-referencing them could panic the application. The error message reported by #2174 was triggered by nil inbound value.  It probably needs a separate investigation for the root cause of the missing inbound metadata, but I am adding the nil check to make it more robust for now.