### PR TITLE
Add NB4A in README/Other/sing-box

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@
   - [installReality](https://github.com/BoxXt/installReality)
   - [sbox-reality](https://github.com/Misaka-blog/sbox-reality)
   - [sing-box-for-ios](https://github.com/SagerNet/sing-box-for-ios)
+  - [NekoBox for Android](https://github.com/MatsuriDayo/NekoBoxForAndroid)
 
 ## Contributing
 


### PR DESCRIPTION
[NB4A](https://github.com/MatsuriDayo/NekoBoxForAndroid) is an Android client powered by sing-box, which support VLESS, REALITY and many other xray features.

License: [GPLv3](https://github.com/MatsuriDayo/NekoBoxForAndroid/blob/main/LICENSE)