### PR TITLE
Test: Delete temporary file afterwards

### DIFF
--- a/common/log/logger_test.go
+++ b/common/log/logger_test.go
@@ -16,6 +16,7 @@ func TestFileLogger(t *testing.T) {
 	common.Must(err)
 	path := f.Name()
 	common.Must(f.Close())
+	defer os.Remove(path)
 
 	creator, err := CreateFileLogWriter(path)
 	common.Must(err)


### PR DESCRIPTION
The temporary file created by `common/log.TestFileLogger()` is currently not deleted.