### PR TITLE
Add link to tutorial for "Xray with WireGuard inbound"

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
   - [REALITY (English)](https://cscot.pages.dev/2023/03/02/Xray-REALITY-tutorial/)
   - [XTLS-Iran-Reality (English)](https://github.com/SasukeFreestyle/XTLS-Iran-Reality)
   - [Xray REALITY with 'steal oneself' (English)](https://computerscot.github.io/vless-xtls-utls-reality-steal-oneself.html)
+  - [Xray with WireGuard inbound (English)](https://g800.pages.dev/wireguard)
 
 ## GUI Clients
 


### PR DESCRIPTION
Add link to tutorial for "Xray with WireGuard inbound" using the new WireGuard inbound feature added in Xray-core v1.8.6.