### PR TITLE
#2017 fix: Check if address is nil for IsValid() function.

### DIFF
--- a/common/net/destination.go
+++ b/common/net/destination.go
@@ -113,7 +113,7 @@ func (d Destination) String() string {
 
 // IsValid returns true if this Destination is valid.
 func (d Destination) IsValid() bool {
-	return d.Network != Network_Unknown
+	return d.Address != nil && d.Network != Network_Unknown
 }
 
 // AsDestination converts current Endpoint into Destination.


### PR DESCRIPTION
#2017 Panic due to nil dereferencing

While I was investigating #2017, I saw the error log reported by @base510 

```
2023/04/30 20:00:38 [Error] common/net: invalid IP format: []
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x982078]

goroutine 92630 [running]:
github.com/xtls/xray-core/app/proxyman/outbound.(*Handler).getUoTConnection(0xc0001d5ce0, {0x13eeb40, 0xc0008e5290}, {{0x0?, 0x0?}, 0x7f?, 0x0?})
github.com/xtls/xray-core/app/proxyman/outbound/uot.go:14 +0x58
github.com/xtls/xray-core/app/proxyman/outbound.(*Handler).Dial(0xc0001d5ce0, {0x13eeb40?, 0xc0008e5290?}, {{0x0, 0x0}, 0xb, 0x2})
github.com/xtls/xray-core/app/proxyman/outbound/handler.go:214 +0xa26
github.com/xtls/xray-core/proxy/freedom.(*Handler).Process.func1()
github.com/xtls/xray-core/proxy/freedom/freedom.go:140 +0x2c6
github.com/xtls/xray-core/common/retry.(*retryer).On(0xc00125dd08, 0xc00125dd60)
github.com/xtls/xray-core/common/retry/retry.go:27 +0xdb
github.com/xtls/xray-core/proxy/freedom.(*Handler).Process(0xc00021bce0, {0x13eeb40, 0xc0008e5290}, 0xc0008e2460, {0x13e6748, 0xc0001d5ce0})
github.com/xtls/xray-core/proxy/freedom/freedom.go:126 +0x4b0
github.com/xtls/xray-core/app/proxyman/outbound.(*Handler).Dispatch(0xc000c07920?, {0x13eeb40, 0xc0008e5290}, 0xc0008e2460)
github.com/xtls/xray-core/app/proxyman/outbound/handler.go:147 +0x211
github.com/xtls/xray-core/app/dispatcher.(*DefaultDispatcher).routedDispatch(0xc0001c7f80, {0x13eeb40, 0xc0008e5290}, 0xc0008e2460, {{0x0, 0x0}, 0xb, 0x2})
github.com/xtls/xray-core/app/dispatcher/default.go:492 +0xbfe
created by github.com/xtls/xray-core/app/dispatcher.(*DefaultDispatcher).Dispatch
github.com/xtls/xray-core/app/dispatcher/default.go:302 +0x4ea
```

The error message right before the segfault suggests the root cause of the application panic. What happened under the hood was that, ```getUoTConnection()``` has a de-referencing like ```dest.Address.Family()```, while ```dest.Address``` could be nil.

```go
func (h *Handler) getUoTConnection(ctx context.Context, dest net.Destination) (stat.Connection, error) {
	if !dest.Address.Family().IsDomain() {
		return nil, os.ErrInvalid
	}
	...
}
```

After some code searching, I noticed the real problem wasn't the function itself, but rather the outbound handler. 

```go
func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer internet.Dialer) error {
	outbound := session.OutboundFromContext(ctx)
	if outbound == nil || !outbound.Target.IsValid() {
		return newError("target not specified.")
	}
       ...
```
Before proceeding with the traffic handling logic, the code first checks if the outbound target(which is the destination address, net.Destination) is valid, which does make sense. However, I believe the ```IsValid()``` function is broken, because it's possible that the ```Address``` field could be nil. See following code.

```go
type Destination struct {
	Address Address
	Port    Port
	Network Network
}
...
func DestinationFromAddr(addr net.Addr) Destination {
	switch addr := addr.(type) {
	case *net.TCPAddr:
		return TCPDestination(IPAddress(addr.IP), Port(addr.Port))
       ...
}
...
func IPAddress(ip []byte) Address {
	switch len(ip) {
	case net.IPv4len:
       ...
	default:
		newError("invalid IP format: ", ip).AtError().WriteToLog()
		return nil
	}
}
```

Also from semantic perspective, for the destination of the proxy request, a valid destination should always include address, port and network type. In this case, ```Port``` is never nil, so I updated the function to also include address check.