### PR TITLE
Docker: Add multi-arch builds and Loyalsoldier flavor

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -2,21 +2,27 @@
 FROM --platform=$BUILDPLATFORM golang:alpine AS build
 WORKDIR /src
 COPY . .
-ARG TARGETOS TARGETARCH
+ARG TARGETOS
+ARG TARGETARCH
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -o xray -trimpath -ldflags "-s -w -buildid=" ./main
+ADD https://github.com/v2fly/geoip/releases/latest/download/geoip.dat /v2fly/geoip.dat
+ADD https://github.com/v2fly/domain-list-community/releases/latest/download/dlc.dat /v2fly/geosite.dat
+ADD https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geoip.dat /loyalsoldier/geoip.dat
+ADD https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat /loyalsoldier/geosite.dat
 
-FROM --platform=${TARGETPLATFORM} alpine:latest
-WORKDIR /root
+# chainguard/static contains only tzdata and ca-certificates, can be built with multiarch static binaries.
+FROM --platform=linux/amd64 chainguard/static:latest
+WORKDIR /var/log/xray
 COPY .github/docker/files/config.json /etc/xray/config.json
-COPY --from=build /src/xray /usr/bin/xray
-RUN set -ex \
-	&& apk add --no-cache tzdata ca-certificates \
-	&& mkdir -p /var/log/xray /usr/share/xray \
-    && chmod +x /usr/bin/xray \
-	&& wget -O /usr/share/xray/geosite.dat https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat \
-	&& wget -O /usr/share/xray/geoip.dat https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geoip.dat
+COPY --from=build --chmod=755 /src/xray /usr/bin/xray
 
+USER root
+WORKDIR /root
 VOLUME /etc/xray
-ENV TZ=Asia/Shanghai
+ARG TZ=Asia/Shanghai
+ENV TZ=$TZ
 ENTRYPOINT [ "/usr/bin/xray" ]
 CMD [ "-config", "/etc/xray/config.json" ]
+
+ARG flavor=v2fly
+COPY --from=build /$flavor /usr/share/xray

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,8 +25,8 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
-      - name: Docker metadata LS (short for Loyalsoldier) flavor
-        id: ls
+      - name: Docker metadata Loyalsoldier flavor
+        id: loyalsoldier
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/xray-core
@@ -73,4 +73,4 @@ jobs:
           build-args: flavor=loyalsoldier
           push: true
           tags: |
-            ${{ steps.ls.outputs.tags }}
+            ${{ steps.loyalsoldier.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,27 +25,14 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
-      - name: Docker metadata Loyalsoldier flavor
-        id: loyalsoldier
+      - name: Docker metadata LS (short for Loyalsoldier) flavor
+        id: ls
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/xray-core
           flavor: |
             latest=auto
-            suffix=-loyalsoldier,onlatest=true
-          tags: |
-            type=sha
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-      - name: Docker metadata L (short for Loyalsoldier) flavor
-        id: l
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/xray-core
-          flavor: |
-            latest=auto
-            suffix=-l,onlatest=true
+            suffix=-ls,onlatest=true
           tags: |
             type=sha
             type=ref,event=branch
@@ -86,5 +73,4 @@ jobs:
           build-args: flavor=loyalsoldier
           push: true
           tags: |
-            ${{ steps.loyalsoldier.outputs.tags }}
-            ${{ steps.l.outputs.tags }}
+            ${{ steps.ls.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,24 +25,84 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
+      - name: Docker metadata Loyalsoldier flavor
+        id: loyalsoldier
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/xray-core
+          flavor: |
+            latest=auto
+            suffix=-loyalsoldier,onlatest=true
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+      - name: Docker metadata L (short for Loyalsoldier) flavor
+        id: l
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/xray-core
+          flavor: |
+            latest=auto
+            suffix=-l,onlatest=true
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - # Add support for more platforms with QEMU (optional)
-        # https://github.com/docker/setup-qemu-action
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: |
+            linux/386
+            linux/amd64
+            linux/arm
+            linux/arm64
+            linux/loong64
+            linux/mips
+            linux/mips64
+            linux/mips64le
+            linux/mipsle
+            linux/ppc64
+            linux/ppc64le
+            linux/riscv64
+            linux/s390x
+          provenance: false
           file: .github/docker/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Build and push Loyalsoldier flavor
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: |
+            linux/386
+            linux/amd64
+            linux/arm
+            linux/arm64
+            linux/loong64
+            linux/mips
+            linux/mips64
+            linux/mips64le
+            linux/mipsle
+            linux/ppc64
+            linux/ppc64le
+            linux/riscv64
+            linux/s390x
+          provenance: false
+          file: .github/docker/Dockerfile
+          build-args: flavor=loyalsoldier
+          push: true
+          tags: |
+            ${{ steps.loyalsoldier.outputs.tags }}
+            ${{ steps.l.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,19 +64,10 @@ jobs:
         with:
           context: .
           platforms: |
-            linux/386
             linux/amd64
-            linux/arm
             linux/arm64
             linux/loong64
-            linux/mips
-            linux/mips64
-            linux/mips64le
-            linux/mipsle
-            linux/ppc64
-            linux/ppc64le
             linux/riscv64
-            linux/s390x
           provenance: false
           file: .github/docker/Dockerfile
           push: true
@@ -86,19 +77,10 @@ jobs:
         with:
           context: .
           platforms: |
-            linux/386
             linux/amd64
-            linux/arm
             linux/arm64
             linux/loong64
-            linux/mips
-            linux/mips64
-            linux/mips64le
-            linux/mipsle
-            linux/ppc64
-            linux/ppc64le
             linux/riscv64
-            linux/s390x
           provenance: false
           file: .github/docker/Dockerfile
           build-args: flavor=loyalsoldier


### PR DESCRIPTION
1. Add multi-arch builds (386, amd64, arm, arm64, loong64, mips, mips64, mips64le, mipsle, ppc64, ppc64le, riscv64, s390x):
Replace `alpine` with `chainguard/static`, which contains only tzdata and ca-certificates without any ELF binaries, can be built with multi-arch static binaries.
https://hub.docker.com/r/chainguard/static

2. Use official geoip and geosite by default:
Default tags use official geoip and geosite, and this is consistent with the Release version.
https://github.com/XTLS/Xray-core/pull/3580
Such as: `latest, 1.8.21, main, sha-c07e022`

3. Add Loyalsoldier flavor:
Loyalsoldier flavor tags with suffix `-loyalsoldier` or `-l` (short for Loyalsoldier) use the third-party Loyalsoldier geoip and geosite.
Such as: `latest-loyalsoldier, latest-l, 1.8.21-loyalsoldier, 1.8.21-l, main-loyalsoldier, main-l, sha-c07e022-loyalsoldier, sha-c07e022-l`

Demo repo: https://github.com/mayampi01/Xray-core/pkgs/container/xray-core