### PR TITLE
next iteration on splithttp

### DIFF
--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -185,7 +185,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 	req, err := http.NewRequestWithContext(
 		httptrace.WithClientTrace(ctx, trace),
 		"GET",
-		requestURL.String()+"?session="+sessionId,
+		requestURL.String()+sessionId,
 		nil,
 	)
 	if err != nil {
@@ -213,7 +213,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 		return nil, newError("invalid status code on download:", downResponse.Status)
 	}
 
-	uploadUrl := requestURL.String() + "?session=" + sessionId + "&seq="
+	uploadUrl := requestURL.String() + sessionId + "/"
 
 	uploadPipeReader, uploadPipeWriter := pipe.New(pipe.WithSizeLimit(maxUploadSize))
 

--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -29,6 +29,46 @@ type requestHandler struct {
 	localAddr gonet.TCPAddr
 }
 
+type httpSession struct {
+	uploadQueue *UploadQueue
+	// for as long as the GET request is not opened by the client, this will be
+	// open ("undone"), and the session may be expired within a certain TTL.
+	// after the client connects, this becomes "done" and the session lives as
+	// long as the GET request.
+	isFullyConnected *done.Instance
+}
+
+func (h *requestHandler) maybeReapSession(isFullyConnected *done.Instance, sessionId string) {
+	shouldReap := done.New()
+	go func() {
+		time.Sleep(30 * time.Second)
+		shouldReap.Done()
+	}()
+
+	select {
+	case <-isFullyConnected.Wait():
+		return
+	case <-shouldReap.Wait():
+		h.sessions.Delete(sessionId)
+	}
+}
+
+func (h *requestHandler) upsertSession(sessionId string) *httpSession {
+	currentSessionAny, ok := h.sessions.Load(sessionId)
+	if ok {
+		return currentSessionAny.(*httpSession)
+	}
+
+	s := &httpSession{
+		uploadQueue:      NewUploadQueue(int(2 * h.ln.config.GetNormalizedMaxConcurrentUploads())),
+		isFullyConnected: done.New(),
+	}
+
+	h.sessions.Store(sessionId, s)
+	go h.maybeReapSession(s.isFullyConnected, sessionId)
+	return s
+}
+
 func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	if len(h.host) > 0 && request.Host != h.host {
 		newError("failed to validate host, request:", request.Host, ", config:", h.host).WriteToLog()
@@ -66,14 +106,9 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		}
 	}
 
-	if request.Method == "POST" {
-		uploadQueue, ok := h.sessions.Load(sessionId)
-		if !ok {
-			newError("sessionid does not exist").WriteToLog()
-			writer.WriteHeader(http.StatusBadRequest)
-			return
-		}
+	currentSession := h.upsertSession(sessionId)
 
+	if request.Method == "POST" {
 		seq := ""
 		if len(subpath) > 1 {
 			seq = subpath[1]
@@ -99,7 +134,7 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 			return
 		}
 
-		err = uploadQueue.(*UploadQueue).Push(Packet{
+		err = currentSession.uploadQueue.Push(Packet{
 			Payload: payload,
 			Seq:     seqInt,
 		})
@@ -117,10 +152,9 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 			panic("expected http.ResponseWriter to be an http.Flusher")
 		}
 
-		uploadQueue := NewUploadQueue(int(2 * h.ln.config.GetNormalizedMaxConcurrentUploads()))
-
-		h.sessions.Store(sessionId, uploadQueue)
-		// the connection is finished, clean up map
+		// after GET is done, the connection is finished. disable automatic
+		// session reaping, and handle it in defer
+		currentSession.isFullyConnected.Done()
 		defer h.sessions.Delete(sessionId)
 
 		// magic header instructs nginx + apache to not buffer response body
@@ -140,7 +174,7 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 				downloadDone:    downloadDone,
 				responseFlusher: responseFlusher,
 			},
-			reader:     uploadQueue,
+			reader:     currentSession.uploadQueue,
 			remoteAddr: remoteAddr,
 		}
 

--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -42,7 +42,7 @@ func (h *requestHandler) maybeReapSession(isFullyConnected *done.Instance, sessi
 	shouldReap := done.New()
 	go func() {
 		time.Sleep(30 * time.Second)
-		shouldReap.Done()
+		shouldReap.Close()
 	}()
 
 	select {
@@ -154,7 +154,7 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 
 		// after GET is done, the connection is finished. disable automatic
 		// session reaping, and handle it in defer
-		currentSession.isFullyConnected.Done()
+		currentSession.isFullyConnected.Close()
 		defer h.sessions.Delete(sessionId)
 
 		// magic header instructs nginx + apache to not buffer response body

--- a/transport/internet/splithttp/lazy_reader.go
+++ b/transport/internet/splithttp/lazy_reader.go
@@ -1,0 +1,57 @@
+package splithttp
+
+import (
+	"io"
+	"sync"
+)
+
+type LazyReader struct {
+	readerSync   sync.Mutex
+	CreateReader func() (io.ReadCloser, error)
+	reader       io.ReadCloser
+	readerError  error
+}
+
+func (r *LazyReader) getReader() (io.ReadCloser, error) {
+	r.readerSync.Lock()
+	defer r.readerSync.Unlock()
+	if r.reader != nil {
+		return r.reader, nil
+	}
+
+	if r.readerError != nil {
+		return nil, r.readerError
+	}
+
+	reader, err := r.CreateReader()
+	if err != nil {
+		r.readerError = err
+		return nil, err
+	}
+
+	r.reader = reader
+	return reader, nil
+}
+
+func (r *LazyReader) Read(b []byte) (int, error) {
+	reader, err := r.getReader()
+	if err != nil {
+		return 0, err
+	}
+	n, err := reader.Read(b)
+	return n, err
+}
+
+func (r *LazyReader) Close() error {
+	r.readerSync.Lock()
+	defer r.readerSync.Unlock()
+
+	var err error
+	if r.reader != nil {
+		err = r.reader.Close()
+		r.reader = nil
+		r.readerError = newError("closed reader")
+	}
+
+	return err
+}


### PR DESCRIPTION
as discussed at the end of #3412 

* querystring is gone, path is my new friend. `/<session>` and `/<session>/<seq>` is used. this is really conservative when it comes to special characters required, but it's difficult to extend IMO
* "early data" is implemented, the client can now send GET and POST at the same time. the server spawns another goroutine per session, which cleans up the session if the GET request has not been sent within 30 seconds.
* I found my use of `ctx` incorrect, and this caused randomly cancelled requests. This is a bug in 1.8.15 as well. Fixed it by using `context.WithoutCancel`, and making sure that `dialContext` uses `ctxInner` instead of the outer scopes' context

**This PR is a breaking change from 1.8.15**. Server 1.8.15 is incompatible with client 1.8.16, and vice versa.

this is a bit hard to review, if you want separate PRs let me know. I can maybe build PRs which use each other as base branch, to avoid merge conflicts.