### PR TITLE
fix typo in default.go

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -195,7 +195,7 @@ func (d *DefaultDispatcher) shouldOverride(ctx context.Context, result SniffResu
 		protocolString = resComp.ProtocolForDomainResult()
 	}
 	for _, p := range request.OverrideDestinationForProtocol {
-		if strings.HasPrefix(protocolString, p) || strings.HasPrefix(protocolString, p) {
+		if strings.HasPrefix(protocolString, p) || strings.HasPrefix(p, protocolString) {
 			return true
 		}
 		if fkr0, ok := d.fdns.(dns.FakeDNSEngineRev0); ok && protocolString != "bittorrent" && p == "fakedns" &&


### PR DESCRIPTION
`strings.HasPrefix(p, protocolString)` is for `strings.HasPrefix("fakedns+others", "fakedns")`.

I tested that "fakedns+others" does not work at all so this fix is in fact meaningless, only making "fakedns+others" identical to "fakedns". Maybe you can remove related code.

related:
https://github.com/v2fly/v2ray-core/commit/1b0e046
https://github.com/v2fly/v2ray-core/compare/9bbc3af...3c0aff7 (incorrect fix)
