### PR TITLE
fix: correct the logic of converting Socksaddr into net.Destination.

### DIFF
--- a/common/singbridge/destination.go
+++ b/common/singbridge/destination.go
@@ -18,19 +18,25 @@ func ToNetwork(network string) net.Network {
 }
 
 func ToDestination(socksaddr M.Socksaddr, network net.Network) net.Destination {
+	// IsFqdn() implicitly checks if the domain name is valid
 	if socksaddr.IsFqdn() {
 		return net.Destination{
 			Network: network,
 			Address: net.DomainAddress(socksaddr.Fqdn),
 			Port:    net.Port(socksaddr.Port),
 		}
-	} else {
+	}
+
+	// IsIP() implicitly checks if the IP address is valid
+	if socksaddr.IsIP() {
 		return net.Destination{
 			Network: network,
 			Address: net.IPAddress(socksaddr.Addr.AsSlice()),
 			Port:    net.Port(socksaddr.Port),
 		}
 	}
+
+	return net.Destination{}
 }
 
 func ToSocksaddr(destination net.Destination) M.Socksaddr {

--- a/proxy/shadowsocks_2022/inbound_multi.go
+++ b/proxy/shadowsocks_2022/inbound_multi.go
@@ -204,7 +204,12 @@ func (i *MultiUserInbound) NewConnection(ctx context.Context, conn net.Conn, met
 	})
 	newError("tunnelling request to tcp:", metadata.Destination).WriteToLog(session.ExportIDToError(ctx))
 	dispatcher := session.DispatcherFromContext(ctx)
-	link, err := dispatcher.Dispatch(ctx, singbridge.ToDestination(metadata.Destination, net.Network_TCP))
+	destination := singbridge.ToDestination(metadata.Destination, net.Network_TCP)
+	if !destination.IsValid() {
+		return newError("invalid destination")
+	}
+
+	link, err := dispatcher.Dispatch(ctx, destination)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is following up the error log posted by @base510 in PR #2017.

The error log is as following,

```
panic: Dispatcher: Invalid destination.

goroutine 47593 [running]:
github.com/xtls/xray-core/app/dispatcher.(*DefaultDispatcher).Dispatch(0xc0002203c0, {0x13bf960, 0xc0002264b0}, {{0x0, 0x0}, 0xb, 0x2})
github.com/xtls/xray-core/app/dispatcher/default.go:287 +0x519
github.com/xtls/xray-core/common/mux.(*Server).Dispatch(0x0?, {0x13bf960?, 0xc0002264b0?}, {{0x0?, 0x0?}, 0x11?, 0x0?})
github.com/xtls/xray-core/common/mux/server.go:41 +0xcf
github.com/xtls/xray-core/proxy/shadowsocks_2022.(*MultiUserInbound).NewConnection(0xc0001c5500, {0x13bf960, 0xc0002263f0}, {0x13c5358, 0xc000224070}, {{0x120ab67, 0xb}, {{{0x0, 0xffff59745902}, 0xc000012120}, ...}, ...})
github.com/xtls/xray-core/proxy/shadowsocks_2022/inbound_multi.go:207 +0x3ef
github.com/sagernet/sing-shadowsocks/shadowaead_2022.(*MultiService[...]).newConnection(0x13cd6e0, {0x13bf960, 0xc000226210}, {0x13c6278, 0xc000014010}, {{0x120ab67, 0xb}, {{{0x0, 0xffff59745902}, 0xc000012120}, ...}, ...})
github.com/sagernet/sing-shadowsocks@v0.2.2/shadowaead_2022/service_multi.go:245 +0x11d3
github.com/sagernet/sing-shadowsocks/shadowaead_2022.(*MultiService[...]).NewConnection(0xc000ffb860?, {0x13bf960?, 0xc000226210?}, {0x13c6278?, 0xc000014010?}, {{0x0, 0x0}, {{{0x0, 0xffff59745902}, 0xc000012120}, ...}, ...})
github.com/sagernet/sing-shadowsocks@v0.2.2/shadowaead_2022/service_multi.go:118 +0x89
github.com/xtls/xray-core/proxy/shadowsocks_2022.(*MultiUserInbound).Process(0xc0001c5500, {0x13bf960, 0xc0002261e0}, 0x2, {0x13c6220?, 0xc000014010}, {0x13c1c00?, 0xc000209560})
github.com/xtls/xray-core/proxy/shadowsocks_2022/inbound_multi.go:167 +0x305
github.com/xtls/xray-core/app/proxyman/inbound.(*tcpWorker).callback(0xc000193c20, {0x13c6220, 0xc000014010})
github.com/xtls/xray-core/app/proxyman/inbound/worker.go:107 +0x6d7
created by github.com/xtls/xray-core/app/proxyman/inbound.(*tcpWorker).Start.func1
github.com/xtls/xray-core/app/proxyman/inbound/worker.go:121 +0x98
```

After some investigation, the root cause is the incorrect usage of one of the sing functions. For Shadowaead 2022 protocol, we use sing-shadowsocks library to decode the request packet. The library is supposed to return us the requesting(destination) socket address, that is either an IP address or FQDN. See here: 
https://github.com/SagerNet/sing/blob/dev/common/metadata/serializer.go
https://github.com/SagerNet/sing/blob/dev/common/metadata/addr.go#L13

The problem is that, in our code, we convert the ```Socksaddr``` into ```net.Destination```, using the function,
```go
func ToDestination(socksaddr M.Socksaddr, network net.Network) net.Destination {
	if socksaddr.IsFqdn() {
		return net.Destination{
			Network: network,
			Address: net.DomainAddress(socksaddr.Fqdn),
			Port:    net.Port(socksaddr.Port),
		}
	} else {
               return net.Destination{
			Network: network,
			Address: net.IPAddress(socksaddr.Addr.AsSlice()),
			Port:    net.Port(socksaddr.Port),
		}
        }
```

However, ```IsFqdn()``` also checks if the domain is valid internally. The function is poorly named, it should have been called ```IsValidFqdn()```. For example, ```www.example.com``` is certainly a valid domain name, but something like ```&^@&#*^aaabbbccc*&*^``` may not be a valid domain. See here: 
https://github.com/SagerNet/sing/blob/dev/common/metadata/addr.go#L45C1-L45C30
https://github.com/SagerNet/sing/blob/97761c4f0098f61ee95896e736abd07c60e6bba1/common/metadata/domain.go#L6

In other words, ```IsFqdn()``` returns false when the domain name is not valid, but it doesn't always mean the address is using IP address. As of now, it's still possible that the user can supply this garbage data into the request header. Based on this logic, if the parsed ```Socksaddr``` contains a invalid domain name, the logic will parse the socketaddr with ```net.IPAddress()```, and ```socksaddr.Addr.AsSlice()``` can be an empty array because it's not initialized.

```go
package main

import (
	"net/netip"
)

func main() {

	var ip netip.Addr

	println(ip.IsValid())      // false
	println(ip.AsSlice())      // [0/0]0x0
	println(len(ip.AsSlice())) // 0
}
```

Ideally sing library should have validate the domain name before returning the result.