### PR TITLE
Browser Dialer: Change from ES5 to ES6+ for performance

### DIFF
--- a/transport/internet/browser_dialer/dialer.html
+++ b/transport/internet/browser_dialer/dialer.html
@@ -5,21 +5,22 @@
 </head>
 <body>
 	<script>
+		"use strict";
+		// Enable a much more aggressive JIT for performance gains
+
 		// Copyright (c) 2021 XRAY. Mozilla Public License 2.0.
-		var url = "ws://" + window.location.host + "/websocket?token=csrfToken";
-		var clientIdleCount = 0;
-		var upstreamGetCount = 0;
-		var upstreamWsCount = 0;
-		var upstreamPostCount = 0;
-		setInterval(check, 1000);
-		function check() {
+		let url = "ws://" + window.location.host + "/websocket?token=csrfToken";
+		let clientIdleCount = 0;
+		let upstreamGetCount = 0;
+		let upstreamWsCount = 0;
+		let upstreamPostCount = 0;
+		let check = function () {
 			if (clientIdleCount > 0) {
 				return;
-			}
-
+			};
 			clientIdleCount += 1;
 			console.log("Prepare", url);
-			var ws = new WebSocket(url);
+			let ws = new WebSocket(url);
 			// arraybuffer is significantly faster in chrome than default
 			// blob, tested with chrome 123
 			ws.binaryType = "arraybuffer";
@@ -31,7 +32,7 @@
 					console.log("Dial WS", url, protocol);
 					const wss = new WebSocket(url, protocol);
 					wss.binaryType = "arraybuffer";
-					var opened = false;
+					let opened = false;
 					ws.onmessage = function (event) {
 						wss.send(event.data)
 					}
@@ -130,7 +131,8 @@
 			ws.onerror = function (event) {
 				ws.close()
 			}
-		}
+		};
+		let checkTask = setInterval(check, 1000);
 	</script>
 </body>
 </html>

--- a/transport/internet/browser_dialer/dialer.html
+++ b/transport/internet/browser_dialer/dialer.html
@@ -24,113 +24,120 @@
 			// arraybuffer is significantly faster in chrome than default
 			// blob, tested with chrome 123
 			ws.binaryType = "arraybuffer";
-			ws.onmessage = function (event) {
+			ws.addEventListener("message", (event) => {
 				clientIdleCount -= 1;
 				let [method, url, protocol] = event.data.split(" ");
-				if (method == "WS") {
-					upstreamWsCount += 1;
-					console.log("Dial WS", url, protocol);
-					const wss = new WebSocket(url, protocol);
-					wss.binaryType = "arraybuffer";
-					let opened = false;
-					ws.onmessage = function (event) {
-						wss.send(event.data)
-					}
-					wss.onopen = function (event) {
-						opened = true;
-						ws.send("ok")
-					}
-					wss.onmessage = function (event) {
-						ws.send(event.data)
-					}
-					wss.onclose = function (event) {
-						upstreamWsCount -= 1;
-						console.log("Dial WS DONE, remaining: ", upstreamWsCount);
-						ws.close()
-					}
-					wss.onerror = function (event) {
-						!opened && ws.send("fail")
-						wss.close()
-					}
-					ws.onclose = function (event) {
-						wss.close()
-					}
-				} else if (method == "GET") {
-					(async () => {
-						console.log("Dial GET", url);
-						ws.send("ok");
-						const controller = new AbortController();
-
-						/*
-						Aborting a streaming response in JavaScript
-						requires two levers to be pulled:
-
-						First, the streaming read itself has to be cancelled using
-						reader.cancel(), only then controller.abort() will actually work.
-
-						If controller.abort() alone is called while a
-						reader.read() is ongoing, it will block until the server closes the
-						response, the page is refreshed or the network connection is lost.
-						*/
-
-						let reader = null;
-						ws.onclose = (event) => {
-							try {
-								reader && reader.cancel();
-							} catch(e) {}
-
-							try {
-								controller.abort();
-							} catch(e) {}
-						}
-
-						try {
-							upstreamGetCount += 1;
-							const response = await fetch(url, {signal: controller.signal});
-
-							const body = await response.body;
-							reader = body.getReader();
-
-							while (true) {
-								const { done, value } = await reader.read();
-								ws.send(value);
-								if (done) break;
-							}
-						} finally {
-							upstreamGetCount -= 1;
-							console.log("Dial GET DONE, remaining: ", upstreamGetCount);
-							ws.close();
-						}
-					})()
-				} else if (method == "POST") {
-					upstreamPostCount += 1;
-					console.log("Dial POST", url);
-					ws.send("ok");
-					ws.onmessage = async (event) => {
-						try {
-							const response = await fetch(
-								url,
-								{method: "POST", body: event.data}
-							);
-							if (response.ok) {
-								ws.send("ok");
-							} else {
-								console.error("bad status code");
-								ws.send("fail");
-							}
-						} finally {
-							upstreamPostCount -= 1;
-							console.log("Dial POST DONE, remaining: ", upstreamPostCount);
-							ws.close();
-						}
+				switch (method) {
+					case "WS": {
+						upstreamWsCount += 1;
+						console.log("Dial WS", url, protocol);
+						const wss = new WebSocket(url, protocol);
+						wss.binaryType = "arraybuffer";
+						let opened = false;
+						ws.onmessage = function (event) {
+							wss.send(event.data)
+						};
+						wss.onopen = function (event) {
+							opened = true;
+							ws.send("ok")
+						};
+						wss.onmessage = function (event) {
+							ws.send(event.data)
+						};
+						wss.onclose = function (event) {
+							upstreamWsCount -= 1;
+							console.log("Dial WS DONE, remaining: ", upstreamWsCount);
+							ws.close()
+						};
+						wss.onerror = function (event) {
+							!opened && ws.send("fail")
+							wss.close()
+						};
+						ws.onclose = function (event) {
+							wss.close()
+						};
+						break;
 					};
-				}
+					case "GET": {
+						(async () => {
+							console.log("Dial GET", url);
+							ws.send("ok");
+							const controller = new AbortController();
 
-				check()
-			}
-			ws.onerror = function (event) {
-				ws.close()
-			}
+							/*
+							Aborting a streaming response in JavaScript
+							requires two levers to be pulled:
+
+							First, the streaming read itself has to be cancelled using
+							reader.cancel(), only then controller.abort() will actually work.
+
+							If controller.abort() alone is called while a
+							reader.read() is ongoing, it will block until the server closes the
+							response, the page is refreshed or the network connection is lost.
+							*/
+
+							let reader = null;
+							ws.onclose = (event) => {
+								try {
+									reader && reader.cancel();
+								} catch(e) {};
+
+								try {
+									controller.abort();
+								} catch(e) {};
+							};
+
+							try {
+								upstreamGetCount += 1;
+								const response = await fetch(url, {signal: controller.signal});
+
+								const body = await response.body;
+								reader = body.getReader();
+
+								while (true) {
+									const { done, value } = await reader.read();
+									ws.send(value);
+									if (done) break;
+								};
+							} finally {
+								upstreamGetCount -= 1;
+								console.log("Dial GET DONE, remaining: ", upstreamGetCount);
+								ws.close();
+							};
+						})();
+						break;
+					};
+					case "POST": {
+						upstreamPostCount += 1;
+						console.log("Dial POST", url);
+						ws.send("ok");
+						ws.onmessage = async (event) => {
+							try {
+								const response = await fetch(
+									url,
+									{method: "POST", body: event.data}
+								);
+								if (response.ok) {
+									ws.send("ok");
+								} else {
+									console.error("bad status code");
+									ws.send("fail");
+								};
+							} finally {
+								upstreamPostCount -= 1;
+								console.log("Dial POST DONE, remaining: ", upstreamPostCount);
+								ws.close();
+							};
+						};
+						break;
+					};
+				};
+
+				check();
+			});
+			ws.addEventListener("error", (event) => {
+				ws.close();
+			});
 		};
 		let checkTask = setInterval(check, 1000);
 	</script>


