### PR TITLE
fix(common): strmatcher match domain safety

### DIFF
--- a/common/strmatcher/ac_automaton_matcher.go
+++ b/common/strmatcher/ac_automaton_matcher.go
@@ -225,7 +225,11 @@ func (ac *ACAutomaton) Match(s string) bool {
 	// 2. the match string is through a fail edge. NOT FULL MATCH
 	// 2.1 Through a fail edge, but there exists a valid node. SUBSTR
 	for i := len(s) - 1; i >= 0; i-- {
-		idx := char2Index[s[i]]
+		chr := int(s[i])
+		if chr >= len(char2Index) {
+			return false
+		}
+		idx := char2Index[chr]
 		fullMatch = fullMatch && ac.trie[node][idx].edgeType
 		node = ac.trie[node][idx].nextNode
 		switch ac.exists[node].matchType {

--- a/common/strmatcher/strmatcher_test.go
+++ b/common/strmatcher/strmatcher_test.go
@@ -217,6 +217,10 @@ func TestACAutomaton(t *testing.T) {
 				pattern: "vvgoogle.com",
 				res:     true,
 			},
+			{
+				pattern: "½",
+				res:     false,
+			},
 		}
 		for _, test := range cases2Output {
 			if m := ac.Match(test.pattern); m != test.res {
@@ -224,7 +228,6 @@ func TestACAutomaton(t *testing.T) {
 			}
 		}
 	}
-
 	{
 		cases3Input := []struct {
 			pattern string


### PR DESCRIPTION
DomainMatcher panic when dispatch invalid domain

```
Aug 22 11:58:48 cds04 xray[237757]: panic: runtime error: index out of range [189] with length 127
Aug 22 11:58:48 cds04 xray[237757]: goroutine 6439 [running]:
Aug 22 11:58:48 cds04 xray[237757]: github.com/xtls/xray-core/common/strmatcher.(*ACAutomaton).Match(...)
Aug 22 11:58:48 cds04 xray[237757]: #011github.com/xtls/xray-core/common/strmatcher/ac_automaton_matcher.go:228
Aug 22 11:58:48 cds04 xray[237757]: github.com/xtls/xray-core/common/strmatcher.(*MphMatcherGroup).Match(0xc0004e4900, {0xc001839cd0, 0xc})
Aug 22 11:58:48 cds04 xray[237757]: #011github.com/xtls/xray-core/common/strmatcher/mph_matcher.go:186 +0x39b
Aug 22 11:58:48 cds04 xray[237757]: github.com/xtls/xray-core/app/router.(*DomainMatcher).ApplyDomain(0xc000265650, {0xc001839cd0?, 0xc0002f1150?})
Aug 22 11:58:48 cds04 xray[237757]: #011github.com/xtls/xray-core/app/router/condition.go:102 +0x4a
Aug 22 11:58:48 cds04 xray[237757]: github.com/xtls/xray-core/app/router.(*DomainMatcher).Apply(0xc000128630?, {0x13f6e18?, 0xc0007c7050?})
Aug 22 11:58:48 cds04 xray[237757]: #011github.com/xtls/xray-core/app/router/condition.go:111 +0x4d
Aug 22 11:58:48 cds04 xray[237757]: github.com/xtls/xray-core/app/router.(*ConditionChan).Apply(0xc00112ad10?, {0x13f6e18, 0xc0007c7050})
Aug 22 11:58:48 cds04 xray[237757]: #011github.com/xtls/xray-core/app/router/condition.go:32 +0x6e
Aug 22 11:58:48 cds04 xray[237757]: github.com/xtls/xray-core/app/router.(*Rule).Apply(...)
Aug 22 11:58:48 cds04 xray[237757]: #011github.com/xtls/xray-core/app/router/config.go:63
Aug 22 11:58:48 cds04 xray[237757]: github.com/xtls/xray-core/app/router.(*Router).pickRouteInternal(0xc00003fcc0, {0x13f6e18, 0xc0007c7050})
Aug 22 11:58:48 cds04 xray[237757]: #011github.com/xtls/xray-core/app/router/router.go:94 +0x196
Aug 22 11:58:48 cds04 xray[237757]: github.com/xtls/xray-core/app/router.(*Router).PickRoute(0x13eeb40?, {0x13f6e18?, 0xc0007c7050?})
Aug 22 11:58:48 cds04 xray[237757]: #011github.com/xtls/xray-core/app/router/router.go:72 +0x27
Aug 22 11:58:48 cds04 xray[237757]: github.com/xtls/xray-core/app/dispatcher.(*DefaultDispatcher).routedDispatch(0xc0004bdce0, {0x13eeb40, 0xc000bf9a10}, 0xc0004f4160, {{0x13f0548, 0xc000d86420}, 0x7d01, 0x2})
Aug 22 11:58:48 cds04 xray[237757]: #011github.com/xtls/xray-core/app/dispatcher/default.go:452 +0x2bc
Aug 22 11:58:48 cds04 xray[237757]: github.com/xtls/xray-core/app/dispatcher.(*DefaultDispatcher).Dispatch.func1()
Aug 22 11:58:48 cds04 xray[237757]: #011github.com/xtls/xray-core/app/dispatcher/default.go:323 +0x4c5
Aug 22 11:58:48 cds04 xray[237757]: created by github.com/xtls/xray-core/app/dispatcher.(*DefaultDispatcher).Dispatch
Aug 22 11:58:48 cds04 xray[237757]: #011github.com/xtls/xray-core/app/dispatcher/default.go:304 +0x3dd
Aug 22 11:58:48 cds04 systemd[1]: xray.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
```