### PR TITLE
sniff: 支持非http入站使用attrs进行路由

### DIFF
--- a/app/dispatcher/sniffer.go
+++ b/app/dispatcher/sniffer.go
@@ -35,7 +35,7 @@ type Sniffer struct {
 func NewSniffer(ctx context.Context) *Sniffer {
 	ret := &Sniffer{
 		sniffer: []protocolSnifferWithMetadata{
-			{func(c context.Context, b []byte) (SniffResult, error) { return http.SniffHTTP(b) }, false, net.Network_TCP},
+			{func(c context.Context, b []byte) (SniffResult, error) { return http.SniffHTTP(b, c) }, false, net.Network_TCP},
 			{func(c context.Context, b []byte) (SniffResult, error) { return tls.SniffTLS(b) }, false, net.Network_TCP},
 			{func(c context.Context, b []byte) (SniffResult, error) { return bittorrent.SniffBittorrent(b) }, false, net.Network_TCP},
 			{func(c context.Context, b []byte) (SniffResult, error) { return quic.SniffQUIC(b) }, false, net.Network_UDP},

--- a/common/protocol/http/sniff.go
+++ b/common/protocol/http/sniff.go
@@ -90,6 +90,16 @@ func SniffHTTP(b []byte, c context.Context) (*SniffHeader, error) {
 			sh.host = dest.Address.String()
 		}
 	}
+	// Parse request line
+	// Request line is like this
+	// "GET /homo/114514 HTTP/1.1"
+	if len(headers) > 0 {
+		RequestLineParts := bytes.Split(headers[0], []byte{' '})
+		if len(RequestLineParts) == 3 {
+			content.SetAttribute(":method", string(RequestLineParts[0]))
+			content.SetAttribute(":path", string(RequestLineParts[1]))
+		}
+	}
 
 	if len(sh.host) > 0 {
 		return sh, nil


### PR DESCRIPTION
在看QUIC sniffer的时候顺便读了一下其他sniffer的代码 之前写配置用到attrs结果无效 问了之后才发现只有http入站才支持这个字段 明明可以嗅探host头 为什么不嗅探其他http头呢
现在sniffer可以直接从http流量中嗅探出http头(以及方法和路径)供路由模块使用 不再要求http入站