### PR TITLE
新增一个安装脚本

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 
 - Linux Script
   - [XTLS/Xray-install](https://github.com/XTLS/Xray-install)
+  - [team-cloudchaser/tempest](https://github.com/team-cloudchaser/tempest) (For Linux without systemd)
 - Docker
   - Official: [ghcr.io/xtls/xray-core](https://ghcr.io/xtls/xray-core) 
   - [iamybj/docker-xray](https://hub.docker.com/r/iamybj/docker-xray)


### PR DESCRIPTION
官方的脚本仅适用于有sysemd的系统，部分不支持systemd的系统是没法用的(点名alpine)，而且也没有其他脚本有安装方式。 隔壁还好 alpine的apk可以装v2ray 但是xray就没进包管理器了 这个脚本支持alpine(使用openrc)甚至termux(小声说一句v2ray其实也在termux的源里) ~~只是守护就没法守护了~~