### PR TITLE
SplitHTTP: Fix wrong config deserialization

### DIFF
--- a/transport/internet/splithttp/config.go
+++ b/transport/internet/splithttp/config.go
@@ -37,7 +37,7 @@ func (c *Config) GetRequestHeader() http.Header {
 }
 
 func (c *Config) GetNormalizedMaxConcurrentUploads(isServer bool) RandRangeConfig {
-	if c.MaxConcurrentUploads == nil {
+	if c.MaxConcurrentUploads == nil || c.MaxConcurrentUploads.To == 0 {
 		if isServer {
 			return RandRangeConfig{
 				From: 200,
@@ -55,7 +55,7 @@ func (c *Config) GetNormalizedMaxConcurrentUploads(isServer bool) RandRangeConfi
 }
 
 func (c *Config) GetNormalizedMaxUploadSize(isServer bool) RandRangeConfig {
-	if c.MaxUploadSize == nil {
+	if c.MaxUploadSize == nil || c.MaxUploadSize.To == 0 {
 		if isServer {
 			return RandRangeConfig{
 				From: 2000000,
@@ -73,7 +73,7 @@ func (c *Config) GetNormalizedMaxUploadSize(isServer bool) RandRangeConfig {
 }
 
 func (c *Config) GetNormalizedMinUploadInterval() RandRangeConfig {
-	if c.MinUploadIntervalMs == nil {
+	if c.MinUploadIntervalMs == nil || c.MinUploadIntervalMs.To == 0 {
 		return RandRangeConfig{
 			From: 30,
 			To:   30,


### PR DESCRIPTION
Manual testing was conducted only using explicitly set parameters. However, when the parameters are not explicitly set in JSON config, it seems that `c.MaxUploadSize` will contain `RandRangeConfig { From: 0, To: 0 }` instead of `nil`, which breaks upload entirely.

I now tested all combinations and can confirm that h1, h2, h3 work fine against both new and old servers.

