### PR TITLE
fix(proxy): removed the udp payload length check when encryption is disabled

### DIFF
--- a/proxy/shadowsocks/validator.go
+++ b/proxy/shadowsocks/validator.go
@@ -80,6 +80,11 @@ func (v *Validator) Get(bs []byte, command protocol.RequestCommand) (u *protocol
 
 	for _, user := range v.users {
 		if account := user.Account.(*MemoryAccount); account.Cipher.IsAEAD() {
+			// AEAD payload decoding requires the payload to be over 32 bytes
+			if len(bs) < 32 {
+				continue
+			}
+
 			aeadCipher := account.Cipher.(*AEADCipher)
 			ivLen = aeadCipher.IVSize()
 			iv := bs[:ivLen]


### PR DESCRIPTION
Following up on the issue #2310 and the previous PR #2315, I did some investigation and found the length check is not necessary when the encryption is disabled, even though it's not very common use-case to disable encryption for Shadowsocks protocol. 

Given the current way the Shadowsocks header is parsed, the length check on the payload is only necessary when the validator decrypts the payload, in which there might be array out of bound exception. To fix the problem, I moved the length check inside the validator, such that if the payload size is too short, the validator wouldn't even attempt to decrypt the payload. Meanwhile, I added a set of unit tests to cover the change.