### PR TITLE
Validate /websocket requests from browser dialer page

### DIFF
--- a/common/platform/platform.go
+++ b/common/platform/platform.go
@@ -21,7 +21,6 @@ const (
 
 	BufferSize           = "xray.ray.buffer.size"
 	BrowserDialerAddress = "xray.browser.dialer"
-	BrowserDialerOrigin = "xray.browser.dialer.origin"
 	XUDPLog              = "xray.xudp.show"
 	XUDPBaseKey          = "xray.xudp.basekey"
 )

--- a/common/platform/platform.go
+++ b/common/platform/platform.go
@@ -21,6 +21,7 @@ const (
 
 	BufferSize           = "xray.ray.buffer.size"
 	BrowserDialerAddress = "xray.browser.dialer"
+	BrowserDialerOrigin = "xray.browser.dialer.origin"
 	XUDPLog              = "xray.xudp.show"
 	XUDPBaseKey          = "xray.xudp.basekey"
 )

--- a/transport/internet/websocket/dialer.go
+++ b/transport/internet/websocket/dialer.go
@@ -26,18 +26,32 @@ var conns chan *websocket.Conn
 
 func init() {
 	addr := platform.NewEnvFlag(platform.BrowserDialerAddress).GetValue(func() string { return "" })
-	if addr != "" {
+
+    if addr != "" {
+        allowedOrigin := platform.NewEnvFlag(platform.BrowserDialerOrigin).GetValue(func() string { return "http://" + addr })
+
 		conns = make(chan *websocket.Conn, 256)
 		go http.ListenAndServe(addr, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/websocket" {
-				if conn, err := upgrader.Upgrade(w, r, nil); err == nil {
-					conns <- conn
-				} else {
-					newError("Browser dialer http upgrade unexpected error").AtError().WriteToLog()
-				}
-			} else {
-				w.Write(webpage)
-			}
+			if r.URL.Path != "/websocket" {
+                w.Write(webpage)
+                return
+            }
+
+            origin := r.Header.Get("origin")
+
+            if origin != allowedOrigin {
+                newError("Browser dialer unexpected origin: " + origin + " if this is the expected origin, set XRAY_BROWSER_DIALER_ORIGIN").AtError().WriteToLog()
+                return
+            }
+
+            conn, err := upgrader.Upgrade(w, r, nil)
+
+            if err != nil {
+                newError("Browser dialer http upgrade unexpected error").AtError().WriteToLog()
+                return
+            }
+
+            conns <- conn
 		}))
 	}
 }

--- a/transport/internet/websocket/dialer.go
+++ b/transport/internet/websocket/dialer.go
@@ -28,7 +28,7 @@ var conns chan *websocket.Conn
 func init() {
 	addr := platform.NewEnvFlag(platform.BrowserDialerAddress).GetValue(func() string { return "" })
 	if addr != "" {
-        csrfToken := uuid.New()
+		csrfToken := uuid.New()
 		conns = make(chan *websocket.Conn, 256)
 		go http.ListenAndServe(addr, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/websocket" && r.URL.Query().Get("csrf") == csrfToken.String() {
@@ -39,9 +39,9 @@ func init() {
 				}
 			} else {
 				w.Write(webpage)
-                w.Write([]byte("<script>\ncsrfToken = \""))
-                w.Write([]byte(csrfToken.String()))
-                w.Write([]byte("\";\n</script>"))
+				w.Write([]byte("<script>\ncsrfToken = \""))
+				w.Write([]byte(csrfToken.String()))
+				w.Write([]byte("\";\n</script>"))
 			}
 		}))
 	}

