### PR TITLE
Command: Add `wg` for wireguard key generation

### DIFF
--- a/main/commands/all/commands.go
+++ b/main/commands/all/commands.go
@@ -16,5 +16,6 @@ func init() {
 		tls.CmdTLS,
 		cmdUUID,
 		cmdX25519,
+		cmdWG,
 	)
 }

--- a/main/commands/all/curve25519.go
+++ b/main/commands/all/curve25519.go
@@ -1,0 +1,57 @@
+package all
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+
+	"golang.org/x/crypto/curve25519"
+)
+
+func Curve25519Genkey(StdEncoding bool, input_base64 string) {
+	var output string
+	var err error
+	var privateKey, publicKey []byte
+	var encoding *base64.Encoding
+	if *input_stdEncoding || StdEncoding {
+		encoding = base64.StdEncoding
+	} else {
+		encoding = base64.RawURLEncoding
+	}
+
+	if len(input_base64) > 0 {
+		privateKey, err = encoding.DecodeString(input_base64)
+		if err != nil {
+			output = err.Error()
+			goto out
+		}
+		if len(privateKey) != curve25519.ScalarSize {
+			output = "Invalid length of private key."
+			goto out
+		}
+	}
+
+	if privateKey == nil {
+		privateKey = make([]byte, curve25519.ScalarSize)
+		if _, err = rand.Read(privateKey); err != nil {
+			output = err.Error()
+			goto out
+		}
+	}
+
+	// Modify random bytes using algorithm described at:
+	// https://cr.yp.to/ecdh.html.
+	privateKey[0] &= 248
+	privateKey[31] &= 127 | 64
+
+	if publicKey, err = curve25519.X25519(privateKey, curve25519.Basepoint); err != nil {
+		output = err.Error()
+		goto out
+	}
+
+	output = fmt.Sprintf("Private key: %v\nPublic key: %v",
+		encoding.EncodeToString(privateKey),
+		encoding.EncodeToString(publicKey))
+out:
+	fmt.Println(output)
+}

--- a/main/commands/all/wg.go
+++ b/main/commands/all/wg.go
@@ -1,12 +1,7 @@
 package all
 
 import (
-	"crypto/rand"
-	"encoding/base64"
-	"fmt"
-
 	"github.com/xtls/xray-core/main/commands/base"
-	"golang.org/x/crypto/curve25519"
 )
 
 var cmdWG = &base.Command{
@@ -25,47 +20,8 @@ func init() {
 	cmdWG.Run = executeWG // break init loop
 }
 
-var input_curve25519 = cmdWG.Flag.String("i", "", "")
+var input_wireguard = cmdWG.Flag.String("i", "", "")
 
 func executeWG(cmd *base.Command, args []string) {
-	var output string
-	var err error
-	var privateKey, publicKey []byte
-	var encoding = base64.StdEncoding
-
-	if len(*input_curve25519) > 0 {
-		privateKey, err = base64.StdEncoding.DecodeString(*input_curve25519)
-		if err != nil {
-			output = err.Error()
-			goto out
-		}
-		if len(privateKey) != curve25519.ScalarSize {
-			output = "Invalid length of private key."
-			goto out
-		}
-	}
-
-	if privateKey == nil {
-		privateKey = make([]byte, curve25519.ScalarSize)
-		if _, err = rand.Read(privateKey); err != nil {
-			output = err.Error()
-			goto out
-		}
-	}
-
-	// Modify random bytes using algorithm described at:
-	// https://cr.yp.to/ecdh.html.
-	privateKey[0] &= 248
-	privateKey[31] &= 127 | 64
-
-	if publicKey, err = curve25519.X25519(privateKey, curve25519.Basepoint); err != nil {
-		output = err.Error()
-		goto out
-	}
-
-	output = fmt.Sprintf("Private key: %v\nPublic key: %v",
-		encoding.EncodeToString(privateKey),
-		encoding.EncodeToString(publicKey))
-out:
-	fmt.Println(output)
+	Curve25519Genkey(true, *input_wireguard)
 }

--- a/main/commands/all/wg.go
+++ b/main/commands/all/wg.go
@@ -1,0 +1,71 @@
+package all
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/xtls/xray-core/main/commands/base"
+	"golang.org/x/crypto/curve25519"
+)
+
+var cmdWG = &base.Command{
+	UsageLine: `{{.Exec}} wg [-i "private key (base64.StdEncoding)"]`,
+	Short:     `Generate key pair for wireguard key exchange`,
+	Long: `
+Generate key pair for wireguard key exchange.
+
+Random: {{.Exec}} wg
+
+From private key: {{.Exec}} wg -i "private key (base64.StdEncoding)"
+`,
+}
+
+func init() {
+	cmdWG.Run = executeWG // break init loop
+}
+
+var input_curve25519 = cmdWG.Flag.String("i", "", "")
+
+func executeWG(cmd *base.Command, args []string) {
+	var output string
+	var err error
+	var privateKey, publicKey []byte
+	var encoding = base64.StdEncoding
+
+	if len(*input_curve25519) > 0 {
+		privateKey, err = base64.StdEncoding.DecodeString(*input_curve25519)
+		if err != nil {
+			output = err.Error()
+			goto out
+		}
+		if len(privateKey) != curve25519.ScalarSize {
+			output = "Invalid length of private key."
+			goto out
+		}
+	}
+
+	if privateKey == nil {
+		privateKey = make([]byte, curve25519.ScalarSize)
+		if _, err = rand.Read(privateKey); err != nil {
+			output = err.Error()
+			goto out
+		}
+	}
+
+	// Modify random bytes using algorithm described at:
+	// https://cr.yp.to/ecdh.html.
+	privateKey[0] &= 248
+	privateKey[31] &= 127 | 64
+
+	if publicKey, err = curve25519.X25519(privateKey, curve25519.Basepoint); err != nil {
+		output = err.Error()
+		goto out
+	}
+
+	output = fmt.Sprintf("Private key: %v\nPublic key: %v",
+		encoding.EncodeToString(privateKey),
+		encoding.EncodeToString(publicKey))
+out:
+	fmt.Println(output)
+}

