### PR TITLE
outbound target should be overridden when fake dns sniffer takes effect

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -314,7 +314,11 @@ func (d *DefaultDispatcher) Dispatch(ctx context.Context, destination net.Destin
 				domain := result.Domain()
 				newError("sniffed domain: ", domain).WriteToLog(session.ExportIDToError(ctx))
 				destination.Address = net.ParseAddress(domain)
-				if sniffingRequest.RouteOnly && result.Protocol() != "fakedns" {
+				protocolString := result.Protocol()
+				if resComp, ok := result.(SnifferResultComposite); ok {
+					protocolString = resComp.ProtocolForDomainResult()
+				}
+				if sniffingRequest.RouteOnly && protocolString != "fakedns" {
 					ob.RouteTarget = destination
 				} else {
 					ob.Target = destination
@@ -356,7 +360,11 @@ func (d *DefaultDispatcher) DispatchLink(ctx context.Context, destination net.De
 			domain := result.Domain()
 			newError("sniffed domain: ", domain).WriteToLog(session.ExportIDToError(ctx))
 			destination.Address = net.ParseAddress(domain)
-			if sniffingRequest.RouteOnly && result.Protocol() != "fakedns" {
+			protocolString := result.Protocol()
+			if resComp, ok := result.(SnifferResultComposite); ok {
+				protocolString = resComp.ProtocolForDomainResult()
+			}
+			if sniffingRequest.RouteOnly && protocolString != "fakedns" {
 				ob.RouteTarget = destination
 			} else {
 				ob.Target = destination


### PR DESCRIPTION
这里返回的嗅探结果有可能是多个sniffer参与的结果，也就是CompositeResult
[https://github.com/XTLS/Xray-core/blob/51769fdde1ca663dcb08d942618e480bee13109f/app/dispatcher/default.go#L309](https://github.com/XTLS/Xray-core/blob/51769fdde1ca663dcb08d942618e480bee13109f/app/dispatcher/default.go#L309)

因此需要判断是否有fake dns sniffer参与，如果有，需要复写outbound.Target，才能正确代理/直连目标