### PR TITLE
SplitHTTP: Fix connection leaks and crashes

### DIFF
--- a/transport/internet/splithttp/client.go
+++ b/transport/internet/splithttp/client.go
@@ -108,7 +108,7 @@ func (c *DefaultDialerClient) OpenDownload(ctx context.Context, baseURL string) 
 	}
 
 	lazyDownload := &LazyReader{
-		CreateReader: func() (io.ReadCloser, error) {
+		CreateReader: func() (io.Reader, error) {
 			<-gotDownResponse.Wait()
 			if downResponse == nil {
 				return nil, errors.New("downResponse failed")
@@ -187,7 +187,7 @@ func (c *DefaultDialerClient) SendUploadRequest(ctx context.Context, url string,
 }
 
 type downloadBody struct {
-	io.ReadCloser
+	io.Reader
 	cancel context.CancelFunc
 }
 

--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -222,8 +222,12 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		h.ln.addConn(stat.Connection(&conn))
 
 		// "A ResponseWriter may not be used after [Handler.ServeHTTP] has returned."
-		<-downloadDone.Wait()
+		select {
+		case <-request.Context().Done():
+		case <-downloadDone.Wait():
+		}
 
+		conn.Close()
 	} else {
 		writer.WriteHeader(http.StatusMethodNotAllowed)
 	}

--- a/transport/internet/splithttp/lazy_reader.go
+++ b/transport/internet/splithttp/lazy_reader.go
@@ -3,18 +3,20 @@ package splithttp
 import (
 	"io"
 	"sync"
-
-	"github.com/xtls/xray-core/common/errors"
 )
 
+// Close is intentionally not supported by LazyReader because it's not clear
+// how CreateReader should be aborted in case of Close. It's best to wrap
+// LazyReader in another struct that handles Close correctly, or better, stop
+// using LazyReader entirely.
 type LazyReader struct {
 	readerSync   sync.Mutex
-	CreateReader func() (io.ReadCloser, error)
-	reader       io.ReadCloser
+	CreateReader func() (io.Reader, error)
+	reader       io.Reader
 	readerError  error
 }
 
-func (r *LazyReader) getReader() (io.ReadCloser, error) {
+func (r *LazyReader) getReader() (io.Reader, error) {
 	r.readerSync.Lock()
 	defer r.readerSync.Unlock()
 	if r.reader != nil {
@@ -42,18 +44,4 @@ func (r *LazyReader) Read(b []byte) (int, error) {
 	}
 	n, err := reader.Read(b)
 	return n, err
-}
-
-func (r *LazyReader) Close() error {
-	r.readerSync.Lock()
-	defer r.readerSync.Unlock()
-
-	var err error
-	if r.reader != nil {
-		err = r.reader.Close()
-		r.reader = nil
-		r.readerError = errors.New("closed reader")
-	}
-
-	return err
 }

--- a/transport/internet/splithttp/strip_ok_reader.go
+++ b/transport/internet/splithttp/strip_ok_reader.go
@@ -1,0 +1,48 @@
+package splithttp
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/xtls/xray-core/common/errors"
+)
+
+// in older versions of splithttp, the server would respond with `ok` to flush
+// out HTTP response headers early. Response headers and a 200 OK were required
+// to initiate the connection. Later versions of splithttp dropped this
+// requirement, and in xray 1.8.24 the server stopped sending "ok" if it sees
+// x_padding. For compatibility, we need to remove "ok" from the underlying
+// reader if it exists, and otherwise forward the stream as-is.
+type stripOkReader struct {
+	io.ReadCloser
+	firstDone  bool
+	prefixRead []byte
+}
+
+func (r *stripOkReader) Read(b []byte) (int, error) {
+	if !r.firstDone {
+		r.firstDone = true
+
+		// skip "ok" response
+		prefixRead := []byte{0, 0}
+		_, err := io.ReadFull(r.ReadCloser, prefixRead)
+		if err != nil {
+			return 0, errors.New("failed to read initial response").Base(err)
+		}
+
+		if !bytes.Equal(prefixRead, []byte("ok")) {
+			// we read some garbage byte that may not have been "ok" at
+			// all. return a reader that replays what we have read so far
+			r.prefixRead = prefixRead
+		}
+	}
+
+	if len(r.prefixRead) > 0 {
+		n := copy(b, r.prefixRead)
+		r.prefixRead = r.prefixRead[n:]
+		return n, nil
+	}
+
+	n, err := r.ReadCloser.Read(b)
+	return n, err
+}

--- a/transport/internet/splithttp/upload_queue.go
+++ b/transport/internet/splithttp/upload_queue.go
@@ -51,8 +51,10 @@ func (h *uploadQueue) Close() error {
 	h.writeCloseMutex.Lock()
 	defer h.writeCloseMutex.Unlock()
 
-	h.closed = true
-	close(h.pushedPackets)
+	if !h.closed {
+		h.closed = true
+		close(h.pushedPackets)
+	}
 	return nil
 }
 


### PR DESCRIPTION


There are a few bugs that are fixed here:

1. (all http versions) When the client opens a connection and closes it without any traffic, the Close would lock forever and not appear on the wire at all
2. (all http versions) When the client terminates the connection correctly, the server would not notice and keep the upload queue and related datastructures around until the proxied connection times out.
3. (quic only) closing the connection might crash the client as well, Fix https://github.com/XTLS/Xray-core/issues/3699

Are fixed in the following way:

* Problem 1 is addressed by removing the use of LazyReader. It turns out that while `ok` is being peeked, `Close` is entirely ignored
* Problem 2 is addressed on the server by using the request's context to close the connection
* Problem 3 is addressed by using the request's context to close the connection instead of `Body.Close`.