### PR TITLE
XHTTP client: Enable XMUX for download in U-D-S

### DIFF
--- a/transport/internet/memory_settings.go
+++ b/transport/internet/memory_settings.go
@@ -7,6 +7,7 @@ type MemoryStreamConfig struct {
 	SecurityType     string
 	SecuritySettings interface{}
 	SocketSettings   *SocketConfig
+	DownloadSettings *MemoryStreamConfig
 }
 
 // ToMemoryStreamConfig converts a StreamConfig to MemoryStreamConfig. It returns a default non-nil MemoryStreamConfig for nil input.


### PR DESCRIPTION
**XHTTP 上下行分离时的 XMUX 并不对称**，举个例子，若上下行均未填 XMUX，即均取以下默认值时：

```jsonc
{
  "maxConcurrency": "16-32",
  "maxConnections": 0,
  "cMaxReuseTimes": "64-128",
  "cMaxLifetimeMs": 0
}
```

**上下行分别在 range 内 roll 出的确定值是独立、无关的**，比如可能上行 maxConcurrency=16，下行 maxConcurrency=32

**这样随着时间的推移，同一子连接的上下行会更容易被分到上行的第 N 号连接、下行的第 M 号连接，反分析效果更好**

若以 maxConnections 为基础，则会加速随机，因为它是先开满连接数然后 rand 取用，而 maxConcurrency 是遍历数组

所以若以固定值的 maxConcurrency + cMaxReuseTimes + cMaxLifetimeMs 为基础，可能会导致上下行的 XMUX 对称

