### PR TITLE
允许路由中type留空

### DIFF
--- a/infra/conf/router.go
+++ b/infra/conf/router.go
@@ -636,7 +636,7 @@ func ParseRule(msg json.RawMessage) (*router.RoutingRule, error) {
 	if err != nil {
 		return nil, newError("invalid router rule").Base(err)
 	}
-	if strings.EqualFold(rawRule.Type, "field") {
+	if rawRule.Type == "" || strings.EqualFold(rawRule.Type, "field") {
 		fieldrule, err := parseFieldRule(msg)
 		if err != nil {
 			return nil, newError("invalid field rule").Base(err)


### PR DESCRIPTION
留空 默认值为field 不用再必须留个了 "type":"field"
翻了代码 才知道原来还有两个type 不知道为什么文档不写 虽然没啥用属于可以删的级别（）