### PR TITLE
XHTTP: Add "stream-one" mode for client & server

### DIFF
--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -307,7 +307,7 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 	switch c.Mode {
 	case "":
 		c.Mode = "auto"
-	case "auto", "packet-up", "stream-up":
+	case "auto", "packet-up", "stream-up", "stream-one":
 	default:
 		return nil, errors.New("unsupported mode: " + c.Mode)
 	}
@@ -327,6 +327,9 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 	}
 	var err error
 	if c.DownloadSettings != nil {
+		if c.Mode == "stream-one" {
+			return nil, errors.New(`Can not use "downloadSettings" in "stream-one" mode.`)
+		}
 		if c.Extra != nil {
 			c.DownloadSettings.SocketSettings = nil
 		}

--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -713,6 +713,7 @@ func (p TransportProtocol) Build() (string, error) {
 		errors.PrintDeprecatedFeatureWarning("HTTP transport", "XHTTP transport")
 		return "http", nil
 	case "grpc":
+		errors.PrintMigrateFeatureInfo("gRPC transport", "XHTTP transport")
 		return "grpc", nil
 	case "httpupgrade":
 		return "httpupgrade", nil

--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -710,6 +710,7 @@ func (p TransportProtocol) Build() (string, error) {
 	case "ws", "websocket":
 		return "websocket", nil
 	case "h2", "h3", "http":
+		errors.PrintDeprecatedFeatureWarning("HTTP transport", "XHTTP transport")
 		return "http", nil
 	case "grpc":
 		return "grpc", nil

--- a/transport/internet/splithttp/browser_client.go
+++ b/transport/internet/splithttp/browser_client.go
@@ -14,6 +14,10 @@ import (
 // has no fields because everything is global state :O)
 type BrowserDialerClient struct{}
 
+func (c *BrowserDialerClient) Open(ctx context.Context, pureURL string) (io.WriteCloser, io.ReadCloser) {
+	panic("not implemented yet")
+}
+
 func (c *BrowserDialerClient) OpenUpload(ctx context.Context, baseURL string) io.WriteCloser {
 	panic("not implemented yet")
 }

--- a/transport/internet/splithttp/client.go
+++ b/transport/internet/splithttp/client.go
@@ -29,6 +29,10 @@ type DialerClient interface {
 	// (ctx, baseURL) -> uploadWriter
 	// baseURL already contains sessionId
 	OpenUpload(context.Context, string) io.WriteCloser
+
+	// (ctx, pureURL) -> (uploadWriter, downloadReader)
+	// pureURL can not contain sessionId
+	Open(context.Context, string) (io.WriteCloser, io.ReadCloser)
 }
 
 // implements splithttp.DialerClient in terms of direct network connections
@@ -40,6 +44,30 @@ type DefaultDialerClient struct {
 	// pool of net.Conn, created using dialUploadConn
 	uploadRawPool  *sync.Pool
 	dialUploadConn func(ctxInner context.Context) (net.Conn, error)
+}
+
+func (c *DefaultDialerClient) Open(ctx context.Context, pureURL string) (io.WriteCloser, io.ReadCloser) {
+	reader, writer := io.Pipe()
+	req, _ := http.NewRequestWithContext(ctx, "POST", pureURL, reader)
+	req.Header = c.transportConfig.GetRequestHeader()
+	if !c.transportConfig.NoGRPCHeader {
+		req.Header.Set("Content-Type", "application/grpc")
+	}
+	wrc := &WaitReadCloser{Wait: make(chan struct{})}
+	go func() {
+		response, err := c.client.Do(req)
+		if err != nil || response.StatusCode != 200 {
+			if err != nil {
+				errors.LogInfoInner(ctx, err, "failed to open ", pureURL)
+			} else {
+				errors.LogInfo(ctx, "unexpected status ", response.StatusCode)
+			}
+			wrc.Close()
+			return
+		}
+		wrc.Set(response.Body)
+	}()
+	return writer, wrc
 }
 
 func (c *DefaultDialerClient) OpenUpload(ctx context.Context, baseURL string) io.WriteCloser {
@@ -224,5 +252,42 @@ type downloadBody struct {
 
 func (c downloadBody) Close() error {
 	c.cancel()
+	return nil
+}
+
+type WaitReadCloser struct {
+	Wait chan struct{}
+	io.ReadCloser
+}
+
+func (w *WaitReadCloser) Set(rc io.ReadCloser) {
+	w.ReadCloser = rc
+	defer func() {
+		if recover() != nil {
+			rc.Close()
+		}
+	}()
+	close(w.Wait)
+}
+
+func (w *WaitReadCloser) Read(b []byte) (int, error) {
+	if w.ReadCloser == nil {
+		if <-w.Wait; w.ReadCloser == nil {
+			return 0, io.ErrClosedPipe
+		}
+	}
+	return w.ReadCloser.Read(b)
+}
+
+func (w *WaitReadCloser) Close() error {
+	if w.ReadCloser != nil {
+		return w.ReadCloser.Close()
+	}
+	defer func() {
+		if recover() != nil && w.ReadCloser != nil {
+			w.ReadCloser.Close()
+		}
+	}()
+	close(w.Wait)
 	return nil
 }

--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -281,7 +281,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 	}
 
 	mode := transportConfiguration.Mode
-	if mode == "auto" {
+	if mode == "" || mode == "auto" {
 		mode = "packet-up"
 		if (tlsConfig != nil && (len(tlsConfig.NextProtocol) != 1 || tlsConfig.NextProtocol[0] == "h2")) || realityConfig != nil {
 			mode = "stream-up"

--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -3,6 +3,7 @@ package splithttp
 import (
 	"context"
 	gotls "crypto/tls"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -279,9 +280,33 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 		requestURL2.RawQuery = config2.GetNormalizedQuery()
 	}
 
-	reader, remoteAddr, localAddr, err := httpClient2.OpenDownload(context.WithoutCancel(ctx), requestURL2.String())
-	if err != nil {
-		return nil, err
+	mode := transportConfiguration.Mode
+	if mode == "auto" {
+		mode = "packet-up"
+		if (tlsConfig != nil && (len(tlsConfig.NextProtocol) != 1 || tlsConfig.NextProtocol[0] == "h2")) || realityConfig != nil {
+			mode = "stream-up"
+		}
+		if realityConfig != nil && transportConfiguration.DownloadSettings == nil {
+			mode = "stream-one"
+		}
+	}
+	errors.LogInfo(ctx, "XHTTP is using mode: "+mode)
+
+	var writer io.WriteCloser
+	var reader io.ReadCloser
+	var remoteAddr, localAddr net.Addr
+	var err error
+
+	if mode == "stream-one" {
+		requestURL.Path = transportConfiguration.GetNormalizedPath()
+		writer, reader = httpClient.Open(context.WithoutCancel(ctx), requestURL.String())
+		remoteAddr = &net.TCPAddr{}
+		localAddr = &net.TCPAddr{}
+	} else {
+		reader, remoteAddr, localAddr, err = httpClient2.OpenDownload(context.WithoutCancel(ctx), requestURL2.String())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if muxRes != nil {
@@ -293,7 +318,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 	closed := false
 
 	conn := splitConn{
-		writer:     nil,
+		writer:     writer,
 		reader:     reader,
 		remoteAddr: remoteAddr,
 		localAddr:  localAddr,
@@ -311,14 +336,9 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 		},
 	}
 
-	mode := transportConfiguration.Mode
-	if mode == "auto" {
-		mode = "packet-up"
-		if (tlsConfig != nil && len(tlsConfig.NextProtocol) != 1) || realityConfig != nil {
-			mode = "stream-up"
-		}
+	if mode == "stream-one" {
+		return stat.Connection(&conn), nil
 	}
-	errors.LogInfo(ctx, "XHTTP is using mode: "+mode)
 	if mode == "stream-up" {
 		conn.writer = httpClient.OpenUpload(ctx, requestURL.String())
 		return stat.Connection(&conn), nil

--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -159,8 +159,8 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 				errors.LogInfoInner(context.Background(), err, "failed to upload (PushReader)")
 				writer.WriteHeader(http.StatusConflict)
 			} else {
-				if request.Header.Get("Content-Type") == "grpc" {
-					writer.Header().Set("Content-Type", "grpc")
+				if request.Header.Get("Content-Type") == "application/grpc" {
+					writer.Header().Set("Content-Type", "application/grpc")
 				}
 				writer.WriteHeader(http.StatusOK)
 				<-request.Context().Done()
@@ -227,8 +227,8 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		// teeing the response stream into their cache, causing slowdowns.
 		writer.Header().Set("Cache-Control", "no-store")
 
-		if request.Header.Get("Content-Type") == "grpc" {
-			writer.Header().Set("Content-Type", "grpc")
+		if request.Header.Get("Content-Type") == "application/grpc" {
+			writer.Header().Set("Content-Type", "application/grpc")
 		} else if !h.config.NoSSEHeader {
 			// magic header to make the HTTP middle box consider this as SSE to disable buffer
 			writer.Header().Set("Content-Type", "text/event-stream")

--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -116,7 +116,7 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		sessionId = subpath[0]
 	}
 
-	if sessionId == "" && h.config.Mode != "auto" && h.config.Mode != "stream-one" && h.config.Mode != "stream-up" {
+	if sessionId == "" && h.config.Mode != "" && h.config.Mode != "auto" && h.config.Mode != "stream-one" && h.config.Mode != "stream-up" {
 		errors.LogInfo(context.Background(), "stream-one mode is not allowed")
 		writer.WriteHeader(http.StatusBadRequest)
 		return
@@ -147,7 +147,7 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		}
 
 		if seq == "" {
-			if h.config.Mode != "auto" && h.config.Mode != "stream-up" {
+			if h.config.Mode != "" && h.config.Mode != "auto" && h.config.Mode != "stream-up" {
 				errors.LogInfo(context.Background(), "stream-up mode is not allowed")
 				writer.WriteHeader(http.StatusBadRequest)
 				return
@@ -168,7 +168,7 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 			return
 		}
 
-		if h.config.Mode != "auto" && h.config.Mode != "packet-up" {
+		if h.config.Mode != "" && h.config.Mode != "auto" && h.config.Mode != "packet-up" {
 			errors.LogInfo(context.Background(), "packet-up mode is not allowed")
 			writer.WriteHeader(http.StatusBadRequest)
 			return

--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -102,14 +102,22 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 
 	h.config.WriteResponseHeader(writer)
 
+	validRange := h.config.GetNormalizedXPaddingBytes()
+	x_padding := int32(len(request.URL.Query().Get("x_padding")))
+	if validRange.To > 0 && (x_padding < validRange.From || x_padding > validRange.To) {
+		errors.LogInfo(context.Background(), "invalid x_padding length:", x_padding)
+		writer.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	sessionId := ""
 	subpath := strings.Split(request.URL.Path[len(h.path):], "/")
 	if len(subpath) > 0 {
 		sessionId = subpath[0]
 	}
 
-	if sessionId == "" {
-		errors.LogInfo(context.Background(), "no sessionid on request:", request.URL.Path)
+	if sessionId == "" && h.config.Mode != "auto" && h.config.Mode != "stream-one" && h.config.Mode != "stream-up" {
+		errors.LogInfo(context.Background(), "stream-one mode is not allowed")
 		writer.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -126,17 +134,20 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		}
 	}
 
-	currentSession := h.upsertSession(sessionId)
+	var currentSession *httpSession
+	if sessionId != "" {
+		currentSession = h.upsertSession(sessionId)
+	}
 	scMaxEachPostBytes := int(h.ln.config.GetNormalizedScMaxEachPostBytes().To)
 
-	if request.Method == "POST" {
+	if request.Method == "POST" && sessionId != "" {
 		seq := ""
 		if len(subpath) > 1 {
 			seq = subpath[1]
 		}
 
 		if seq == "" {
-			if h.config.Mode == "packet-up" {
+			if h.config.Mode != "auto" && h.config.Mode != "stream-up" {
 				errors.LogInfo(context.Background(), "stream-up mode is not allowed")
 				writer.WriteHeader(http.StatusBadRequest)
 				return
@@ -148,13 +159,16 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 				errors.LogInfoInner(context.Background(), err, "failed to upload (PushReader)")
 				writer.WriteHeader(http.StatusConflict)
 			} else {
+				if request.Header.Get("Content-Type") == "grpc" {
+					writer.Header().Set("Content-Type", "grpc")
+				}
 				writer.WriteHeader(http.StatusOK)
 				<-request.Context().Done()
 			}
 			return
 		}
 
-		if h.config.Mode == "stream-up" {
+		if h.config.Mode != "auto" && h.config.Mode != "packet-up" {
 			errors.LogInfo(context.Background(), "packet-up mode is not allowed")
 			writer.WriteHeader(http.StatusBadRequest)
 			return
@@ -193,16 +207,18 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		}
 
 		writer.WriteHeader(http.StatusOK)
-	} else if request.Method == "GET" {
+	} else if request.Method == "GET" || sessionId == "" {
 		responseFlusher, ok := writer.(http.Flusher)
 		if !ok {
 			panic("expected http.ResponseWriter to be an http.Flusher")
 		}
 
-		// after GET is done, the connection is finished. disable automatic
-		// session reaping, and handle it in defer
-		currentSession.isFullyConnected.Close()
-		defer h.sessions.Delete(sessionId)
+		if sessionId != "" {
+			// after GET is done, the connection is finished. disable automatic
+			// session reaping, and handle it in defer
+			currentSession.isFullyConnected.Close()
+			defer h.sessions.Delete(sessionId)
+		}
 
 		// magic header instructs nginx + apache to not buffer response body
 		writer.Header().Set("X-Accel-Buffering", "no")
@@ -210,7 +226,10 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		// Should be able to prevent overloading the cache, or stop CDNs from
 		// teeing the response stream into their cache, causing slowdowns.
 		writer.Header().Set("Cache-Control", "no-store")
-		if !h.config.NoSSEHeader {
+
+		if request.Header.Get("Content-Type") == "grpc" {
+			writer.Header().Set("Content-Type", "grpc")
+		} else if !h.config.NoSSEHeader {
 			// magic header to make the HTTP middle box consider this as SSE to disable buffer
 			writer.Header().Set("Content-Type", "text/event-stream")
 		}
@@ -227,8 +246,11 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 				downloadDone:    downloadDone,
 				responseFlusher: responseFlusher,
 			},
-			reader:     currentSession.uploadQueue,
+			reader:     request.Body,
 			remoteAddr: remoteAddr,
+		}
+		if sessionId != "" {
+			conn.reader = currentSession.uploadQueue
 		}
 
 		h.ln.addConn(stat.Connection(&conn))


### PR DESCRIPTION
https://github.com/XTLS/Xray-core/pull/3994#issuecomment-2497920598 让我们补上 XHTTP 近期最后一大块拼图：

现有的 HTTP 传输层使用“**一条子连接**”承载一条被代理请求，即没有任何上下行逻辑分离。**但它一直以来存在一个没有 header padding 的大问题，即请求头和响应头在 TLS 上会表现出固定的长度特征。** 加 header padding 不难，但穿墙协议的安全更新不应默认兼容旧版，否则会被旧版客户端所拖累。此外 HTTP 传输层与代理协议的名称相撞，亦没有 XHTTP 的 XMUX 等功能。

**所以，最佳解决方案是将 HTTP transport with header padding 作为 stream-one 模式并入 XHTTP 传输层，这样一来也有了 XMUX 等功能而无需维护两份代码。** XHTTP 服务端会检查客户端发来的 x_padding 是否符合所配置的范围（有默认值），以确保不默认兼容原 HTTP 传输层。虽然你也可以将 xPaddingBytes 设为 -1 以兼容原 HTTP 传输层，但不建议，也没有必要这样做。

就像 [stream-up](https://github.com/XTLS/Xray-core/pull/3994) 模式，**stream-one** 模式也默认有 [gRPC header](https://github.com/XTLS/Xray-core/pull/4042) 伪装，据称也可以过 CF H2。**此外，客户端发 gRPC header 伪装时，这个 PR 补上了服务端回应 gRPC header 伪装。** 然而 CDN 可能对 gRPC 有流量限制，所以更建议用 stream-up 仅上行。

所以 **stream-one** 模式和 stream-up 模式的主要区别是前者无需服务端 "session" 机制，**流量特征上也略有不同**。

~~本来看到服务端提前发送了响应头而没有等数据一起，本想改成粘着，后来想到了一项不知道是否已公开的研究，就没改。~~

**"mode" 四选一，客户端、服务端默认值都是 "auto"：**
- "auto" - 客户端：TLS H2 时 stream-up，**REALITY 时 stream-one**（有 downloadSettings 时 stream-up），否则 packet-up / 服务端：同时接受三种模式
- "packet-up" - 客户端：分包上行 + 流式下行（单独的子连接）/ 服务端：仅接受 packet-up
- "stream-up" - 客户端：流式上行 + 流式下行（另一条子连接）/ 服务端：仅接受 stream-up 和 stream-one
- "stream-one" - 客户端：流式上行 + 流式下行（同一条子连接），不能有 downloadSettings / 服务端：仅接受 stream-one

新模式的加入也使得 XHTTP 更加完备，预计月底 release，正好接棒一个月：**借我一个月，还你们一个完全体 XHTTP**

**REALITY 的 NFT 也即将发行，别错过收藏 Project X NFT 送 REALITY NFT 的最后机会：[Announcement of NFTs by Project X](https://github.com/XTLS/Xray-core/discussions/3633)**

（初始售价 0.033 ETH 的 Project X NFT 现已涨至 0.18 ETH，且还会送 REALITY NFT，只能说越早上车越香，现在才刚开始）