### PR TITLE
SplitHTTP client: Raise idle timeout to 5 minutes

### DIFF
--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -90,9 +90,7 @@ func getHTTPClient(ctx context.Context, dest net.Destination, streamSettings *in
 
 	if isH3 {
 		quicConfig := &quic.Config{
-			KeepAlivePeriod:      0,
-			HandshakeIdleTimeout: time.Second * 8,
-			MaxIdleTimeout:       time.Second * 300,
+			MaxIdleTimeout: time.Second * 300,
 		}
 		roundTripper := &http3.RoundTripper{
 			QUICConfig:      quicConfig,

--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -89,7 +89,13 @@ func getHTTPClient(ctx context.Context, dest net.Destination, streamSettings *in
 	var uploadTransport http.RoundTripper
 
 	if isH3 {
+		quicConfig := &quic.Config{
+			KeepAlivePeriod:      0,
+			HandshakeIdleTimeout: time.Second * 8,
+			MaxIdleTimeout:       time.Second * 300,
+		}
 		roundTripper := &http3.RoundTripper{
+			QUICConfig:      quicConfig,
 			TLSClientConfig: gotlsConfig,
 			Dial: func(ctx context.Context, addr string, tlsCfg *gotls.Config, cfg *quic.Config) (quic.EarlyConnection, error) {
 				conn, err := internet.DialSystem(ctx, dest, streamSettings.SocketSettings)


### PR DESCRIPTION
Copy the settings from QUIC transport. See
https://github.com/XTLS/Xray-core/pull/3565#issuecomment-2264356688 -- Tested with CDN and it seems better than before (fewer reconnections)

Keep-alive packets are still turned off, so the original concern of that PR should still be resolved.