### PR TITLE
XHTTP client: Allow different paths in U-D-S

### DIFF
--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -275,7 +275,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 		if requestURL2.Host == "" {
 			requestURL2.Host = memory2.Destination.NetAddr()
 		}
-		requestURL2.Path = requestURL.Path // the same
+		requestURL2.Path = config2.GetNormalizedPath() + sessionIdUuid.String()
 		requestURL2.RawQuery = config2.GetNormalizedQuery()
 	}
 


### PR DESCRIPTION
**XHTTP 上下行分离 https://github.com/XTLS/Xray-core/pull/3955 要求到达同一 XHTTP 入站的 POST、GET 基于同一 path，否则 XHTTP 入站会拒绝处理**

我看到有群友用 Nginx 改了 path，还有些中间件会 trim prefix，索性放开客户端的限制，反正最终 path 一致就行