### PR TITLE
Test: Remove temporary directory afterwards

### DIFF
--- a/testing/scenarios/common.go
+++ b/testing/scenarios/common.go
@@ -96,6 +96,7 @@ func InitializeServerConfig(config *core.Config) (*exec.Cmd, error) {
 
 var (
 	testBinaryPath    string
+	testBinaryCleanFn func()
 	testBinaryPathGen sync.Once
 )
 
@@ -108,6 +109,7 @@ func genTestBinaryPath() {
 				return err
 			}
 			tempDir = dir
+			testBinaryCleanFn = func() { os.RemoveAll(dir) }
 			return nil
 		}))
 		file := filepath.Join(tempDir, "xray.test")

--- a/testing/scenarios/main_test.go
+++ b/testing/scenarios/main_test.go
@@ -1,0 +1,12 @@
+package scenarios
+
+import (
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	genTestBinaryPath()
+	defer testBinaryCleanFn()
+
+	m.Run()
+}


### PR DESCRIPTION
The temporary directory created by `testing/scenarios.genTestBinaryPath()` is currently not deleted. Note that `TestMain()` is a [special function that is executed before any tests in a package](https://pkg.go.dev/testing#hdr-Main).