### PR TITLE
Wireguard inbound: Do not use system TUN

### DIFF
--- a/proxy/wireguard/config.go
+++ b/proxy/wireguard/config.go
@@ -31,6 +31,11 @@ func (c *DeviceConfig) fallbackIP6() bool {
 }
 
 func (c *DeviceConfig) createTun() tunCreator {
+	// System TUN not support promiscuous mode yet, don't use it when work in inbound mode
+	// See tun_linux.go createKernelTun()
+	if !c.IsClient {
+		return createGVisorTun
+	}
 	if c.NoKernelTun {
 		errors.LogWarning(context.Background(), "Using gVisor TUN.")
 		return createGVisorTun


### PR DESCRIPTION
fix #3959
白话：system TUN 没做混杂模式支持 压根不能用 只能用 gvisor 如果没有设置的话 刚好又是Linux有权限 会尝试去用 然后炸掉 导致问题
对了 这个不是新版本引入的 旧版本也有问题