### PR TITLE
fix dns client ip format detect error

### DIFF
--- a/features/dns/localdns/client.go
+++ b/features/dns/localdns/client.go
@@ -33,10 +33,10 @@ func (*Client) LookupIP(host string, option dns.IPOption) ([]net.IP, error) {
 		if parsed != nil {
 			parsedIPs = append(parsedIPs, parsed.IP())
 		}
-		if len(ip) == net.IPv4len {
+		if ip.To4() != nil {
 			ipv4 = append(ipv4, ip)
 		}
-		if len(ip) == net.IPv6len {
+		if ip.To16() != nil {
 			ipv6 = append(ipv6, ip)
 		}
 	}


### PR DESCRIPTION
Problem line: https://github.com/XTLS/Xray-core/blob/e244db76fbf871cc61f2f4d99f2676be27c2d9e8/features/dns/localdns/client.go#L36

IPv4 format address is recognized as ipv6 format address.

Code below should fix this issue:

```go
for _, ip := range ips {
	parsed := net.IPAddress(ip)
	if parsed != nil {
		parsedIPs = append(parsedIPs, parsed.IP())
	}
	if ip.To4() != nil {
		ipv4 = append(ipv4, ip)
	}
	if ip.To16() != nil {
		ipv6 = append(ipv6, ip)
	}
}
```