### PR TITLE
Fix int overflow on x32 processors causing panic using burstObservatory 

### DIFF
--- a/app/observatory/burst/healthping.go
+++ b/app/observatory/burst/healthping.go
@@ -156,7 +156,7 @@ func (h *HealthPing) doCheck(tags []string, duration time.Duration, rounds int) 
 		for i := 0; i < rounds; i++ {
 			delay := time.Duration(0)
 			if duration > 0 {
-				delay = time.Duration(dice.Roll(int(duration)))
+				delay = time.Duration(dice.RollInt63n(int64(duration)))
 			}
 			time.AfterFunc(delay, func() {
 				errors.LogDebug(h.ctx, "checking ", handler)

--- a/common/dice/dice.go
+++ b/common/dice/dice.go
@@ -14,6 +14,14 @@ func Roll(n int) int {
 	return rand.Intn(n)
 }
 
+// RollInt63n returns a non-negative number between 0 (inclusive) and n (exclusive).
+func RollInt63n(n int64) int64 {
+	if n == 1 {
+		return 0
+	}
+	return rand.Int63n(n)
+}
+
 // Roll returns a non-negative number between 0 (inclusive) and n (exclusive).
 func RollDeterministic(n int, seed int64) int {
 	if n == 1 {


### PR DESCRIPTION
When using burstObservatory I get a panic on the mipsle processor. During the [roll](https://github.com/XTLS/Xray-core/blob/main/app/observatory/burst/healthping.go#L159), "duration" is converted to int, causing overflow on x32 processors. The value may be very small, causing private queries, or negative, causing a panic in rand.Intn.

Version: `Xray 1.8.18 (Xray, Penetrates Everything.) 9e6d7a3c (go1.22.5 linux/mipsle)`

Config burstObservatory:
```json
{
    "burstObservatory": {
        "subjectSelector": ["proxy"],
        "pingConfig": {
            "destination": "https://connectivitycheck.gstatic.com/generate_204",
            "connectivity": "",
            "interval": "30s",
            "sampling": 3,
            "timeout": "3s"
        }
    }
}
```

Stdout:
```
panic: invalid argument to Intn

goroutine 35 [running]:
math/rand.(*Rand).Intn(0x21139e0, 0xf46b0400)
        math/rand/rand.go:180 +0xd0
math/rand.Intn(0xf46b0400)
        math/rand/rand.go:453 +0x48
github.com/xtls/xray-core/common/dice.Roll(...)
        github.com/xtls/xray-core/common/dice/dice.go:14
github.com/xtls/xray-core/app/observatory/burst.(*HealthPing).doCheck(0x241f820, {0x22853c0, 0x5, 0x8}, 0x14f46b0400, 0x3)
        github.com/xtls/xray-core/app/observatory/burst/healthping.go:159 +0x3c4
github.com/xtls/xray-core/app/observatory/burst.(*HealthPing).StartScheduler.func2.1()
        github.com/xtls/xray-core/app/observatory/burst/healthping.go:100 +0x194
created by github.com/xtls/xray-core/app/observatory/burst.(*HealthPing).StartScheduler.func2 in goroutine 8
        github.com/xtls/xray-core/app/observatory/burst/healthping.go:94 +0xe0
```