### PR TITLE
common/ocsp: fix dropped error

### DIFF
--- a/common/ocsp/ocsp.go
+++ b/common/ocsp/ocsp.go
@@ -28,6 +28,9 @@ func GetOCSPStapling(cert [][]byte, path string) ([]byte, error) {
 	ocspData, err := GetOCSPForFile(path)
 	if err != nil {
 		ocspData, err = GetOCSPForCert(cert)
+		if err != nil {
+			return nil, err
+		}
 		if !CheckOCSPFileIsNotExist(path) {
 			err = os.Remove(path)
 			if err != nil {


### PR DESCRIPTION
This fixes a dropped `err` variable in `common/ocsp`.