### PR TITLE
fix: config `burstObservatory` override

### DIFF
--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -481,6 +481,10 @@ func (c *Config) Override(o *Config, fn string) {
 		c.Observatory = o.Observatory
 	}
 
+	if o.BurstObservatory != nil {
+		c.BurstObservatory = o.BurstObservatory
+	}
+
 	// deprecated attrs... keep them for now
 	if o.InboundConfig != nil {
 		c.InboundConfig = o.InboundConfig


### PR DESCRIPTION
问题: 当`burstObservatory`项不在第一个配置文件中时，将丢失。

修复`burstObservatory`项在多配置文件中无法覆写问题。
