### PR TITLE
Reduce size and time of UDP test

### DIFF
--- a/testing/scenarios/dokodemo_test.go
+++ b/testing/scenarios/dokodemo_test.go
@@ -171,7 +171,7 @@ func TestDokodemoUDP(t *testing.T) {
 	common.Must(err)
 	defer CloseServer(server)
 
-	clientPortRange := uint32(5)
+	clientPortRange := uint32(3)
 	retry := 1
 	clientPort := uint32(udp.PickPort())
 	for {

--- a/testing/scenarios/shadowsocks_2022_test.go
+++ b/testing/scenarios/shadowsocks_2022_test.go
@@ -32,14 +32,22 @@ func TestShadowsocks2022Tcp(t *testing.T) {
 	}
 }
 
-func TestShadowsocks2022Udp(t *testing.T) {
-	for _, method := range shadowaead_2022.List {
-		password := make([]byte, 32)
-		rand.Read(password)
-		t.Run(method, func(t *testing.T) {
-			testShadowsocks2022Udp(t, method, base64.StdEncoding.EncodeToString(password))
-		})
-	}
+func TestShadowsocks2022UdpAES128(t *testing.T) {
+	password := make([]byte, 32)
+	rand.Read(password)
+	testShadowsocks2022Udp(t, shadowaead_2022.List[0], base64.StdEncoding.EncodeToString(password))
+}
+
+func TestShadowsocks2022UdpAES256(t *testing.T) {
+	password := make([]byte, 32)
+	rand.Read(password)
+	testShadowsocks2022Udp(t, shadowaead_2022.List[1], base64.StdEncoding.EncodeToString(password))
+}
+
+func TestShadowsocks2022UdpChacha(t *testing.T) {
+	password := make([]byte, 32)
+	rand.Read(password)
+	testShadowsocks2022Udp(t, shadowaead_2022.List[2], base64.StdEncoding.EncodeToString(password))
 }
 
 func testShadowsocks2022Tcp(t *testing.T, method string, password string) {
@@ -199,7 +207,7 @@ func testShadowsocks2022Udp(t *testing.T, method string, password string) {
 	defer CloseAllServers(servers)
 
 	var errGroup errgroup.Group
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 2; i++ {
 		errGroup.Go(testUDPConn(udpClientPort, 1024, time.Second*5))
 	}
 

--- a/testing/scenarios/shadowsocks_test.go
+++ b/testing/scenarios/shadowsocks_test.go
@@ -289,7 +289,7 @@ func TestShadowsocksAES128GCMUDP(t *testing.T) {
 	defer CloseAllServers(servers)
 
 	var errGroup errgroup.Group
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 2; i++ {
 		errGroup.Go(testUDPConn(clientPort, 1024, time.Second*5))
 	}
 	if err := errGroup.Wait(); err != nil {
@@ -391,7 +391,7 @@ func TestShadowsocksAES128GCMUDPMux(t *testing.T) {
 	defer CloseAllServers(servers)
 
 	var errGroup errgroup.Group
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 2; i++ {
 		errGroup.Go(testUDPConn(clientPort, 1024, time.Second*5))
 	}
 	if err := errGroup.Wait(); err != nil {

--- a/testing/scenarios/vmess_test.go
+++ b/testing/scenarios/vmess_test.go
@@ -475,7 +475,7 @@ func TestVMessGCMUDP(t *testing.T) {
 	defer CloseAllServers(servers)
 
 	var errg errgroup.Group
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 2; i++ {
 		errg.Go(testUDPConn(clientPort, 1024, time.Second*5))
 	}
 	if err := errg.Wait(); err != nil {
@@ -1176,7 +1176,7 @@ func TestVMessGCMMuxUDP(t *testing.T) {
 
 	for range "ab" {
 		var errg errgroup.Group
-		for i := 0; i < 16; i++ {
+		for i := 0; i < 2; i++ {
 			errg.Go(testTCPConn(clientPort, 1024, time.Second*10))
 			errg.Go(testUDPConn(clientUDPPort, 1024, time.Second*10))
 		}


### PR DESCRIPTION
In the past, the UDP test in mass parallel proved to be the source of instability. This change try to improve pass rate.