### PR TITLE
Core: Add mutex to injection resolution

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -106,7 +106,7 @@ func init() {
 	common.Must(common.RegisterConfig((*Config)(nil), func(ctx context.Context, config interface{}) (interface{}, error) {
 		d := new(DefaultDispatcher)
 		if err := core.RequireFeatures(ctx, func(om outbound.Manager, router routing.Router, pm policy.Manager, sm stats.Manager, dc dns.Client) error {
-			core.RequireFeatures(ctx, func(fdns dns.FakeDNSEngine) { // FakeDNSEngine is optional
+			core.OptionalFeatures(ctx, func(fdns dns.FakeDNSEngine) {
 				d.fdns = fdns
 			})
 			return d.Init(config.(*Config), om, router, pm, sm, dc)

--- a/app/dns/nameserver.go
+++ b/app/dns/nameserver.go
@@ -56,7 +56,7 @@ func NewServer(ctx context.Context, dest net.Destination, dispatcher routing.Dis
 			return NewTCPLocalNameServer(u, queryStrategy)
 		case strings.EqualFold(u.String(), "fakedns"):
 			var fd dns.FakeDNSEngine
-			core.RequireFeatures(ctx, func(fdns dns.FakeDNSEngine) { // FakeDNSEngine is optional
+			core.RequireFeatures(ctx, func(fdns dns.FakeDNSEngine) {
 				fd = fdns
 			})
 			return NewFakeDNSServer(fd), nil

--- a/app/observatory/command/command.go
+++ b/app/observatory/command/command.go
@@ -38,7 +38,7 @@ func init() {
 		sv := &service{v: s}
 		err := s.RequireFeatures(func(Observatory extension.Observatory) {
 			sv.observatory = Observatory
-		})
+		}, false)
 		if err != nil {
 			return nil, err
 		}

--- a/app/proxyman/command/command.go
+++ b/app/proxyman/command/command.go
@@ -177,7 +177,7 @@ func (s *service) Register(server *grpc.Server) {
 	common.Must(s.v.RequireFeatures(func(im inbound.Manager, om outbound.Manager) {
 		hs.ihm = im
 		hs.ohm = om
-	}))
+	}, false))
 	RegisterHandlerServiceServer(server, hs)
 
 	// For compatibility purposes

--- a/app/router/balancing.go
+++ b/app/router/balancing.go
@@ -5,6 +5,7 @@ import (
 	sync "sync"
 
 	"github.com/xtls/xray-core/app/observatory"
+	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/core"
 	"github.com/xtls/xray-core/features/extension"
@@ -31,9 +32,10 @@ type RoundRobinStrategy struct {
 func (s *RoundRobinStrategy) InjectContext(ctx context.Context) {
 	s.ctx = ctx
 	if len(s.FallbackTag) > 0 {
-		core.RequireFeaturesAsync(s.ctx, func(observatory extension.Observatory) {
+		common.Must(core.RequireFeatures(s.ctx, func(observatory extension.Observatory) error {
 			s.observatory = observatory
-		})
+			return nil
+		}))
 	}
 }
 

--- a/app/router/command/command.go
+++ b/app/router/command/command.go
@@ -135,7 +135,7 @@ func (s *service) Register(server *grpc.Server) {
 		vCoreDesc := RoutingService_ServiceDesc
 		vCoreDesc.ServiceName = "v2ray.core.app.router.command.RoutingService"
 		server.RegisterService(&vCoreDesc, rs)
-	}))
+	}, false))
 }
 
 func init() {

--- a/app/router/strategy_leastload.go
+++ b/app/router/strategy_leastload.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/xtls/xray-core/app/observatory"
+	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/dice"
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/core"
@@ -59,9 +60,10 @@ type node struct {
 
 func (s *LeastLoadStrategy) InjectContext(ctx context.Context) {
 	s.ctx = ctx
-	core.RequireFeaturesAsync(s.ctx, func(observatory extension.Observatory) {
+	common.Must(core.RequireFeatures(s.ctx, func(observatory extension.Observatory) error {
 		s.observer = observatory
-	})
+		return nil
+	}))
 }
 
 func (s *LeastLoadStrategy) PickOutbound(candidates []string) string {

--- a/app/router/strategy_leastping.go
+++ b/app/router/strategy_leastping.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/xtls/xray-core/app/observatory"
+	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/core"
 	"github.com/xtls/xray-core/features/extension"
@@ -20,9 +21,10 @@ func (l *LeastPingStrategy) GetPrincipleTarget(strings []string) []string {
 
 func (l *LeastPingStrategy) InjectContext(ctx context.Context) {
 	l.ctx = ctx
-	core.RequireFeaturesAsync(l.ctx, func(observatory extension.Observatory) {
+	common.Must(core.RequireFeatures(l.ctx, func(observatory extension.Observatory) error {
 		l.observatory = observatory
-	})
+		return nil
+	}))
 }
 
 func (l *LeastPingStrategy) PickOutbound(strings []string) string {

--- a/app/router/strategy_random.go
+++ b/app/router/strategy_random.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/xtls/xray-core/app/observatory"
+	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/dice"
 	"github.com/xtls/xray-core/core"
 	"github.com/xtls/xray-core/features/extension"
@@ -20,9 +21,10 @@ type RandomStrategy struct {
 func (s *RandomStrategy) InjectContext(ctx context.Context) {
 	s.ctx = ctx
 	if len(s.FallbackTag) > 0 {
-		core.RequireFeaturesAsync(s.ctx, func(observatory extension.Observatory) {
+		common.Must(core.RequireFeatures(s.ctx, func(observatory extension.Observatory) error {
 			s.observatory = observatory
-		})
+			return nil
+		}))
 	}
 }
 

--- a/core/xray.go
+++ b/core/xray.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"reflect"
 	"sync"
-	"time"
 
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/errors"
@@ -157,12 +156,6 @@ func RequireFeatures(ctx context.Context, callback interface{}) error {
 	return v.RequireFeatures(callback)
 }
 
-// RequireFeaturesAsync registers a callback, which will be called when all dependent features are registered. The order of app init doesn't matter
-func RequireFeaturesAsync(ctx context.Context, callback interface{}) {
-	v := MustFromContext(ctx)
-	v.RequireFeaturesAsync(callback)
-}
-
 // New returns a new Xray instance based on given configuration.
 // The instance is not started at this point.
 // To ensure Xray instance works properly, the config must contain one Dispatcher, one InboundHandlerManager and one OutboundHandlerManager. Other features are optional.
@@ -295,36 +288,6 @@ func (s *Instance) RequireFeatures(callback interface{}) error {
 	}
 	s.featureResolutions = append(s.featureResolutions, r)
 	return nil
-}
-
-// RequireFeaturesAsync registers a callback, which will be called when all dependent features are registered. The order of app init doesn't matter
-func (s *Instance) RequireFeaturesAsync(callback interface{}) {
-	callbackType := reflect.TypeOf(callback)
-	if callbackType.Kind() != reflect.Func {
-		panic("not a function")
-	}
-
-	var featureTypes []reflect.Type
-	for i := 0; i < callbackType.NumIn(); i++ {
-		featureTypes = append(featureTypes, reflect.PtrTo(callbackType.In(i)))
-	}
-
-	r := resolution{
-		deps:     featureTypes,
-		callback: callback,
-	}
-	go func() {
-		var finished = false
-		for i := 0; !finished; i++ {
-			if i > 100000 {
-				errors.LogError(s.ctx, "RequireFeaturesAsync failed after count ", i)
-				break;
-			}
-			finished, _ = r.resolve(s.features)
-			time.Sleep(time.Millisecond)
-		}
-		s.featureResolutions = append(s.featureResolutions, r)
-	}()
 }
 
 // AddFeature registers a feature into current Instance.

--- a/core/xray_test.go
+++ b/core/xray_test.go
@@ -30,7 +30,7 @@ func TestXrayDependency(t *testing.T) {
 			t.Error("expected dns client fulfilled, but actually nil")
 		}
 		wait <- true
-	})
+	}, false)
 	instance.AddFeature(localdns.New())
 	<-wait
 }

--- a/proxy/dns/dns.go
+++ b/proxy/dns/dns.go
@@ -27,7 +27,7 @@ func init() {
 	common.Must(common.RegisterConfig((*Config)(nil), func(ctx context.Context, config interface{}) (interface{}, error) {
 		h := new(Handler)
 		if err := core.RequireFeatures(ctx, func(dnsClient dns.Client, policyManager policy.Manager) error {
-			core.RequireFeatures(ctx, func(fdns dns.FakeDNSEngine) { // FakeDNSEngine is optional
+			core.OptionalFeatures(ctx, func(fdns dns.FakeDNSEngine) {
 				h.fdns = fdns
 			})
 			return h.Init(config.(*Config), dnsClient, policyManager)


### PR DESCRIPTION
- Turns out we already support async DI resolution regardless of feature ordering
Previous code contain a race condition causing some resolution is lost
- Note that the new mutex cover s.pendingResolutions and s.features
but must not cover callbackResolution() due to deadlock
- Refactor some method names and simplify code