### PR TITLE
Core: Fix memory leaks with RequireFeatures()

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -106,7 +106,7 @@ func init() {
 	common.Must(common.RegisterConfig((*Config)(nil), func(ctx context.Context, config interface{}) (interface{}, error) {
 		d := new(DefaultDispatcher)
 		if err := core.RequireFeatures(ctx, func(om outbound.Manager, router routing.Router, pm policy.Manager, sm stats.Manager, dc dns.Client) error {
-			core.RequireFeatures(ctx, func(fdns dns.FakeDNSEngine) {
+			core.RequireFeatures(ctx, func(fdns dns.FakeDNSEngine) { // FakeDNSEngine is optional
 				d.fdns = fdns
 			})
 			return d.Init(config.(*Config), om, router, pm, sm, dc)

--- a/app/dns/nameserver.go
+++ b/app/dns/nameserver.go
@@ -35,7 +35,7 @@ type Client struct {
 var errExpectedIPNonMatch = errors.New("expectIPs not match")
 
 // NewServer creates a name server object according to the network destination url.
-func NewServer(dest net.Destination, dispatcher routing.Dispatcher, queryStrategy QueryStrategy) (Server, error) {
+func NewServer(dest net.Destination, dispatcher routing.Dispatcher, queryStrategy QueryStrategy, fd dns.FakeDNSEngine) (Server, error) {
 	if address := dest.Address; address.Family().IsDomain() {
 		u, err := url.Parse(address.Domain())
 		if err != nil {
@@ -55,7 +55,7 @@ func NewServer(dest net.Destination, dispatcher routing.Dispatcher, queryStrateg
 		case strings.EqualFold(u.Scheme, "tcp+local"): // DNS-over-TCP Local mode
 			return NewTCPLocalNameServer(u, queryStrategy)
 		case strings.EqualFold(u.String(), "fakedns"):
-			return NewFakeDNSServer(), nil
+			return NewFakeDNSServer(fd), nil
 		}
 	}
 	if dest.Network == net.Network_Unknown {
@@ -78,9 +78,9 @@ func NewClient(
 ) (*Client, error) {
 	client := &Client{}
 
-	err := core.RequireFeatures(ctx, func(dispatcher routing.Dispatcher) error {
+	err := core.RequireFeatures(ctx, func(dispatcher routing.Dispatcher, fd dns.FakeDNSEngine) error {
 		// Create a new server for each client for now
-		server, err := NewServer(ns.Address.AsDestination(), dispatcher, ns.GetQueryStrategy())
+		server, err := NewServer(ns.Address.AsDestination(), dispatcher, ns.GetQueryStrategy(), fd)
 		if err != nil {
 			return errors.New("failed to create nameserver").Base(err).AtWarning()
 		}

--- a/app/dns/nameserver.go
+++ b/app/dns/nameserver.go
@@ -78,7 +78,11 @@ func NewClient(
 ) (*Client, error) {
 	client := &Client{}
 
-	err := core.RequireFeatures(ctx, func(dispatcher routing.Dispatcher, fd dns.FakeDNSEngine) error {
+	var fd dns.FakeDNSEngine
+	err := core.RequireFeatures(ctx, func(dispatcher routing.Dispatcher) error {
+		core.RequireFeatures(ctx, func(fdns dns.FakeDNSEngine) { // FakeDNSEngine is optional
+			fd = fdns
+		})
 		// Create a new server for each client for now
 		server, err := NewServer(ns.Address.AsDestination(), dispatcher, ns.GetQueryStrategy(), fd)
 		if err != nil {

--- a/app/dns/nameserver_fakedns.go
+++ b/app/dns/nameserver_fakedns.go
@@ -21,6 +21,10 @@ func (FakeDNSServer) Name() string {
 }
 
 func (f *FakeDNSServer) QueryIP(ctx context.Context, domain string, _ net.IP, opt dns.IPOption, _ bool) ([]net.IP, error) {
+	if f.fakeDNSEngine == nil {
+		return nil, errors.New("Unable to locate a fake DNS Engine").AtError()
+	}
+
 	var ips []net.Address
 	if fkr0, ok := f.fakeDNSEngine.(dns.FakeDNSEngineRev0); ok {
 		ips = fkr0.GetFakeIPForDomain3(domain, opt.IPv4Enable, opt.IPv6Enable)

--- a/app/dns/nameserver_fakedns.go
+++ b/app/dns/nameserver_fakedns.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/net"
-	"github.com/xtls/xray-core/core"
 	"github.com/xtls/xray-core/features/dns"
 )
 
@@ -13,8 +12,8 @@ type FakeDNSServer struct {
 	fakeDNSEngine dns.FakeDNSEngine
 }
 
-func NewFakeDNSServer() *FakeDNSServer {
-	return &FakeDNSServer{}
+func NewFakeDNSServer(fd dns.FakeDNSEngine) *FakeDNSServer {
+	return &FakeDNSServer{fakeDNSEngine: fd}
 }
 
 func (FakeDNSServer) Name() string {
@@ -22,13 +21,6 @@ func (FakeDNSServer) Name() string {
 }
 
 func (f *FakeDNSServer) QueryIP(ctx context.Context, domain string, _ net.IP, opt dns.IPOption, _ bool) ([]net.IP, error) {
-	if f.fakeDNSEngine == nil {
-		if err := core.RequireFeatures(ctx, func(fd dns.FakeDNSEngine) {
-			f.fakeDNSEngine = fd
-		}); err != nil {
-			return nil, errors.New("Unable to locate a fake DNS Engine").Base(err).AtError()
-		}
-	}
 	var ips []net.Address
 	if fkr0, ok := f.fakeDNSEngine.(dns.FakeDNSEngineRev0); ok {
 		ips = fkr0.GetFakeIPForDomain3(domain, opt.IPv4Enable, opt.IPv6Enable)

--- a/app/observatory/burst/burstobserver.go
+++ b/app/observatory/burst/burstobserver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/xtls/xray-core/core"
 	"github.com/xtls/xray-core/features/extension"
 	"github.com/xtls/xray-core/features/outbound"
+	"github.com/xtls/xray-core/features/routing"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -88,13 +89,15 @@ func (o *Observer) Close() error {
 
 func New(ctx context.Context, config *Config) (*Observer, error) {
 	var outboundManager outbound.Manager
-	err := core.RequireFeatures(ctx, func(om outbound.Manager) {
+	var dispatcher routing.Dispatcher
+	err := core.RequireFeatures(ctx, func(om outbound.Manager, rd routing.Dispatcher) {
 		outboundManager = om
+		dispatcher = rd
 	})
 	if err != nil {
 		return nil, errors.New("Cannot get depended features").Base(err)
 	}
-	hp := NewHealthPing(ctx, config.PingConfig)
+	hp := NewHealthPing(ctx, dispatcher, config.PingConfig)
 	return &Observer{
 		config: config,
 		ctx:    ctx,

--- a/app/observatory/burst/healthping.go
+++ b/app/observatory/burst/healthping.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/xtls/xray-core/common/dice"
 	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/features/routing"
 )
 
 // HealthPingSettings holds settings for health Checker
@@ -23,6 +24,7 @@ type HealthPingSettings struct {
 // HealthPing is the health checker for balancers
 type HealthPing struct {
 	ctx         context.Context
+	dispatcher  routing.Dispatcher
 	access      sync.Mutex
 	ticker      *time.Ticker
 	tickerClose chan struct{}
@@ -32,7 +34,7 @@ type HealthPing struct {
 }
 
 // NewHealthPing creates a new HealthPing with settings
-func NewHealthPing(ctx context.Context, config *HealthPingConfig) *HealthPing {
+func NewHealthPing(ctx context.Context, dispatcher routing.Dispatcher, config *HealthPingConfig) *HealthPing {
 	settings := &HealthPingSettings{}
 	if config != nil {
 		settings = &HealthPingSettings{
@@ -65,6 +67,7 @@ func NewHealthPing(ctx context.Context, config *HealthPingConfig) *HealthPing {
 	}
 	return &HealthPing{
 		ctx:      ctx,
+		dispatcher: dispatcher,
 		Settings: settings,
 		Results:  nil,
 	}
@@ -149,6 +152,7 @@ func (h *HealthPing) doCheck(tags []string, duration time.Duration, rounds int) 
 		handler := tag
 		client := newPingClient(
 			h.ctx,
+			h.dispatcher,
 			h.Settings.Destination,
 			h.Settings.Timeout,
 			handler,

--- a/app/observatory/burst/ping.go
+++ b/app/observatory/burst/ping.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/features/routing"
 	"github.com/xtls/xray-core/transport/internet/tagged"
 )
 
@@ -14,10 +15,10 @@ type pingClient struct {
 	httpClient  *http.Client
 }
 
-func newPingClient(ctx context.Context, destination string, timeout time.Duration, handler string) *pingClient {
+func newPingClient(ctx context.Context, dispatcher routing.Dispatcher, destination string, timeout time.Duration, handler string) *pingClient {
 	return &pingClient{
 		destination: destination,
-		httpClient:  newHTTPClient(ctx, handler, timeout),
+		httpClient:  newHTTPClient(ctx, dispatcher, handler, timeout),
 	}
 }
 
@@ -28,7 +29,7 @@ func newDirectPingClient(destination string, timeout time.Duration) *pingClient 
 	}
 }
 
-func newHTTPClient(ctxv context.Context, handler string, timeout time.Duration) *http.Client {
+func newHTTPClient(ctxv context.Context, dispatcher routing.Dispatcher, handler string, timeout time.Duration) *http.Client {
 	tr := &http.Transport{
 		DisableKeepAlives: true,
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -36,7 +37,7 @@ func newHTTPClient(ctxv context.Context, handler string, timeout time.Duration) 
 			if err != nil {
 				return nil, err
 			}
-			return tagged.Dialer(ctxv, dest, handler)
+			return tagged.Dialer(ctxv, dispatcher, dest, handler)
 		},
 	}
 	return &http.Client{

--- a/app/router/balancing.go
+++ b/app/router/balancing.go
@@ -31,6 +31,12 @@ type RoundRobinStrategy struct {
 
 func (s *RoundRobinStrategy) InjectContext(ctx context.Context) {
 	s.ctx = ctx
+	if len(s.FallbackTag) > 0 {
+		common.Must(core.RequireFeatures(s.ctx, func(observatory extension.Observatory) error {
+			s.observatory = observatory
+			return nil
+		}))
+	}
 }
 
 func (s *RoundRobinStrategy) GetPrincipleTarget(strings []string) []string {
@@ -38,12 +44,6 @@ func (s *RoundRobinStrategy) GetPrincipleTarget(strings []string) []string {
 }
 
 func (s *RoundRobinStrategy) PickOutbound(tags []string) string {
-	if len(s.FallbackTag) > 0 && s.observatory == nil {
-		common.Must(core.RequireFeatures(s.ctx, func(observatory extension.Observatory) error {
-			s.observatory = observatory
-			return nil
-		}))
-	}
 	if s.observatory != nil {
 		observeReport, err := s.observatory.GetObservation(s.ctx)
 		if err == nil {

--- a/app/router/balancing.go
+++ b/app/router/balancing.go
@@ -5,7 +5,6 @@ import (
 	sync "sync"
 
 	"github.com/xtls/xray-core/app/observatory"
-	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/core"
 	"github.com/xtls/xray-core/features/extension"
@@ -32,10 +31,9 @@ type RoundRobinStrategy struct {
 func (s *RoundRobinStrategy) InjectContext(ctx context.Context) {
 	s.ctx = ctx
 	if len(s.FallbackTag) > 0 {
-		common.Must(core.RequireFeatures(s.ctx, func(observatory extension.Observatory) error {
+		core.RequireFeaturesAsync(s.ctx, func(observatory extension.Observatory) {
 			s.observatory = observatory
-			return nil
-		}))
+		})
 	}
 }
 

--- a/app/router/strategy_leastload.go
+++ b/app/router/strategy_leastload.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/xtls/xray-core/app/observatory"
-	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/dice"
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/core"
@@ -60,10 +59,9 @@ type node struct {
 
 func (s *LeastLoadStrategy) InjectContext(ctx context.Context) {
 	s.ctx = ctx
-	common.Must(core.RequireFeatures(s.ctx, func(observatory extension.Observatory) error {
+	core.RequireFeaturesAsync(s.ctx, func(observatory extension.Observatory) {
 		s.observer = observatory
-		return nil
-	}))
+	})
 }
 
 func (s *LeastLoadStrategy) PickOutbound(candidates []string) string {

--- a/app/router/strategy_leastload.go
+++ b/app/router/strategy_leastload.go
@@ -58,8 +58,12 @@ type node struct {
 	RTTDeviationCost time.Duration
 }
 
-func (l *LeastLoadStrategy) InjectContext(ctx context.Context) {
-	l.ctx = ctx
+func (s *LeastLoadStrategy) InjectContext(ctx context.Context) {
+	s.ctx = ctx
+	common.Must(core.RequireFeatures(s.ctx, func(observatory extension.Observatory) error {
+		s.observer = observatory
+		return nil
+	}))
 }
 
 func (s *LeastLoadStrategy) PickOutbound(candidates []string) string {
@@ -135,12 +139,6 @@ func (s *LeastLoadStrategy) selectLeastLoad(nodes []*node) []*node {
 }
 
 func (s *LeastLoadStrategy) getNodes(candidates []string, maxRTT time.Duration) []*node {
-	if s.observer == nil {
-		common.Must(core.RequireFeatures(s.ctx, func(observatory extension.Observatory) error {
-			s.observer = observatory
-			return nil
-		}))
-	}
 	observeResult, err := s.observer.GetObservation(s.ctx)
 	if err != nil {
 		errors.LogInfoInner(s.ctx, err, "cannot get observation")

--- a/app/router/strategy_leastload.go
+++ b/app/router/strategy_leastload.go
@@ -61,6 +61,7 @@ func (s *LeastLoadStrategy) InjectContext(ctx context.Context) {
 	s.ctx = ctx
 	core.RequireFeaturesAsync(s.ctx, func(observatory extension.Observatory) {
 		s.observer = observatory
+		errors.LogDebug(s.ctx, "InjectContext ", observatory)
 	})
 }
 

--- a/app/router/strategy_leastload.go
+++ b/app/router/strategy_leastload.go
@@ -139,6 +139,10 @@ func (s *LeastLoadStrategy) selectLeastLoad(nodes []*node) []*node {
 }
 
 func (s *LeastLoadStrategy) getNodes(candidates []string, maxRTT time.Duration) []*node {
+	if s.observer == nil {
+		errors.LogError(s.ctx, "observer is nil")
+		return make([]*node, 0)
+	}
 	observeResult, err := s.observer.GetObservation(s.ctx)
 	if err != nil {
 		errors.LogInfoInner(s.ctx, err, "cannot get observation")

--- a/app/router/strategy_leastload.go
+++ b/app/router/strategy_leastload.go
@@ -61,7 +61,6 @@ func (s *LeastLoadStrategy) InjectContext(ctx context.Context) {
 	s.ctx = ctx
 	core.RequireFeaturesAsync(s.ctx, func(observatory extension.Observatory) {
 		s.observer = observatory
-		errors.LogDebug(s.ctx, "InjectContext ", observatory)
 	})
 }
 

--- a/app/router/strategy_leastping.go
+++ b/app/router/strategy_leastping.go
@@ -21,16 +21,13 @@ func (l *LeastPingStrategy) GetPrincipleTarget(strings []string) []string {
 
 func (l *LeastPingStrategy) InjectContext(ctx context.Context) {
 	l.ctx = ctx
+	common.Must(core.RequireFeatures(l.ctx, func(observatory extension.Observatory) error {
+		l.observatory = observatory
+		return nil
+	}))
 }
 
 func (l *LeastPingStrategy) PickOutbound(strings []string) string {
-	if l.observatory == nil {
-		common.Must(core.RequireFeatures(l.ctx, func(observatory extension.Observatory) error {
-			l.observatory = observatory
-			return nil
-		}))
-	}
-
 	observeReport, err := l.observatory.GetObservation(l.ctx)
 	if err != nil {
 		errors.LogInfoInner(l.ctx, err, "cannot get observe report")

--- a/app/router/strategy_leastping.go
+++ b/app/router/strategy_leastping.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/xtls/xray-core/app/observatory"
-	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/core"
 	"github.com/xtls/xray-core/features/extension"
@@ -21,10 +20,9 @@ func (l *LeastPingStrategy) GetPrincipleTarget(strings []string) []string {
 
 func (l *LeastPingStrategy) InjectContext(ctx context.Context) {
 	l.ctx = ctx
-	common.Must(core.RequireFeatures(l.ctx, func(observatory extension.Observatory) error {
+	core.RequireFeaturesAsync(l.ctx, func(observatory extension.Observatory) {
 		l.observatory = observatory
-		return nil
-	}))
+	})
 }
 
 func (l *LeastPingStrategy) PickOutbound(strings []string) string {

--- a/app/router/strategy_leastping.go
+++ b/app/router/strategy_leastping.go
@@ -28,9 +28,13 @@ func (l *LeastPingStrategy) InjectContext(ctx context.Context) {
 }
 
 func (l *LeastPingStrategy) PickOutbound(strings []string) string {
+	if l.observatory == nil {
+		errors.LogError(l.ctx, "observer is nil")
+		return ""
+	}
 	observeReport, err := l.observatory.GetObservation(l.ctx)
 	if err != nil {
-		errors.LogInfoInner(l.ctx, err, "cannot get observe report")
+		errors.LogInfoInner(l.ctx, err, "cannot get observer report")
 		return ""
 	}
 	outboundsList := outboundList(strings)

--- a/app/router/strategy_random.go
+++ b/app/router/strategy_random.go
@@ -20,6 +20,12 @@ type RandomStrategy struct {
 
 func (s *RandomStrategy) InjectContext(ctx context.Context) {
 	s.ctx = ctx
+	if len(s.FallbackTag) > 0 {
+		common.Must(core.RequireFeatures(s.ctx, func(observatory extension.Observatory) error {
+			s.observatory = observatory
+			return nil
+		}))
+	}
 }
 
 func (s *RandomStrategy) GetPrincipleTarget(strings []string) []string {
@@ -27,12 +33,6 @@ func (s *RandomStrategy) GetPrincipleTarget(strings []string) []string {
 }
 
 func (s *RandomStrategy) PickOutbound(candidates []string) string {
-	if len(s.FallbackTag) > 0 && s.observatory == nil {
-		common.Must(core.RequireFeatures(s.ctx, func(observatory extension.Observatory) error {
-			s.observatory = observatory
-			return nil
-		}))
-	}
 	if s.observatory != nil {
 		observeReport, err := s.observatory.GetObservation(s.ctx)
 		if err == nil {

--- a/app/router/strategy_random.go
+++ b/app/router/strategy_random.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/xtls/xray-core/app/observatory"
-	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/dice"
 	"github.com/xtls/xray-core/core"
 	"github.com/xtls/xray-core/features/extension"
@@ -21,10 +20,9 @@ type RandomStrategy struct {
 func (s *RandomStrategy) InjectContext(ctx context.Context) {
 	s.ctx = ctx
 	if len(s.FallbackTag) > 0 {
-		common.Must(core.RequireFeatures(s.ctx, func(observatory extension.Observatory) error {
+		core.RequireFeaturesAsync(s.ctx, func(observatory extension.Observatory) {
 			s.observatory = observatory
-			return nil
-		}))
+		})
 	}
 }
 

--- a/core/xray.go
+++ b/core/xray.go
@@ -316,7 +316,7 @@ func (s *Instance) RequireFeaturesAsync(callback interface{}) {
 	go func() {
 		var finished = false
 		for i := 0; !finished; i++ {
-			if i > 1000 {
+			if i > 100000 {
 				errors.LogError(s.ctx, "RequireFeaturesAsync failed after count ", i)
 				break;
 			}

--- a/core/xray.go
+++ b/core/xray.go
@@ -316,7 +316,6 @@ func (s *Instance) RequireFeaturesAsync(callback interface{}) {
 	go func() {
 		var finished = false
 		for i := 0; !finished; i++ {
-			errors.LogDebug(s.ctx, "RequireFeaturesAsync count ", i)
 			if i > 1000 {
 				errors.LogError(s.ctx, "RequireFeaturesAsync failed after count ", i)
 				break;

--- a/core/xray.go
+++ b/core/xray.go
@@ -316,6 +316,7 @@ func (s *Instance) RequireFeaturesAsync(callback interface{}) {
 	go func() {
 		var finished = false
 		for i := 0; !finished; i++ {
+			errors.LogDebug(s.ctx, "RequireFeaturesAsync count ", i)
 			if i > 1000 {
 				errors.LogError(s.ctx, "RequireFeaturesAsync failed after count ", i)
 				break;

--- a/core/xray.go
+++ b/core/xray.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/errors"
@@ -156,6 +157,12 @@ func RequireFeatures(ctx context.Context, callback interface{}) error {
 	return v.RequireFeatures(callback)
 }
 
+// RequireFeaturesAsync registers a callback, which will be called when all dependent features are registered. The order of app init doesn't matter
+func RequireFeaturesAsync(ctx context.Context, callback interface{}) {
+	v := MustFromContext(ctx)
+	v.RequireFeaturesAsync(callback)
+}
+
 // New returns a new Xray instance based on given configuration.
 // The instance is not started at this point.
 // To ensure Xray instance works properly, the config must contain one Dispatcher, one InboundHandlerManager and one OutboundHandlerManager. Other features are optional.
@@ -288,6 +295,36 @@ func (s *Instance) RequireFeatures(callback interface{}) error {
 	}
 	s.featureResolutions = append(s.featureResolutions, r)
 	return nil
+}
+
+// RequireFeaturesAsync registers a callback, which will be called when all dependent features are registered. The order of app init doesn't matter
+func (s *Instance) RequireFeaturesAsync(callback interface{}) {
+	callbackType := reflect.TypeOf(callback)
+	if callbackType.Kind() != reflect.Func {
+		panic("not a function")
+	}
+
+	var featureTypes []reflect.Type
+	for i := 0; i < callbackType.NumIn(); i++ {
+		featureTypes = append(featureTypes, reflect.PtrTo(callbackType.In(i)))
+	}
+
+	r := resolution{
+		deps:     featureTypes,
+		callback: callback,
+	}
+	go func() {
+		var finished = false
+		for i := 0; !finished; i++ {
+			if i > 1000 {
+				errors.LogError(s.ctx, "RequireFeaturesAsync failed after count ", i)
+				break;
+			}
+			finished, _ = r.resolve(s.features)
+			time.Sleep(time.Millisecond)
+		}
+		s.featureResolutions = append(s.featureResolutions, r)
+	}()
 }
 
 // AddFeature registers a feature into current Instance.

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -576,7 +576,6 @@ func (c *Config) Build() (*core.Config, error) {
 			return nil, err
 		}
 		config.App = append(config.App, serial.ToTypedMessage(r))
-		errors.LogDebug(context.Background(), "Append Observatory!")
 	}
 
 	if c.BurstObservatory != nil {
@@ -585,7 +584,6 @@ func (c *Config) Build() (*core.Config, error) {
 			return nil, err
 		}
 		config.App = append(config.App, serial.ToTypedMessage(r))
-		errors.LogDebug(context.Background(), "Append BurstObservatory!")
 	}
 
 	var inbounds []InboundDetourConfig

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -576,6 +576,7 @@ func (c *Config) Build() (*core.Config, error) {
 			return nil, err
 		}
 		config.App = append(config.App, serial.ToTypedMessage(r))
+		errors.LogDebug(context.Background(), "Config append Observatory")
 	}
 
 	if c.BurstObservatory != nil {
@@ -584,6 +585,7 @@ func (c *Config) Build() (*core.Config, error) {
 			return nil, err
 		}
 		config.App = append(config.App, serial.ToTypedMessage(r))
+		errors.LogDebug(context.Background(), "Config append BurstObservatory")
 	}
 
 	var inbounds []InboundDetourConfig

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -576,6 +576,7 @@ func (c *Config) Build() (*core.Config, error) {
 			return nil, err
 		}
 		config.App = append(config.App, serial.ToTypedMessage(r))
+		errors.LogDebug(context.Background(), "Append Observatory!")
 	}
 
 	if c.BurstObservatory != nil {
@@ -584,6 +585,7 @@ func (c *Config) Build() (*core.Config, error) {
 			return nil, err
 		}
 		config.App = append(config.App, serial.ToTypedMessage(r))
+		errors.LogDebug(context.Background(), "Append BurstObservatory!")
 	}
 
 	var inbounds []InboundDetourConfig

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -576,7 +576,6 @@ func (c *Config) Build() (*core.Config, error) {
 			return nil, err
 		}
 		config.App = append(config.App, serial.ToTypedMessage(r))
-		errors.LogDebug(context.Background(), "Config append Observatory")
 	}
 
 	if c.BurstObservatory != nil {
@@ -585,7 +584,6 @@ func (c *Config) Build() (*core.Config, error) {
 			return nil, err
 		}
 		config.App = append(config.App, serial.ToTypedMessage(r))
-		errors.LogDebug(context.Background(), "Config append BurstObservatory")
 	}
 
 	var inbounds []InboundDetourConfig

--- a/proxy/dns/dns.go
+++ b/proxy/dns/dns.go
@@ -27,7 +27,7 @@ func init() {
 	common.Must(common.RegisterConfig((*Config)(nil), func(ctx context.Context, config interface{}) (interface{}, error) {
 		h := new(Handler)
 		if err := core.RequireFeatures(ctx, func(dnsClient dns.Client, policyManager policy.Manager) error {
-			core.RequireFeatures(ctx, func(fdns dns.FakeDNSEngine) {
+			core.RequireFeatures(ctx, func(fdns dns.FakeDNSEngine) { // FakeDNSEngine is optional
 				h.fdns = fdns
 			})
 			return h.Init(config.(*Config), dnsClient, policyManager)

--- a/transport/internet/tagged/tagged.go
+++ b/transport/internet/tagged/tagged.go
@@ -4,8 +4,9 @@ import (
 	"context"
 
 	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/features/routing"
 )
 
-type DialFunc func(ctx context.Context, dest net.Destination, tag string) (net.Conn, error)
+type DialFunc func(ctx context.Context, dispatcher routing.Dispatcher, dest net.Destination, tag string) (net.Conn, error)
 
 var Dialer DialFunc

--- a/transport/internet/tagged/taggedimpl/impl.go
+++ b/transport/internet/tagged/taggedimpl/impl.go
@@ -12,17 +12,10 @@ import (
 	"github.com/xtls/xray-core/transport/internet/tagged"
 )
 
-func DialTaggedOutbound(ctx context.Context, dest net.Destination, tag string) (net.Conn, error) {
-	var dispatcher routing.Dispatcher
+func DialTaggedOutbound(ctx context.Context, dispatcher routing.Dispatcher, dest net.Destination, tag string) (net.Conn, error) {
 	if core.FromContext(ctx) == nil {
 		return nil, errors.New("Instance context variable is not in context, dial denied. ")
 	}
-	if err := core.RequireFeatures(ctx, func(dispatcherInstance routing.Dispatcher) {
-		dispatcher = dispatcherInstance
-	}); err != nil {
-		return nil, errors.New("Required Feature dispatcher not resolved").Base(err)
-	}
-
 	content := new(session.Content)
 	content.SkipDNSResolve = true
 


### PR DESCRIPTION
RequireFeatures() must be called at init.

It should fix memory leak at balancers, observatory and fakedns. Need some testing to confirm it is working as expected.