### PR TITLE
Add Streisand to README/GUI Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@
 - iOS & macOS arm64
   - [Mango](https://github.com/arror/Mango)
   - [FoXray](https://apps.apple.com/app/foxray/id6448898396)
+  - [Streisand](https://apps.apple.com/app/streisand/id6450534064)
 - macOS arm64 & x64
   - [V2rayU](https://github.com/yanue/V2rayU)
   - [V2RayXS](https://github.com/tzmax/V2RayXS)


### PR DESCRIPTION
Streisand is a free iOS client with Xray-Core v1.8.4 support, offering routing and custom DNS features.