### PR TITLE
More docker tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,8 @@
 name: Build docker image
 
 on:
+  release:
+    types: [published]
   push:
     branches:
       - main
@@ -19,6 +21,7 @@ jobs:
           images: ghcr.io/${{ github.repository_owner }}/xray-core
           flavor: latest=true
           tags: |
+            type=sha
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}


### PR DESCRIPTION
push tags for:

* every SHA on master, format `sha-<shortid>`
* every release, format `1.8.16`

right now it is hard to pin a version in my infrastructure, because basically nothing is tagged.