### PR TITLE
Chore : change httpupgrade header "upgrade" to "Upgrade"

### DIFF
--- a/transport/internet/httpupgrade/dialer.go
+++ b/transport/internet/httpupgrade/dialer.go
@@ -80,7 +80,7 @@ func dialhttpUpgrade(ctx context.Context, dest net.Destination, streamSettings *
 	for key, value := range transportConfiguration.Header {
 		AddHeader(req.Header, key, value)
 	}
-	req.Header.Set("Connection", "upgrade")
+	req.Header.Set("Connection", "Upgrade")
 	req.Header.Set("Upgrade", "websocket")
 
 	err = req.Write(conn)


### PR DESCRIPTION
Since both Chromium and Firefox use `Connection : 'U'pgrade ` in their request header I changed it so it doesn't differ from them and be same as the header in websocket transport 
![image](https://github.com/XTLS/Xray-core/assets/144580664/6cd26d36-7ca0-4c98-83d3-176782729c09)
![image](https://github.com/XTLS/Xray-core/assets/144580664/33a06611-ba7e-4541-8e31-6d373c17afcd)
