### PR TITLE
fix(conf): add Windows support for Unix Domain Socket

### DIFF
--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/xtls/xray-core/app/dispatcher"
@@ -188,7 +189,7 @@ func (c *InboundDetourConfig) Build() (*core.InboundHandlerConfig, error) {
 	} else {
 		// Listen on specific IP or Unix Domain Socket
 		receiverSettings.Listen = c.ListenOn.Build()
-		listenDS := c.ListenOn.Family().IsDomain() && (c.ListenOn.Domain()[0] == '/' || c.ListenOn.Domain()[0] == '@')
+		listenDS := c.ListenOn.Family().IsDomain() && (filepath.IsAbs(c.ListenOn.Domain()) || c.ListenOn.Domain()[0] == '@')
 		listenIP := c.ListenOn.Family().IsIP() || (c.ListenOn.Family().IsDomain() && c.ListenOn.Domain() == "localhost")
 		if listenIP {
 			// Listen on specific IP, must set PortList


### PR DESCRIPTION
## Summary

add Windows support for Unix Domain Socket.

## Supports

[Windows Insider Build 17063 and later](https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/) does support Unix Domain Socket, but the UDS check logic has blocked using UDS in windows.

## Tests

config:

```yaml
log:
  loglevel: warning

inbounds:
  - listen: "C:\\Absolute-path\\to\\xray.sock"
    tag: xray
    protocol: http
    sniffing:
      enabled: true
      destOverride: ["http", "tls"]
    settings:
      auth: noauth
      allowTransparent: false

outbounds:
  - tag: freedom
    protocol: freedom

routing:
  domainStrategy: AsIs
  # all pass
  rules:
    - type: field
      inboundTag: xray
      outboundTag: freedom
```

Run `curl` (with [PowerShell Core](https://github.com/PowerShell/PowerShell)) to test the http proxy server:

```bash
curl -I --unix-socket 'C:\\Absolute-path\\to\\xray.sock' -X connect http:/ --next https://www.baidu.com/
```
