### PR TITLE
Fix: Return error when Fingerprint does not support TLS 1.3

### DIFF
--- a/transport/internet/reality/reality.go
+++ b/transport/internet/reality/reality.go
@@ -140,6 +140,9 @@ func UClient(c net.Conn, config *Config, ctx context.Context, dest net.Destinati
 		if err != nil {
 			return nil, errors.New("REALITY: publicKey == nil")
 		}
+		if uConn.HandshakeState.State13.EcdheKey == nil {
+			return nil, errors.New("Current fingerprint ", uConn.ClientHelloID.Client, uConn.ClientHelloID.Version, " does not support TLS 1.3, REALITY handshake cannot establish.")
+		}
 		uConn.AuthKey, _ = uConn.HandshakeState.State13.EcdheKey.ECDH(publicKey)
 		if uConn.AuthKey == nil {
 			return nil, errors.New("REALITY: SharedKey == nil")


### PR DESCRIPTION
在尝试解决 https://github.com/XTLS/Xray-core/issues/2896 的时候 稍微调试了一下，发现 `uConn.HandshakeState.State13.EcdheKey` 竟然是nil, 调查后发现 utls 的安卓11指纹（实为OkHttp）是仅TLS 1.2的 (见 https://github.com/refraction-networking/utls/blob/23de245734c7c25b11200f8b5859c2114c032e51/u_parrots.go#L1595 因为它没有 `SupportedVersionsExtension` 扩展) 连TLS1.3都不是  `EcdheKey` 自然就是nil了 继续尝试调用其ECDH方法自然就导致了空指针panic
我认为这是utls库的一个错误，因为OkHttp在安卓10就默认使用了TLS13 不过考虑到可能还有其他仅TLS12的指纹 被random到踩到坑 还是在Xray这边检测并返回错误 避免直接panic比较好
闲的话可以把服务器证书换成GTS签发的 然后用android指纹 会因为使用TLS12导致证书泄露 GFW看到GTS的证书就会把服务器IP阻断几分钟 ~~我本地测试的时候发现的~~