### PR TITLE
Makefile: export GOARCH, GOOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,15 @@ NAME = xray
 
 VERSION=$(shell git describe --always --dirty)
 
+export GOARCH ?=
+export GOOS ?=
+
+ifdef GOARCH
+	ifeq ($(GOOS),darwin)
+		NAME:=$(NAME)-$(GOARCH)
+	endif
+endif
+
 LDFLAGS = -X github.com/xtls/xray-core/core.build=$(VERSION) -s -w -buildid=
 PARAMS = -trimpath -ldflags "$(LDFLAGS)" -v
 MAIN = ./main


### PR DESCRIPTION
On macOS it's possible to compile both x86_64 and aarch64 binaries and then merge them together to produce universal build. It doesn't seem possible to achieve without passing `GOARCH` and `GOOS` into the `go build` command, so this PR re-exports those env variables and tweaks the binary name to reflect the architecture.

Example usage:

```sh
XRAY_SRC_DIR="<path to xray-core checkout>"

GOOS=darwin GOARCH=amd64 make -C "$XRAY_SRC_DIR"
GOOS=darwin GOARCH=arm64 make -C "$XRAY_SRC_DIR"

local amd64_bin="$XRAY_SRC_DIR/xray-amd64"
local arm64_bin="$XRAY_SRC_DIR/xray-arm64"
local fat_bin="$XRAY_SRC_DIR/xray"

lipo -create "$amd64_bin" "$arm64_bin" -output "$fat_bin"
```
