### PR TITLE
JSON with Comments (jsonc) ext file

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -57,7 +57,7 @@ func GetFormatByExtension(ext string) string {
 		return "yaml"
 	case "toml":
 		return "toml"
-	case "json":
+	case "json", "jsonc":
 		return "json"
 	default:
 		return ""

--- a/main/run.go
+++ b/main/run.go
@@ -113,13 +113,15 @@ func dirExists(file string) bool {
 func getRegepxByFormat() string {
 	switch strings.ToLower(*format) {
 	case "json":
-		return `^.+\.json$`
+		// return `^.+\.jsonc?$`
+		return `^.+\.(json|jsonc)$`
 	case "toml":
 		return `^.+\.toml$`
 	case "yaml", "yml":
 		return `^.+\.(yaml|yml)$`
 	default:
-		return `^.+\.(json|toml|yaml|yml)$`
+		// return `^.+\.(jsonc?|toml|yaml|yml)$`
+		return `^.+\.(json|jsonc|toml|yaml|yml)$`
 	}
 }
 

--- a/main/run.go
+++ b/main/run.go
@@ -113,14 +113,12 @@ func dirExists(file string) bool {
 func getRegepxByFormat() string {
 	switch strings.ToLower(*format) {
 	case "json":
-		// return `^.+\.jsonc?$`
 		return `^.+\.(json|jsonc)$`
 	case "toml":
 		return `^.+\.toml$`
 	case "yaml", "yml":
 		return `^.+\.(yaml|yml)$`
 	default:
-		// return `^.+\.(jsonc?|toml|yaml|yml)$`
 		return `^.+\.(json|jsonc|toml|yaml|yml)$`
 	}
 }


### PR DESCRIPTION
既然 Xray/V2ray 内核支持可注释的 JSON，何不支持 jsonc 格式的文件呢？

例如 `config.jsonc` ，这样的文件在使用编辑工具打开时会自动识别为 JSON with Comments 文件，不会给注释报错