### PR TITLE
SplitHTTP: Server supports HTTP/3

### DIFF
--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -327,7 +327,7 @@ func ListenSH(ctx context.Context, address net.Address, port net.Port, streamSet
 			}
 		}()
 	}
-
+	l.listener = listener
 	if config := v2tls.ConfigFromStreamSettings(streamSettings); config != nil {
 		if tlsConfig := config.GetTLSConfig(); tlsConfig != nil {
 			listener = tls.NewListener(listener, tlsConfig)

--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -280,10 +280,13 @@ func ListenSH(ctx context.Context, address net.Address, port net.Port, streamSet
 		}
 		errors.LogInfo(ctx, "listening unix domain socket(for SH) on ", address)
 	} else if l.isH3 { // quic
-		Conn, err := net.ListenUDP("udp", &net.UDPAddr{
+		Conn, err := internet.ListenSystemPacket(context.Background(), &net.UDPAddr{
 			IP:   address.IP(),
 			Port: int(port),
-		})
+		}, streamSettings.SocketSettings)
+		if err != nil {
+			return nil,  errors.New("failed to listen UDP(for SH3) on ", address, ":", port).Base(err)
+		}
 		h3listener, err := quic.ListenEarly(Conn,tlsConfig, nil)
 		if err != nil {
 			return nil, errors.New("failed to listen QUIC(for SH3) on ", address, ":", port).Base(err)


### PR DESCRIPTION
我不知道为什么会有人尝试直连 SplitHTTP3 而不去使用 tuic, hysteria 或者直接用 quic transport ，不过我去实现一下也不会有什么坏处。或许我应该直接加一个 UpDownSplit 用于使上下行各自用一个连接。
让 tlssettings.alpn 只有 ["h3"] 即可使用 SplitHTTP3 Server，虽然说一个正常的服务器支持了 h3 也应该支持 h2 和 http/1.1 ，不过其他的 QUIC 协议都没有这么做，所以我不在意，试试加两个 inbound
或许考虑一下 RFC 9220: Bootstrapping WebSockets with HTTP/3 会更好。
此提交使用原版 quic-go 而不是 uQuic ，与 #3550 平行。