### PR TITLE
Errors: Add PrintRemovedFeatureError & PrintDeprecatedFeatureWarning

### DIFF
--- a/app/dns/dns.go
+++ b/app/dns/dns.go
@@ -96,7 +96,7 @@ func New(ctx context.Context, config *Config) (*DNS, error) {
 	geoipContainer := router.GeoIPMatcherContainer{}
 
 	for _, endpoint := range config.NameServers {
-		features.PrintDeprecatedFeatureWarning("simple DNS server")
+		features.PrintDeprecatedFeatureWarning("simple DNS server", nil)
 		client, err := NewSimpleClient(ctx, endpoint, clientIP)
 		if err != nil {
 			return nil, errors.New("failed to create client").Base(err)

--- a/app/dns/dns.go
+++ b/app/dns/dns.go
@@ -15,7 +15,6 @@ import (
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/session"
 	"github.com/xtls/xray-core/common/strmatcher"
-	"github.com/xtls/xray-core/features"
 	"github.com/xtls/xray-core/features/dns"
 )
 
@@ -96,7 +95,7 @@ func New(ctx context.Context, config *Config) (*DNS, error) {
 	geoipContainer := router.GeoIPMatcherContainer{}
 
 	for _, endpoint := range config.NameServers {
-		features.PrintDeprecatedFeatureWarning("simple DNS server", "")
+		errors.PrintDeprecatedFeatureWarning("simple DNS server", "")
 		client, err := NewSimpleClient(ctx, endpoint, clientIP)
 		if err != nil {
 			return nil, errors.New("failed to create client").Base(err)

--- a/app/dns/dns.go
+++ b/app/dns/dns.go
@@ -96,7 +96,7 @@ func New(ctx context.Context, config *Config) (*DNS, error) {
 	geoipContainer := router.GeoIPMatcherContainer{}
 
 	for _, endpoint := range config.NameServers {
-		features.PrintDeprecatedFeatureWarning("simple DNS server", nil)
+		features.PrintDeprecatedFeatureWarning("simple DNS server", "")
 		client, err := NewSimpleClient(ctx, endpoint, clientIP)
 		if err != nil {
 			return nil, errors.New("failed to create client").Base(err)

--- a/app/dns/hosts.go
+++ b/app/dns/hosts.go
@@ -26,7 +26,7 @@ func NewStaticHosts(hosts []*Config_HostMapping, legacy map[string]*net.IPOrDoma
 	}
 
 	if legacy != nil {
-		features.PrintDeprecatedFeatureWarning("simple host mapping")
+		features.PrintDeprecatedFeatureWarning("simple host mapping", nil)
 
 		for domain, ip := range legacy {
 			matcher, err := strmatcher.Full.New(domain)

--- a/app/dns/hosts.go
+++ b/app/dns/hosts.go
@@ -26,7 +26,7 @@ func NewStaticHosts(hosts []*Config_HostMapping, legacy map[string]*net.IPOrDoma
 	}
 
 	if legacy != nil {
-		features.PrintDeprecatedFeatureWarning("simple host mapping", nil)
+		features.PrintDeprecatedFeatureWarning("simple host mapping", "")
 
 		for domain, ip := range legacy {
 			matcher, err := strmatcher.Full.New(domain)

--- a/app/dns/hosts.go
+++ b/app/dns/hosts.go
@@ -7,7 +7,6 @@ import (
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/strmatcher"
-	"github.com/xtls/xray-core/features"
 	"github.com/xtls/xray-core/features/dns"
 )
 
@@ -26,7 +25,7 @@ func NewStaticHosts(hosts []*Config_HostMapping, legacy map[string]*net.IPOrDoma
 	}
 
 	if legacy != nil {
-		features.PrintDeprecatedFeatureWarning("simple host mapping", "")
+		errors.PrintDeprecatedFeatureWarning("simple host mapping", "")
 
 		for domain, ip := range legacy {
 			matcher, err := strmatcher.Full.New(domain)

--- a/common/errors/feature_errors.go
+++ b/common/errors/feature_errors.go
@@ -1,0 +1,21 @@
+package errors
+
+// PrintDeprecatedFeatureWarning prints a warning for deprecated and going to be removed feature.
+// Do not remove this function even there is no reference to it.
+func PrintDeprecatedFeatureWarning(feature string, migrateFeature string) {
+	if len(migrateFeature) > 0 {
+		LogWarning(context.Background(), "This feature " + feature + " is deprecated and being migrated to " + migrateFeature + ". Please update your config(s) according to release note and documentation before removal.")
+	} else {
+		LogWarning(context.Background(), "This feature " + feature + " is deprecated. Please update your config(s) according to release note and documentation before removal.")
+	}
+}
+
+// PrintRemovedFeatureError prints an error message for removed feature then return an error. And after long enough time the message can also be removed, uses as an indicator.
+// Do not remove this function even there is no reference to it.
+func PrintRemovedFeatureError(feature string, migrateFeature string) (error) {
+	if len(migrateFeature) > 0 {
+		return New("The feature " + feature + " has been removed and migrated to " + migrateFeature + ". Please update your config(s) according to release note and documentation.")
+	} else {
+		return New("The feature " + feature + " has been removed. Please update your config(s) according to release note and documentation.")
+	}
+}

--- a/common/errors/feature_errors.go
+++ b/common/errors/feature_errors.go
@@ -1,5 +1,9 @@
 package errors
 
+import (
+	"context"
+)
+
 // PrintDeprecatedFeatureWarning prints a warning for deprecated and going to be removed feature.
 // Do not remove this function even there is no reference to it.
 func PrintDeprecatedFeatureWarning(feature string, migrateFeature string) {

--- a/features/feature.go
+++ b/features/feature.go
@@ -22,6 +22,6 @@ func PrintDeprecatedFeatureWarning(feature string) {
 }
 
 // PrintRemovedFeatureError prints an error message for removed feature. And after long enough time the message can also be removed, use as an indicator.
-func PrintRemovedFeatureError(feature string) {
-	errors.New("The feature " + feature + " is removed. Please update your config file(s) according to release notes and documentations.")
+func PrintRemovedFeatureError(feature string) (error) {
+	return errors.New("The feature " + feature + " is removed. Please update your config file(s) according to release notes and documentations.")
 }

--- a/features/feature.go
+++ b/features/feature.go
@@ -4,34 +4,11 @@ import (
 	"context"
 
 	"github.com/xtls/xray-core/common"
-	"github.com/xtls/xray-core/common/errors"
 )
-
-//go:generate go run github.com/xtls/xray-core/common/errors/errorgen
 
 // Feature is the interface for Xray features. All features must implement this interface.
 // All existing features have an implementation in app directory. These features can be replaced by third-party ones.
 type Feature interface {
 	common.HasType
 	common.Runnable
-}
-
-// PrintDeprecatedFeatureWarning prints a warning for deprecated and going to be removed feature.
-// Do not remove this function even there is no reference to it.
-func PrintDeprecatedFeatureWarning(feature string, migrateFeature string) {
-	if len(migrateFeature) > 0 {
-		errors.LogWarning(context.Background(), "This feature " + feature + " is deprecated and being migrated to " + migrateFeature + ". Please update your config(s) according to release note and documentation before removal.")
-	} else {
-		errors.LogWarning(context.Background(), "This feature " + feature + " is deprecated. Please update your config(s) according to release note and documentation before removal.")
-	}
-}
-
-// PrintRemovedFeatureError prints an error message for removed feature then return an error. And after long enough time the message can also be removed, uses as an indicator.
-// Do not remove this function even there is no reference to it.
-func PrintRemovedFeatureError(feature string, migrateFeature string) (error) {
-	if len(migrateFeature) > 0 {
-		return errors.New("The feature " + feature + " has been removed and migrated to " + migrateFeature + ". Please update your config(s) according to release note and documentation.")
-	} else {
-		return errors.New("The feature " + feature + " has been removed. Please update your config(s) according to release note and documentation.")
-	}
 }

--- a/features/feature.go
+++ b/features/feature.go
@@ -18,10 +18,10 @@ type Feature interface {
 
 // PrintDeprecatedFeatureWarning prints a warning for deprecated feature.
 func PrintDeprecatedFeatureWarning(feature string) {
-	errors.LogWarning(context.Background(), "You are using a deprecated feature: " + feature + ". Please update your config file(s) with latest configuration format, or update your client software.")
+	errors.LogWarning(context.Background(), "You are using a deprecated feature: " + feature + ". Please update your config file(s), or update your client software.")
 }
 
 // PrintRemovedFeatureError prints an error message for removed feature. And after long enough time the message can also be removed, use as an indicator.
 func PrintRemovedFeatureError(feature string) (error) {
-	return errors.New("The feature " + feature + " is removed. Please update your config file(s) according to release notes and documentations.")
+	return errors.New("The feature " + feature + " has been removed. Please update your config file(s) according to release notes and documentations.")
 }

--- a/features/feature.go
+++ b/features/feature.go
@@ -19,19 +19,19 @@ type Feature interface {
 // PrintDeprecatedFeatureWarning prints a warning for deprecated and going to be removed feature.
 // Do not remove this function even there is no reference to it.
 func PrintDeprecatedFeatureWarning(feature string, migrateFeature string) {
-	if migrateFeature == nil {
-		errors.LogWarning(context.Background(), "This feature " + feature + " is deprecated. Please update your config(s) according to release note and documentation before removal.")
-	} else {
+	if len(migrateFeature) > 0 {
 		errors.LogWarning(context.Background(), "This feature " + feature + " is deprecated and being migrated to " + migrateFeature + ". Please update your config(s) according to release note and documentation before removal.")
+	} else {
+		errors.LogWarning(context.Background(), "This feature " + feature + " is deprecated. Please update your config(s) according to release note and documentation before removal.")
 	}
 }
 
 // PrintRemovedFeatureError prints an error message for removed feature then return an error. And after long enough time the message can also be removed, uses as an indicator.
 // Do not remove this function even there is no reference to it.
 func PrintRemovedFeatureError(feature string, migrateFeature string) (error) {
-	if migrateFeature == nil {
-		return errors.New("The feature " + feature + " has been removed. Please update your config(s) according to release note and documentation.")
-	} else {
+	if len(migrateFeature) > 0 {
 		return errors.New("The feature " + feature + " has been removed and migrated to " + migrateFeature + ". Please update your config(s) according to release note and documentation.")
+	} else {
+		return errors.New("The feature " + feature + " has been removed. Please update your config(s) according to release note and documentation.")
 	}
 }

--- a/features/feature.go
+++ b/features/feature.go
@@ -1,8 +1,6 @@
 package features
 
 import (
-	"context"
-
 	"github.com/xtls/xray-core/common"
 )
 

--- a/features/feature.go
+++ b/features/feature.go
@@ -16,12 +16,22 @@ type Feature interface {
 	common.Runnable
 }
 
-// PrintDeprecatedFeatureWarning prints a warning for deprecated feature.
-func PrintDeprecatedFeatureWarning(feature string) {
-	errors.LogWarning(context.Background(), "You are using a deprecated feature: " + feature + ". Please update your config file(s), or update your client software.")
+// PrintDeprecatedFeatureWarning prints a warning for deprecated and going to be removed feature.
+// Do not remove this function even there is no reference to it.
+func PrintDeprecatedFeatureWarning(feature string, migrateFeature string) {
+	if migrateFeature == nil {
+		errors.LogWarning(context.Background(), "This feature " + feature + " is deprecated. Please update your config(s) according to release note and documentation before removal.")
+	} else {
+		errors.LogWarning(context.Background(), "This feature " + feature + " is deprecated and being migrated to " + migrateFeature + ". Please update your config(s) according to release note and documentation before removal.")
+	}
 }
 
-// PrintRemovedFeatureError prints an error message for removed feature. And after long enough time the message can also be removed, use as an indicator.
-func PrintRemovedFeatureError(feature string) (error) {
-	return errors.New("The feature " + feature + " has been removed. Please update your config file(s) according to release notes and documentations.")
+// PrintRemovedFeatureError prints an error message for removed feature then return an error. And after long enough time the message can also be removed, uses as an indicator.
+// Do not remove this function even there is no reference to it.
+func PrintRemovedFeatureError(feature string, migrateFeature string) (error) {
+	if migrateFeature == nil {
+		return errors.New("The feature " + feature + " has been removed. Please update your config(s) according to release note and documentation.")
+	} else {
+		return errors.New("The feature " + feature + " has been removed and migrated to " + migrateFeature + ". Please update your config(s) according to release note and documentation.")
+	}
 }

--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -814,7 +814,7 @@ func (c *StreamConfig) Build() (*internet.StreamConfig, error) {
 		config.SecuritySettings = append(config.SecuritySettings, tm)
 		config.SecurityType = tm.Type
 	case "xtls":
-		return nil, features.PrintRemovedFeatureError(`Legacy XTLS (replaced by xtls-rprx-vision with TLS or REALITY)`)
+		return nil, features.PrintRemovedFeatureError(`Legacy XTLS`, `xtls-rprx-vision with TLS or REALITY`)
 	default:
 		return nil, errors.New(`Unknown security "` + c.Security + `".`)
 	}

--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -15,6 +15,7 @@ import (
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/platform/filesystem"
 	"github.com/xtls/xray-core/common/serial"
+	"github.com/xtls/xray-core/features"
 	"github.com/xtls/xray-core/transport/internet"
 	httpheader "github.com/xtls/xray-core/transport/internet/headers/http"
 	"github.com/xtls/xray-core/transport/internet/http"
@@ -813,7 +814,7 @@ func (c *StreamConfig) Build() (*internet.StreamConfig, error) {
 		config.SecuritySettings = append(config.SecuritySettings, tm)
 		config.SecurityType = tm.Type
 	case "xtls":
-		return nil, errors.New(`Please use VLESS flow "xtls-rprx-vision" with TLS or REALITY.`)
+		return nil, return nil, features.PrintRemovedFeatureError(`Legacy XTLS (replaced by xtls-rprx-vision with TLS or REALITY)`)
 	default:
 		return nil, errors.New(`Unknown security "` + c.Security + `".`)
 	}

--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -814,7 +814,7 @@ func (c *StreamConfig) Build() (*internet.StreamConfig, error) {
 		config.SecuritySettings = append(config.SecuritySettings, tm)
 		config.SecurityType = tm.Type
 	case "xtls":
-		return nil, return nil, features.PrintRemovedFeatureError(`Legacy XTLS (replaced by xtls-rprx-vision with TLS or REALITY)`)
+		return nil, features.PrintRemovedFeatureError(`Legacy XTLS (replaced by xtls-rprx-vision with TLS or REALITY)`)
 	default:
 		return nil, errors.New(`Unknown security "` + c.Security + `".`)
 	}

--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -15,7 +15,6 @@ import (
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/platform/filesystem"
 	"github.com/xtls/xray-core/common/serial"
-	"github.com/xtls/xray-core/features"
 	"github.com/xtls/xray-core/transport/internet"
 	httpheader "github.com/xtls/xray-core/transport/internet/headers/http"
 	"github.com/xtls/xray-core/transport/internet/http"
@@ -814,7 +813,7 @@ func (c *StreamConfig) Build() (*internet.StreamConfig, error) {
 		config.SecuritySettings = append(config.SecuritySettings, tm)
 		config.SecurityType = tm.Type
 	case "xtls":
-		return nil, features.PrintRemovedFeatureError(`Legacy XTLS`, `xtls-rprx-vision with TLS or REALITY`)
+		return nil, errors.PrintRemovedFeatureError(`Legacy XTLS`, `xtls-rprx-vision with TLS or REALITY`)
 	default:
 		return nil, errors.New(`Unknown security "` + c.Security + `".`)
 	}

--- a/infra/conf/trojan.go
+++ b/infra/conf/trojan.go
@@ -53,7 +53,7 @@ func (c *TrojanClientConfig) Build() (proto.Message, error) {
 			return nil, errors.New("Trojan password is not specified.")
 		}
 		if rec.Flow != "" {
-			return nil, features.PrintRemovedFeatureError(`Flow for Trojan`)
+			return nil, features.PrintRemovedFeatureError(`Flow for Trojan`, nil)
 		}
 
 		config.Server[idx] = &protocol.ServerEndpoint{
@@ -107,7 +107,7 @@ func (c *TrojanServerConfig) Build() (proto.Message, error) {
 
 	for idx, rawUser := range c.Clients {
 		if rawUser.Flow != "" {
-			return nil, features.PrintRemovedFeatureError(`Flow for Trojan`)
+			return nil, features.PrintRemovedFeatureError(`Flow for Trojan`, nil)
 		}
 
 		config.Users[idx] = &protocol.User{

--- a/infra/conf/trojan.go
+++ b/infra/conf/trojan.go
@@ -12,6 +12,7 @@ import (
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/protocol"
 	"github.com/xtls/xray-core/common/serial"
+	"github.com/xtls/xray-core/features"
 	"github.com/xtls/xray-core/proxy/trojan"
 	"google.golang.org/protobuf/proto"
 )
@@ -52,7 +53,7 @@ func (c *TrojanClientConfig) Build() (proto.Message, error) {
 			return nil, errors.New("Trojan password is not specified.")
 		}
 		if rec.Flow != "" {
-			return nil, errors.New(`Trojan doesn't support "flow" anymore.`)
+			return nil, features.PrintRemovedFeatureError(`Flow for Trojan`)
 		}
 
 		config.Server[idx] = &protocol.ServerEndpoint{
@@ -106,7 +107,7 @@ func (c *TrojanServerConfig) Build() (proto.Message, error) {
 
 	for idx, rawUser := range c.Clients {
 		if rawUser.Flow != "" {
-			return nil, errors.New(`Trojan doesn't support "flow" anymore.`)
+			return nil, features.PrintRemovedFeatureError(`Flow for Trojan`)
 		}
 
 		config.Users[idx] = &protocol.User{

--- a/infra/conf/trojan.go
+++ b/infra/conf/trojan.go
@@ -12,7 +12,6 @@ import (
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/protocol"
 	"github.com/xtls/xray-core/common/serial"
-	"github.com/xtls/xray-core/features"
 	"github.com/xtls/xray-core/proxy/trojan"
 	"google.golang.org/protobuf/proto"
 )
@@ -53,7 +52,7 @@ func (c *TrojanClientConfig) Build() (proto.Message, error) {
 			return nil, errors.New("Trojan password is not specified.")
 		}
 		if rec.Flow != "" {
-			return nil, features.PrintRemovedFeatureError(`Flow for Trojan`, ``)
+			return nil, errors.PrintRemovedFeatureError(`Flow for Trojan`, ``)
 		}
 
 		config.Server[idx] = &protocol.ServerEndpoint{
@@ -107,7 +106,7 @@ func (c *TrojanServerConfig) Build() (proto.Message, error) {
 
 	for idx, rawUser := range c.Clients {
 		if rawUser.Flow != "" {
-			return nil, features.PrintRemovedFeatureError(`Flow for Trojan`, ``)
+			return nil, errors.PrintRemovedFeatureError(`Flow for Trojan`, ``)
 		}
 
 		config.Users[idx] = &protocol.User{

--- a/infra/conf/trojan.go
+++ b/infra/conf/trojan.go
@@ -53,7 +53,7 @@ func (c *TrojanClientConfig) Build() (proto.Message, error) {
 			return nil, errors.New("Trojan password is not specified.")
 		}
 		if rec.Flow != "" {
-			return nil, features.PrintRemovedFeatureError(`Flow for Trojan`, nil)
+			return nil, features.PrintRemovedFeatureError(`Flow for Trojan`, ``)
 		}
 
 		config.Server[idx] = &protocol.ServerEndpoint{
@@ -107,7 +107,7 @@ func (c *TrojanServerConfig) Build() (proto.Message, error) {
 
 	for idx, rawUser := range c.Clients {
 		if rawUser.Flow != "" {
-			return nil, features.PrintRemovedFeatureError(`Flow for Trojan`, nil)
+			return nil, features.PrintRemovedFeatureError(`Flow for Trojan`, ``)
 		}
 
 		config.Users[idx] = &protocol.User{

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -594,7 +594,7 @@ func (c *Config) Build() (*core.Config, error) {
 	}
 
 	if len(c.Transport) > 0 {
-		return nil, features.PrintRemovedFeatureError("Global transport config", `streamSettings in inbounds and outbounds`)
+		return nil, features.PrintRemovedFeatureError("Global transport config", "streamSettings in inbounds and outbounds")
 	}
 
 	for _, rawInboundConfig := range inbounds {

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -15,6 +15,7 @@ import (
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/serial"
+	"github.com/xtls/xray-core/features"
 	core "github.com/xtls/xray-core/core"
 	"github.com/xtls/xray-core/transport/internet"
 )
@@ -593,7 +594,7 @@ func (c *Config) Build() (*core.Config, error) {
 	}
 
 	if len(c.Transport) > 0 {
-		return nil, errors.New("Global transport config is deprecated")
+		return nil, features.PrintRemovedFeatureError("Global transport config")
 	}
 
 	for _, rawInboundConfig := range inbounds {

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -15,7 +15,6 @@ import (
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/serial"
-	"github.com/xtls/xray-core/features"
 	core "github.com/xtls/xray-core/core"
 	"github.com/xtls/xray-core/transport/internet"
 )
@@ -594,7 +593,7 @@ func (c *Config) Build() (*core.Config, error) {
 	}
 
 	if len(c.Transport) > 0 {
-		return nil, features.PrintRemovedFeatureError("Global transport config", "streamSettings in inbounds and outbounds")
+		return nil, errors.PrintRemovedFeatureError("Global transport config", "streamSettings in inbounds and outbounds")
 	}
 
 	for _, rawInboundConfig := range inbounds {

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -594,7 +594,7 @@ func (c *Config) Build() (*core.Config, error) {
 	}
 
 	if len(c.Transport) > 0 {
-		return nil, features.PrintRemovedFeatureError("Global transport config")
+		return nil, features.PrintRemovedFeatureError("Global transport config", `streamSettings in inbounds and outbounds`)
 	}
 
 	for _, rawInboundConfig := range inbounds {

--- a/proxy/socks/server.go
+++ b/proxy/socks/server.go
@@ -16,7 +16,6 @@ import (
 	"github.com/xtls/xray-core/common/signal"
 	"github.com/xtls/xray-core/common/task"
 	"github.com/xtls/xray-core/core"
-	"github.com/xtls/xray-core/features"
 	"github.com/xtls/xray-core/features/policy"
 	"github.com/xtls/xray-core/features/routing"
 	"github.com/xtls/xray-core/proxy/http"
@@ -56,7 +55,7 @@ func (s *Server) policy() policy.Session {
 	config := s.config
 	p := s.policyManager.ForLevel(config.UserLevel)
 	if config.Timeout > 0 {
-		features.PrintDeprecatedFeatureWarning("Socks timeout", "")
+		errors.PrintDeprecatedFeatureWarning("Socks timeout", "Policy level")
 	}
 	if config.Timeout > 0 && config.UserLevel == 0 {
 		p.Timeouts.ConnectionIdle = time.Duration(config.Timeout) * time.Second

--- a/proxy/socks/server.go
+++ b/proxy/socks/server.go
@@ -56,7 +56,7 @@ func (s *Server) policy() policy.Session {
 	config := s.config
 	p := s.policyManager.ForLevel(config.UserLevel)
 	if config.Timeout > 0 {
-		features.PrintDeprecatedFeatureWarning("Socks timeout", nil)
+		features.PrintDeprecatedFeatureWarning("Socks timeout", "")
 	}
 	if config.Timeout > 0 && config.UserLevel == 0 {
 		p.Timeouts.ConnectionIdle = time.Duration(config.Timeout) * time.Second

--- a/proxy/socks/server.go
+++ b/proxy/socks/server.go
@@ -56,7 +56,7 @@ func (s *Server) policy() policy.Session {
 	config := s.config
 	p := s.policyManager.ForLevel(config.UserLevel)
 	if config.Timeout > 0 {
-		features.PrintDeprecatedFeatureWarning("Socks timeout")
+		features.PrintDeprecatedFeatureWarning("Socks timeout", nil)
 	}
 	if config.Timeout > 0 && config.UserLevel == 0 {
 		p.Timeouts.ConnectionIdle = time.Duration(config.Timeout) * time.Second


### PR DESCRIPTION
接 #3793 

- 此次 pr 稍微修改了两个函数的提示描述，并且升级了 `PrintRemovedFeatureError()` ：此次修改使其在调用时可以正常返回错误从而达成一些遇到停用功能之后自动退出程序的效果，不需要再借助 `errors.New()` （实际上该函数为其封装作为专用用途）。

- 将 `PrintRemovedFeatureError()` 应用到已移除功能上面，提示用户需要修改配置，并且有利于日后的残余代码清理（删除已久的功能）：
  - Trojan Flow
  - `"security": "xtls"`
  - 全局传输设置

~~想给 QUIC 和 DomainSocket 也加上但是没留位置~~

优点是只需在函数信息中填入功能名字即可。
缺点是每次使用这个函数都要引入 features 包，各方面可能不如引入 errors 包方便。