### PR TITLE
Config: Correctly marshal `Address` to JSON

### DIFF
--- a/infra/conf/common.go
+++ b/infra/conf/common.go
@@ -42,6 +42,10 @@ type Address struct {
 	net.Address
 }
 
+func (v Address) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.Address.String())
+}
+
 func (v *Address) UnmarshalJSON(data []byte) error {
 	var rawStr string
 	if err := json.Unmarshal(data, &rawStr); err != nil {

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -258,6 +258,7 @@ func (c *InboundDetourConfig) Build() (*core.InboundHandlerConfig, error) {
 }
 
 type OutboundDetourConfig struct {
+	Name          *string          `json:"name"`
 	Protocol      string           `json:"protocol"`
 	SendThrough   *string          `json:"sendThrough"`
 	Tag           string           `json:"tag"`

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -258,7 +258,6 @@ func (c *InboundDetourConfig) Build() (*core.InboundHandlerConfig, error) {
 }
 
 type OutboundDetourConfig struct {
-	Name          *string          `json:"name"`
 	Protocol      string           `json:"protocol"`
 	SendThrough   *string          `json:"sendThrough"`
 	Tag           string           `json:"tag"`


### PR DESCRIPTION
Because Mr. R has appended new "extra" field to sharing protocol, it's time to use the original config of Xray-core when parsing share links.
This commit contains two modifications.
1. append "Name" field to "OutboundDetourConfig".
2. support marshaling "Address".

Maybe we should make more changes in the future, but it is enough currently for VLESS sharing protocol.