### PR TITLE
add Round-Robin Strategy to balancer

### DIFF
--- a/app/router/balancing.go
+++ b/app/router/balancing.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"context"
+	sync "sync"
 
 	"github.com/xtls/xray-core/common/dice"
 	"github.com/xtls/xray-core/features/extension"
@@ -21,6 +22,40 @@ func (s *RandomStrategy) PickOutbound(tags []string) string {
 	}
 
 	return tags[dice.Roll(n)]
+}
+
+type RoundRobinStrategy struct {
+	ctx        context.Context
+	mu         sync.Mutex
+	tags       []string
+	index      int
+	roundRobin *RoundRobinStrategy
+}
+
+func NewRoundRobin(tags []string) *RoundRobinStrategy {
+	return &RoundRobinStrategy{
+		tags: tags,
+	}
+}
+func (r *RoundRobinStrategy) NextTag() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	tags := r.tags[r.index]
+	r.index = (r.index + 1) % len(r.tags)
+	return tags
+}
+
+func (s *RoundRobinStrategy) PickOutbound(tags []string) string {
+	if len(tags) == 0 {
+		panic("0 tags")
+	}
+	if s.roundRobin == nil {
+		s.roundRobin = NewRoundRobin(tags)
+	}
+	tag := s.roundRobin.NextTag()
+
+	return tag
 }
 
 type Balancer struct {

--- a/app/router/config.go
+++ b/app/router/config.go
@@ -129,6 +129,12 @@ func (br *BalancingRule) Build(ohm outbound.Manager) (*Balancer, error) {
 			strategy:  &LeastPingStrategy{},
 			ohm:       ohm,
 		}, nil
+	case "roundRobin":
+		return &Balancer{
+			selectors: br.OutboundSelector,
+			strategy:  &RoundRobinStrategy{},
+			ohm:       ohm,
+		}, nil
 	case "random":
 		fallthrough
 	default:

--- a/infra/conf/router.go
+++ b/infra/conf/router.go
@@ -43,6 +43,8 @@ func (r *BalancingRule) Build() (*router.BalancingRule, error) {
 		strategy = strategyRandom
 	case strategyLeastPing:
 		strategy = "leastPing"
+	case strategyRoundRobin:
+		strategy = "roundRobin"
 	default:
 		return nil, newError("unknown balancing strategy: " + r.Strategy.Type)
 	}

--- a/infra/conf/router_strategy.go
+++ b/infra/conf/router_strategy.go
@@ -1,6 +1,7 @@
 package conf
 
 const (
-	strategyRandom    string = "random"
-	strategyLeastPing string = "leastping"
+	strategyRandom     string = "random"
+	strategyLeastPing  string = "leastping"
+	strategyRoundRobin string = "roundrobin"
 )


### PR DESCRIPTION
Round-Robin Strategy :
```json
    "routing": {
        "domainStrategy": "AsIs",
        "rules": [
            {
                "type": "field",
                "balancerTag": "b1",
                "domain": [
                  "ipv4.seeip.org"
                ]
              }
                    
        ],
        "balancers" : [{
            "tag": "b1",
            "selector": ["proxy"],
            "strategy": {
                "type":"roundRobin"
            }
          }
        ]
    },

```