### PR TITLE
XHTTP, WS, HU: Forbid "host" in `headers`, read `serverName` instead

### DIFF
--- a/common/reflect/marshal_test.go
+++ b/common/reflect/marshal_test.go
@@ -204,9 +204,7 @@ func getConfig() string {
 			  "security": "none",
 			  "wsSettings": {
 				"path": "/?ed=2048",
-				"headers": {
-				  "Host": "bing.com"
-				}
+				"host": "bing.com"
 			  }
 			}
 		  }

--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -163,7 +163,7 @@ func (c *WebSocketConfig) Build() (proto.Message, error) {
 			path = u.String()
 		}
 	}
-	// Priority: host > serverName > address
+	// Priority (client): host > serverName > address
 	for k, v := range c.Headers {
 		errors.PrintDeprecatedFeatureWarning(`"host" in "headers"`, `independent "host"`)
 		if c.Host == "" {
@@ -202,7 +202,7 @@ func (c *HttpUpgradeConfig) Build() (proto.Message, error) {
 			path = u.String()
 		}
 	}
-	// Priority: host > serverName > address
+	// Priority (client): host > serverName > address
 	for k := range c.Headers {
 		if strings.ToLower(k) == "host" {
 			return nil, errors.New(`"headers" can't contain "host"`)
@@ -270,7 +270,7 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 		c = &extra
 	}
 
-	// Priority: host > serverName > address
+	// Priority (client): host > serverName > address
 	for k := range c.Headers {
 		if strings.ToLower(k) == "host" {
 			return nil, errors.New(`"headers" can't contain "host"`)

--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -165,6 +165,7 @@ func (c *WebSocketConfig) Build() (proto.Message, error) {
 	}
 	// Priority: host > serverName > address
 	for k, v := range c.Headers {
+		errors.PrintDeprecatedFeatureWarning(`"host" in "headers"`, `independent "host"`)
 		if c.Host == "" {
 			c.Host = v
 		}

--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -163,13 +163,11 @@ func (c *WebSocketConfig) Build() (proto.Message, error) {
 			path = u.String()
 		}
 	}
-	// If http host is not set in the Host field, but in headers field, we add it to Host Field here.
-	// If we don't do that, http host will be overwritten as address.
-	// Host priority: Host field > headers field > address.
-	if c.Host == "" && c.Headers["host"] != "" {
-		c.Host = c.Headers["host"]
-	} else if c.Host == "" && c.Headers["Host"] != "" {
-		c.Host = c.Headers["Host"]
+	// Priority: host > serverName > address
+	for k := range c.Headers {
+		if strings.ToLower(k) == "host" {
+			return nil, errors.New(`"headers" can't contain "host"`)
+		}
 	}
 	config := &websocket.Config{
 		Path:                path,
@@ -202,15 +200,11 @@ func (c *HttpUpgradeConfig) Build() (proto.Message, error) {
 			path = u.String()
 		}
 	}
-	// If http host is not set in the Host field, but in headers field, we add it to Host Field here.
-	// If we don't do that, http host will be overwritten as address.
-	// Host priority: Host field > headers field > address.
-	if c.Host == "" && c.Headers["host"] != "" {
-		c.Host = c.Headers["host"]
-		delete(c.Headers, "host")
-	} else if c.Host == "" && c.Headers["Host"] != "" {
-		c.Host = c.Headers["Host"]
-		delete(c.Headers, "Host")
+	// Priority: host > serverName > address
+	for k := range c.Headers {
+		if strings.ToLower(k) == "host" {
+			return nil, errors.New(`"headers" can't contain "host"`)
+		}
 	}
 	config := &httpupgrade.Config{
 		Path:                path,
@@ -274,13 +268,11 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 		c = &extra
 	}
 
-	// If http host is not set in the Host field, but in headers field, we add it to Host Field here.
-	// If we don't do that, http host will be overwritten as address.
-	// Host priority: Host field > headers field > address.
-	if c.Host == "" && c.Headers["host"] != "" {
-		c.Host = c.Headers["host"]
-	} else if c.Host == "" && c.Headers["Host"] != "" {
-		c.Host = c.Headers["Host"]
+	// Priority: host > serverName > address
+	for k := range c.Headers {
+		if strings.ToLower(k) == "host" {
+			return nil, errors.New(`"headers" can't contain "host"`)
+		}
 	}
 
 	if c.Xmux.MaxConnections != nil && c.Xmux.MaxConnections.To > 0 && c.Xmux.MaxConcurrency != nil && c.Xmux.MaxConcurrency.To > 0 {

--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -164,10 +164,11 @@ func (c *WebSocketConfig) Build() (proto.Message, error) {
 		}
 	}
 	// Priority: host > serverName > address
-	for k := range c.Headers {
-		if strings.ToLower(k) == "host" {
-			return nil, errors.New(`"headers" can't contain "host"`)
+	for k, v := range c.Headers {
+		if c.Host == "" {
+			c.Host = v
 		}
+		delete(c.Headers, k)
 	}
 	config := &websocket.Config{
 		Path:                path,

--- a/infra/conf/xray_test.go
+++ b/infra/conf/xray_test.go
@@ -48,9 +48,7 @@ func TestXrayConfig(t *testing.T) {
 					"streamSettings": {
 						"network": "ws",
 						"wsSettings": {
-							"headers": {
-								"host": "example.domain"
-							},
+							"host": "example.domain",
 							"path": ""
 						},
 						"tlsSettings": {
@@ -139,9 +137,6 @@ func TestXrayConfig(t *testing.T) {
 										ProtocolName: "websocket",
 										Settings: serial.ToTypedMessage(&websocket.Config{
 											Host: "example.domain",
-											Header: map[string]string{
-												"host": "example.domain",
-											},
 										}),
 									},
 								},

--- a/transport/internet/httpupgrade/dialer.go
+++ b/transport/internet/httpupgrade/dialer.go
@@ -53,9 +53,10 @@ func dialhttpUpgrade(ctx context.Context, dest net.Destination, streamSettings *
 
 	var conn net.Conn
 	var requestURL url.URL
-	if config := tls.ConfigFromStreamSettings(streamSettings); config != nil {
-		tlsConfig := config.GetTLSConfig(tls.WithDestination(dest), tls.WithNextProto("http/1.1"))
-		if fingerprint := tls.GetFingerprint(config.Fingerprint); fingerprint != nil {
+	tConfig := tls.ConfigFromStreamSettings(streamSettings)
+	if tConfig != nil {
+		tlsConfig := tConfig.GetTLSConfig(tls.WithDestination(dest), tls.WithNextProto("http/1.1"))
+		if fingerprint := tls.GetFingerprint(tConfig.Fingerprint); fingerprint != nil {
 			conn = tls.UClient(pconn, tlsConfig, fingerprint)
 			if err := conn.(*tls.UConn).WebsocketHandshakeContext(ctx); err != nil {
 				return nil, err
@@ -69,12 +70,17 @@ func dialhttpUpgrade(ctx context.Context, dest net.Destination, streamSettings *
 		requestURL.Scheme = "http"
 	}
 
-	requestURL.Host = dest.NetAddr()
+	requestURL.Host = transportConfiguration.Host
+	if requestURL.Host == "" && tConfig != nil {
+		requestURL.Host = tConfig.ServerName
+	}
+	if requestURL.Host == "" {
+		requestURL.Host = dest.Address.String()
+	}
 	requestURL.Path = transportConfiguration.GetNormalizedPath()
 	req := &http.Request{
 		Method: http.MethodGet,
 		URL:    &requestURL,
-		Host:   transportConfiguration.Host,
 		Header: make(http.Header),
 	}
 	for key, value := range transportConfiguration.Header {

--- a/transport/internet/websocket/config.go
+++ b/transport/internet/websocket/config.go
@@ -23,7 +23,6 @@ func (c *Config) GetRequestHeader() http.Header {
 	for k, v := range c.Header {
 		header.Add(k, v)
 	}
-	header.Set("Host", c.Host)
 	return header
 }
 


### PR DESCRIPTION
XHTTP, WS, HU 都有单独的 `host` 参数，没有必要允许 `headers` 里填 "host"，[~~GUI 也不会把它填 `headers` 里~~](https://github.com/XTLS/Xray-core/pull/4142#issuecomment-2531581316)，索性禁了

客户端未设置 `host` 时本来自动取 `address`，但若 TLS 或 REALITY 存在，显然取 `address` 不妥，[应当取 `serverName`](https://github.com/XTLS/Xray-core/pull/4142#issuecomment-2532953355)

**客户端新的优先级顺序：`host` > `serverName` > `address`；服务端 `host` 是校验，没事别设，不会自动取 `serverName`**