### PR TITLE
Build: Use patched newer Go version to build Windows 7 assets

### DIFF
--- a/.github/workflows/release-win7.yml
+++ b/.github/workflows/release-win7.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Checkout codebase
         uses: actions/checkout@v4
-      
+
       - name: Restore Go builder
         uses: actions/cache/restore@v4
         with:

--- a/.github/workflows/release-win7.yml
+++ b/.github/workflows/release-win7.yml
@@ -41,9 +41,10 @@ jobs:
         run: |
           cd ./src
           . ./all.bash
-          cd ../
+          cd ${{ github.workspace }}
           mkdir -p patched-go
           rsync -a --exclude 'patched-go' ./ 'patched-go'
+
       - name: Save patched builder
         uses: actions/cache/save@v4
         with:
@@ -82,6 +83,7 @@ jobs:
                   echo "unhit=true" >> $GITHUB_OUTPUT
               fi
             done
+
       - name: Save Cache
         uses: actions/cache/save@v4
         if: ${{ steps.update.outputs.unhit }}
@@ -117,9 +119,10 @@ jobs:
           _NAME=${{ matrix.assetname }}
           echo "GOOS: ${{ matrix.goos }}, GOARCH: ${{ matrix.goarch }}, RELEASE_NAME: $_NAME"
           echo "ASSET_NAME=$_NAME" >> $GITHUB_ENV
+
       - name: Checkout codebase
         uses: actions/checkout@v4
-
+      
       - name: Restore Go builder
         uses: actions/cache/restore@v4
         with:
@@ -129,20 +132,21 @@ jobs:
       - name: Download dependencies and build Xray
         run: |
           echo "Setup environment..."
-          export PATH=$PATH:$PWD/patched-go/bin
-          ./patched-go/bin/go version
-          ./patched-go/bin/go env -w GOPATH=$PWD
-          ./patched-go/bin/go env -w GOROOT=$PWD/patched-go
+          export PATH=$PATH:${{ github.workspace }}/patched-go/bin
+          ${{ github.workspace }}/patched-go/bin/go version
+          ${{ github.workspace }}/patched-go/bin/go env -w GOPATH=${{ github.workspace }}
+          ${{ github.workspace }}/patched-go/bin/go env -w GOROOT=${{ github.workspace }}/patched-go
           echo "Download dependencies..."
-          ./patched-go/bin/go mod download
+          ${{ github.workspace }}/patched-go/bin/go mod download
           echo "Build Xray..."
           mkdir -p build_assets
-          ./patched-go/bin/go clean -v -i $PWD
+          ${{ github.workspace }}/patched-go/bin/go clean -v -i $PWD
           rm -f xray xray.exe wxray.exe xray_softfloat
-          ./patched-go/bin/go build -o xray.exe -trimpath -ldflags "-s -w -buildid=" -v ./main
-          ./patched-go/bin/go build -o wxray.exe -trimpath -ldflags "-H windowsgui -s -w -buildid=" -v ./main
+          ${{ github.workspace }}/patched-go/bin/go build -o xray.exe -trimpath -ldflags "-X github.com/xtls/xray-core/core.build=win7-${{ github.ref_name }}-${{ github.sha }} -s -w -buildid=" -v ./main
+          ${{ github.workspace }}/patched-go/bin/go build -o wxray.exe -trimpath -ldflags "-H windowsgui -X github.com/xtls/xray-core/core.build=win7-${{ github.ref_name }}-${{ github.sha }} -s -w -buildid=" -v ./main
           echo "Build completed."
           find . -maxdepth 1 -type f -regex './\(wxray\|xray\).exe' -exec mv {} ./build_assets/ \;
+
       - name: Restore Cache
         uses: actions/cache/restore@v4
         with:
