### PR TITLE
优化ws多并发时的表现

### DIFF
--- a/transport/internet/websocket/hub.go
+++ b/transport/internet/websocket/hub.go
@@ -28,8 +28,8 @@ type requestHandler struct {
 var replacer = strings.NewReplacer("+", "-", "/", "_", "=", "")
 
 var upgrader = &websocket.Upgrader{
-	ReadBufferSize:   4 * 1024,
-	WriteBufferSize:  4 * 1024,
+	ReadBufferSize:   0,
+	WriteBufferSize:  0,
 	HandshakeTimeout: time.Second * 4,
 	CheckOrigin: func(r *http.Request) bool {
 		return true


### PR DESCRIPTION
开ws的时候如果连接数过多xray会莫名其妙多吃很多内存 似乎是由于issues里的问题 改掉以后ram占用好像确实会减少(WTF)
见 https://github.com/gorilla/websocket/issues/223