### PR TITLE
CI: Add Linux loong64 build task

### DIFF
--- a/.github/build/friendly-filenames.json
+++ b/.github/build/friendly-filenames.json
@@ -22,6 +22,7 @@
   "linux-ppc64le": { "friendlyName": "linux-ppc64le" },
   "linux-ppc64": { "friendlyName": "linux-ppc64" },
   "linux-riscv64": { "friendlyName": "linux-riscv64" },
+  "linux-loong64": { "friendlyName": "linux-loong64" },
   "linux-s390x": { "friendlyName": "linux-s390x" },
   "openbsd-386": { "friendlyName": "openbsd-32" },
   "openbsd-amd64": { "friendlyName": "openbsd-64" },

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,12 +105,14 @@ jobs:
             goarch: arm
             goarm: 7
           # BEGIN Other architectures
-          # BEGIN riscv64 & ARM64
+          # BEGIN riscv64 & ARM64 & LOONG64
           - goos: linux
             goarch: arm64
           - goos: linux
             goarch: riscv64
-          # END riscv64 & ARM64
+          - goos: linux
+            goarch: loong64
+          # END riscv64 & ARM64 & LOONG64
           # BEGIN MIPS
           - goos: linux
             goarch: mips64

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pires/go-proxyproto v0.7.0
 	github.com/quic-go/quic-go v0.36.2
-	github.com/refraction-networking/utls v1.3.2
+	github.com/refraction-networking/utls v1.3.3
 	github.com/sagernet/sing v0.2.7
 	github.com/sagernet/sing-shadowsocks v0.2.2
 	github.com/sagernet/wireguard-go v0.0.0-20221116151939-c99467f53f2c

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/quic-go/qtls-go1-20 v0.2.2 h1:WLOPx6OY/hxtTxKV1Zrq20FtXtDEkeY00CGQm8G
 github.com/quic-go/qtls-go1-20 v0.2.2/go.mod h1:JKtK6mjbAVcUTN/9jZpvLbGxvdWIKS8uT7EiStoU1SM=
 github.com/quic-go/quic-go v0.36.2 h1:ZX/UNQ4gvpCv2RmwdbA6lrRjF6EBm5yZ7TMoT4NQVrA=
 github.com/quic-go/quic-go v0.36.2/go.mod h1:zPetvwDlILVxt15n3hr3Gf/I3mDf7LpLKPhR4Ez0AZQ=
-github.com/refraction-networking/utls v1.3.2 h1:o+AkWB57mkcoW36ET7uJ002CpBWHu0KPxi6vzxvPnv8=
-github.com/refraction-networking/utls v1.3.2/go.mod h1:fmoaOww2bxzzEpIKOebIsnBvjQpqP7L2vcm/9KUfm/E=
+github.com/refraction-networking/utls v1.3.3 h1:f/TBLX7KBciRyFH3bwupp+CE4fzoYKCirhdRcC490sw=
+github.com/refraction-networking/utls v1.3.3/go.mod h1:DlecWW1LMlMJu+9qpzzQqdHDT/C2LAe03EdpLUz/RL8=
 github.com/riobard/go-bloom v0.0.0-20200614022211-cdc8013cb5b3 h1:f/FNXud6gA3MNr8meMVVGxhp+QBTqY91tM8HjEuMjGg=
 github.com/riobard/go-bloom v0.0.0-20200614022211-cdc8013cb5b3/go.mod h1:HgjTstvQsPGkxUsCd2KWxErBblirPizecHcpD3ffK+s=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=


### PR DESCRIPTION
Bump github.com/refraction-networking/utls from 1.3.2 to 1.3.3 is necessary because it fixes build error on the loong64 port: https://github.com/refraction-networking/utls/pull/195

All build jobs passed: https://github.com/KatyushaScarlet/Xray-core/actions/runs/5572784642/jobs/10179217143