### PR TITLE
Add sniff protocols: BGP, SMB, RDP, SIP, OpenVPN, SSH, NTP, RTSP

### DIFF
--- a/app/dispatcher/sniffer.go
+++ b/app/dispatcher/sniffer.go
@@ -6,9 +6,17 @@ import (
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/protocol/bgp"
 	"github.com/xtls/xray-core/common/protocol/bittorrent"
 	"github.com/xtls/xray-core/common/protocol/http"
+	"github.com/xtls/xray-core/common/protocol/ntp"
+	"github.com/xtls/xray-core/common/protocol/ovpn"
 	"github.com/xtls/xray-core/common/protocol/quic"
+	"github.com/xtls/xray-core/common/protocol/rdp"
+	"github.com/xtls/xray-core/common/protocol/rtsp"
+	"github.com/xtls/xray-core/common/protocol/sip"
+	"github.com/xtls/xray-core/common/protocol/smb"
+	"github.com/xtls/xray-core/common/protocol/ssh"
 	"github.com/xtls/xray-core/common/protocol/tls"
 )
 
@@ -40,6 +48,17 @@ func NewSniffer(ctx context.Context) *Sniffer {
 			{func(c context.Context, b []byte) (SniffResult, error) { return bittorrent.SniffBittorrent(b) }, false, net.Network_TCP},
 			{func(c context.Context, b []byte) (SniffResult, error) { return quic.SniffQUIC(b) }, false, net.Network_UDP},
 			{func(c context.Context, b []byte) (SniffResult, error) { return bittorrent.SniffUTP(b) }, false, net.Network_UDP},
+
+			// additional protocols for sniffing
+			{func(c context.Context, b []byte) (SniffResult, error) { return ssh.SniffSSH(b) }, false, net.Network_TCP},
+			{func(c context.Context, b []byte) (SniffResult, error) { return ntp.SniffNTP(b) }, false, net.Network_UDP},
+			{func(c context.Context, b []byte) (SniffResult, error) { return ovpn.SniffOpenVPN(b) }, false, net.Network_TCP},
+			{func(c context.Context, b []byte) (SniffResult, error) { return ovpn.SniffOpenVPN(b) }, false, net.Network_UDP},
+			{func(c context.Context, b []byte) (SniffResult, error) { return rtsp.SniffRTSP(b) }, false, net.Network_TCP},
+			{func(c context.Context, b []byte) (SniffResult, error) { return rdp.SniffRDP(b) }, false, net.Network_TCP},
+			{func(c context.Context, b []byte) (SniffResult, error) { return sip.SniffSIP(b) }, false, net.Network_TCP},
+			{func(c context.Context, b []byte) (SniffResult, error) { return bgp.SniffBGP(b) }, false, net.Network_TCP},
+			{func(c context.Context, b []byte) (SniffResult, error) { return smb.SniffSMB(b) }, false, net.Network_TCP},
 		},
 	}
 	if sniffer, err := newFakeDNSSniffer(ctx); err == nil {

--- a/common/protocol/bgp/sniff.go
+++ b/common/protocol/bgp/sniff.go
@@ -1,0 +1,32 @@
+package bgp
+
+import (
+	"bytes"
+	"errors"
+)
+
+type SniffHeader struct{}
+
+func (h *SniffHeader) Protocol() string {
+	return "bgp"
+}
+
+func (h *SniffHeader) Domain() string {
+	return ""
+}
+
+var errNotBGP = errors.New("not BGP protocol")
+
+func SniffBGP(b []byte) (*SniffHeader, error) {
+	if len(b) < 18 {
+		return nil, errNotBGP
+	}
+
+	// BGP marker is 16 bytes of 0xFF
+	bgpMarker := []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}
+	if bytes.HasPrefix(b, bgpMarker) {
+		return &SniffHeader{}, nil
+	}
+
+	return nil, errNotBGP
+}

