### PR TITLE
WireGuard inbound: Fix leaking session information between requests

### DIFF
--- a/proxy/wireguard/server.go
+++ b/proxy/wireguard/server.go
@@ -144,19 +144,18 @@ func (s *Server) forwardConnection(dest net.Destination, conn net.Conn) {
 		Reason: "",
 	})
 
-	if s.info.inboundTag != nil {
-		ctx = session.ContextWithInbound(ctx, s.info.inboundTag)
-	}
-
 	// what the hell is this?
 	// useless and making bugs
 
+	//  if s.info.inboundTag != nil {
+	//  ctx = session.ContextWithInbound(ctx, s.info.inboundTag)
+	//  }
 	//	if s.info.outboundTag != nil {
 	//		ctx = session.ContextWithOutbounds(ctx, []*session.Outbound{s.info.outboundTag})
 	//	}
-	//if s.info.contentTag != nil {
-	//	ctx = session.ContextWithContent(ctx, s.info.contentTag)
-	//}
+	//  if s.info.contentTag != nil {
+	//	    ctx = session.ContextWithContent(ctx, s.info.contentTag)
+	//  }
 
 	link, err := s.info.dispatcher.Dispatch(ctx, dest)
 	if err != nil {

--- a/proxy/wireguard/server.go
+++ b/proxy/wireguard/server.go
@@ -144,8 +144,10 @@ func (s *Server) forwardConnection(dest net.Destination, conn net.Conn) {
 		Reason: "",
 	})
 
-	// what the hell is this?
-	// useless and making bugs
+	// what's this?
+	// Session information should not be shared between different connections
+	// why reuse them in server level? This will cause incorrect destoverride and unexpected routing behavior.
+	// Disable it temporarily. Maybe s.info should be removed.
 
 	//  if s.info.inboundTag != nil {
 	//  ctx = session.ContextWithInbound(ctx, s.info.inboundTag)

--- a/proxy/wireguard/server.go
+++ b/proxy/wireguard/server.go
@@ -147,12 +147,16 @@ func (s *Server) forwardConnection(dest net.Destination, conn net.Conn) {
 	if s.info.inboundTag != nil {
 		ctx = session.ContextWithInbound(ctx, s.info.inboundTag)
 	}
-	if s.info.outboundTag != nil {
-		ctx = session.ContextWithOutbounds(ctx, []*session.Outbound{s.info.outboundTag})
-	}
-	if s.info.contentTag != nil {
-		ctx = session.ContextWithContent(ctx, s.info.contentTag)
-	}
+
+	// what the hell is this?
+	// useless and making bugs
+
+	//	if s.info.outboundTag != nil {
+	//		ctx = session.ContextWithOutbounds(ctx, []*session.Outbound{s.info.outboundTag})
+	//	}
+	//if s.info.contentTag != nil {
+	//	ctx = session.ContextWithContent(ctx, s.info.contentTag)
+	//}
 
 	link, err := s.info.dispatcher.Dispatch(ctx, dest)
 	if err != nil {


### PR DESCRIPTION
Fix #3948 #4025 

我本来以为是设计缺陷，结果这竟然是故意的，wg入站在入站级别共享一系列session参数(s.info) 这些参数对于每个请求都应该是独立的 多个入站互相操作这些参数导致目标可能被不正确重置 暂时没看懂为什么这么做