### PR TITLE
Revert "WireGuard inbound: Fix leaking session information between requests"

### DIFF
--- a/proxy/wireguard/server.go
+++ b/proxy/wireguard/server.go
@@ -144,20 +144,15 @@ func (s *Server) forwardConnection(dest net.Destination, conn net.Conn) {
 		Reason: "",
 	})
 
-	// what's this?
-	// Session information should not be shared between different connections
-	// why reuse them in server level? This will cause incorrect destoverride and unexpected routing behavior.
-	// Disable it temporarily. Maybe s.info should be removed.
-
-	//  if s.info.inboundTag != nil {
-	//  ctx = session.ContextWithInbound(ctx, s.info.inboundTag)
-	//  }
-	//	if s.info.outboundTag != nil {
-	//		ctx = session.ContextWithOutbounds(ctx, []*session.Outbound{s.info.outboundTag})
-	//	}
-	//  if s.info.contentTag != nil {
-	//	    ctx = session.ContextWithContent(ctx, s.info.contentTag)
-	//  }
+	if s.info.inboundTag != nil {
+		ctx = session.ContextWithInbound(ctx, s.info.inboundTag)
+	}
+	if s.info.outboundTag != nil {
+		ctx = session.ContextWithOutbounds(ctx, []*session.Outbound{s.info.outboundTag})
+	}
+	if s.info.contentTag != nil {
+		ctx = session.ContextWithContent(ctx, s.info.contentTag)
+	}
 
 	link, err := s.info.dispatcher.Dispatch(ctx, dest)
 	if err != nil {


### PR DESCRIPTION
Reverts XTLS/Xray-core#4030
I got some reports about routing doesn't work in reverse Wireguard! cause sniffing not applied!

@Fangliding 