--- a/main/commands/all/x25519.go
+++ b/main/commands/all/x25519.go
@@ -1,12 +1,7 @@
 package all
 
 import (
-	"crypto/rand"
-	"encoding/base64"
-	"fmt"
-
 	"github.com/xtls/xray-core/main/commands/base"
-	"golang.org/x/crypto/curve25519"
 )
 
 var cmdX25519 = &base.Command{
@@ -26,55 +21,9 @@ func init() {
 	cmdX25519.Run = executeX25519 // break init loop
 }
 
-var input_base64 = cmdX25519.Flag.String("i", "", "")
 var input_stdEncoding = cmdX25519.Flag.Bool("std-encoding", false, "")
+var input_x25519 = cmdX25519.Flag.String("i", "", "")
 
 func executeX25519(cmd *base.Command, args []string) {
-	var output string
-	var err error
-	var privateKey []byte
-	var publicKey []byte
-	var encoding *base64.Encoding
-	if len(*input_base64) > 0 {
-		privateKey, err = base64.RawURLEncoding.DecodeString(*input_base64)
-		if err != nil {
-			output = err.Error()
-			goto out
-		}
-		if len(privateKey) != curve25519.ScalarSize {
-			output = "Invalid length of private key."
-			goto out
-		}
-	}
-
-	if privateKey == nil {
-		privateKey = make([]byte, curve25519.ScalarSize)
-		if _, err = rand.Read(privateKey); err != nil {
-			output = err.Error()
-			goto out
-		}
-	}
-
-	// Modify random bytes using algorithm described at:
-	// https://cr.yp.to/ecdh.html.
-	privateKey[0] &= 248
-	privateKey[31] &= 127
-	privateKey[31] |= 64
-
-	if publicKey, err = curve25519.X25519(privateKey, curve25519.Basepoint); err != nil {
-		output = err.Error()
-		goto out
-	}
-
-	if *input_stdEncoding {
-		encoding = base64.StdEncoding
-	} else {
-		encoding = base64.RawURLEncoding
-	}
-
-	output = fmt.Sprintf("Private key: %v\nPublic key: %v",
-		encoding.EncodeToString(privateKey),
-		encoding.EncodeToString(publicKey))
-out:
-	fmt.Println(output)
+	Curve25519Genkey(false, *input_x25519)
 }


### PR DESCRIPTION
```console
❯ ./xray help wg
usage: xray wg [-i "private key (base64.StdEncoding)"]

Generate key pair for wireguard key exchange.

Random: xray wg

From private key: xray wg -i "private key (base64.StdEncoding)"
❯ ./xray wg
Private key: eM02wAO5f1uVTXSD+TcbSlcV0h2YPmde0zOZk1Hy+z8=
Public key: UFZNg9/XHkLdtrzlov3hTIevmMYf8eHhSLC9SM0tQ0M=
❯ ./xray wg -i eM02wAO5f1uVTXSD+TcbSlcV0h2YPmde0zOZk1Hy+z8=
Private key: eM02wAO5f1uVTXSD+TcbSlcV0h2YPmde0zOZk1Hy+z8=
Public key: UFZNg9/XHkLdtrzlov3hTIevmMYf8eHhSLC9SM0tQ0M=
```

```console
❯ echo eM02wAO5f1uVTXSD+TcbSlcV0h2YPmde0zOZk1Hy+z8= | wg pubkey
UFZNg9/XHkLdtrzlov3hTIevmMYf8eHhSLC9SM0tQ0M=
```