### PR TITLE
Fix: RPC call causes xray panic problem using wrong account type

### DIFF
--- a/proxy/vmess/validator.go
+++ b/proxy/vmess/validator.go
@@ -3,6 +3,7 @@ package vmess
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"fmt"
 	"hash/crc64"
 	"strings"
 	"sync"
@@ -39,7 +40,10 @@ func (v *TimedUserValidator) Add(u *protocol.MemoryUser) error {
 
 	v.users = append(v.users, u)
 
-	account := u.Account.(*MemoryAccount)
+	account, ok := u.Account.(*MemoryAccount)
+	if !ok {
+		return fmt.Errorf("expected *MemoryAccount but got %T", u.Account)
+	}
 	if !v.behaviorFused {
 		hashkdf := hmac.New(sha256.New, []byte("VMESSBSKDF"))
 		hashkdf.Write(account.ID.Bytes())

--- a/proxy/vmess/validator.go
+++ b/proxy/vmess/validator.go
@@ -3,7 +3,6 @@ package vmess
 import (
 	"crypto/hmac"
 	"crypto/sha256"
-	"fmt"
 	"hash/crc64"
 	"strings"
 	"sync"
@@ -42,7 +41,7 @@ func (v *TimedUserValidator) Add(u *protocol.MemoryUser) error {
 
 	account, ok := u.Account.(*MemoryAccount)
 	if !ok {
-		return fmt.Errorf("expected *MemoryAccount but got %T", u.Account)
+		return errors.New("account type is incorrect")
 	}
 	if !v.behaviorFused {
 		hashkdf := hmac.New(sha256.New, []byte("VMESSBSKDF"))


### PR DESCRIPTION
…protocol user in an inbound proxy. If inTag: "VMess-xxx", but the developer carelessly calls the add user method of vless or other protocols, such as xrayCtl.AddVlessUser(user), causing xray panic