### PR TITLE
Test: Change address for DNS over QUIC tests

### DIFF
--- a/app/dns/nameserver_quic_test.go
+++ b/app/dns/nameserver_quic_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestQUICNameServer(t *testing.T) {
-	url, err := url.Parse("quic://dns.adguard.com")
+	url, err := url.Parse("quic://dns.adguard-dns.com")
 	common.Must(err)
 	s, err := NewQUICNameServer(url, QueryStrategy_USE_IP)
 	common.Must(err)
@@ -42,7 +42,7 @@ func TestQUICNameServer(t *testing.T) {
 }
 
 func TestQUICNameServerWithIPv4Override(t *testing.T) {
-	url, err := url.Parse("quic://dns.adguard.com")
+	url, err := url.Parse("quic://dns.adguard-dns.com")
 	common.Must(err)
 	s, err := NewQUICNameServer(url, QueryStrategy_USE_IP4)
 	common.Must(err)
@@ -65,7 +65,7 @@ func TestQUICNameServerWithIPv4Override(t *testing.T) {
 }
 
 func TestQUICNameServerWithIPv6Override(t *testing.T) {
-	url, err := url.Parse("quic://dns.adguard.com")
+	url, err := url.Parse("quic://dns.adguard-dns.com")
 	common.Must(err)
 	s, err := NewQUICNameServer(url, QueryStrategy_USE_IP6)
 	common.Must(err)


### PR DESCRIPTION
My ISP blocks `*.adguard.com` so DNS over QUIC test results look like this:
```
$ go test github.com/xtls/xray-core/app/dns

...

--- FAIL: TestQUICNameServer (2.00s)
panic: context deadline exceeded [recovered]
	panic: context deadline exceeded

goroutine 356 [running]:
testing.tRunner.func1.2({0xb931c0, 0x129f360})
	/usr/local/go/src/testing/testing.go:1631 +0x24a
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1634 +0x377
panic({0xb931c0?, 0x129f360?})
	/usr/local/go/src/runtime/panic.go:770 +0x132
github.com/xtls/xray-core/common.Must(...)
	/Xray-core/common/common.go:21
github.com/xtls/xray-core/app/dns_test.TestQUICNameServer(0xc0000eed00)
	/Xray-core/app/dns/nameserver_quic_test.go:27 +0x2ca
testing.tRunner(0xc0000eed00, 0xc89b80)
	/usr/local/go/src/testing/testing.go:1689 +0xfb
created by testing.(*T).Run in goroutine 1
	/usr/local/go/src/testing/testing.go:1742 +0x390
FAIL	github.com/xtls/xray-core/app/dns	10.338s
FAIL
```

This can be currently fixed by changing domain name from `dns.adguard.com` to `dns.adguard-dns.com` but I am not sure it will work everywhere.

UPDATE

The reason of blocking is AdGuard VPN. AdGuard DNS is collateral damage. As far as I understand `*.adguard-dns.com` is now used exclusively for the DNS service. So it is safe to use it for now.

[Official list of AdGuard DNS servers.](https://adguard-dns.io/en/public-dns.html)