### PR TITLE
Log: show the matching rule tag

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/xtls/xray-core/common"
-	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/buf"
+	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/log"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/protocol"
@@ -421,7 +421,11 @@ func (d *DefaultDispatcher) routedDispatch(ctx context.Context, link *transport.
 			outTag := route.GetOutboundTag()
 			if h := d.ohm.GetHandler(outTag); h != nil {
 				isPickRoute = 2
-				errors.LogInfo(ctx, "taking detour [", outTag, "] for [", destination, "]")
+				if route.GetRuleTag() == "" {
+					errors.LogInfo(ctx, "taking detour [", outTag, "] for [", destination, "]")
+				} else {
+					errors.LogInfo(ctx, "Hit route rule: [", route.GetRuleTag(), "] so taking detour [", outTag, "] for [", destination, "]")
+				}
 				handler = h
 			} else {
 				errors.LogWarning(ctx, "non existing outTag: ", outTag)

--- a/app/router/command/config.go
+++ b/app/router/command/config.go
@@ -28,6 +28,10 @@ func (c routingContext) GetTargetPort() net.Port {
 	return net.Port(c.RoutingContext.GetTargetPort())
 }
 
+func (c routingContext) GetRuleTag() string {
+	return ""
+}
+
 // GetSkipDNSResolve is a mock implementation here to match the interface,
 // SkipDNSResolve is set from dns module, no use if coming from a protobuf object?
 // TODO: please confirm @Vigilans

--- a/app/router/router.go
+++ b/app/router/router.go
@@ -34,6 +34,7 @@ type Route struct {
 	routing.Context
 	outboundGroupTags []string
 	outboundTag       string
+	ruleTag           string
 }
 
 // Init initializes the Router.
@@ -89,7 +90,7 @@ func (r *Router) PickRoute(ctx routing.Context) (routing.Route, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Route{Context: ctx, outboundTag: tag}, nil
+	return &Route{Context: ctx, outboundTag: tag, ruleTag: rule.RuleTag}, nil
 }
 
 // AddRule implements routing.Router.
@@ -237,6 +238,10 @@ func (r *Route) GetOutboundGroupTags() []string {
 // GetOutboundTag implements routing.Route.
 func (r *Route) GetOutboundTag() string {
 	return r.outboundTag
+}
+
+func (r *Route) GetRuleTag() string {
+	return r.ruleTag
 }
 
 func init() {

--- a/features/routing/router.go
+++ b/features/routing/router.go
@@ -30,6 +30,9 @@ type Route interface {
 
 	// GetOutboundTag returns the tag of the outbound the connection was dispatched to.
 	GetOutboundTag() string
+
+	// GetRuleTag returns the matching rule tag for debugging if exists
+	GetRuleTag() string
 }
 
 // RouterType return the type of Router interface. Can be used to implement common.HasType.


### PR DESCRIPTION
For #3311
加一个子命令是不太可能了 但是可以选择在log中输出命中的规则
翻了一下代码之后发现一个似乎没人用文档也没写的 `“ruleTag”` 项 不如用起来
现在如果设置了 `“ruleTag”` 在hit中这个rule的时候便会显示这个tag名 用于调试
效果如图
![image](https://github.com/user-attachments/assets/80c1b686-55e3-49c5-ae7a-a79dc922d89b)
