### PR TITLE
fix FakeDns Udp Src Nat

### DIFF
--- a/common/buf/override.go
+++ b/common/buf/override.go
@@ -26,11 +26,12 @@ type EndpointOverrideWriter struct {
 	Writer
 	Dest         net.Address
 	OriginalDest net.Address
+	FakeIP       bool
 }
 
 func (w *EndpointOverrideWriter) WriteMultiBuffer(mb MultiBuffer) error {
 	for _, b := range mb {
-		if b.UDP != nil && b.UDP.Address == w.Dest {
+		if b.UDP != nil && (b.UDP.Address == w.Dest || w.FakeIP) {
 			b.UDP.Address = w.OriginalDest
 		}
 	}


### PR DESCRIPTION
使用 Xray 部署透明代理，使用 fakedns 的时候 udp不通，
原因是 override.go 这个文件里面，udp 包从 xray 发回至于 客户机的时候，缺少对fakeip的判断，导致回包的 src 地址用的是远程地址而不是fakeIP，导致丢包