### PR TITLE
XHTTP server: Forbid Mux.Cool except pure XUDP

### DIFF
--- a/app/proxyman/inbound/inbound.go
+++ b/app/proxyman/inbound/inbound.go
@@ -7,6 +7,7 @@ import (
 	"github.com/xtls/xray-core/app/proxyman"
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/serial"
 	"github.com/xtls/xray-core/common/session"
 	"github.com/xtls/xray-core/core"
@@ -157,6 +158,9 @@ func NewHandler(ctx context.Context, config *core.InboundHandlerConfig) (inbound
 		ctx = session.ContextWithSockopt(ctx, &session.Sockopt{
 			Mark: streamSettings.SocketSettings.Mark,
 		})
+	}
+	if streamSettings != nil && streamSettings.ProtocolName == "splithttp" {
+		ctx = session.ContextWithAllowedNetwork(ctx, net.Network_UDP)
 	}
 
 	allocStrategy := receiverSettings.AllocationStrategy


### PR DESCRIPTION
[XHTTP](https://github.com/XTLS/Xray-core/discussions/4113) 的 H2 & H3 自带 XMUX，这个 PR 复用了 Vision 通知 Mux.Cool 禁 TCP 的机制，从而防止了双层 Mux，~~至于 H1，它不重要~~

~~底层传输那里 listen 调来调去的太绕了，终于又一次理清后发现加这里最合适~~，**v25 争取把各种 interface 和 register 清掉**