### PR TITLE
fix(config): fix grpc cofnig parsing when service name only has one '/' char

### DIFF
--- a/transport/internet/grpc/config.go
+++ b/transport/internet/grpc/config.go
@@ -21,8 +21,13 @@ func (c *Config) getServiceName() string {
 	if !strings.HasPrefix(c.ServiceName, "/") {
 		return url.PathEscape(c.ServiceName)
 	}
+
 	// Otherwise new custom paths
-	rawServiceName := c.ServiceName[1:strings.LastIndex(c.ServiceName, "/")] // trim from first to last '/'
+	lastIndex := strings.LastIndex(c.ServiceName, "/")
+	if lastIndex < 1 {
+		lastIndex = 1
+	}
+	rawServiceName := c.ServiceName[1:lastIndex] // trim from first to last '/'
 	serviceNameParts := strings.Split(rawServiceName, "/")
 	for i := range serviceNameParts {
 		serviceNameParts[i] = url.PathEscape(serviceNameParts[i])

--- a/transport/internet/grpc/config_test.go
+++ b/transport/internet/grpc/config_test.go
@@ -1,8 +1,9 @@
 package grpc
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConfig_GetServiceName(t *testing.T) {
@@ -30,6 +31,11 @@ func TestConfig_GetServiceName(t *testing.T) {
 			TestName:    "escape absolute path",
 			ServiceName: "/hello /world!/a|b",
 			Expected:    "hello%20/world%21",
+		},
+		{
+			TestName:    "path with only one '/'",
+			ServiceName: "/foo",
+			Expected:    "",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Following up on #2460, it looks like the service name parsing assumes the service name string in the config file always contains more than 2 '/' characters, which is not always the case. 

```go
lastIndex := strings.LastIndex(c.ServiceName, "/")   // Might return 0
c.ServiceName[1:strings.LastIndex(c.ServiceName, "/")]  // Might become c.ServiceName[1:0] ==> slice bounds out of range [1:0]
```

And when it happens, the entire program would crash due to ```panic: runtime error: slice bounds out of range [1:0]``` error. To reduce the amount of application panic with error messages full of golang jargon, that create confusion to new users, I made it the service name parsing safe and would return empty string if it can't find any.

Meanwhile, since I am not too familiar with GRPC, I am not exactly sure if it's legitimate to have the service name as an empty string. We could add this validation logic later on during config parsing to explicitly block empty service name.