### PR TITLE
fix compatibility issues with go 1.21

### DIFF
--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -263,7 +263,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 				} else {
 					var err error
 					var uploadConn any
-					for _ = range 5 {
+					for i := 0; i < 5; i++ {
 						uploadConn = httpClient.uploadRawPool.Get()
 						if uploadConn == nil {
 							uploadConn, err = httpClient.dialUploadConn(ctx)


### PR DESCRIPTION
https://github.com/XTLS/Xray-core/discussions/3373#discussioncomment-9804979

I know 1.21 is not really supported, but the fix is very simple. it seems unnecessary to force the user to change this all the time.

perhaps there can be a minimal build for go 1.21 that does not get new transports? but then, enforced in CI. as chise suggested.