### PR TITLE
Wireguard (Fix): `append(out.rules, r)`

### DIFF
--- a/proxy/wireguard/tun_linux.go
+++ b/proxy/wireguard/tun_linux.go
@@ -199,6 +199,7 @@ func createKernelTun(localAddresses []netip.Addr, mtu int, handler promiscuousMo
 
 		r := netlink.NewRule()
 		r.Table, r.Family, r.Src = ipv6TableIndex, unix.AF_INET6, addr.IPNet
+		out.rules = append(out.rules, r)
 		r = netlink.NewRule()
 		r.Table, r.Family, r.OifName = ipv6TableIndex, unix.AF_INET6, n
 		out.rules = append(out.rules, r)


### PR DESCRIPTION
https://github.com/XTLS/Xray-core/pull/3698#discussion_r1722504971