### PR TITLE
允许通过domainStrategy将内部请求解析为IP

### DIFF
--- a/app/proxyman/outbound/handler.go
+++ b/app/proxyman/outbound/handler.go
@@ -179,7 +179,7 @@ func (h *Handler) Dispatch(ctx context.Context, link *transport.Link) {
 	sockopt := h.streamSettings.SocketSettings
 	if sockopt != nil {
 		dest := ob.Target
-		if internet.CanLookupIP(ctx, dest, sockopt) {
+		if internet.CanLookupIP(ctx, dest, sockopt) && dest.Network == net.Network_TCP {
 			ips, err := internet.LookupIP(dest.Address.String(), sockopt.DomainStrategy, ob.Gateway)
 			if err == nil && len(ips) > 0 {
 				dest.Address = net.IPAddress(ips[dice.Roll(len(ips))])

--- a/app/proxyman/outbound/handler.go
+++ b/app/proxyman/outbound/handler.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/xtls/xray-core/app/proxyman"
 	"github.com/xtls/xray-core/common"
-	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/buf"
 	"github.com/xtls/xray-core/common/dice"
+	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/mux"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/net/cnc"
@@ -176,16 +176,18 @@ func (h *Handler) Dispatch(ctx context.Context, link *transport.Link) {
 	ob := outbounds[len(outbounds)-1]
 
 	//Lookup ip for proxied request
-	sockopt := h.streamSettings.SocketSettings
-	if sockopt != nil {
-		dest := ob.Target
-		if internet.CanLookupIP(ctx, dest, sockopt) && dest.Network == net.Network_TCP {
-			ips, err := internet.LookupIP(dest.Address.String(), sockopt.DomainStrategy, ob.Gateway)
-			if err == nil && len(ips) > 0 {
-				dest.Address = net.IPAddress(ips[dice.Roll(len(ips))])
-				errors.LogInfo(ctx, "replace destination with "+dest.String())
-			} else if err != nil {
-				errors.LogWarningInner(ctx, err, "failed to resolve ip")
+	if h.streamSettings != nil {
+		sockopt := h.streamSettings.SocketSettings
+		if sockopt != nil {
+			dest := ob.Target
+			if internet.CanLookupIP(ctx, dest, sockopt) && dest.Network == net.Network_TCP {
+				ips, err := internet.LookupIP(dest.Address.String(), sockopt.DomainStrategy, ob.Gateway)
+				if err == nil && len(ips) > 0 {
+					dest.Address = net.IPAddress(ips[dice.Roll(len(ips))])
+					errors.LogInfo(ctx, "replace destination with "+dest.String())
+				} else if err != nil {
+					errors.LogWarningInner(ctx, err, "failed to resolve ip")
+				}
 			}
 		}
 	}

--- a/transport/internet/dialer.go
+++ b/transport/internet/dialer.go
@@ -82,7 +82,7 @@ var (
 	obm       outbound.Manager
 )
 
-func lookupIP(domain string, strategy DomainStrategy, localAddr net.Address) ([]net.IP, error) {
+func LookupIP(domain string, strategy DomainStrategy, localAddr net.Address) ([]net.IP, error) {
 	if dnsClient == nil {
 		return nil, nil
 	}
@@ -103,7 +103,7 @@ func lookupIP(domain string, strategy DomainStrategy, localAddr net.Address) ([]
 	return ips, err
 }
 
-func canLookupIP(ctx context.Context, dst net.Destination, sockopt *SocketConfig) bool {
+func CanLookupIP(ctx context.Context, dst net.Destination, sockopt *SocketConfig) bool {
 	if dst.Address.Family().IsIP() || dnsClient == nil {
 		return false
 	}
@@ -146,8 +146,8 @@ func DialSystem(ctx context.Context, dest net.Destination, sockopt *SocketConfig
 		return effectiveSystemDialer.Dial(ctx, src, dest, sockopt)
 	}
 
-	if canLookupIP(ctx, dest, sockopt) {
-		ips, err := lookupIP(dest.Address.String(), sockopt.DomainStrategy, src)
+	if CanLookupIP(ctx, dest, sockopt) {
+		ips, err := LookupIP(dest.Address.String(), sockopt.DomainStrategy, src)
 		if err == nil && len(ips) > 0 {
 			dest.Address = net.IPAddress(ips[dice.Roll(len(ips))])
 			errors.LogInfo(ctx, "replace destination with " + dest.String())


### PR DESCRIPTION
https://github.com/XTLS/Xray-core/issues/3507

之前看r主席介绍过sockopt里的domainstrategy是为了实现类似freedom里的功能 但是翻了代码之后实际作用是影响 outbound到inbound的这个连接 这个实现了对被代理请求的解析

不知道这个字段的本意是不是这个 如果想保留原功能 可能就得加一个sockopt选项了
@RPRX 