### PR TITLE
Replace `github.com/golang/protobuf` with its successor

### DIFF
--- a/app/observatory/observer.go
+++ b/app/observatory/observer.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/common"
 	v2net "github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/session"
@@ -19,6 +18,7 @@ import (
 	"github.com/xtls/xray-core/features/extension"
 	"github.com/xtls/xray-core/features/outbound"
 	"github.com/xtls/xray-core/transport/internet/tagged"
+	"google.golang.org/protobuf/proto"
 )
 
 type Observer struct {

--- a/app/reverse/bridge.go
+++ b/app/reverse/bridge.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/common/mux"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/session"
@@ -12,6 +11,7 @@ import (
 	"github.com/xtls/xray-core/features/routing"
 	"github.com/xtls/xray-core/transport"
 	"github.com/xtls/xray-core/transport/pipe"
+	"google.golang.org/protobuf/proto"
 )
 
 // Bridge is a component in reverse proxy, that relays connections from Portal to local address.

--- a/app/reverse/portal.go
+++ b/app/reverse/portal.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/buf"
 	"github.com/xtls/xray-core/common/mux"
@@ -15,6 +14,7 @@ import (
 	"github.com/xtls/xray-core/features/outbound"
 	"github.com/xtls/xray-core/transport"
 	"github.com/xtls/xray-core/transport/pipe"
+	"google.golang.org/protobuf/proto"
 )
 
 type Portal struct {

--- a/app/router/condition_geoip_test.go
+++ b/app/router/condition_geoip_test.go
@@ -5,12 +5,12 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/app/router"
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/platform"
 	"github.com/xtls/xray-core/common/platform/filesystem"
+	"google.golang.org/protobuf/proto"
 )
 
 func init() {

--- a/app/router/condition_test.go
+++ b/app/router/condition_test.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	. "github.com/xtls/xray-core/app/router"
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/errors"
@@ -18,6 +17,7 @@ import (
 	"github.com/xtls/xray-core/common/session"
 	"github.com/xtls/xray-core/features/routing"
 	routing_session "github.com/xtls/xray-core/features/routing/session"
+	"google.golang.org/protobuf/proto"
 )
 
 func init() {

--- a/common/serial/typed_message.go
+++ b/common/serial/typed_message.go
@@ -1,10 +1,9 @@
 package serial
 
 import (
-	"errors"
-	"reflect"
-
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
 )
 
 // ToTypedMessage converts a proto Message into TypedMessage.
@@ -21,16 +20,17 @@ func ToTypedMessage(message proto.Message) *TypedMessage {
 
 // GetMessageType returns the name of this proto Message.
 func GetMessageType(message proto.Message) string {
-	return proto.MessageName(message)
+	return string(message.ProtoReflect().Descriptor().FullName())
 }
 
 // GetInstance creates a new instance of the message with messageType.
 func GetInstance(messageType string) (interface{}, error) {
-	mType := proto.MessageType(messageType)
-	if mType == nil || mType.Elem() == nil {
-		return nil, errors.New("Serial: Unknown type: " + messageType)
+	messageTypeDescriptor := protoreflect.FullName(messageType)
+	mType, err := protoregistry.GlobalTypes.FindMessageByName(messageTypeDescriptor)
+	if err != nil {
+		return nil, err
 	}
-	return reflect.New(mType.Elem()).Interface(), nil
+	return mType.New().Interface(), nil
 }
 
 // GetInstance converts current TypedMessage into a proto Message.

--- a/core/config.go
+++ b/core/config.go
@@ -4,11 +4,11 @@ import (
 	"io"
 	"strings"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/buf"
 	"github.com/xtls/xray-core/common/cmdarg"
 	"github.com/xtls/xray-core/main/confloader"
+	"google.golang.org/protobuf/proto"
 )
 
 // ConfigFormat is a configurable format of Xray config file.

--- a/core/functions_test.go
+++ b/core/functions_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/xtls/xray-core/app/dispatcher"
 	"github.com/xtls/xray-core/app/proxyman"
@@ -18,6 +17,7 @@ import (
 	"github.com/xtls/xray-core/proxy/freedom"
 	"github.com/xtls/xray-core/testing/servers/tcp"
 	"github.com/xtls/xray-core/testing/servers/udp"
+	"google.golang.org/protobuf/proto"
 )
 
 func xor(b []byte) []byte {

--- a/core/xray_test.go
+++ b/core/xray_test.go
@@ -3,7 +3,6 @@ package core_test
 import (
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/app/dispatcher"
 	"github.com/xtls/xray-core/app/proxyman"
 	"github.com/xtls/xray-core/common"
@@ -19,6 +18,7 @@ import (
 	"github.com/xtls/xray-core/proxy/vmess"
 	"github.com/xtls/xray-core/proxy/vmess/outbound"
 	"github.com/xtls/xray-core/testing/servers/tcp"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestXrayDependency(t *testing.T) {

--- a/features/extension/observatory.go
+++ b/features/extension/observatory.go
@@ -3,8 +3,8 @@ package extension
 import (
 	"context"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/features"
+	"google.golang.org/protobuf/proto"
 )
 
 type Observatory interface {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.20
 require (
 	github.com/ghodss/yaml v1.0.1-0.20220118164431-d8423dcdf344
 	github.com/golang/mock v1.6.0
-	github.com/golang/protobuf v1.5.3
 	github.com/google/go-cmp v0.5.9
 	github.com/gorilla/websocket v1.5.0
 	github.com/miekg/dns v1.1.55
@@ -38,6 +37,7 @@ require (
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/gaukas/godicttls v0.0.3 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/pprof v0.0.0-20230602150820-91b7bce49751 // indirect
 	github.com/klauspost/compress v1.16.6 // indirect

--- a/infra/conf/blackhole.go
+++ b/infra/conf/blackhole.go
@@ -3,9 +3,9 @@ package conf
 import (
 	"encoding/json"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/common/serial"
 	"github.com/xtls/xray-core/proxy/blackhole"
+	"google.golang.org/protobuf/proto"
 )
 
 type NoneResponse struct{}

--- a/infra/conf/buildable.go
+++ b/infra/conf/buildable.go
@@ -1,6 +1,6 @@
 package conf
 
-import "github.com/golang/protobuf/proto"
+import "google.golang.org/protobuf/proto"
 
 type Buildable interface {
 	Build() (proto.Message, error)

--- a/infra/conf/dns_proxy.go
+++ b/infra/conf/dns_proxy.go
@@ -1,9 +1,9 @@
 package conf
 
 import (
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/proxy/dns"
+	"google.golang.org/protobuf/proto"
 )
 
 type DNSOutboundConfig struct {

--- a/infra/conf/dns_test.go
+++ b/infra/conf/dns_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/app/dns"
 	"github.com/xtls/xray-core/app/router"
 	"github.com/xtls/xray-core/common"
@@ -14,6 +13,7 @@ import (
 	"github.com/xtls/xray-core/common/platform"
 	"github.com/xtls/xray-core/common/platform/filesystem"
 	. "github.com/xtls/xray-core/infra/conf"
+	"google.golang.org/protobuf/proto"
 )
 
 func init() {

--- a/infra/conf/dokodemo.go
+++ b/infra/conf/dokodemo.go
@@ -1,8 +1,8 @@
 package conf
 
 import (
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/proxy/dokodemo"
+	"google.golang.org/protobuf/proto"
 )
 
 type DokodemoConfig struct {

--- a/infra/conf/freedom.go
+++ b/infra/conf/freedom.go
@@ -5,10 +5,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/golang/protobuf/proto"
 	v2net "github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/protocol"
 	"github.com/xtls/xray-core/proxy/freedom"
+	"google.golang.org/protobuf/proto"
 )
 
 type FreedomConfig struct {

--- a/infra/conf/general_test.go
+++ b/infra/conf/general_test.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/common"
 	. "github.com/xtls/xray-core/infra/conf"
+	"google.golang.org/protobuf/proto"
 )
 
 func loadJSON(creator func() Buildable) func(string) (proto.Message, error) {

--- a/infra/conf/grpc.go
+++ b/infra/conf/grpc.go
@@ -1,8 +1,8 @@
 package conf
 
 import (
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/transport/internet/grpc"
+	"google.golang.org/protobuf/proto"
 )
 
 type GRPCConfig struct {

--- a/infra/conf/http.go
+++ b/infra/conf/http.go
@@ -3,10 +3,10 @@ package conf
 import (
 	"encoding/json"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/common/protocol"
 	"github.com/xtls/xray-core/common/serial"
 	"github.com/xtls/xray-core/proxy/http"
+	"google.golang.org/protobuf/proto"
 )
 
 type HTTPAccount struct {

--- a/infra/conf/loopback.go
+++ b/infra/conf/loopback.go
@@ -1,8 +1,8 @@
 package conf
 
 import (
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/proxy/loopback"
+	"google.golang.org/protobuf/proto"
 )
 
 type LoopbackConfig struct {

--- a/infra/conf/observatory.go
+++ b/infra/conf/observatory.go
@@ -1,9 +1,9 @@
 package conf
 
 import (
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/app/observatory"
 	"github.com/xtls/xray-core/infra/conf/cfgcommon/duration"
+	"google.golang.org/protobuf/proto"
 )
 
 type ObservatoryConfig struct {

--- a/infra/conf/reverse.go
+++ b/infra/conf/reverse.go
@@ -1,8 +1,8 @@
 package conf
 
 import (
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/app/reverse"
+	"google.golang.org/protobuf/proto"
 )
 
 type BridgeConfig struct {

--- a/infra/conf/router_test.go
+++ b/infra/conf/router_test.go
@@ -7,13 +7,13 @@ import (
 	"testing"
 	_ "unsafe"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/app/router"
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/platform"
 	"github.com/xtls/xray-core/common/platform/filesystem"
 	. "github.com/xtls/xray-core/infra/conf"
+	"google.golang.org/protobuf/proto"
 )
 
 func init() {

--- a/infra/conf/shadowsocks.go
+++ b/infra/conf/shadowsocks.go
@@ -3,13 +3,13 @@ package conf
 import (
 	"strings"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/sagernet/sing-shadowsocks/shadowaead_2022"
 	C "github.com/sagernet/sing/common"
 	"github.com/xtls/xray-core/common/protocol"
 	"github.com/xtls/xray-core/common/serial"
 	"github.com/xtls/xray-core/proxy/shadowsocks"
 	"github.com/xtls/xray-core/proxy/shadowsocks_2022"
+	"google.golang.org/protobuf/proto"
 )
 
 func cipherFromString(c string) shadowsocks.CipherType {

--- a/infra/conf/socks.go
+++ b/infra/conf/socks.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/common/protocol"
 	"github.com/xtls/xray-core/common/serial"
 	"github.com/xtls/xray-core/proxy/socks"
+	"google.golang.org/protobuf/proto"
 )
 
 type SocksAccount struct {

--- a/infra/conf/transport_authenticators.go
+++ b/infra/conf/transport_authenticators.go
@@ -3,7 +3,6 @@ package conf
 import (
 	"sort"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/transport/internet/headers/dns"
 	"github.com/xtls/xray-core/transport/internet/headers/http"
 	"github.com/xtls/xray-core/transport/internet/headers/noop"
@@ -12,6 +11,7 @@ import (
 	"github.com/xtls/xray-core/transport/internet/headers/utp"
 	"github.com/xtls/xray-core/transport/internet/headers/wechat"
 	"github.com/xtls/xray-core/transport/internet/headers/wireguard"
+	"google.golang.org/protobuf/proto"
 )
 
 type NoOpAuthenticator struct{}

--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/platform/filesystem"
 	"github.com/xtls/xray-core/common/protocol"
@@ -26,6 +25,7 @@ import (
 	"github.com/xtls/xray-core/transport/internet/tcp"
 	"github.com/xtls/xray-core/transport/internet/tls"
 	"github.com/xtls/xray-core/transport/internet/websocket"
+	"google.golang.org/protobuf/proto"
 )
 
 var (

--- a/infra/conf/transport_test.go
+++ b/infra/conf/transport_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/common/protocol"
 	"github.com/xtls/xray-core/common/serial"
 	. "github.com/xtls/xray-core/infra/conf"
@@ -18,6 +17,7 @@ import (
 	"github.com/xtls/xray-core/transport/internet/quic"
 	"github.com/xtls/xray-core/transport/internet/tcp"
 	"github.com/xtls/xray-core/transport/internet/websocket"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestSocketConfig(t *testing.T) {

--- a/infra/conf/trojan.go
+++ b/infra/conf/trojan.go
@@ -6,11 +6,11 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/protocol"
 	"github.com/xtls/xray-core/common/serial"
 	"github.com/xtls/xray-core/proxy/trojan"
+	"google.golang.org/protobuf/proto"
 )
 
 // TrojanServerTarget is configuration of a single trojan server

--- a/infra/conf/vless.go
+++ b/infra/conf/vless.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/protocol"
 	"github.com/xtls/xray-core/common/serial"
@@ -14,6 +13,7 @@ import (
 	"github.com/xtls/xray-core/proxy/vless"
 	"github.com/xtls/xray-core/proxy/vless/inbound"
 	"github.com/xtls/xray-core/proxy/vless/outbound"
+	"google.golang.org/protobuf/proto"
 )
 
 type VLessInboundFallback struct {

--- a/infra/conf/vmess.go
+++ b/infra/conf/vmess.go
@@ -4,13 +4,13 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/common/protocol"
 	"github.com/xtls/xray-core/common/serial"
 	"github.com/xtls/xray-core/common/uuid"
 	"github.com/xtls/xray-core/proxy/vmess"
 	"github.com/xtls/xray-core/proxy/vmess/inbound"
 	"github.com/xtls/xray-core/proxy/vmess/outbound"
+	"google.golang.org/protobuf/proto"
 )
 
 type VMessAccount struct {

--- a/infra/conf/wireguard.go
+++ b/infra/conf/wireguard.go
@@ -4,8 +4,8 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/proxy/wireguard"
+	"google.golang.org/protobuf/proto"
 )
 
 type WireGuardPeerConfig struct {

--- a/infra/conf/xray_test.go
+++ b/infra/conf/xray_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/xtls/xray-core/app/dispatcher"
 	"github.com/xtls/xray-core/app/log"
@@ -27,6 +26,7 @@ import (
 	"github.com/xtls/xray-core/transport/internet/http"
 	"github.com/xtls/xray-core/transport/internet/tls"
 	"github.com/xtls/xray-core/transport/internet/websocket"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestXrayConfig(t *testing.T) {

--- a/proxy/vless/encoding/addons.go
+++ b/proxy/vless/encoding/addons.go
@@ -3,10 +3,10 @@ package encoding
 import (
 	"io"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/common/buf"
 	"github.com/xtls/xray-core/common/protocol"
 	"github.com/xtls/xray-core/proxy/vless"
+	"google.golang.org/protobuf/proto"
 )
 
 func EncodeHeaderAddons(buffer *buf.Buffer, addons *Addons) error {

--- a/testing/scenarios/common.go
+++ b/testing/scenarios/common.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/xtls/xray-core/app/dispatcher"
 	"github.com/xtls/xray-core/app/proxyman"
 	"github.com/xtls/xray-core/common"
@@ -25,6 +24,7 @@ import (
 	"github.com/xtls/xray-core/common/serial"
 	"github.com/xtls/xray-core/common/units"
 	core "github.com/xtls/xray-core/core"
+	"google.golang.org/protobuf/proto"
 )
 
 func xor(b []byte) []byte {


### PR DESCRIPTION
Since `google.golang.org/grpc` still uses this library, there's won't noticeable change on binary size   