### PR TITLE
UDS: prevent crash when proxy udp

### DIFF
--- a/app/proxyman/inbound/worker.go
+++ b/app/proxyman/inbound/worker.go
@@ -464,7 +464,8 @@ func (w *dsWorker) callback(conn stat.Connection) {
 		}
 	}
 	ctx = session.ContextWithInbound(ctx, &session.Inbound{
-		Source:  net.DestinationFromAddr(conn.RemoteAddr()),
+		// Unix have no source addr, so we use gateway as source for log.
+		Source:  net.UnixDestination(w.address),
 		Gateway: net.UnixDestination(w.address),
 		Tag:     w.tag,
 		Conn:    conn,

--- a/common/net/destination.go
+++ b/common/net/destination.go
@@ -89,10 +89,12 @@ func UnixDestination(address Address) Destination {
 // NetAddr returns the network address in this Destination in string form.
 func (d Destination) NetAddr() string {
 	addr := ""
-	if d.Network == Network_TCP || d.Network == Network_UDP {
-		addr = d.Address.String() + ":" + d.Port.String()
-	} else if d.Network == Network_UNIX {
-		addr = d.Address.String()
+	if d.Address != nil {
+		if d.Network == Network_TCP || d.Network == Network_UDP {
+			addr = d.Address.String() + ":" + d.Port.String()
+		} else if d.Network == Network_UNIX {
+			addr = d.Address.String()
+		}
 	}
 	return addr
 }


### PR DESCRIPTION
fix #3966
我最开始因为在windows上全改成了127复现不能 因为只发生在使用 uds 的时候 因为 @RPRX  刚好在这里用了 `@xhttp` 的uds 在尝试代理udp的时候会在控制台打印一条access message
```
from tcp: accepted udp:localhost:4000 [direct]
```
这条消息的正确含义是从xxx来了一个请求 xxx是源地址
那uds哪来的源地址 没有 导致网络类型填了一个默认的tcp类型 address更是nil 然后调string 炸了（你想知道它长什么样吗 `:0`）
在这里我把监听的ds文件作为源写入了日志 同时给NetAddr()加了一层nil检查避免以后有类似事故
