### PR TITLE
Add DestIpAddress() in Dialer interface

### DIFF
--- a/app/proxyman/outbound/handler.go
+++ b/app/proxyman/outbound/handler.go
@@ -229,6 +229,10 @@ func (h *Handler) Address() net.Address {
 	return h.senderSettings.Via.AsAddress()
 }
 
+func (h *Handler) DestIpAddress() net.IP {
+	return internet.DestIpAddress()
+}
+
 // Dial implements internet.Dialer.
 func (h *Handler) Dial(ctx context.Context, dest net.Destination) (stat.Connection, error) {
 	if h.senderSettings != nil {

--- a/transport/internet/dialer.go
+++ b/transport/internet/dialer.go
@@ -22,6 +22,9 @@ type Dialer interface {
 
 	// Address returns the address used by this Dialer. Maybe nil if not known.
 	Address() net.Address
+
+	// DestIpAddress returns the ip of proxy server. It is useful in case of Android client, which prepare an IP before proxy connection is established
+	DestIpAddress() net.IP
 }
 
 // dialFunc is an interface to dial network connection to a specific destination.
@@ -66,6 +69,11 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *MemoryStrea
 	}
 
 	return nil, newError("unknown network ", dest.Network)
+}
+
+// DestIpAddress returns the ip of proxy server. It is useful in case of Android client, which prepare an IP before proxy connection is established
+func DestIpAddress() net.IP {
+	return effectiveSystemDialer.DestIpAddress()
 }
 
 var (

--- a/transport/internet/system_dialer.go
+++ b/transport/internet/system_dialer.go
@@ -16,6 +16,7 @@ var effectiveSystemDialer SystemDialer = &DefaultSystemDialer{}
 
 type SystemDialer interface {
 	Dial(ctx context.Context, source net.Address, destination net.Destination, sockopt *SocketConfig) (net.Conn, error)
+	DestIpAddress() net.IP
 }
 
 type DefaultSystemDialer struct {
@@ -108,6 +109,10 @@ func (d *DefaultSystemDialer) Dial(ctx context.Context, src net.Address, dest ne
 	return dialer.DialContext(ctx, dest.Network.SystemString(), dest.NetAddr())
 }
 
+func (d *DefaultSystemDialer) DestIpAddress() net.IP {
+	return nil
+}
+
 type PacketConnWrapper struct {
 	Conn net.PacketConn
 	Dest net.Addr
@@ -170,6 +175,10 @@ func WithAdapter(dialer SystemDialerAdapter) SystemDialer {
 
 func (v *SimpleSystemDialer) Dial(ctx context.Context, src net.Address, dest net.Destination, sockopt *SocketConfig) (net.Conn, error) {
 	return v.adapter.Dial(dest.Network.SystemString(), dest.NetAddr())
+}
+
+func (d *SimpleSystemDialer) DestIpAddress() net.IP {
+	return nil
 }
 
 // UseAlternativeSystemDialer replaces the current system dialer with a given one.


### PR DESCRIPTION
Android client prepares an IP before proxy connection is established. It is useful when connecting to wireguard (or quic) outbound with domain address. E.g. engage.cloudflareclient.com:2408