### PR TITLE
drain buffer correctly in httpupgrade

### DIFF
--- a/transport/internet/httpupgrade/dialer.go
+++ b/transport/internet/httpupgrade/dialer.go
@@ -24,8 +24,8 @@ type ConnRF struct {
 func (c *ConnRF) Read(b []byte) (int, error) {
 	if c.First {
 		c.First = false
-		// TODO The bufio usage here is unreliable
-		resp, err := http.ReadResponse(bufio.NewReader(c.Conn), c.Req) // nolint:bodyclose
+		reader := bufio.NewReader(c.Conn)
+		resp, err := http.ReadResponse(reader, c.Req) // nolint:bodyclose
 		if err != nil {
 			return 0, err
 		}
@@ -34,6 +34,8 @@ func (c *ConnRF) Read(b []byte) (int, error) {
 			strings.ToLower(resp.Header.Get("Connection")) != "upgrade" {
 			return 0, newError("unrecognized reply")
 		}
+		// drain remaining bufreader
+		return reader.Read(b)
 	}
 	return c.Conn.Read(b)
 }


### PR DESCRIPTION
it seems the recently added httupgrade testsuite is causing timeouts on master

i have no evidence this is the real issue, but it feels to me that the server could accidentally over-read, and then the encapsulated connection will block forever trying to read data

let's test it in CI a couple of times, i don't have a way to reproduce the issue