### PR TITLE
Config: create a default Freedom outbound when there is none

### DIFF
--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -16,6 +16,7 @@ import (
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/serial"
 	core "github.com/xtls/xray-core/core"
+	"github.com/xtls/xray-core/proxy/freedom"
 	"github.com/xtls/xray-core/transport/internet"
 )
 
@@ -726,6 +727,14 @@ func (c *Config) Build() (*core.Config, error) {
 		oc, err := rawOutboundConfig.Build()
 		if err != nil {
 			return nil, err
+		}
+		config.Outbound = append(config.Outbound, oc)
+	}
+	// If no outbound, create a freedom as default
+	if len(config.Outbound) == 0 {
+		errors.LogWarning(context.Background(), "No outbound found, creating a freedom outbound as default")
+		oc := &core.OutboundHandlerConfig{
+			ProxySettings: serial.ToTypedMessage(&freedom.Config{}),
 		}
 		config.Outbound = append(config.Outbound, oc)
 	}


### PR DESCRIPTION
rt 好久之前就想做了 如果配置文件没有检测到有outbound 就创建一个最简单的freedom
比如可以用这样的极简配置启动一个socks 不用再添加一个freedom
```
{
  "inbounds": [
    {
      "listen": "127.0.0.1",
      "port": 1080,
      "protocol": "socks"
    }
  ]
}

```