--- a/transport/internet/websocket/dialer.go
+++ b/transport/internet/websocket/dialer.go
@@ -27,31 +27,31 @@ var conns chan *websocket.Conn
 func init() {
 	addr := platform.NewEnvFlag(platform.BrowserDialerAddress).GetValue(func() string { return "" })
 
-    if addr != "" {
-        allowedOrigin := platform.NewEnvFlag(platform.BrowserDialerOrigin).GetValue(func() string { return "http://" + addr })
+	if addr != "" {
+		allowedOrigin := platform.NewEnvFlag(platform.BrowserDialerOrigin).GetValue(func() string { return "http://" + addr })
 
 		conns = make(chan *websocket.Conn, 256)
 		go http.ListenAndServe(addr, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path != "/websocket" {
-                w.Write(webpage)
-                return
-            }
+				w.Write(webpage)
+				return
+			}
 
-            origin := r.Header.Get("origin")
+			origin := r.Header.Get("origin")
 
-            if origin != allowedOrigin {
-                newError("Browser dialer unexpected origin: " + origin + " if this is the expected origin, set XRAY_BROWSER_DIALER_ORIGIN").AtError().WriteToLog()
-                return
-            }
+			if origin != allowedOrigin {
+				newError("Browser dialer unexpected origin: " + origin + " if this is the expected origin, set XRAY_BROWSER_DIALER_ORIGIN").AtError().WriteToLog()
+				return
+			}
 
-            conn, err := upgrader.Upgrade(w, r, nil)
+			conn, err := upgrader.Upgrade(w, r, nil)
 
-            if err != nil {
-                newError("Browser dialer http upgrade unexpected error").AtError().WriteToLog()
-                return
-            }
+			if err != nil {
+				newError("Browser dialer http upgrade unexpected error").AtError().WriteToLog()
+				return
+			}
 
-            conns <- conn
+			conns <- conn
 		}))
 	}
 }

--- a/transport/internet/websocket/dialer.html
+++ b/transport/internet/websocket/dialer.html
@@ -1,52 +1,55 @@
 <!DOCTYPE html>
