### PR TITLE
refactor: temporarily cache geo data

### DIFF
--- a/infra/conf/router.go
+++ b/infra/conf/router.go
@@ -242,7 +242,6 @@ func (c *GeoCache) Clear() {
 }
 
 // newIPCache creates a new ipCache.
-// after use, call close() to release memory.
 func newIPCache() *ipCache {
 	return &ipCache{
 		fileContent: make(map[string][]byte),
@@ -251,7 +250,7 @@ func newIPCache() *ipCache {
 }
 
 // reset remove the content of ipCache.
-// returns true if the cache is not empty.
+// Returns true if the cache is not empty before reset.
 func (c *ipCache) reset() bool {
 	if len(c.fileContent) == 0 && len(c.geoIPs) == 0 {
 		return false
@@ -288,7 +287,6 @@ func (c *ipCache) loadIP(file, code string) ([]*router.CIDR, error) {
 }
 
 // newSiteCache creates a new siteCache.
-// after use, call close() to release memory.
 func newSiteCache() *siteCache {
 	return &siteCache{
 		fileContent: make(map[string][]byte),
@@ -297,7 +295,7 @@ func newSiteCache() *siteCache {
 }
 
 // reset remove the content of siteCache.
-// returns true if the cache is not empty.
+// Returns true if the cache is not empty before reset.
 func (c *siteCache) reset() bool {
 	if len(c.fileContent) == 0 && len(c.geoSites) == 0 {
 		return false

--- a/infra/conf/router_test.go
+++ b/infra/conf/router_test.go
@@ -44,7 +44,10 @@ func TestToCidrList(t *testing.T) {
 		"ext-ip:geoiptestrouter.dat:!ca",
 	})
 
-	_, err := ToCidrList(ips)
+	cache := NewGeoCache()
+	defer cache.Clear()
+
+	_, err := cache.ToCidrList(ips)
 	if err != nil {
 		t.Fatalf("Failed to parse geoip list, got %s", err)
 	}


### PR DESCRIPTION
## Description

Thie PR created some wrappers to temporarily cache the geo data which can reduce the CPU usage.

## Tesing

### Environment

```plain
CPU: 13th Gen Intel(R) Core(TM) i5-13600K
Memory: DDR5 32 GB@5200 MT/s
Disk: 1 TB (fs: Btrfs)
```

### Stat script

```bash
if [ -z "$1" ]; then
	echo "Usage: $0 [before|after]"
	exit 1
fi

name=$1

rm -f "${name}.sqlite"

pid=$(pgrep xray | tail -n 1)

echo "pid: $pid"

# Make 5000 records per second
procpath record --stop-without-result -i 1 -r 5000 -d "${name}.sqlite" "$..children[?(@.stat.pid == ${pid})]"

# generate the stat svg
procpath plot -d "${name}.sqlite" -q rss -q cpu -p ${pid} -f "${name}.svg"

echo "======== ${name} ========"

# io stat
echo "io stat"
echo "read_char write_char read_sys write_sys"
cat /proc/$pid/io | xargs | awk '{print $2"\t"$4"\t"$6"\t"$8}'

# cpu stat
echo
echo "cpu usage"
echo -e "user\tsystem\tidle\tio wait"
cat /proc/$pid/stat | awk '{print $14"ms\t"$15"ms\t"$16"ms\t"$42"ms"}'

echo
```

### Preparation

- With [Procpath](https://procpath.readthedocs.io/en/latest/index.html) installed to record the memory usage.
- Add `time.Sleep()` in main function for delay the configuration parsing.
- With the [latest geo data](https://github.com/Loyalsoldier/v2ray-rules-dat) downloaded.
- Setup the xray config:

  ```yaml
  log:
    loglevel: warning

  inbounds:
    - tag: transparent
      port: 10893
      protocol: dokodemo-door
      settings:
        followRedirect: true
        network: tcp,udp
      sniffing:
        destOverride:
          - http
          - tls
          - quic
        enabled: true
      streamSettings:
        sockopt:
          mark: 255
          tproxy: tproxy

  outbounds:
    - tag: direct
      protocol: freedom
      streamSettings:
        sockopt:
          mark: 255

    - tag: block
      protocol: blackhole

  routing:
    domainStrategy: IPIfNonMatch
    rules:
      - type: field
        outboundTag: direct
        domain:
          - acm.org
          - adobe.com
          - aspnetcdn.com
          - azureedge.net
          - beego.me
          - bing.net
          - caomeikeyan.com
          - cn.download.nvidia.com
          - debian.org
          - elsevier.com
          - epicgames.com
          - exp-tas.com
          - gfx.ms
          - gvt1.com
          - hcaptcha.com
          - ieee.org
          - ipify.org
          - jsdelivr.net
          - k8s.io
          - microsoftonline.com
          - msauth.net
          - msecnd.net
          - msn.com
          - npmmirror.com
          - nr-data.net
          - office.com
          - office.net
          - onenote.com
          - onenote.net
          - ooklaserver.net
          - oracle.com
          - spotify.com
          - swsindex.com
          - swsresearch.com
          - test-ipv6.com
          - time.is
          - trafficmanager.net
          - ubi.com
          - ubisoft.com
          - visualstudio.com
          - vsassets.io
          - windows.com
          - windows.net
          - windowsupdate.com
          - www.speedtest.net

      - type: field
        outboundTag: direct
        inboundTag:
          - transparent
        network: udp
        port: 123

      - type: field
        outboundTag: direct
        protocol:
          - bittorrent

      - type: field
        outboundTag: proxy
        domain:
          - gstatic.com

      - type: field
        outboundTag: direct
        ip:
          - geoip:private
          - geoip:cn

      - type: field
        outboundTag: direct
        domain:
          - geosite:cn
          - geosite:private
          - geosite:category-games@cn
          - geosite:mdn

      - type: field
        outboundTag: blackhole
        port: 0-65535
  ```

### Run tests

1. Run xray: `./xray run -c config.yaml`
2. Run the stat script:  `bash ./stat.sh [before|after]` (using "before", "after" to identify the build before or after the changes).
3. After the `xray` loaded the ruleset, hit <kbd>Ctrl + C</kbd> to stop recording and generate the usage image.

### Result

Records (please download the following images, as these images may not be viewable online):

| Before | After |
| --- | --- |
| ![before](https://github.com/XTLS/Xray-core/assets/15844309/a392205b-609d-43e5-b6d8-ee7e4e755485) | ![after](https://github.com/XTLS/Xray-core/assets/15844309/687574ee-af3b-4708-806f-edebec8371f0) |

---

Proc stat:

**Before:**

```plain
======== before ========
io stat
read_char write_char read_sys write_sys
45696753        319     5619    9

cpu usage
user    system  idle    io wait
28ms    9ms     0ms     0ms
```

**After:**

```plain
======== after ========
io stat
read_char write_char read_sys write_sys
16788810        318     2082    8

cpu usage
user    system  idle    io wait
13ms    5ms     0ms     0ms
```

---

After testing, the changes here can significantly reduce IO reads and reduce the CPU usage duration the configuration loading of this program. There is no very obvious increase in memory usage (in a small number of tests, a peak memory usage of "75MB" can be observed.
