### PR TITLE
chore(ci): use go version file to specify the go version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
           check-latest: true
 
       - name: Get project dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,13 +27,13 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v4
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
           check-latest: true
-      - name: Checkout codebase
-        uses: actions/checkout@v4
       - name: Restore Cache
         uses: actions/cache/restore@v4
         with:


### PR DESCRIPTION
Use [go version file to get go version](https://github.com/actions/setup-go/tree/main?tab=readme-ov-file#getting-go-version-from-the-gomod-file) instead of manually specifying.