### PR TITLE
Use a more direct and less error-prone return value

### DIFF
--- a/proxy/vmess/validator.go
+++ b/proxy/vmess/validator.go
@@ -81,7 +81,7 @@ func (v *TimedUserValidator) GetAEAD(userHash []byte) (*protocol.MemoryUser, boo
 	if err != nil {
 		return nil, false, err
 	}
-	return userd.(*protocol.MemoryUser), true, err
+	return userd.(*protocol.MemoryUser), true, nil
 }
 
 func (v *TimedUserValidator) Remove(email string) bool {


### PR DESCRIPTION
Since err != nil has been judged before, nil is returned directly here, which is more obvious, readable and less error-prone. 

Just like  https://github.com/XTLS/Xray-core/blob/44b1dd0e674347691c62a13d227edf0d36b7e290/proxy/proxy.go#L538