--- a/common/protocol/bgp/sniff_test.go
+++ b/common/protocol/bgp/sniff_test.go
@@ -1,0 +1,21 @@
+package bgp
+
+import (
+	"testing"
+)
+
+func TestSniffBGP(t *testing.T) {
+	bgpPacket := []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x01}
+	_, err := SniffBGP(bgpPacket)
+	if err != nil {
+		t.Errorf("Expected BGP protocol to be detected, got error: %v", err)
+	}
+}
+
+func TestSniffNotBGP(t *testing.T) {
+	nonBgpPacket := []byte{0x00, 0x01, 0x02, 0x03}
+	_, err := SniffBGP(nonBgpPacket)
+	if err == nil {
+		t.Errorf("Expected error for non-BGP packet, got none")
+	}
+}

--- a/common/protocol/ntp/sniff.go
+++ b/common/protocol/ntp/sniff.go
@@ -1,0 +1,34 @@
+package ntp
+
+import (
+	"errors"
+)
+
+type SniffHeader struct{}
+
+func (h *SniffHeader) Protocol() string {
+	return "ntp"
+}
+
+func (h *SniffHeader) Domain() string {
+	return ""
+}
+
+var errNotNTP = errors.New("not NTP protocol")
+
+func SniffNTP(b []byte) (*SniffHeader, error) {
+	if len(b) < 48 {
+		return nil, errNotNTP
+	}
+
+	firstByte := b[0]
+	_ = (firstByte >> 6) & 0x03   // Leap Indicator
+	vn := (firstByte >> 3) & 0x07 // Version Number
+	mode := firstByte & 0x07      // Mode
+
+	if (vn == 3 || vn == 4) && mode == 3 {
+		return &SniffHeader{}, nil
+	}
+
+	return nil, errNotNTP
+}

--- a/common/protocol/ntp/sniff_test.go
+++ b/common/protocol/ntp/sniff_test.go
@@ -1,0 +1,18 @@
+package ntp_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/xtls/xray-core/common"
+	"github.com/xtls/xray-core/common/protocol/ntp"
+)
+
+func TestSniffNTP(t *testing.T) {
+	pkt, err := hex.DecodeString("1b0203e800000000000000000000000000000000000000000000000000000000000000000000000000")
+	common.Must(err)
+	_, err = ntp.SniffNTP(pkt)
+	if err != nil {
+		t.Error("failed to parse NTP packet")
+	}
+}

--- a/common/protocol/ovpn/sniff.go
+++ b/common/protocol/ovpn/sniff.go
@@ -1,0 +1,37 @@
+package ovpn
+
+import (
+	"bytes"
+	"errors"
+)
+
+type SniffHeader struct{}
+
+func (h *SniffHeader) Protocol() string {
+	return "openvpn"
+}
+
+func (h *SniffHeader) Domain() string {
+	return ""
+}
+
+var errNotOpenVPN = errors.New("not OpenVPN protocol")
+
+func SniffOpenVPN(b []byte) (*SniffHeader, error) {
+	if len(b) < 2 {
+		return nil, errNotOpenVPN
+	}
+
+	if bytes.HasPrefix(b, []byte{0x38, 0x00}) {
+		return &SniffHeader{}, nil
+	}
+	if bytes.HasPrefix(b, []byte{0x38, 0x01}) {
+		return &SniffHeader{}, nil
+	}
+
+	if b[0] == 0x16 && len(b) > 5 {
+		return &SniffHeader{}, nil
+	}
+
+	return nil, errNotOpenVPN
+}

--- a/common/protocol/ovpn/sniff_test.go
+++ b/common/protocol/ovpn/sniff_test.go
@@ -1,0 +1,18 @@
+package ovpn_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/xtls/xray-core/common"
+	"github.com/xtls/xray-core/common/protocol/ovpn"
+)
+
+func TestSniffOpenVPN(t *testing.T) {
+	pkt, err := hex.DecodeString("370e0400000102030405060708090a0b0c0d0e0f")
+	common.Must(err)
+	_, err = ovpn.SniffOpenVPN(pkt)
+	if err != nil {
+		t.Error("failed to parse OpenVPN packet")
+	}
+}

