### PR TITLE
Allow read access to geoip.dat and geosite.dat for every user

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -25,4 +25,4 @@ ENTRYPOINT [ "/usr/bin/xray" ]
 CMD [ "-config", "/etc/xray/config.json" ]
 
 ARG flavor=v2fly
-COPY --from=build /$flavor /usr/share/xray
+COPY --from=build --chmod=644 /$flavor /usr/share/xray


### PR DESCRIPTION
It's required to run a container as a non-root user.