### PR TITLE
TLS Hello Fragmenting: New Single TLS Hello Fragmenting Method

### DIFF
--- a/infra/conf/freedom.go
+++ b/infra/conf/freedom.go
@@ -62,8 +62,8 @@ func (c *FreedomConfig) Build() (proto.Message, error) {
 		var err, err2 error
 
 		switch strings.ToLower(c.Fragment.Packets) {
-		case "recordlayer":
-			// TLS Hello Fragmentation (into two record layer fragments)
+		case "singletlshello":
+			// TLS Hello Fragmentation (into multiple handshake messages but one tcp segment)
 			config.Fragment.PacketsFrom = 1
 			config.Fragment.PacketsTo = 1
 		case "tlshello":

--- a/infra/conf/freedom.go
+++ b/infra/conf/freedom.go
@@ -62,8 +62,8 @@ func (c *FreedomConfig) Build() (proto.Message, error) {
 		var err, err2 error
 
 		switch strings.ToLower(c.Fragment.Packets) {
-		case "singletlshello":
-			// TLS Hello Fragmentation (two TLS Hello Fragments into one tcp segment)
+		case "recordlayer":
+			// TLS Hello Fragmentation (into two record layer fragments)
 			config.Fragment.PacketsFrom = 1
 			config.Fragment.PacketsTo = 1
 		case "tlshello":

--- a/infra/conf/freedom.go
+++ b/infra/conf/freedom.go
@@ -62,6 +62,10 @@ func (c *FreedomConfig) Build() (proto.Message, error) {
 		var err, err2 error
 
 		switch strings.ToLower(c.Fragment.Packets) {
+		case "singletlshello":
+			// TLS Hello Fragmentation (two TLS Hello Fragments into one tcp segment)
+			config.Fragment.PacketsFrom = 1
+			config.Fragment.PacketsTo = 1
 		case "tlshello":
 			// TLS Hello Fragmentation (into multiple handshake messages)
 			config.Fragment.PacketsFrom = 0


### PR DESCRIPTION
* Splits the TLS Hello message into two fragments and sends them within a single TCP segment.
* Proven effective in Iran with MTN and MCI operators.
* Capable of generating additional fragments if needed.

I’ve been using this method for about three months without any issues in my DnsSafeguard project.