### PR TITLE
Routing: Add mutex for `Attributes` temporarily

### DIFF
--- a/common/session/session.go
+++ b/common/session/session.go
@@ -105,13 +105,13 @@ type Sockopt struct {
 }
 
 // Some how when using mux, there will be a same ctx between different requests
-// This will cause problem as it‘s designed for single request, like concurrent map writes
+// This will cause problem as it's designed for single request, like concurrent map writes
 // Add a Mutex as a temp solution
 
 // SetAttribute attaches additional string attributes to content.
 func (c *Content) SetAttribute(name string, value string) {
 	if c.isLocked {
-		errors.LogError(context.Background(), "Multiple goroutine is tring to access one routing content, tring to write ", name, ":", value)
+		errors.LogError(context.Background(), "Multiple goroutines are tring to access one routing content, tring to write ", name, ":", value)
 	}
 	c.mu.Lock()
 	c.isLocked = true

--- a/common/session/session.go
+++ b/common/session/session.go
@@ -4,6 +4,7 @@ package session // import "github.com/xtls/xray-core/common/session"
 import (
 	"context"
 	"math/rand"
+	"sync"
 
 	c "github.com/xtls/xray-core/common/ctx"
 	"github.com/xtls/xray-core/common/errors"
@@ -65,7 +66,7 @@ type Outbound struct {
 	Tag string
 	// Name of the outbound proxy that handles the connection.
 	Name string
-	// Conn is actually internet.Connection. May be nil. It is currently nil for outbound with proxySettings 
+	// Conn is actually internet.Connection. May be nil. It is currently nil for outbound with proxySettings
 	Conn net.Conn
 	// CanSpliceCopy is a property for this connection
 	// 1 = can, 2 = after processing protocol info should be able to, 3 = cannot
@@ -91,6 +92,10 @@ type Content struct {
 	Attributes map[string]string
 
 	SkipDNSResolve bool
+
+	mu sync.Mutex
+
+	isLocked bool
 }
 
 // Sockopt is the settings for socket connection.
@@ -99,8 +104,22 @@ type Sockopt struct {
 	Mark int32
 }
 
+// Some how when using mux, there will be a same ctx between different requests
+// This will cause problem as it‘s designed for single request, like concurrent map writes
+// Add a Mutex as a temp solution
+
 // SetAttribute attaches additional string attributes to content.
 func (c *Content) SetAttribute(name string, value string) {
+	if c.isLocked {
+		errors.LogError(context.Background(), "Multiple goroutine is tring to access one routing content, tring to write ", name, ":", value)
+	}
+	c.mu.Lock()
+	c.isLocked = true
+	defer func() {
+		c.isLocked = false
+		c.mu.Unlock()
+	}()
+
 	if c.Attributes == nil {
 		c.Attributes = make(map[string]string)
 	}


### PR DESCRIPTION
见 #3904 
mmm似乎在inbound上遇到了类似的问题 这里的问题是content
问题还是老问题 对于一条被mux的连接 多个子请求在内部共享一条ctx
mmm的做法是在mux阶段创建一个深拷贝避免它们相互影响
这里更麻烦一些 因为content是在mux后面的dispatcher才被创建的 没法在mux处理 我也拿不定怎么搞 或许WithCancel另起一个新的ctx? 不是很敢乱动
说回这个issue 本质是多个连接都在尝试往content写入数据 当同时写入的时候遇到竞争就炸了 临时解决办法是加锁 这样好歹不会崩溃 但是并没有解决多个连接共享content的问题 这可能导致预期外的路由或者其他非规定行为