### PR TITLE
Send tls fragment in one tcp packet if interval is zero

### DIFF
--- a/proxy/freedom/freedom.go
+++ b/proxy/freedom/freedom.go
@@ -402,6 +402,7 @@ func (f *FragmentWriter) Write(b []byte) (int, error) {
 		}
 		data := b[5:recordLen]
 		buf := make([]byte, 1024)
+		var hello []byte
 		for from := 0; ; {
 			to := from + int(randBetween(int64(f.fragment.LengthMin), int64(f.fragment.LengthMax)))
 			if to > len(data) {
@@ -413,12 +414,23 @@ func (f *FragmentWriter) Write(b []byte) (int, error) {
 			from = to
 			buf[3] = byte(l >> 8)
 			buf[4] = byte(l)
-			_, err := f.writer.Write(buf[:5+l])
-			time.Sleep(time.Duration(randBetween(int64(f.fragment.IntervalMin), int64(f.fragment.IntervalMax))) * time.Millisecond)
-			if err != nil {
-				return 0, err
+			if f.fragment.IntervalMax == 0 { // If interval is 0, we sent them in one tcp packet
+				hello = append(hello, buf[:5+l]...)
+			} else {
+				_, err := f.writer.Write(buf[:5+l])
+				time.Sleep(time.Duration(randBetween(int64(f.fragment.IntervalMin), int64(f.fragment.IntervalMax))) * time.Millisecond)
+				if err != nil {
+					return 0, err
+				}
 			}
 			if from == len(data) {
+				if f.fragment.IntervalMax == 0 {
+					if len(b) > recordLen {
+						hello = append(hello, b[recordLen:]...)
+					}
+					f.writer.Write(hello)
+					return len(b), nil
+				}
 				if len(b) > recordLen {
 					n, err := f.writer.Write(b[recordLen:])
 					if err != nil {

--- a/proxy/freedom/freedom.go
+++ b/proxy/freedom/freedom.go
@@ -414,7 +414,7 @@ func (f *FragmentWriter) Write(b []byte) (int, error) {
 			from = to
 			buf[3] = byte(l >> 8)
 			buf[4] = byte(l)
-			if f.fragment.IntervalMax == 0 { // If interval is 0, we sent them in one tcp packet
+			if f.fragment.IntervalMax == 0 { // combine fragmented tlshello if interval is 0
 				hello = append(hello, buf[:5+l]...)
 			} else {
 				_, err := f.writer.Write(buf[:5+l])
@@ -424,12 +424,11 @@ func (f *FragmentWriter) Write(b []byte) (int, error) {
 				}
 			}
 			if from == len(data) {
-				if f.fragment.IntervalMax == 0 {
-					if len(b) > recordLen {
-						hello = append(hello, b[recordLen:]...)
+				if len(hello) > 0 {
+					_, err := f.writer.Write(hello)
+					if err != nil {
+						return 0, err
 					}
-					f.writer.Write(hello)
-					return len(b), nil
 				}
 				if len(b) > recordLen {
 					n, err := f.writer.Write(b[recordLen:])


### PR DESCRIPTION
https://github.com/XTLS/Xray-core/pull/3660#issuecomment-2277473149
当interval为0时把分片写在一个包（同3660 简单一些 同时复用length等参数）
为什么不用 -1？
因为里面的值是uint（无符号整数） 不想改。 break proto是个坏习惯（吗）

TODO: support interval: 1/2(这必须要改类型了 那还不如把楼上改成int 如果有人做的话记得把值从0改成-1)