### PR TITLE
API: Improve MarshalToJson() in common/reflect/marshal.go

### DIFF
--- a/common/reflect/marshal.go
+++ b/common/reflect/marshal.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"reflect"
 
+	cnet "github.com/xtls/xray-core/common/net"
 	cserial "github.com/xtls/xray-core/common/serial"
 )
 
@@ -43,6 +44,19 @@ func marshalSlice(v reflect.Value, ignoreNullValue bool) interface{} {
 	return r
 }
 
+func isNullValue(v interface{}) bool {
+	if v == nil {
+		return true
+	}
+	kind := reflect.TypeOf(v).Kind()
+	switch kind {
+	case reflect.Slice, reflect.Array, reflect.Map, reflect.Struct:
+		return reflect.ValueOf(v).Len() == 0
+	default:
+		return false
+	}
+}
+
 func marshalStruct(v reflect.Value, ignoreNullValue bool) interface{} {
 	r := make(map[string]interface{})
 	t := v.Type()
@@ -53,7 +67,7 @@ func marshalStruct(v reflect.Value, ignoreNullValue bool) interface{} {
 			name := ft.Name
 			value := rv.Interface()
 			tv := marshalInterface(value, ignoreNullValue)
-			if tv != nil || !ignoreNullValue {
+			if !ignoreNullValue || !isNullValue(tv) {
 				r[name] = tv
 			}
 		}
@@ -87,7 +101,6 @@ func marshalIString(v interface{}) (r string, ok bool) {
 			ok = false
 		}
 	}()
-
 	if iStringFn, ok := v.(interface{ String() string }); ok {
 		return iStringFn.String(), true
 	}
@@ -104,10 +117,13 @@ func marshalKnownType(v interface{}, ignoreNullValue bool) (interface{}, bool) {
 		return ty, true
 	case []json.RawMessage:
 		return ty, true
-	case *json.RawMessage:
+	case *json.RawMessage, json.RawMessage:
 		return ty, true
-	case json.RawMessage:
-		return ty, true
+	case *cnet.IPOrDomain:
+		if d := v.(*cnet.IPOrDomain); d != nil {
+			return d.AsAddress().String(), true
+		}
+		return nil, false
 	default:
 		return nil, false
 	}
@@ -152,7 +168,13 @@ func marshalInterface(v interface{}, ignoreNullValue bool) interface{} {
 	if k == reflect.Invalid {
 		return nil
 	}
+
 	if isValueKind(k) {
+		if ty := rv.Type().Name(); k.String() != ty {
+			if s, ok := marshalIString(v); ok {
+				return s
+			}
+		}
 		return v
 	}
 

--- a/common/reflect/marshal_test.go
+++ b/common/reflect/marshal_test.go
@@ -6,10 +6,39 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/xtls/xray-core/common/protocol"
 	. "github.com/xtls/xray-core/common/reflect"
 	cserial "github.com/xtls/xray-core/common/serial"
 	iserial "github.com/xtls/xray-core/infra/conf/serial"
+	"github.com/xtls/xray-core/proxy/shadowsocks"
 )
+
+func TestMashalAccount(t *testing.T) {
+	account := &shadowsocks.Account{
+		Password:   "shadowsocks-password",
+		CipherType: shadowsocks.CipherType_CHACHA20_POLY1305,
+	}
+
+	user := &protocol.User{
+		Level:   0,
+		Email:   "love@v2ray.com",
+		Account: cserial.ToTypedMessage(account),
+	}
+
+	j, ok := MarshalToJson(user, false)
+	if !ok || strings.Contains(j, "_TypedMessage_") {
+
+		t.Error("marshal account failed")
+	}
+
+	kws := []string{"CHACHA20_POLY1305", "cipherType", "shadowsocks-password"}
+	for _, kw := range kws {
+		if !strings.Contains(j, kw) {
+			t.Error("marshal account failed")
+		}
+	}
+	// t.Log(j)
+}
 
 func TestMashalStruct(t *testing.T) {
 	type Foo = struct {
@@ -36,8 +65,8 @@ func TestMashalStruct(t *testing.T) {
 		Arr: &arr,
 	}
 
-	s, ok1 := MarshalToJson(f1)
-	sp, ok2 := MarshalToJson(&f1)
+	s, ok1 := MarshalToJson(f1, true)
+	sp, ok2 := MarshalToJson(&f1, true)
 
 	if !ok1 || !ok2 || s != sp {
 		t.Error("marshal failed")
@@ -69,7 +98,7 @@ func TestMarshalConfigJson(t *testing.T) {
 	}
 
 	tmsg := cserial.ToTypedMessage(bc)
-	tc, ok := MarshalToJson(tmsg)
+	tc, ok := MarshalToJson(tmsg, true)
 	if !ok {
 		t.Error("marshal config failed")
 	}
@@ -79,15 +108,14 @@ func TestMarshalConfigJson(t *testing.T) {
 	keywords := []string{
 		"4784f9b8-a879-4fec-9718-ebddefa47750",
 		"bing.com",
-		"DomainStrategy",
-		"InboundTag",
-		"Level",
-		"Stats",
-		"UserDownlink",
-		"UserUplink",
-		"System",
-		"InboundDownlink",
-		"OutboundUplink",
+		"inboundTag",
+		"level",
+		"stats",
+		"userDownlink",
+		"userUplink",
+		"system",
+		"inboundDownlink",
+		"outboundUplink",
 	}
 	for _, kw := range keywords {
 		if !strings.Contains(tc, kw) {

--- a/infra/conf/serial/builder.go
+++ b/infra/conf/serial/builder.go
@@ -17,7 +17,7 @@ func MergeConfigFromFiles(files []string, formats []string) (string, error) {
 		return "", err
 	}
 
-	if j, ok := creflect.MarshalToJson(c); ok {
+	if j, ok := creflect.MarshalToJson(c, true); ok {
 		return j, nil
 	}
 	return "", errors.New("marshal to json failed.").AtError()


### PR DESCRIPTION
这个 PR 对 common/reflect/marshal.go 里面的 MarshalToJson() 做了以下优化了：
 * enum 由原来的显示数字改为显示变量名
 * 设置了 json 标签的 struct 字段，改为显示 json 标签内容
 * 不显示空值、空字符串 或者 设置了 json:"omitempty" 的零值
 * IP 地址由原来的显示数组 [127, 0, 0, 1] 改为显示字符串 "127.0.0.1"
 * 端口列表由原来的显示结构体改为显示字符串
 * 添加参数控制是否显示 `_TypedMessage_` 项

一个简单的样例：
```json
{
  "account": {
    "cipherType": "CHACHA20_POLY1305",
    "password": "shadowsocks-password"
  },
  "email": "love@v2ray.com"
}
```

之前是这样：
```json
{
    "Account": {
        "CipherType": 7,
        "IvCheck": false,
        "Password": "shadowsocks-password",
        "_TypedMessage_": "xray.proxy.shadowsocks.Account"
    },
    "Email": "love@v2ray.com",
    "Level": 0
}
```

<details>

<summary>更详细的样例</summary>

<table>
<tr>
<td> config.json </td> <td> ./xray.exe -c config.json -dump </td>
</tr>
<tr>
<td>

```json
{
  "log": {
    "loglevel": "debug"
  },
  "inbounds": [
    {
      "tag": "agentin",
      "protocol": "http",
      "port": 8080,
      "listen": "127.0.0.1",
      "settings": {}
    }
  ],
  "outbounds": [
    {
      "tag": "ssout",
      "protocol": "shadowsocks",
      "settings": {
        "servers": [
          {
            "address": "bing.com",
            "port": 443,
            "method": "chacha20-ietf-poly1305",
            "password": "1234",
            "ota": false,
            "level": 0
          }
        ]
      }
    }
  ]
}


```

</td>
<td>

```json
{
  "inbounds": [
    {
      "listen": "127.0.0.1",
      "port": 8080,
      "protocol": "http",
      "settings": {},
      "tag": "agentin"
    }
  ],
  "log": {
    "dnsLog": false,
    "loglevel": "debug"
  },
  "outbounds": [
    {
      "protocol": "shadowsocks",
      "settings": {
        "servers": [
          {
            "address": "bing.com",
            "port": 443,
            "method": "chacha20-ietf-poly1305",
            "password": "1234",
            "ota": false,
            "level": 0
          }
        ]
      },
      "tag": "ssout"
    }
  ],
  "port": 0
}
```

</td>
</tr>
</table>

</details>
