### PR TITLE
DNS: do not use cache when returned DNS result has errors

### DIFF
--- a/app/dns/nameserver_doh.go
+++ b/app/dns/nameserver_doh.go
@@ -365,7 +365,7 @@ func (s *DoHNameServer) QueryIP(ctx context.Context, domain string, clientIP net
 		errors.LogDebug(ctx, "DNS cache is disabled. Querying IP for ", domain, " at ", s.name)
 	} else {
 		ips, err := s.findIPsForDomain(fqdn, option)
-		if err != errRecordNotFound {
+		if err == nil || err == dns_feature.ErrEmptyResponse {
 			errors.LogDebugInner(ctx, err, s.name, " cache HIT ", domain, " -> ", ips)
 			log.Record(&log.DNSLog{Server: s.name, Domain: domain, Result: ips, Status: log.DNSCacheHit, Elapsed: 0, Error: err})
 			return ips, err

--- a/app/dns/nameserver_quic.go
+++ b/app/dns/nameserver_quic.go
@@ -300,7 +300,7 @@ func (s *QUICNameServer) QueryIP(ctx context.Context, domain string, clientIP ne
 		errors.LogDebug(ctx, "DNS cache is disabled. Querying IP for ", domain, " at ", s.name)
 	} else {
 		ips, err := s.findIPsForDomain(fqdn, option)
-		if err != errRecordNotFound {
+		if err == nil || err == dns_feature.ErrEmptyResponse {
 			errors.LogDebugInner(ctx, err, s.name, " cache HIT ", domain, " -> ", ips)
 			log.Record(&log.DNSLog{Server: s.name, Domain: domain, Result: ips, Status: log.DNSCacheHit, Elapsed: 0, Error: err})
 			return ips, err

--- a/app/dns/nameserver_tcp.go
+++ b/app/dns/nameserver_tcp.go
@@ -323,7 +323,7 @@ func (s *TCPNameServer) QueryIP(ctx context.Context, domain string, clientIP net
 		errors.LogDebug(ctx, "DNS cache is disabled. Querying IP for ", domain, " at ", s.name)
 	} else {
 		ips, err := s.findIPsForDomain(fqdn, option)
-		if err != errRecordNotFound {
+		if err == nil || err == dns_feature.ErrEmptyResponse {
 			errors.LogDebugInner(ctx, err, s.name, " cache HIT ", domain, " -> ", ips)
 			log.Record(&log.DNSLog{Server: s.name, Domain: domain, Result: ips, Status: log.DNSCacheHit, Elapsed: 0, Error: err})
 			return ips, err

--- a/app/dns/nameserver_udp.go
+++ b/app/dns/nameserver_udp.go
@@ -250,7 +250,7 @@ func (s *ClassicNameServer) QueryIP(ctx context.Context, domain string, clientIP
 		errors.LogDebug(ctx, "DNS cache is disabled. Querying IP for ", domain, " at ", s.name)
 	} else {
 		ips, err := s.findIPsForDomain(fqdn, option)
-		if err != errRecordNotFound {
+		if err == nil || err == dns_feature.ErrEmptyResponse {
 			errors.LogDebugInner(ctx, err, s.name, " cache HIT ", domain, " -> ", ips)
 			log.Record(&log.DNSLog{Server: s.name, Domain: domain, Result: ips, Status: log.DNSCacheHit, Elapsed: 0, Error: err})
 			return ips, err


### PR DESCRIPTION
见 #1231 
原代码里写的是 如果没有found到 就跳过缓存(if err != errRecordNotFound)
但是如1231中的问题 它确实found到了 但是found的是什么? found到了一个 `rcode 3`（摊手）
修改之后只要遇到错误就绕过缓存 重新解析 代码里还豁免了一种情况 `dns_feature.ErrEmptyResponse`  因为这个错误表示没hit对 比如指定解析ipv4 但是解析出来只有v6 这种情况我们它是正常的 不然的话正常单栈v6会被认为解析失败而反复解析

但是注意 现在被修改之后对于一些无效的请求 每一次xray都会进行转发而不会cache住 可能会多大量不必要的无效请求
其实原来的行为其实是合理的 不对的地址就是不对 这会不对的地址怎么等会又对了 感觉只有上游瞎玩dnsmasq之类的玩意才会造成这种问题 是否要其他人为这些DNS灵车爱好者买单？