### PR TITLE
允许不向服务端发送SNI

### DIFF
--- a/transport/internet/reality/reality.go
+++ b/transport/internet/reality/reality.go
@@ -116,6 +116,8 @@ func UClient(c net.Conn, config *Config, ctx context.Context, dest net.Destinati
 	}
 	if utlsConfig.ServerName == "" {
 		utlsConfig.ServerName = dest.Address.String()
+	} else if strings.ToLower(utlsConfig.ServerName) == "nosni" { // If ServerName is set to "nosni", we set it empty.
+		utlsConfig.ServerName = ""
 	}
 	uConn.ServerName = utlsConfig.ServerName
 	fingerprint := tls.GetFingerprint(config.Fingerprint)


### PR DESCRIPTION
只需要 在SNI项填入 ```nosni```  客户端就不会再发送这个扩展
```
"serverName": "nosni",
"allowInsecure": true
```
由于gotls本身的限制，如果SNI为空则必须启用Insecure.