-<title>Browser Dialer</title>
-
-<script>
-	// Copyright (c) 2021 XRAY. Mozilla Public License 2.0.
-	var count = 0
-	setInterval(check, 1000)
-	function check() {
-		// The csrfToken global is injected into the HTML from golang code,
-		// as a separate script tag
-		var url = `ws://${window.location.host}/websocket?csrf=${csrfToken}`
-		if (count <= 0) {
-			count += 1
-			console.log("Prepare", url)
-			var ws = new WebSocket(url)
-			var wss = undefined
-			var first = true
-			ws.onmessage = function (event) {
-				if (first) {
-					first = false
-					count -= 1
-					var arr = event.data.split(" ")
-					console.log("Dial", arr[0], arr[1])
-					wss = new WebSocket(arr[0], arr[1])
-					var opened = false
-					wss.onopen = function (event) {
-						opened = true
-						ws.send("ok")
-					}
-					wss.onmessage = function (event) {
-						ws.send(event.data)
-					}
-					wss.onclose = function (event) {
-						ws.close()
-					}
-					wss.onerror = function (event) {
-						!opened && ws.send("fail")
-						wss.close()
-					}
-					check()
-				} else wss.send(event.data)
-			}
-			ws.onclose = function (event) {
-				if (first) count -= 1
-				else wss.close()
-			}
-			ws.onerror = function (event) {
-				ws.close()
+<html>
+<head>
+	<title>Browser Dialer</title>
+</head>
+<body>
+	<script>
+		// Copyright (c) 2021 XRAY. Mozilla Public License 2.0.
+		var url = "ws://" + window.location.host + "/websocket?token=csrfToken"
+		var count = 0
+		setInterval(check, 1000)
+		function check() {
+			if (count <= 0) {
+				count += 1
+				console.log("Prepare", url)
+				var ws = new WebSocket(url)
+				var wss = undefined
+				var first = true
+				ws.onmessage = function (event) {
+					if (first) {
+						first = false
+						count -= 1
+						var arr = event.data.split(" ")
+						console.log("Dial", arr[0], arr[1])
+						wss = new WebSocket(arr[0], arr[1])
+						var opened = false
+						wss.onopen = function (event) {
+							opened = true
+							ws.send("ok")
+						}
+						wss.onmessage = function (event) {
+							ws.send(event.data)
+						}
+						wss.onclose = function (event) {
+							ws.close()
+						}
+						wss.onerror = function (event) {
+							!opened && ws.send("fail")
+							wss.close()
+						}
+						check()
+					} else wss.send(event.data)
+				}
+				ws.onclose = function (event) {
+					if (first) count -= 1
+					else wss.close()
+				}
+				ws.onerror = function (event) {
+					ws.close()
+				}
 			}
 		}
-	}
-</script>
+	</script>
+</body>
+</html>

--- a/transport/internet/websocket/dialer.html
+++ b/transport/internet/websocket/dialer.html
@@ -1,55 +1,52 @@
 <!DOCTYPE html>
-<html>
-<head>
-	<title>Browser Dialer</title>
-</head>
-<body>
-	<script>
-		// Copyright (c) 2021 XRAY. Mozilla Public License 2.0.
-		var url = "ws://" + window.location.host + "/websocket"
-		var count = 0
-		setInterval(check, 1000)
-		function check() {
-			if (count <= 0) {
-				count += 1
-				console.log("Prepare", url)
-				var ws = new WebSocket(url)
-				var wss = undefined
-				var first = true
-				ws.onmessage = function (event) {
-					if (first) {
-						first = false
-						count -= 1
-						var arr = event.data.split(" ")
-						console.log("Dial", arr[0], arr[1])
-						wss = new WebSocket(arr[0], arr[1])
-						var opened = false
-						wss.onopen = function (event) {
-							opened = true
-							ws.send("ok")
-						}
-						wss.onmessage = function (event) {
-							ws.send(event.data)
-						}
-						wss.onclose = function (event) {
-							ws.close()
-						}
-						wss.onerror = function (event) {
-							!opened && ws.send("fail")
-							wss.close()
-						}
-						check()
-					} else wss.send(event.data)
-				}
-				ws.onclose = function (event) {
-					if (first) count -= 1
-					else wss.close()
-				}
-				ws.onerror = function (event) {
-					ws.close()
-				}
+<title>Browser Dialer</title>
+
+<script>
+	// Copyright (c) 2021 XRAY. Mozilla Public License 2.0.
+	var count = 0
+	setInterval(check, 1000)
+	function check() {
+		// The csrfToken global is injected into the HTML from golang code,
+		// as a separate script tag
+		var url = `ws://${window.location.host}/websocket?csrf=${csrfToken}`
+		if (count <= 0) {
+			count += 1
+			console.log("Prepare", url)
+			var ws = new WebSocket(url)
+			var wss = undefined
+			var first = true
+			ws.onmessage = function (event) {
+				if (first) {
+					first = false
+					count -= 1
+					var arr = event.data.split(" ")
+					console.log("Dial", arr[0], arr[1])
+					wss = new WebSocket(arr[0], arr[1])
+					var opened = false
+					wss.onopen = function (event) {
+						opened = true
+						ws.send("ok")
+					}
+					wss.onmessage = function (event) {
+						ws.send(event.data)
+					}
+					wss.onclose = function (event) {
+						ws.close()
+					}
+					wss.onerror = function (event) {
+						!opened && ws.send("fail")
+						wss.close()
+					}
+					check()
+				} else wss.send(event.data)
+			}
+			ws.onclose = function (event) {
+				if (first) count -= 1
+				else wss.close()
+			}
+			ws.onerror = function (event) {
+				ws.close()
 			}
 		}
-	</script>
-</body>
-</html>
+	}
+</script>


### PR DESCRIPTION
Fix https://github.com/XTLS/Xray-core/issues/3236

Validate the origin of inbound websocket requests by default.

If the user wants to change origin validation, they can set `XRAY_BROWSER_DIALER_ORIGIN=http://custom.localhost.net:3000`

The current implementation is very inconvenient, because the origin is validated very strictly. If `XRAY_BROWSER_DIALER=http://127.0.0.1:3000`, then the user has to visit `127.0.0.1`, not `localhost`. Is there a function to normalize this difference? Should xray perform DNS requests to normalize host names (I think this could open more attack vectors, using DNS rebinding)