@@ -154,6 +158,7 @@ jobs:
           mv -f resources/* build_assets
           cp ${GITHUB_WORKSPACE}/README.md ./build_assets/README.md
           cp ${GITHUB_WORKSPACE}/LICENSE ./build_assets/LICENSE
+
       - name: Create ZIP archive
         if: github.event_name == 'release'
         shell: bash
@@ -168,15 +173,18 @@ jobs:
           do
             openssl dgst -$METHOD $FILE | sed 's/([^)]*)//g' >>$DGST
           done
+
       - name: Change the name
         run: |
           mv build_assets Xray-${{ env.ASSET_NAME }}
+
       - name: Upload files to Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: Xray-${{ env.ASSET_NAME }}
           path: |
             ./Xray-${{ env.ASSET_NAME }}/*
+
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
         if: github.event_name == 'release'

--- a/.github/workflows/release-win7.yml
+++ b/.github/workflows/release-win7.yml
@@ -1,0 +1,187 @@
+name: Build and Release for Windows 7
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+  push:
+    branches:
+      - main
+    paths:
+      # - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/release-win7.yml"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      # - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/release-win7.yml"
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go compiler
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+          check-latest: true
+
+      - name: Download patched Go
+        uses: actions/checkout@v4
+        with:
+          # To change the repository of toolchail, change it here
+          repository: 'MetaCubeX/go'
+          ref: 'release-branch.go1.23'
+
+      - name: Build patched Go
+        run: |
+          cd ./src
+          . ./all.bash
+          cd ../
+          mkdir -p patched-go
+          rsync -a --exclude 'patched-go' ./ 'patched-go'
+      - name: Save patched builder
+        uses: actions/cache/save@v4
+        with:
+          path: patched-go
+          key: xray-patched-go-${{ github.sha }}-${{ github.run_number }}
+
+      - name: Restore Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: resources
+          key: xray-geodat-
+
+      - name: Update Geodat
+        id: update
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 60
+          retry_wait_seconds: 60
+          max_attempts: 60
+          command: |
+            [ -d 'resources' ] || mkdir resources
+            LIST=('geoip geoip geoip' 'domain-list-community dlc geosite')
+            for i in "${LIST[@]}"
+            do
+              INFO=($(echo $i | awk 'BEGIN{FS=" ";OFS=" "} {print $1,$2,$3}'))
+              FILE_NAME="${INFO[2]}.dat"
+              echo -e "Verifying HASH key..."
+              HASH="$(curl -sL "https://raw.githubusercontent.com/v2fly/${INFO[0]}/release/${INFO[1]}.dat.sha256sum" | awk -F ' ' '{print $1}')"
+              if [ -s "./resources/${FILE_NAME}" ] && [ "$(sha256sum "./resources/${FILE_NAME}" | awk -F ' ' '{print $1}')" == "${HASH}" ]; then
+                  continue
+              else
+                  echo -e "Downloading https://raw.githubusercontent.com/v2fly/${INFO[0]}/release/${INFO[1]}.dat..."
+                  curl -L "https://raw.githubusercontent.com/v2fly/${INFO[0]}/release/${INFO[1]}.dat" -o ./resources/${FILE_NAME}
+                  echo -e "Verifying HASH key..."
+                  [ "$(sha256sum "./resources/${FILE_NAME}" | awk -F ' ' '{print $1}')" == "${HASH}" ] || { echo -e "The HASH key of ${FILE_NAME} does not match cloud one."; exit 1; }
+                  echo "unhit=true" >> $GITHUB_OUTPUT
+              fi
+            done
+      - name: Save Cache
+        uses: actions/cache/save@v4
+        if: ${{ steps.update.outputs.unhit }}
+        with:
+          path: resources
+          key: xray-geodat-${{ github.sha }}-${{ github.run_number }}
+
+  build:
+    needs: prepare
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        include:
+          # BEGIN Windows 7
+          - goos: windows
+            goarch: amd64
+            assetname: win7-64
+          - goos: windows
+            goarch: 386
+            assetname: win7-32
+          # END Windows 7
+      fail-fast: false
+
+    runs-on: ubuntu-latest
+    env:
+      GOOS: ${{ matrix.goos}}
+      GOARCH: ${{ matrix.goarch }}
+      CGO_ENABLED: 0
+    steps:
+      - name: Show workflow information
+        run: |
+          _NAME=${{ matrix.assetname }}
+          echo "GOOS: ${{ matrix.goos }}, GOARCH: ${{ matrix.goarch }}, RELEASE_NAME: $_NAME"
+          echo "ASSET_NAME=$_NAME" >> $GITHUB_ENV
+      - name: Checkout codebase
+        uses: actions/checkout@v4
+
+      - name: Restore Go builder
+        uses: actions/cache/restore@v4
+        with:
+          path: patched-go
+          key: xray-patched-go-${{ github.sha }}-${{ github.run_number }}
+
+      - name: Download dependencies and build Xray
+        run: |
+          echo "Setup environment..."
+          export PATH=$PATH:$PWD/patched-go/bin
+          ./patched-go/bin/go version
+          ./patched-go/bin/go env -w GOPATH=$PWD
+          ./patched-go/bin/go env -w GOROOT=$PWD/patched-go
+          echo "Download dependencies..."
+          ./patched-go/bin/go mod download
+          echo "Build Xray..."
+          mkdir -p build_assets
+          ./patched-go/bin/go clean -v -i $PWD
+          rm -f xray xray.exe wxray.exe xray_softfloat
+          ./patched-go/bin/go build -o xray.exe -trimpath -ldflags "-s -w -buildid=" -v ./main
+          ./patched-go/bin/go build -o wxray.exe -trimpath -ldflags "-H windowsgui -s -w -buildid=" -v ./main
+          echo "Build completed."
+          find . -maxdepth 1 -type f -regex './\(wxray\|xray\).exe' -exec mv {} ./build_assets/ \;
+      - name: Restore Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: resources
+          key: xray-geodat-
+
+      - name: Copy README.md & LICENSE
+        run: |
+          mv -f resources/* build_assets
+          cp ${GITHUB_WORKSPACE}/README.md ./build_assets/README.md
+          cp ${GITHUB_WORKSPACE}/LICENSE ./build_assets/LICENSE
+      - name: Create ZIP archive
+        if: github.event_name == 'release'
+        shell: bash
+        run: |
+          pushd build_assets || exit 1
+          touch -mt $(date +%Y01010000) *
+          zip -9vr ../Xray-${{ env.ASSET_NAME }}.zip .
+          popd || exit 1
+          FILE=./Xray-${{ env.ASSET_NAME }}.zip
+          DGST=$FILE.dgst
+          for METHOD in {"md5","sha1","sha256","sha512"}
+          do
+            openssl dgst -$METHOD $FILE | sed 's/([^)]*)//g' >>$DGST
+          done
+      - name: Change the name
+        run: |
+          mv build_assets Xray-${{ env.ASSET_NAME }}
+      - name: Upload files to Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Xray-${{ env.ASSET_NAME }}
+          path: |
+            ./Xray-${{ env.ASSET_NAME }}/*
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        if: github.event_name == 'release'
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./Xray-${{ env.ASSET_NAME }}.zip*
+          tag: ${{ github.ref }}
+          file_glob: true

--- a/.github/workflows/release-win7.yml
+++ b/.github/workflows/release-win7.yml
@@ -102,8 +102,7 @@ jobs:
       - name: Setup patched builder
         run: |
           GOSDK=$(go env GOROOT)
-          curl -O -L https://github.com/XTLS/go-win7/releases/latest/download/
-go-for-win7-linux-amd64.zip
+          curl -O -L https://github.com/XTLS/go-win7/releases/latest/download/go-for-win7-linux-amd64.zip
           rm -r $GOSDK/*
           unzip ./go-for-win7-linux-amd64.zip -d $GOSDK
 

--- a/.github/workflows/release-win7.yml
+++ b/.github/workflows/release-win7.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: stable
           check-latest: true
 
       - name: Setup patched builder

--- a/.github/workflows/release-win7.yml
+++ b/.github/workflows/release-win7.yml
@@ -24,33 +24,6 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go compiler
-        uses: actions/setup-go@v5
-        with:
-          go-version: 'stable'
-          check-latest: true
-
-      - name: Download patched Go
-        uses: actions/checkout@v4
-        with:
-          # To change the repository of toolchail, change it here
-          repository: 'MetaCubeX/go'
-          ref: 'release-branch.go1.23'
-
-      - name: Build patched Go
-        run: |
-          cd ./src
-          . ./all.bash
-          cd ${{ github.workspace }}
-          mkdir -p patched-go
-          rsync -a --exclude 'patched-go' ./ 'patched-go'
-
-      - name: Save patched builder
-        uses: actions/cache/save@v4
-        with:
-          path: patched-go
-          key: xray-patched-go-${{ github.sha }}-${{ github.run_number }}
-
       - name: Restore Cache
         uses: actions/cache/restore@v4
         with:
@@ -120,31 +93,30 @@ jobs:
           echo "GOOS: ${{ matrix.goos }}, GOARCH: ${{ matrix.goarch }}, RELEASE_NAME: $_NAME"
           echo "ASSET_NAME=$_NAME" >> $GITHUB_ENV
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: true
+
+      - name: Setup patched builder
+        run: |
+          GOSDK=$(go env GOROOT)
+          curl -O -L https://github.com/XTLS/go-win7/releases/latest/download/
+go-for-win7-linux-amd64.zip
+          rm -r $GOSDK/*
+          unzip ./go-for-win7-linux-amd64.zip -d $GOSDK
+
       - name: Checkout codebase
         uses: actions/checkout@v4
 
-      - name: Restore Go builder
-        uses: actions/cache/restore@v4
-        with:
-          path: patched-go
-          key: xray-patched-go-${{ github.sha }}-${{ github.run_number }}
+      - name: Get project dependencies
+        run: go mod download
 
-      - name: Download dependencies and build Xray
+      - name: Build Xray
         run: |
-          echo "Setup environment..."
-          export PATH=$PATH:${{ github.workspace }}/patched-go/bin
-          ${{ github.workspace }}/patched-go/bin/go version
-          ${{ github.workspace }}/patched-go/bin/go env -w GOPATH=${{ github.workspace }}
-          ${{ github.workspace }}/patched-go/bin/go env -w GOROOT=${{ github.workspace }}/patched-go
-          echo "Download dependencies..."
-          ${{ github.workspace }}/patched-go/bin/go mod download
-          echo "Build Xray..."
           mkdir -p build_assets
-          ${{ github.workspace }}/patched-go/bin/go clean -v -i $PWD
-          rm -f xray xray.exe wxray.exe xray_softfloat
-          ${{ github.workspace }}/patched-go/bin/go build -o xray.exe -trimpath -ldflags "-X github.com/xtls/xray-core/core.build=win7-${{ github.ref_name }}-${{ github.sha }} -s -w -buildid=" -v ./main
-          ${{ github.workspace }}/patched-go/bin/go build -o wxray.exe -trimpath -ldflags "-H windowsgui -X github.com/xtls/xray-core/core.build=win7-${{ github.ref_name }}-${{ github.sha }} -s -w -buildid=" -v ./main
-          echo "Build completed."
+          make
           find . -maxdepth 1 -type f -regex './\(wxray\|xray\).exe' -exec mv {} ./build_assets/ \;
 
       - name: Restore Cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,6 @@ jobs:
         goarch: [amd64, 386]
         gotoolchain: [""]
         patch-assetname: [""]
-
         exclude:
           # Exclude i386 on darwin
           - goarch: 386
@@ -155,16 +154,6 @@ jobs:
             goarch: arm
             goarm: 7
           # END OPENBSD ARM
-          # BEGIN Windows 7
-          - goos: windows
-            goarch: amd64
-            gotoolchain: 1.21.4
-            patch-assetname: win7-64
-          - goos: windows
-            goarch: 386
-            gotoolchain: 1.21.4
-            patch-assetname: win7-32
-          # END Windows 7
       fail-fast: false
 
     runs-on: ubuntu-latest
@@ -187,7 +176,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.gotoolchain || '1.23' }}
+          go-version-file: go.mod
           check-latest: true
 
       - name: Get project dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,6 @@ jobs:
         # Include amd64 on all platforms.
         goos: [windows, freebsd, openbsd, linux, darwin]
         goarch: [amd64, 386]
-        gotoolchain: [""]
         patch-assetname: [""]
         exclude:
           # Exclude i386 on darwin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
           check-latest: true
       - name: Restore Cache
         uses: actions/cache/restore@v4

--- a/common/reflect/marshal.go
+++ b/common/reflect/marshal.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 
 	cnet "github.com/xtls/xray-core/common/net"
@@ -31,9 +32,6 @@ func JSONMarshalWithoutEscape(t interface{}) ([]byte, error) {
 }
 
 func marshalTypedMessage(v *cserial.TypedMessage, ignoreNullValue bool, insertTypeInfo bool) interface{} {
-	if v == nil {
-		return nil
-	}
 	tmsg, err := v.GetInstance()
 	if err != nil {
 		return nil
@@ -194,29 +192,28 @@ func marshalKnownType(v interface{}, ignoreNullValue bool, insertTypeInfo bool) 
 	}
 }
 
+var valueKinds = []reflect.Kind{
+	reflect.Bool,
+	reflect.Int,
+	reflect.Int8,
+	reflect.Int16,
+	reflect.Int32,
+	reflect.Int64,
+	reflect.Uint,
+	reflect.Uint8,
+	reflect.Uint16,
+	reflect.Uint32,
+	reflect.Uint64,
+	reflect.Uintptr,
+	reflect.Float32,
+	reflect.Float64,
+	reflect.Complex64,
+	reflect.Complex128,
+	reflect.String,
+}
+
 func isValueKind(kind reflect.Kind) bool {
-	switch kind {
-	case reflect.Bool,
-		reflect.Int,
-		reflect.Int8,
-		reflect.Int16,
-		reflect.Int32,
-		reflect.Int64,
-		reflect.Uint,
-		reflect.Uint8,
-		reflect.Uint16,
-		reflect.Uint32,
-		reflect.Uint64,
-		reflect.Uintptr,
-		reflect.Float32,
-		reflect.Float64,
-		reflect.Complex64,
-		reflect.Complex128,
-		reflect.String:
-		return true
-	default:
-		return false
-	}
+	return slices.Contains(valueKinds, kind)
 }
 
 func marshalInterface(v interface{}, ignoreNullValue bool, insertTypeInfo bool) interface{} {

--- a/core/config.go
+++ b/core/config.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/xtls/xray-core/common"
@@ -64,14 +65,11 @@ func GetMergedConfig(args cmdarg.Arg) (string, error) {
 	supported := []string{"json", "yaml", "toml"}
 	for _, file := range args {
 		format := getFormat(file)
-		for _, s := range supported {
-			if s == format {
-				files = append(files, &ConfigSource{
-					Name:   file,
-					Format: format,
-				})
-				break
-			}
+		if slices.Contains(supported, format) {
+			files = append(files, &ConfigSource{
+				Name:   file,
+				Format: format,
+			})
 		}
 	}
 	return ConfigMergedFormFiles(files)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/xtls/xray-core
 
-go 1.21.4
+go 1.23
 
 require (
 	github.com/OmarTariq612/goech v0.0.0-20240405204721-8e2e1dafd3a0


### PR DESCRIPTION
见 https://github.com/XTLS/Xray-core/pull/4192#issuecomment-2558491444

~~该 pr 包含移除使用 Go 1.21.4 编译 win7 版本的更改，应用该 pr 后，自动构建过程不会再产生 `win7-32` 及 `win7-64` 两组二进制。同时在 Github Actions 中构建时使用的 Go 版本取决于 `go.mod` （和之前一致）。~~

~~该 pr 并非 #3530 的完全还原，`patch-assetname` 暂时被保留（可用于其它用途）。~~

~~**建议仅在决定移除使用 Go 1.21.4 提供对 Windows 7 的支持时合并**~~

如果计划用打了 win7 支持补丁的 Go 在 Actions 进行编译，大概需要：一个经过修改的 Go 库，一个修改过的 setup-go，以及单独准备的 actions 文件。~~说不定会出现在 actions 里面先 build go 再用 build 出来的 go 编译特殊版本的事~~