### PR TITLE
Fix connection reuse in splithttp HTTP/1.1

### DIFF
--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -1,6 +1,7 @@
 package splithttp
 
 import (
+	"bytes"
 	"context"
 	gotls "crypto/tls"
 	"io"
@@ -263,6 +264,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 					return
 				}
 
+				req.ContentLength = int64(chunk.Len())
 				req.Header = transportConfiguration.GetRequestHeader()
 
 				if httpClient.isH2 {
@@ -280,11 +282,19 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 						return
 					}
 				} else {
-					var err error
 					var uploadConn any
-					for i := 0; i < 5; i++ {
+
+					// stringify the entire HTTP/1.1 request so it can be
+					// safely retried. if instead req.Write is called multiple
+					// times, the body is already drained after the first
+					// request
+					requestBytes := new(bytes.Buffer)
+					common.Must(req.Write(requestBytes))
+
+					for {
 						uploadConn = httpClient.uploadRawPool.Get()
-						if uploadConn == nil {
+						newConnection := uploadConn == nil
+						if newConnection {
 							uploadConn, err = httpClient.dialUploadConn(context.WithoutCancel(ctx))
 							if err != nil {
 								errors.LogInfoInner(ctx, err, "failed to connect upload")
@@ -293,16 +303,19 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 							}
 						}
 
-						err = req.Write(uploadConn.(net.Conn))
+						_, err = uploadConn.(net.Conn).Write(requestBytes.Bytes())
+
+						// if the write failed, we try another connection from
+						// the pool, until the write on a new connection fails.
+						// failed writes to a pooled connection are normal when
+						// the connection has been closed in the meantime.
 						if err == nil {
 							break
+						} else if newConnection {
+							errors.LogInfoInner(ctx, err, "failed to send upload")
+							uploadPipeReader.Interrupt()
+							return
 						}
-					}
-
-					if err != nil {
-						errors.LogInfoInner(ctx, err, "failed to send upload")
-						uploadPipeReader.Interrupt()
-						return
 					}
 
 					httpClient.uploadRawPool.Put(uploadConn)


### PR DESCRIPTION
Fix two bugs:

* When the connection pool contains more than 5 dead connections, the write fails after 5 tries and is aborted. Instead, pull infinite amount of connections from the pool and when the pool is empty, fail the write on the first fresh connection.

* When the write is retried, the request body is already drained, and the upload request will contain no payload at all. Fix this by stringifying the request eagerly.

Also explicitly set content-length so that transfer-encoding: chunked is avoided. This really doesn't seem to matter to any CDN at all though.

In a future version, there should be an explicit mechanism to read responses asynchronously and retry. This will certainly increase reliability further. ~However, if you actually care about reliability you should use h2~