### PR TITLE
Routing: Fix regexp syntax support in UserMatcher

### DIFF
--- a/app/router/condition.go
+++ b/app/router/condition.go
@@ -202,7 +202,7 @@ func NewUserMatcher(users []string) *UserMatcher {
 	for _, user := range users {
 		if len(user) > 0 {
 			if len(user) > 7 && strings.HasPrefix(user, "regexp:") {
-				if re, err := regexp.Compile(user[7:]); err != nil {
+				if re, err := regexp.Compile(user[7:]); err == nil {
 					patternsCopy = append(patternsCopy, re)
 				}
 				// Items of users slice with an invalid regexp syntax are ignored.


### PR DESCRIPTION
Last month the regexp syntax support in UserMatcher was added by https://github.com/XTLS/Xray-core/pull/3799. I've just noticed I made a typo which prevents regular expression matching at all. Sorry for that. This PR makes it work fine.