### PR TITLE
sort Outbound selector output

### DIFF
--- a/app/proxyman/outbound/outbound.go
+++ b/app/proxyman/outbound/outbound.go
@@ -152,6 +152,7 @@ func (m *Manager) Select(selectors []string) []string {
 		for _, selector := range selectors {
 			if strings.HasPrefix(tag, selector) {
 				tags = append(tags, tag)
+				break
 			}
 		}
 	}

--- a/app/proxyman/outbound/outbound.go
+++ b/app/proxyman/outbound/outbound.go
@@ -148,15 +148,10 @@ func (m *Manager) Select(selectors []string) []string {
 	tags := make([]string, 0, len(selectors))
 
 	for tag := range m.taggedHandler {
-		match := false
 		for _, selector := range selectors {
 			if strings.HasPrefix(tag, selector) {
-				match = true
-				break
+				tags = append(tags, tag)
 			}
-		}
-		if match {
-			tags = append(tags, tag)
 		}
 	}
 

--- a/app/proxyman/outbound/outbound.go
+++ b/app/proxyman/outbound/outbound.go
@@ -4,6 +4,8 @@ package outbound
 
 import (
 	"context"
+	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -154,6 +156,8 @@ func (m *Manager) Select(selectors []string) []string {
 			}
 		}
 	}
+	sort.Strings(tags)
+	fmt.Printf("tags: %v\n", tags)
 
 	return tags
 }

--- a/app/proxyman/outbound/outbound.go
+++ b/app/proxyman/outbound/outbound.go
@@ -4,7 +4,6 @@ package outbound
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"strings"
 	"sync"
@@ -157,8 +156,6 @@ func (m *Manager) Select(selectors []string) []string {
 		}
 	}
 	sort.Strings(tags)
-	fmt.Printf("tags: %v\n", tags)
-
 	return tags
 }
 


### PR DESCRIPTION
as mentioned https://github.com/XTLS/Xray-core/issues/2898#issuecomment-1880261654
outbound selector tags output may not run by order in :
https://github.com/XTLS/Xray-core/blob/3f0bc134298cf512bd29660221a030db91594faf/app/proxyman/outbound/outbound.go#L150
as mentions in golang ref 
See https://golang.org/ref/spec#For_statements


`The iteration order over maps is not specified and is not guaranteed to be the same from one iteration to the next. If a map entry that has not yet been reached is removed during iteration, the corresponding iteration value will not be produced. If a map entry is created during iteration, that entry may be produced during the iteration or may be skipped. The choice may vary for each entry created and from one iteration to the next. If the map is nil, the number of iterations is 0.
`