### PR TITLE
Add support for flow=none in VLESS

### DIFF
--- a/infra/conf/vless.go
+++ b/infra/conf/vless.go
@@ -56,7 +56,7 @@ func (c *VLessInboundConfig) Build() (proto.Message, error) {
 		account.Id = u.String()
 
 		switch account.Flow {
-		case "", vless.XRV:
+		case "", "none", vless.XRV:
 		default:
 			return nil, errors.New(`VLESS clients: "flow" doesn't support "` + account.Flow + `" in this version`)
 		}
@@ -180,7 +180,7 @@ func (c *VLessOutboundConfig) Build() (proto.Message, error) {
 			account.Id = u.String()
 
 			switch account.Flow {
-			case "", vless.XRV, vless.XRV + "-udp443":
+			case "", "none", vless.XRV, vless.XRV + "-udp443":
 			default:
 				return nil, errors.New(`VLESS users: "flow" doesn't support "` + account.Flow + `" in this version`)
 			}


### PR DESCRIPTION
https://xtls.github.io/en/config/inbounds/vless.html#clientobject

Flow is documented to accept `none`, but when this is actually used, the config is considered invalid.

There's some server panel that ran into this while generating json configs, I guess it is better/cleaner to support it than to update the docs.