### PR TITLE
Update Dockerfile to Use Multiple Config Files

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -22,7 +22,7 @@ VOLUME /etc/xray
 ARG TZ=Asia/Shanghai
 ENV TZ=$TZ
 ENTRYPOINT [ "/usr/bin/xray" ]
-CMD [ "-config", "/etc/xray/config.json" ]
+CMD [ "-confdir", "/etc/xray/" ]
 
 ARG flavor=v2fly
 COPY --from=build --chmod=644 /$flavor /usr/share/xray


### PR DESCRIPTION
Docker volume /etc/xray only contain s config.json in default condition. Changing to confdir could provide support to both single file mode and multi-file mode.