### PR TITLE
Test: Fix incorrect output format

### DIFF
--- a/app/dns/dnscommon_test.go
+++ b/app/dns/dnscommon_test.go
@@ -88,7 +88,7 @@ func Test_parseResponse(t *testing.T) {
 				got.Expire = time.Time{}
 			}
 			if cmp.Diff(got, tt.want) != "" {
-				t.Errorf(cmp.Diff(got, tt.want))
+				t.Error(cmp.Diff(got, tt.want))
 				// t.Errorf("handleResponse() = %#v, want %#v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
Fix prompt from go vet

`dns/dnscommon_test.go:91:14: non-constant format string in call to (*testing.common).Errorf`