### PR TITLE
SplitHTTP server: Only "ok" to older clients

### DIFF
--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -192,12 +192,15 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		h.config.WriteResponseHeader(writer)
 
 		writer.WriteHeader(http.StatusOK)
-		// in earlier versions, this initial body data was used to immediately
-		// start a 200 OK on all CDN. but xray client since 1.8.16 does not
-		// actually require an immediate 200 OK, but now requires these
-		// additional bytes "ok". xray client 1.8.24+ doesn't require "ok"
-		// anymore, and so this line should be removed in later versions.
-		writer.Write([]byte("ok"))
+		if _, ok := request.URL.Query()["x_padding"]; !ok {
+			// in earlier versions, this initial body data was used to immediately
+			// start a 200 OK on all CDN. but xray client since 1.8.16 does not
+			// actually require an immediate 200 OK, but now requires these
+			// additional bytes "ok". xray client 1.8.24+ doesn't require "ok"
+			// anymore, and so this line should be removed in later versions.
+			writer.Write([]byte("ok"))
+		}
+
 		responseFlusher.Flush()
 
 		downloadDone := done.New()


### PR DESCRIPTION
https://github.com/XTLS/Xray-core/pull/3643#issuecomment-2282304185

It makes sense. In earlier discussions of breaking changes, we assumed the server updates much faster than the client. But this is easy to do.

Note: `responseFlusher.Flush()` could also be conditional. It would mean that HTTP response headers are only written when the first VLESS response byte is written. For some CDN this is already the case. I am not sure what is preferred from a padding perspective. I guess technically response X-Padding can be removed if `responseFlusher.Flush()` is removed, and VLESS brings its own padding in the future. Anyway, I don't want to change it right now, because I am not sure if it triggers different timeout settings in the CDN. It can be changed later, it's not a breaking change.