### PR TITLE
Log: Improve feature deprecation/removal logs

### DIFF
--- a/features/feature.go
+++ b/features/feature.go
@@ -21,6 +21,7 @@ func PrintDeprecatedFeatureWarning(feature string) {
 	errors.LogWarning(context.Background(), "You are using a deprecated feature: " + feature + ". Please update your config file(s) with latest configuration format, or update your client software.")
 }
 
+// PrintRemovedFeatureWarning prints an error message for removed feature. And after long enough time the message can also be removed, use as an indicator.
 func PrintRemovedFeatureWarning(feature string) {
 	errors.New("The feature " + feature + " is removed. Please update your config file(s) according to release notes and documentations.")
 }

--- a/features/feature.go
+++ b/features/feature.go
@@ -21,7 +21,7 @@ func PrintDeprecatedFeatureWarning(feature string) {
 	errors.LogWarning(context.Background(), "You are using a deprecated feature: " + feature + ". Please update your config file(s) with latest configuration format, or update your client software.")
 }
 
-// PrintRemovedFeatureWarning prints an error message for removed feature. And after long enough time the message can also be removed, use as an indicator.
-func PrintRemovedFeatureWarning(feature string) {
+// PrintRemovedFeatureError prints an error message for removed feature. And after long enough time the message can also be removed, use as an indicator.
+func PrintRemovedFeatureError(feature string) {
 	errors.New("The feature " + feature + " is removed. Please update your config file(s) according to release notes and documentations.")
 }

--- a/features/feature.go
+++ b/features/feature.go
@@ -18,5 +18,9 @@ type Feature interface {
 
 // PrintDeprecatedFeatureWarning prints a warning for deprecated feature.
 func PrintDeprecatedFeatureWarning(feature string) {
-	errors.LogInfo(context.Background(), "You are using a deprecated feature: " + feature + ". Please update your config file with latest configuration format, or update your client software.")
+	errors.LogWarning(context.Background(), "You are using a deprecated feature: " + feature + ". Please update your config file(s) with latest configuration format, or update your client software.")
+}
+
+func PrintRemovedFeatureWarning(feature string) {
+	errors.New("The feature " + feature + " is removed. Please update your config file(s) according to release notes and documentations.")
 }


### PR DESCRIPTION
The default `logLevel` is `warning` so normally there are not many people know the features that are deprecating.

This pr does these:

- Changing the feature deprecation warning lo level `warning`: so normally most people can see the warning, and we can have a good use of it.
- Add feature removal warning: This indicate the feature has been removed, and can be use as a "REMOVE BEFORE FLIGHT" tag so we can remove this warning after a long enough period of time.

这个改动是像原来设计/现在这样放在 `features` 里面，还是转移到 `errors` 比较好？