### PR TITLE
修复ws X-Forwarded-For 读取

### DIFF
--- a/transport/internet/httpupgrade/httpupgrade_test.go
+++ b/transport/internet/httpupgrade/httpupgrade_test.go
@@ -151,7 +151,7 @@ func TestDialWithRemoteAddr(t *testing.T) {
 				return
 			}
 
-			_, err = c.Write([]byte("Response"))
+			_, err = c.Write([]byte(c.RemoteAddr().String()))
 			common.Must(err)
 		}(conn)
 	})
@@ -169,7 +169,7 @@ func TestDialWithRemoteAddr(t *testing.T) {
 	var b [1024]byte
 	n, err := conn.Read(b[:])
 	common.Must(err)
-	if string(b[:n]) != "Response" {
+	if string(b[:n]) != "1.1.1.1:0" {
 		t.Error("response: ", string(b[:n]))
 	}
 

--- a/transport/internet/splithttp/splithttp_test.go
+++ b/transport/internet/splithttp/splithttp_test.go
@@ -96,7 +96,7 @@ func TestDialWithRemoteAddr(t *testing.T) {
 				return
 			}
 
-			_, err = c.Write([]byte("Response"))
+			_, err = c.Write([]byte(c.RemoteAddr().String()))
 			common.Must(err)
 		}(conn)
 	})
@@ -113,7 +113,7 @@ func TestDialWithRemoteAddr(t *testing.T) {
 
 	var b [1024]byte
 	n, _ := conn.Read(b[:])
-	if string(b[:n]) != "Response" {
+	if string(b[:n]) != "1.1.1.1:0" {
 		t.Error("response: ", string(b[:n]))
 	}
 

--- a/transport/internet/websocket/connection.go
+++ b/transport/internet/websocket/connection.go
@@ -14,15 +14,19 @@ import (
 var _ buf.Writer = (*connection)(nil)
 
 // connection is a wrapper for net.Conn over WebSocket connection.
+// remoteAddr is used to pass "virtual" remote IP addresses in X-Forwarded-For.
+// so we shouldn't directly read it form conn.
 type connection struct {
-	conn   *websocket.Conn
-	reader io.Reader
+	conn       *websocket.Conn
+	reader     io.Reader
+	remoteAddr net.Addr
 }
 
 func NewConnection(conn *websocket.Conn, remoteAddr net.Addr, extraReader io.Reader) *connection {
 	return &connection{
-		conn:   conn,
-		reader: extraReader,
+		conn:       conn,
+		remoteAddr: remoteAddr,
+		reader:     extraReader,
 	}
 }
 
@@ -90,7 +94,7 @@ func (c *connection) LocalAddr() net.Addr {
 }
 
 func (c *connection) RemoteAddr() net.Addr {
-	return c.conn.RemoteAddr()
+	return c.remoteAddr
 }
 
 func (c *connection) SetDeadline(t time.Time) error {

--- a/transport/internet/websocket/ws_test.go
+++ b/transport/internet/websocket/ws_test.go
@@ -91,7 +91,7 @@ func TestDialWithRemoteAddr(t *testing.T) {
 				return
 			}
 
-			_, err = c.Write([]byte("Response"))
+			_, err = c.Write([]byte(c.RemoteAddr().String()))
 			common.Must(err)
 		}(conn)
 	})
@@ -109,7 +109,7 @@ func TestDialWithRemoteAddr(t *testing.T) {
 	var b [1024]byte
 	n, err := conn.Read(b[:])
 	common.Must(err)
-	if string(b[:n]) != "Response" {
+	if string(b[:n]) != "1.1.1.1:0" {
 		t.Error("response: ", string(b[:n]))
 	}
 


### PR DESCRIPTION
似乎在 https://github.com/XTLS/Xray-core/commit/c8f6ba9ff0fd346543b8c2580247cf00b2e5655b 删掉了看起来不必要的远程IP字段改为直接从conn读取 但是这个字段用于传递X-Forwarded-For里的信息 直接读等于无视了这个头里的信息 导致了https://github.com/XTLS/Xray-core/issues/3545