### PR DESCRIPTION
First of all... What. The. Heck.

## Problems with the current code
I can only do so much to try getting the current code up to shape.

### A mix of ES5 and ES6+ syntax in compatible mode
- [Strict mode - JavaScript | MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode)

I really don't know if the browser dialer was designed to work on Internet Explorer, but proper web stream API support don't really exist on that platform. So why didn't the browser dialer have strict mode enabled when this could bring performance gains...

### Unscoped value declarations with `var`
- [var - JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var)
- [let - JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let)

TL;DR, avoid using `var` at all costs. `var` introduces problems of the yesteryear, where `let` declarations are much safer, cleaner and straightforward, with stricter constraints allowing the JS JIT to work more efficiently.

### Uses `if`-`else` chains instead of `switch`
I don't know why `if`-`else` chains are used instead of `switch`, as this isn't either C or C++. Both JS and Go support using switch on any type, and JS in specific has single-pass optimizations for `switch` statements, avoiding sequentially querying for each possibility.

## Fundamental design flaws
### The problems
I have no idea why the data plane and the control plane are smashed together. Evident in the code that each message of the single local WebSocket connection is parsed, where with a separation of data plane and control plane can avoid most of the processing. Unless it's tuned for the individual upload packets SplitHTTP needs, so in this specific case data could be smashed together. Since WebSocket can overwhelm the browser easily with enough throughput and without any counteracting measure, the only solution for now would be get rid processing as much as possible on the data plane.

And somehow the browser dialer of SplitHTTP is implemented via WebSocket instead of `fetch` request in either direction. At least on Chrome, `ReadableStream` could be set as the body, so instead of reading and processing chunks, bodies can simply be passed along without the browser doing much at all. Even better, since Chrome has streaming support for WebSocket in the latest versions, a zero-cost optimization is incredibly feasible with separated control and data planes.

### A probably better design
Feel free to conduct critique on this, as this isn't fleshed out much yet.

#### `/control?token=csrfToken`
Control socket. Where the control messages should go, be it `WS  `, `GET ` or `POST`. Though non-streamed uploads should go here as well to reduce the overhead.

#### `/ws?socket=aRandomId`
Direct WebSocket message pass-through between the server and the client.

#### `/http?socket=aRandomId&role=ingress`
Where the magic for streamed web request happens. Allows stream pass-through without any manual reading, [unless it's on Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1387483).

Because the browser doesn't support `h2c`, two request streams for each client-facing streamed SplitHTTP connection are required. `ingress` streams are what the Xray server sends to the client, and `egress` streams are what the client sends to the server.