### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
   - [ghcr.io/xtls/xray-core](https://ghcr.io/xtls/xray-core) (**Official**)
   - [teddysun/xray](https://hub.docker.com/r/teddysun/xray)
   - [wulabing/xray_docker](https://github.com/wulabing/xray_docker)
-- Web Panel - **WARNING: Please DO NOT USE plain HTTP panels like 3X-UI**, as they are believed to be bribed by Iran GFW for supporting plain HTTP by default and refused to change (https://github.com/XTLS/Xray-core/pull/3884#issuecomment-2439595331), which has already put many users' data security in danger in the past few years. **If you are already using 3X-UI, please switch to the following panels, which are verified to support HTTPS and SSH port forwarding only:**
+- Web Panel
   - [Marzban](https://github.com/Gozargah/Marzban)
   - [Xray-UI](https://github.com/qist/xray-ui)
   - [Hiddify](https://github.com/hiddify/Hiddify-Manager)


### PR DESCRIPTION
If you check out [this](https://github.com/MHSanaei/3x-ui?tab=readme-ov-file#ssl-certificate), you'll see that you can add SSL right after installing panel without even going into the panel.

Also it's a good thing that the panel can be opened with HTTP because people can use a reverse proxy like Nginx or Cloudflare (which adds SSL automatically). 