--- a/common/protocol/rdp/sniff.go
+++ b/common/protocol/rdp/sniff.go
@@ -1,0 +1,31 @@
+package rdp
+
+import (
+	"bytes"
+	"errors"
+)
+
+type SniffHeader struct{}
+
+func (h *SniffHeader) Protocol() string {
+	return "rdp"
+}
+
+func (h *SniffHeader) Domain() string {
+	return ""
+}
+
+var errNotRDP = errors.New("not RDP protocol")
+
+func SniffRDP(b []byte) (*SniffHeader, error) {
+	if len(b) < 12 {
+		return nil, errNotRDP
+	}
+
+	// RDP TCP negotiation packet starts with 0x03 0x00 0x00 0x13 followed by more data
+	if bytes.HasPrefix(b, []byte{0x03, 0x00, 0x00, 0x13}) {
+		return &SniffHeader{}, nil
+	}
+
+	return nil, errNotRDP
+}

--- a/common/protocol/rdp/sniff_test.go
+++ b/common/protocol/rdp/sniff_test.go
@@ -1,0 +1,47 @@
+package rdp
+
+import (
+	"testing"
+)
+
+func TestSniffRDP(t *testing.T) {
+	tests := []struct {
+		input    []byte
+		expected *SniffHeader
+		wantErr  bool
+	}{
+		{
+			input:    []byte{0x03, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x00},
+			expected: &SniffHeader{},
+			wantErr:  false,
+		},
+		{
+			input:    []byte{0x01, 0x02, 0x03, 0x04},
+			expected: nil,
+			wantErr:  true,
+		},
+		{
+			input:    []byte{0x03, 0x00, 0x00, 0x13, 0x00, 0x00},
+			expected: &SniffHeader{},
+			wantErr:  false,
+		},
+		{
+			input:    []byte{0x03, 0x00, 0x00, 0x12},
+			expected: nil,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			got, err := SniffRDP(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SniffRDP() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != nil && !tt.wantErr && *got != *tt.expected {
+				t.Errorf("SniffRDP() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/common/protocol/rtsp/headers.go
+++ b/common/protocol/rtsp/headers.go
@@ -1,0 +1,70 @@
+package rtsp
+
+import (
+	"strings"
+	"strconv"
+	"github.com/xtls/xray-core/common/net"
+)
+
+// ParseXTransport parses X-Transport header in RTSP headers, returning the transport options.
+func ParseXTransport(header map[string]string) []string {
+	xTransport := header["Transport"]
+	if xTransport == "" {
+		return nil
+	}
+	return strings.Split(xTransport, ",")
+}
+
+// RemoveHopByHopHeaders removes hop-by-hop headers in RTSP header list.
+func RemoveHopByHopHeaders(header map[string]string) {
+	delete(header, "Proxy-Connection")
+	delete(header, "Proxy-Authenticate")
+	delete(header, "Proxy-Authorization")
+	delete(header, "TE")
+	delete(header, "Trailers")
+	delete(header, "Transfer-Encoding")
+	delete(header, "Upgrade")
+
+	connections := header["Connection"]
+	delete(header, "Connection")
+	if connections == "" {
+		return
+	}
+	for _, h := range strings.Split(connections, ",") {
+		delete(header, strings.TrimSpace(h))
+	}
+}
+
+// ParseHost splits host and port from a raw string. Default port is used when raw string doesn't contain port.
+func ParseHost(rawHost string, defaultPort net.Port) (net.Destination, error) {
+	port := defaultPort
+	host, rawPort, err := net.SplitHostPort(rawHost)
+	if err != nil {
+		if addrError, ok := err.(*net.AddrError); ok && strings.Contains(addrError.Err, "missing port") {
+			host = rawHost
+		} else {
+			return net.Destination{}, err
+		}
+	} else if len(rawPort) > 0 {
+		intPort, err := strconv.Atoi(rawPort)
+		if err != nil {
+			return net.Destination{}, err
+		}
+		port = net.Port(intPort)
+	}
+
+	return net.TCPDestination(net.ParseAddress(host), port), nil
+}
+
+// parsing headers RTSP
+func ParseRTSPHeaders(rawHeaders string) map[string]string {
+	headers := make(map[string]string)
+	lines := strings.Split(rawHeaders, "\n")
+	for _, line := range lines {
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) == 2 {
+			headers[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		}
+	}
+	return headers
+}

--- a/common/protocol/rtsp/sniff.go
+++ b/common/protocol/rtsp/sniff.go
@@ -1,0 +1,93 @@
+package rtsp
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+
+	"github.com/xtls/xray-core/common"
+	"github.com/xtls/xray-core/common/net"
+)
+
+type version byte
+
+const (
+	RTSP1 version = iota
+)
+
+type SniffHeader struct {
+	version version
+	host    string
+}
+
+func (h *SniffHeader) Protocol() string {
+	switch h.version {
+	case RTSP1:
+		return "rtsp1"
+	default:
+		return "unknown"
+	}
+}
+
+func (h *SniffHeader) Domain() string {
+	return h.host
+}
+
+var (
+	methods = [...]string{
+		"options", "describe", "setup", "play", "pause", "teardown", "get_parameter", "set_parameter", "announce", "record",
+	}
+
+	errNotRTSPMethod = errors.New("not an RTSP method")
+)
+
+func beginWithRTSPMethod(b []byte) error {
+	for _, m := range &methods {
+		if len(b) >= len(m) && strings.EqualFold(string(b[:len(m)]), m) {
+			return nil
+		}
+
+		if len(b) < len(m) {
+			return common.ErrNoClue
+		}
+	}
+
+	return errNotRTSPMethod
+}
+
+func SniffRTSP(b []byte) (*SniffHeader, error) {
+	if err := beginWithRTSPMethod(b); err != nil {
+		return nil, err
+	}
+
+	sh := &SniffHeader{
+		version: RTSP1,
+	}
+
+	headers := bytes.Split(b, []byte{'\n'})
+	for i := 1; i < len(headers); i++ {
+		header := headers[i]
+		if len(header) == 0 {
+			break
+		}
+		parts := bytes.SplitN(header, []byte{':'}, 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.ToLower(string(parts[0]))
+		if key == "host" {
+			rawHost := strings.ToLower(string(bytes.TrimSpace(parts[1])))
+			dest, err := ParseHost(rawHost, net.Port(554))
+			if err != nil {
+				return nil, err
+			}
+			sh.host = dest.Address.String()
+		}
+	}
+
+	if len(sh.host) > 0 {
+		return sh, nil
+	}
+
+	return nil, common.ErrNoClue
+}

--- a/common/protocol/rtsp/sniff_test.go
+++ b/common/protocol/rtsp/sniff_test.go
@@ -1,0 +1,51 @@
+package rtsp_test
+
+import (
+	"testing"
+
+	. "github.com/xtls/xray-core/common/protocol/rtsp"
+)
+
+func TestRTSPHeaders(t *testing.T) {
+	cases := []struct {
+		input  string
+		domain string
+		err    bool
+	}{
+		{
+			input: `OPTIONS rtsp://example.com/media.mp4 RTSP/1.0
+CSeq: 1
+User-Agent: LibVLC/3.0.8`,
+			domain: "example.com",
+		},
+		{
+			input: `PLAY rtsp://localhost/media.mp4 RTSP/1.0
+CSeq: 2
+User-Agent: VLC/3.0.8`,
+			domain: "localhost",
+		},
+		{
+			input: `X OPTIONS rtsp://localhost/media.mp4 RTSP/1.0
+CSeq: 2
+User-Agent: VLC/3.0.8`,
+			domain: "",
+			err:    true,
+		},
+	}
+
+	for _, test := range cases {
+		header, err := SniffRTSP([]byte(test.input))
+		if test.err {
+			if err == nil {
+				t.Errorf("Expect error but nil, in test: %v", test)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Expect no error but actually %s in test %v", err.Error(), test)
+			}
+			if header.Domain() != test.domain {
+				t.Error("expected domain ", test.domain, " but got ", header.Domain())
+			}
+		}
+	}
+}

--- a/common/protocol/sip/sniff.go
+++ b/common/protocol/sip/sniff.go
@@ -1,0 +1,35 @@
+package sip
+
+import (
+	"bytes"
+	"errors"
+)
+
+type SniffHeader struct{}
+
+func (h *SniffHeader) Protocol() string {
+	return "sip"
+}
+
+func (h *SniffHeader) Domain() string {
+	return ""
+}
+
+var errNotSIP = errors.New("not SIP protocol")
+
+func SniffSIP(b []byte) (*SniffHeader, error) {
+	if len(b) < 4 {
+		return nil, errNotSIP
+	}
+
+	// SIP requests start with methods like INVITE, ACK, OPTIONS, BYE, CANCEL
+	if bytes.HasPrefix(b, []byte("INVITE")) ||
+		bytes.HasPrefix(b, []byte("ACK")) ||
+		bytes.HasPrefix(b, []byte("OPTIONS")) ||
+		bytes.HasPrefix(b, []byte("BYE")) ||
+		bytes.HasPrefix(b, []byte("CANCEL")) {
+		return &SniffHeader{}, nil
+	}
+
+	return nil, errNotSIP
+}

--- a/common/protocol/sip/sniff_test.go
+++ b/common/protocol/sip/sniff_test.go
@@ -1,0 +1,29 @@
+package sip
+
+import (
+	"testing"
+)
+
+func TestSniffSIPInvite(t *testing.T) {
+	sipPacket := []byte("INVITE sip:user@example.com SIP/2.0")
+	_, err := SniffSIP(sipPacket)
+	if err != nil {
+		t.Errorf("Expected SIP protocol to be detected, got error: %v", err)
+	}
+}
+
+func TestSniffSIPAck(t *testing.T) {
+	sipPacket := []byte("ACK sip:user@example.com SIP/2.0")
+	_, err := SniffSIP(sipPacket)
+	if err != nil {
+		t.Errorf("Expected SIP protocol to be detected, got error: %v", err)
+	}
+}
+
+func TestSniffNotSIP(t *testing.T) {
+	nonSipPacket := []byte{0x00, 0x01, 0x02, 0x03}
+	_, err := SniffSIP(nonSipPacket)
+	if err == nil {
+		t.Errorf("Expected error for non-SIP packet, got none")
+	}
+}

--- a/common/protocol/smb/sniff.go
+++ b/common/protocol/smb/sniff.go
@@ -1,0 +1,36 @@
+package smb
+
+import (
+	"bytes"
+	"errors"
+)
+
+type SniffHeader struct{}
+
+func (h *SniffHeader) Protocol() string {
+	return "smb"
+}
+
+func (h *SniffHeader) Domain() string {
+	return ""
+}
+
+var errNotSMB = errors.New("not SMB protocol")
+
+func SniffSMB(b []byte) (*SniffHeader, error) {
+	if len(b) < 4 {
+		return nil, errNotSMB
+	}
+
+	// SMB1 magic bytes: 0xFF 0x53 0x4D 0x42 ("SMB")
+	if bytes.HasPrefix(b, []byte{0xFF, 0x53, 0x4D, 0x42}) {
+		return &SniffHeader{}, nil
+	}
+
+	// SMB2/SMB3 magic bytes: 0xFE 0x53 0x4D 0x42
+	if bytes.HasPrefix(b, []byte{0xFE, 0x53, 0x4D, 0x42}) {
+		return &SniffHeader{}, nil
+	}
+
+	return nil, errNotSMB
+}

--- a/common/protocol/smb/sniff_test.go
+++ b/common/protocol/smb/sniff_test.go
@@ -1,0 +1,29 @@
+package smb
+
+import (
+	"testing"
+)
+
+func TestSniffSMB1(t *testing.T) {
+	smbPacket := []byte{0xFF, 0x53, 0x4D, 0x42}
+	_, err := SniffSMB(smbPacket)
+	if err != nil {
+		t.Errorf("Expected SMB1 protocol to be detected, got error: %v", err)
+	}
+}
+
+func TestSniffSMB2(t *testing.T) {
+	smbPacket := []byte{0xFE, 0x53, 0x4D, 0x42}
+	_, err := SniffSMB(smbPacket)
+	if err != nil {
+		t.Errorf("Expected SMB2/SMB3 protocol to be detected, got error: %v", err)
+	}
+}
+
+func TestSniffNotSMB(t *testing.T) {
+	nonSmbPacket := []byte{0x00, 0x01, 0x02, 0x03}
+	_, err := SniffSMB(nonSmbPacket)
+	if err == nil {
+		t.Errorf("Expected error for non-SMB packet, got none")
+	}
+}

--- a/common/protocol/ssh/sniff.go
+++ b/common/protocol/ssh/sniff.go
@@ -1,0 +1,39 @@
+package ssh
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/xtls/xray-core/common"
+	"github.com/xtls/xray-core/common/buf"
+)
+
+type SniffHeader struct{}
+
+func (h *SniffHeader) Protocol() string {
+	return "ssh"
+}
+
+func (h *SniffHeader) Domain() string {
+	return ""
+}
+
+var errNotSSH = errors.New("not SSH header")
+
+func SniffSSH(b []byte) (*SniffHeader, error) {
+	if len(b) < 4 {
+		return nil, common.ErrNoClue
+	}
+
+	buffer := buf.FromBytes(b)
+	var idBuffer [4]byte
+	if _, err := buffer.Read(idBuffer[:]); err != nil {
+		return nil, common.ErrNoClue
+	}
+
+	if !strings.HasPrefix(string(idBuffer[:]), "SSH-") {
+		return nil, errNotSSH
+	}
+
+	return &SniffHeader{}, nil
+}

--- a/common/protocol/ssh/sniff_test.go
+++ b/common/protocol/ssh/sniff_test.go
@@ -1,0 +1,15 @@
+package ssh_test
+
+import (
+	"testing"
+
+	"github.com/xtls/xray-core/common/protocol/ssh"
+)
+
+func TestSniffSSH(t *testing.T) {
+	pkt := []byte("SSH-2.0-OpenSSH_8.1")
+	_, err := ssh.SniffSSH(pkt)
+	if err != nil {
+		t.Error("failed to parse SSH packet")
+	}
+}

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -64,10 +64,26 @@ func (c *SniffingConfig) Build() (*proxyman.SniffingConfig, error) {
 			switch strings.ToLower(protocol) {
 			case "http":
 				p = append(p, "http")
+			case "rtsp":
+				p = append(p, "rtsp")
 			case "tls", "https", "ssl":
 				p = append(p, "tls")
+			case "ssh":
+				p = append(p, "ssh")
+			case "ntp":
+				p = append(p, "ntp")
+			case "smb":
+				p = append(p, "smb")
+			case "rdp":
+				p = append(p, "rdp")
+			case "sip":
+				p = append(p, "sip")
+			case "bgp":
+				p = append(p, "bgp")
 			case "quic":
 				p = append(p, "quic")
+			case "ovpn":
+				p = append(p, "ovpn")
 			case "fakedns":
 				p = append(p, "fakedns")
 			case "fakedns+others":
@@ -363,7 +379,7 @@ func (c *StatsConfig) Build() (*stats.Config, error) {
 type Config struct {
 	// Deprecated: Global transport config is no longer used
 	// left for returning error
-	Transport        map[string]json.RawMessage `json:"transport"`
+	Transport map[string]json.RawMessage `json:"transport"`
 
 	LogConfig        *LogConfig              `json:"log"`
 	RouterConfig     *RouterConfig           `json:"routing"`


### PR DESCRIPTION
I added additional protocols to the sniffer configuration to better and more conveniently distribute traffic between different outbound based on protocols

Added protocols:
- BGP
- SMB
- RDP
- SIP
- OpenVPN
- SSH
- NTP
- RTSP