### PR TITLE
fix reality ECDH crash 

### DIFF
--- a/transport/internet/reality/reality.go
+++ b/transport/internet/reality/reality.go
@@ -136,7 +136,10 @@ func UClient(c net.Conn, config *Config, ctx context.Context, dest net.Destinati
 		if config.Show {
 			newError(fmt.Sprintf("REALITY localAddr: %v\thello.SessionId[:16]: %v\n", localAddr, hello.SessionId[:16])).WriteToLog(session.ExportIDToError(ctx))
 		}
-		publicKey, _ := ecdh.X25519().NewPublicKey(config.PublicKey)
+		publicKey, err := ecdh.X25519().NewPublicKey(config.PublicKey)
+		if err != nil {
+			return nil, errors.New("REALITY: publicKey == nil")
+		}
 		uConn.AuthKey, _ = uConn.HandshakeState.State13.EcdheKey.ECDH(publicKey)
 		if uConn.AuthKey == nil {
 			return nil, errors.New("REALITY: SharedKey == nil")


### PR DESCRIPTION
recently we have crash in new xray versions on IOS.
```go
EXC_BAD_ACCESS KERN_INVALID_ADDRESS 0x0000000000000000
Crashed: Thread
0  app                          0x67f658 crypto/ecdh.(*PrivateKey).ECDH + 24
1  app                          0xa65768 github.com/xtls/xray-core/transport/internet/reality.UClient + 1608

```

also see: https://github.com/XTLS/Xray-core/commit/bcae55430410011b93dd750140e327c7601e6b6c
@yuhan6665 