### PR TITLE
Add tags cache to app.proxyman.ohm.Select()

### DIFF
--- a/app/proxyman/outbound/outbound.go
+++ b/app/proxyman/outbound/outbound.go
@@ -169,8 +169,6 @@ func (m *Manager) Select(selectors []string) []string {
 	}
 
 	sort.Strings(tags)
-
-	m.tagsCache = make(map[string][]string)
 	m.tagsCache[key] = tags
 
 	return tags

--- a/app/proxyman/outbound/outbound.go
+++ b/app/proxyman/outbound/outbound.go
@@ -22,12 +22,14 @@ type Manager struct {
 	taggedHandler    map[string]outbound.Handler
 	untaggedHandlers []outbound.Handler
 	running          bool
+	tagsCache        map[string][]string
 }
 
 // New creates a new Manager.
 func New(ctx context.Context, config *proxyman.OutboundConfig) (*Manager, error) {
 	m := &Manager{
 		taggedHandler: make(map[string]outbound.Handler),
+		tagsCache:     make(map[string][]string),
 	}
 	return m, nil
 }
@@ -104,6 +106,8 @@ func (m *Manager) AddHandler(ctx context.Context, handler outbound.Handler) erro
 	m.access.Lock()
 	defer m.access.Unlock()
 
+	m.tagsCache = make(map[string][]string)
+
 	if m.defaultHandler == nil {
 		m.defaultHandler = handler
 	}
@@ -133,6 +137,8 @@ func (m *Manager) RemoveHandler(ctx context.Context, tag string) error {
 	m.access.Lock()
 	defer m.access.Unlock()
 
+	m.tagsCache = make(map[string][]string)
+
 	delete(m.taggedHandler, tag)
 	if m.defaultHandler != nil && m.defaultHandler.Tag() == tag {
 		m.defaultHandler = nil
@@ -146,6 +152,11 @@ func (m *Manager) Select(selectors []string) []string {
 	m.access.RLock()
 	defer m.access.RUnlock()
 
+	key := strings.Join(selectors, ",")
+	if cache, ok := m.tagsCache[key]; ok {
+		return cache
+	}
+
 	tags := make([]string, 0, len(selectors))
 
 	for tag := range m.taggedHandler {
@@ -156,7 +167,12 @@ func (m *Manager) Select(selectors []string) []string {
 			}
 		}
 	}
+
 	sort.Strings(tags)
+
+	m.tagsCache = make(map[string][]string)
+	m.tagsCache[key] = tags
+
 	return tags
 }
 

--- a/app/router/balancing.go
+++ b/app/router/balancing.go
@@ -2,7 +2,6 @@ package router
 
 import (
 	"context"
-	reflect "reflect"
 	sync "sync"
 
 	"github.com/xtls/xray-core/common/dice"
@@ -26,35 +25,20 @@ func (s *RandomStrategy) PickOutbound(tags []string) string {
 }
 
 type RoundRobinStrategy struct {
-	mu         sync.Mutex
-	tags       []string
-	index      int
-	roundRobin *RoundRobinStrategy
-}
-
-func NewRoundRobin(tags []string) *RoundRobinStrategy {
-	return &RoundRobinStrategy{
-		tags: tags,
-	}
-}
-func (r *RoundRobinStrategy) NextTag() string {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	tags := r.tags[r.index]
-	r.index = (r.index + 1) % len(r.tags)
-	return tags
+	mu    sync.Mutex
+	index int
 }
 
 func (s *RoundRobinStrategy) PickOutbound(tags []string) string {
-	if len(tags) == 0 {
+	n := len(tags)
+	if n == 0 {
 		panic("0 tags")
 	}
-	if s.roundRobin == nil || !reflect.DeepEqual(s.roundRobin.tags, tags) {
-		s.roundRobin = NewRoundRobin(tags)
-	}
-	tag := s.roundRobin.NextTag()
 
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	tag := tags[s.index%n]
+	s.index = (s.index + 1) % n
 	return tag
 }
 


### PR DESCRIPTION
负载均衡从outbounds manager获取tags时，很多时候返回的tags是相同的。这个PR给ohm.Select()添加缓存，减少sort次数。