### PR TITLE
Chore: Use a more direct and less error-prone return value

### DIFF
--- a/proxy/vmess/validator.go
+++ b/proxy/vmess/validator.go
@@ -81,7 +81,7 @@ func (v *TimedUserValidator) GetAEAD(userHash []byte) (*protocol.MemoryUser, boo
 	if err != nil {
 		return nil, false, err
 	}
-	return userd.(*protocol.MemoryUser), true, err
+	return userd.(*protocol.MemoryUser), true, nil
 }
 
 func (v *TimedUserValidator) Remove(email string) bool {

--- a/transport/internet/tls/config_other.go
+++ b/transport/internet/tls/config_other.go
@@ -51,5 +51,5 @@ func (c *Config) getCertPool() (*x509.CertPool, error) {
 			return nil, errors.New("append cert to root").AtWarning().Base(err)
 		}
 	}
-	return pool, err
+	return pool, nil
 }


### PR DESCRIPTION
The new pr for https://github.com/XTLS/Xray-core/pull/4005.


I wrote a tool to detect this, but it has a high false positive rate. 

I checked it one by one and I am sure there are only two such examples in the current code...