### PR TITLE
Allow to inject custom validator in VLESS controller

### DIFF
--- a/proxy/vless/encoding/encoding.go
+++ b/proxy/vless/encoding/encoding.go
@@ -64,7 +64,7 @@ func EncodeRequestHeader(writer io.Writer, request *protocol.RequestHeader, requ
 }
 
 // DecodeRequestHeader decodes and returns (if successful) a RequestHeader from an input stream.
-func DecodeRequestHeader(isfb bool, first *buf.Buffer, reader io.Reader, validator *vless.Validator) (*protocol.RequestHeader, *Addons, bool, error) {
+func DecodeRequestHeader(isfb bool, first *buf.Buffer, reader io.Reader, validator vless.Validator) (*protocol.RequestHeader, *Addons, bool, error) {
 	buffer := buf.StackNew()
 	defer buffer.Release()
 

--- a/proxy/vless/encoding/encoding_test.go
+++ b/proxy/vless/encoding/encoding_test.go
@@ -42,7 +42,7 @@ func TestRequestSerialization(t *testing.T) {
 	buffer := buf.StackNew()
 	common.Must(EncodeRequestHeader(&buffer, expectedRequest, expectedAddons))
 
-	Validator := new(vless.Validator)
+	Validator := new(vless.MemoryValidator)
 	Validator.Add(user)
 
 	actualRequest, actualAddons, _, err := DecodeRequestHeader(false, nil, &buffer, Validator)
@@ -83,7 +83,7 @@ func TestInvalidRequest(t *testing.T) {
 	buffer := buf.StackNew()
 	common.Must(EncodeRequestHeader(&buffer, expectedRequest, expectedAddons))
 
-	Validator := new(vless.Validator)
+	Validator := new(vless.MemoryValidator)
 	Validator.Add(user)
 
 	_, _, _, err := DecodeRequestHeader(false, nil, &buffer, Validator)
@@ -114,7 +114,7 @@ func TestMuxRequest(t *testing.T) {
 	buffer := buf.StackNew()
 	common.Must(EncodeRequestHeader(&buffer, expectedRequest, expectedAddons))
 
-	Validator := new(vless.Validator)
+	Validator := new(vless.MemoryValidator)
 	Validator.Add(user)
 
 	actualRequest, actualAddons, _, err := DecodeRequestHeader(false, nil, &buffer, Validator)


### PR DESCRIPTION
Made validator an interface and moved its creation out from VLESS constructor to allow custom validators.

It may be the way towards custom validators in Xray, but more importantly it will help people who imports Xray as a library. For example i wanted to implement custom logging and also store users in key-value DB with long term in-memory cache. With this change it will be possible.