### PR TITLE
修改go.mod中的一个小错误

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/xtls/xray-core
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/ghodss/yaml v1.0.1-0.20220118164431-d8423dcdf344


### PR DESCRIPTION
里面写的1.22但是实际上go的release没有1.22这种东西，真身是1.22.0，action里似乎没有出现问题因为本来就是1.22，但是在一些只有go1.21的机器上会尝试下载go1.22 然后这里就出现上述问题了 会报错 ```go: download go1.22 for linux/amd64: toolchain not available```
解决办法: 加上去（）