### PR TITLE
Override inbounds in multi config files

### DIFF
--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -492,11 +492,11 @@ func (c *Config) Override(o *Config, fn string) {
 		for i := range o.InboundConfigs {
 			if idx := c.findInboundTag(o.InboundConfigs[i].Tag); idx > -1 {
 				c.InboundConfigs[idx] = o.InboundConfigs[i]
-				ctllog.Println("[", fn, "] updated inbound with tag: ", o.InboundConfigs[0].Tag)
+				newError("[", fn, "] updated inbound with tag: ", o.InboundConfigs[i].Tag).AtInfo().WriteToLog()
 
 			} else {
 				c.InboundConfigs = append(c.InboundConfigs, o.InboundConfigs[i])
-				ctllog.Println("[", fn, "] appended inbound with tag: ", o.InboundConfigs[0].Tag)
+				newError("[", fn, "] appended inbound with tag: ", o.InboundConfigs[i].Tag).AtInfo().WriteToLog()
 			}
 
 		}

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -489,16 +489,16 @@ func (c *Config) Override(o *Config, fn string) {
 
 	// update the Inbound in slice if the only one in overide config has same tag
 	if len(o.InboundConfigs) > 0 {
-		if len(c.InboundConfigs) > 0 && len(o.InboundConfigs) == 1 {
-			if idx := c.findInboundTag(o.InboundConfigs[0].Tag); idx > -1 {
-				c.InboundConfigs[idx] = o.InboundConfigs[0]
+		for i := range o.InboundConfigs {
+			if idx := c.findInboundTag(o.InboundConfigs[i].Tag); idx > -1 {
+				c.InboundConfigs[idx] = o.InboundConfigs[i]
 				ctllog.Println("[", fn, "] updated inbound with tag: ", o.InboundConfigs[0].Tag)
+
 			} else {
-				c.InboundConfigs = append(c.InboundConfigs, o.InboundConfigs[0])
+				c.InboundConfigs = append(c.InboundConfigs, o.InboundConfigs[i])
 				ctllog.Println("[", fn, "] appended inbound with tag: ", o.InboundConfigs[0].Tag)
 			}
-		} else {
-			c.InboundConfigs = o.InboundConfigs
+
 		}
 	}
 

--- a/infra/conf/xray_test.go
+++ b/infra/conf/xray_test.go
@@ -427,7 +427,7 @@ func TestConfig_Override(t *testing.T) {
 			&Config{InboundConfigs: []InboundDetourConfig{{Tag: "pos0"}, {Protocol: "vmess", Tag: "pos1"}}},
 			&Config{InboundConfigs: []InboundDetourConfig{{Tag: "pos1", Protocol: "kcp"}, {Tag: "pos2", Protocol: "kcp"}}},
 			"",
-			&Config{InboundConfigs: []InboundDetourConfig{{Tag: "pos1", Protocol: "kcp"}, {Tag: "pos2", Protocol: "kcp"}}},
+			&Config{InboundConfigs: []InboundDetourConfig{{Tag: "pos0"}, {Tag: "pos1", Protocol: "kcp"}, {Tag: "pos2", Protocol: "kcp"}}},
 		},
 		{
 			"replace/notag-append",


### PR DESCRIPTION
when use multi config file inbounds not appends :
` ./xray -c config.json -c config2.json -c config3.json`
issue mentioned in https://github.com/XTLS/Xray-core/issues/2606