### PR TITLE
Correctly propagate error in AuthenticationReader readBuffer

### DIFF
--- a/common/crypto/auth.go
+++ b/common/crypto/auth.go
@@ -178,7 +178,7 @@ func (r *AuthenticationReader) readInternal(soft bool, mb *buf.MultiBuffer) erro
 	if size <= buf.Size {
 		b, err := r.readBuffer(int32(size), int32(padding))
 		if err != nil {
-			return nil
+			return err
 		}
 		*mb = append(*mb, b)
 		return nil


### PR DESCRIPTION
一个 安全漏洞(大概是深夜敲代码不小心写错了罢) https://github.com/v2fly/v2ray-core/releases/tag/v5.14.0