### PR TITLE
fix: revert previous change on IsValid() function

### DIFF
--- a/app/proxyman/outbound/uot.go
+++ b/app/proxyman/outbound/uot.go
@@ -11,6 +11,9 @@ import (
 )
 
 func (h *Handler) getUoTConnection(ctx context.Context, dest net.Destination) (stat.Connection, error) {
+	if dest.Address == nil {
+		return nil, newError("nil destination address")
+	}
 	if !dest.Address.Family().IsDomain() {
 		return nil, os.ErrInvalid
 	}

--- a/common/net/destination.go
+++ b/common/net/destination.go
@@ -113,7 +113,7 @@ func (d Destination) String() string {
 
 // IsValid returns true if this Destination is valid.
 func (d Destination) IsValid() bool {
-	return d.Address != nil && d.Network != Network_Unknown
+	return d.Network != Network_Unknown
 }
 
 // AsDestination converts current Endpoint into Destination.


### PR DESCRIPTION
My previous change: https://github.com/XTLS/Xray-core/pull/2335 made a bold assumption that in order for the destination to be valid, the IpAddress must not be nil. But throughout the code base, there might be places where the assumption is false, as the error log reported by @base510,

```
goroutine 47593 [running]:
github.com/xtls/xray-core/app/dispatcher.(*DefaultDispatcher).Dispatch(0xc0002203c0, {0x13bf960, 0xc0002264b0}, {{0x0, 0x0}, 0xb, 0x2})
github.com/xtls/xray-core/app/dispatcher/default.go:287 +0x519
github.com/xtls/xray-core/common/mux.(*Server).Dispatch(0x0?, {0x13bf960?, 0xc0002264b0?}, {{0x0?, 0x0?}, 0x11?, 0x0?})
github.com/xtls/xray-core/common/mux/server.go:41 +0xcf
...
```

For now we should revert the change and add the nil check in the function instead.