### PR TITLE
Remove unnecessary sleep from test

### DIFF
--- a/transport/internet/httpupgrade/httpupgrade_test.go
+++ b/transport/internet/httpupgrade/httpupgrade_test.go
@@ -58,7 +58,6 @@ func Test_listenHTTPUpgradeAndDial(t *testing.T) {
 	}
 
 	common.Must(conn.Close())
-	<-time.After(time.Second * 5)
 	conn, err = Dial(ctx, net.TCPDestination(net.DomainAddress("localhost"), listenPort), streamSettings)
 	common.Must(err)
 	_, err = conn.Write([]byte("Test connection 2"))
@@ -118,7 +117,6 @@ func Test_listenHTTPUpgradeAndDialWithHeaders(t *testing.T) {
 	}
 
 	common.Must(conn.Close())
-	<-time.After(time.Second * 5)
 	conn, err = Dial(ctx, net.TCPDestination(net.DomainAddress("localhost"), listenPort), streamSettings)
 	common.Must(err)
 	_, err = conn.Write([]byte("Test connection 2"))

--- a/transport/internet/websocket/ws_test.go
+++ b/transport/internet/websocket/ws_test.go
@@ -58,7 +58,6 @@ func Test_listenWSAndDial(t *testing.T) {
 	}
 
 	common.Must(conn.Close())
-	<-time.After(time.Second * 5)
 	conn, err = Dial(ctx, net.TCPDestination(net.DomainAddress("localhost"), listenPort), streamSettings)
 	common.Must(err)
 	_, err = conn.Write([]byte("Test connection 2"))


### PR DESCRIPTION
These were copypasted to splithttp tests and then removed there

I can't imagine what they were supposed to do, the tests run fine without