### PR TITLE
Cleanup sing buffer usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/pires/go-proxyproto v0.7.0
 	github.com/quic-go/quic-go v0.40.1
 	github.com/refraction-networking/utls v1.5.4
-	github.com/sagernet/sing v0.2.19
+	github.com/sagernet/sing v0.3.0-beta.2
 	github.com/sagernet/sing-shadowsocks v0.2.6
 	github.com/seiflotfy/cuckoofilter v0.0.0-20220411075957-e3b120b3f5fb
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/refraction-networking/utls v1.5.4/go.mod h1:SPuDbBmgLGp8s+HLNc83Fuavw
 github.com/riobard/go-bloom v0.0.0-20200614022211-cdc8013cb5b3 h1:f/FNXud6gA3MNr8meMVVGxhp+QBTqY91tM8HjEuMjGg=
 github.com/riobard/go-bloom v0.0.0-20200614022211-cdc8013cb5b3/go.mod h1:HgjTstvQsPGkxUsCd2KWxErBblirPizecHcpD3ffK+s=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
-github.com/sagernet/sing v0.2.19 h1:Mdj/YJ5TtEyG+eIZaAlvX8j2cHxMN6eW4RF6Xh9iWyg=
-github.com/sagernet/sing v0.2.19/go.mod h1:Ce5LNojQOgOiWhiD8pPD6E9H7e2KgtOe3Zxx4Ou5u80=
+github.com/sagernet/sing v0.3.0-beta.2 h1:7wqgP+cMQeHS3M/64WWvJLeX07fLctBkE4+lguAFWeU=
+github.com/sagernet/sing v0.3.0-beta.2/go.mod h1:9pfuAH6mZfgnz/YjP6xu5sxx882rfyjpcrTdUpd6w3g=
 github.com/sagernet/sing-shadowsocks v0.2.6 h1:xr7ylAS/q1cQYS8oxKKajhuQcchd5VJJ4K4UZrrpp0s=
 github.com/sagernet/sing-shadowsocks v0.2.6/go.mod h1:j2YZBIpWIuElPFL/5sJAj470bcn/3QQ5lxZUNKLDNAM=
 github.com/seiflotfy/cuckoofilter v0.0.0-20220411075957-e3b120b3f5fb h1:XfLJSPIOUX+osiMraVgIrMR27uMXnRJWGm1+GL8/63U=

--- a/proxy/shadowsocks_2022/inbound.go
+++ b/proxy/shadowsocks_2022/inbound.go
@@ -88,13 +88,13 @@ func (i *Inbound) Process(ctx context.Context, network net.Network, connection s
 			}
 			for _, buffer := range mb {
 				packet := B.As(buffer.Bytes()).ToOwned()
+				buffer.Release()
 				err = i.service.NewPacket(ctx, pc, packet, metadata)
 				if err != nil {
 					packet.Release()
 					buf.ReleaseMulti(mb)
 					return err
 				}
-				buffer.Release()
 			}
 		}
 	}

--- a/proxy/shadowsocks_2022/inbound_multi.go
+++ b/proxy/shadowsocks_2022/inbound_multi.go
@@ -177,13 +177,13 @@ func (i *MultiUserInbound) Process(ctx context.Context, network net.Network, con
 			}
 			for _, buffer := range mb {
 				packet := B.As(buffer.Bytes()).ToOwned()
+				buffer.Release()
 				err = i.service.NewPacket(ctx, pc, packet, metadata)
 				if err != nil {
 					packet.Release()
 					buf.ReleaseMulti(mb)
 					return err
 				}
-				buffer.Release()
 			}
 		}
 	}

--- a/proxy/shadowsocks_2022/inbound_relay.go
+++ b/proxy/shadowsocks_2022/inbound_relay.go
@@ -109,13 +109,13 @@ func (i *RelayInbound) Process(ctx context.Context, network net.Network, connect
 			}
 			for _, buffer := range mb {
 				packet := B.As(buffer.Bytes()).ToOwned()
+				buffer.Release()
 				err = i.service.NewPacket(ctx, pc, packet, metadata)
 				if err != nil {
 					packet.Release()
 					buf.ReleaseMulti(mb)
 					return err
 				}
-				buffer.Release()
 			}
 		}
 	}

--- a/proxy/shadowsocks_2022/outbound.go
+++ b/proxy/shadowsocks_2022/outbound.go
@@ -2,7 +2,6 @@ package shadowsocks_2022
 
 import (
 	"context"
-	"runtime"
 	"time"
 
 	shadowsocks "github.com/sagernet/sing-shadowsocks"
@@ -102,27 +101,25 @@ func (o *Outbound) Process(ctx context.Context, link *transport.Link, dialer int
 			if err != nil && err != buf.ErrNotTimeoutReader && err != buf.ErrReadTimeout {
 				return newError("read payload").Base(err)
 			}
-			_payload := B.New()
-			payload := C.Dup(_payload)
-			defer payload.Release()
+			payload := B.New()
 			for {
-				payload.FullReset()
+				payload.Reset()
 				nb, n := buf.SplitBytes(mb, payload.FreeBytes())
 				if n > 0 {
 					payload.Truncate(n)
 					_, err = serverConn.Write(payload.Bytes())
 					if err != nil {
+						payload.Release()
 						return newError("write payload").Base(err)
 					}
 					handshake = true
 				}
 				if nb.IsEmpty() {
 					break
-				} else {
-					mb = nb
 				}
+				mb = nb
 			}
-			runtime.KeepAlive(_payload)
+			payload.Release()
 		}
 		if !handshake {
 			_, err = serverConn.Write(nil)


### PR DESCRIPTION
#2805 fixed compatibiltiy with newer SagerNet/sing versions. However, it is not a complete upgrade and only removed the usage to a removed function, and there are some deprecated functions still in use which should be migrated.

This PR updated sing to v0.3.x beta versions, removed stack buffer related codes, improved some buffer release scenarios and migrated FullReset usage.