### PR TITLE
mux cool: Add maxReuseTimes

### DIFF
--- a/app/proxyman/config.pb.go
+++ b/app/proxyman/config.pb.go
@@ -411,8 +411,10 @@ type MultiplexingConfig struct {
 	XudpConcurrency int32 `protobuf:"varint,3,opt,name=xudpConcurrency,proto3" json:"xudpConcurrency,omitempty"`
 	// "reject" (default), "allow" or "skip".
 	XudpProxyUDP443 string `protobuf:"bytes,4,opt,name=xudpProxyUDP443,proto3" json:"xudpProxyUDP443,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// MaxReuseTimes for an connection
+	MaxReuseTimes int32 `protobuf:"varint,5,opt,name=maxReuseTimes,proto3" json:"maxReuseTimes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *MultiplexingConfig) Reset() {
@@ -473,6 +475,13 @@ func (x *MultiplexingConfig) GetXudpProxyUDP443() string {
 	return ""
 }
 
+func (x *MultiplexingConfig) GetMaxReuseTimes() int32 {
+	if x != nil {
+		return x.MaxReuseTimes
+	}
+	return 0
+}
+
 var File_app_proxyman_config_proto protoreflect.FileDescriptor
 
 const file_app_proxyman_config_proto_rawDesc = "" +
@@ -503,12 +512,13 @@ const file_app_proxyman_config_proto_rawDesc = "" +
 	"\x0eproxy_settings\x18\x03 \x01(\v2$.xray.transport.internet.ProxyConfigR\rproxySettings\x12T\n" +
 	"\x12multiplex_settings\x18\x04 \x01(\v2%.xray.app.proxyman.MultiplexingConfigR\x11multiplexSettings\x12\x19\n" +
 	"\bvia_cidr\x18\x05 \x01(\tR\aviaCidr\x12P\n" +
-	"\x0ftarget_strategy\x18\x06 \x01(\x0e2'.xray.transport.internet.DomainStrategyR\x0etargetStrategy\"\xa4\x01\n" +
+	"\x0ftarget_strategy\x18\x06 \x01(\x0e2'.xray.transport.internet.DomainStrategyR\x0etargetStrategy\"\xca\x01\n" +
 	"\x12MultiplexingConfig\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12 \n" +
 	"\vconcurrency\x18\x02 \x01(\x05R\vconcurrency\x12(\n" +
 	"\x0fxudpConcurrency\x18\x03 \x01(\x05R\x0fxudpConcurrency\x12(\n" +
-	"\x0fxudpProxyUDP443\x18\x04 \x01(\tR\x0fxudpProxyUDP443BU\n" +
+	"\x0fxudpProxyUDP443\x18\x04 \x01(\tR\x0fxudpProxyUDP443\x12$\n" +
+	"\rmaxReuseTimes\x18\x05 \x01(\x05R\rmaxReuseTimesBU\n" +
 	"\x15com.xray.app.proxymanP\x01Z&github.com/xtls/xray-core/app/proxyman\xaa\x02\x11Xray.App.Proxymanb\x06proto3"
 
 var (

--- a/app/proxyman/config.proto
+++ b/app/proxyman/config.proto
@@ -68,4 +68,6 @@ message MultiplexingConfig {
   int32 xudpConcurrency = 3;
   // "reject" (default), "allow" or "skip".
   string xudpProxyUDP443 = 4;
+  // MaxReuseTimes for an connection
+  int32 maxReuseTimes = 5;
 }

--- a/common/buf/copy.go
+++ b/common/buf/copy.go
@@ -56,6 +56,10 @@ type readError struct {
 	error
 }
 
+func NewReadError(err error) error {
+	return readError{err}
+}
+
 func (e readError) Error() string {
 	return e.error.Error()
 }
@@ -72,6 +76,10 @@ func IsReadError(err error) bool {
 
 type writeError struct {
 	error
+}
+
+func NewWriteError(err error) error {
+	return writeError{err}
 }
 
 func (e writeError) Error() string {

--- a/common/mux/bench_test.go
+++ b/common/mux/bench_test.go
@@ -1,0 +1,70 @@
+package mux_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/xtls/xray-core/common"
+	"github.com/xtls/xray-core/common/buf"
+	"github.com/xtls/xray-core/common/mux"
+	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/session"
+	"github.com/xtls/xray-core/transport"
+	"github.com/xtls/xray-core/transport/pipe"
+)
+
+func BenchmarkMuxThroughput(b *testing.B) {
+	serverCtx := session.ContextWithOutbounds(context.Background(), []*session.Outbound{{}})
+	muxServerUplink, muxServerDownlink := newLinkPair()
+	dispatcher := TestDispatcher{
+		OnDispatch: func(ctx context.Context, dest net.Destination) (*transport.Link, error) {
+			inputReader, inputWriter := pipe.New(pipe.WithSizeLimit(512 * 1024))
+			outputReader, outputWriter := pipe.New(pipe.WithSizeLimit(512 * 1024))
+			go func() {
+				defer outputWriter.Close()
+				for {
+					mb, err := inputReader.ReadMultiBuffer()
+					if err != nil {
+						break
+					}
+					buf.ReleaseMulti(mb)
+				}
+			}()
+			return &transport.Link{
+				Reader: outputReader,
+				Writer: inputWriter,
+			}, nil
+		},
+	}
+	_, err := mux.NewServerWorker(serverCtx, &dispatcher, muxServerUplink)
+	common.Must(err)
+	client, err := mux.NewClientWorker(*muxServerDownlink, mux.ClientStrategy{})
+	common.Must(err)
+	clientCtx := session.ContextWithOutbounds(context.Background(), []*session.Outbound{{
+		Target: net.TCPDestination(net.DomainAddress("www.example.com"), 80),
+	}})
+	muxClientUplink, muxClientDownlink := newLinkPair()
+	go func() {
+		for {
+			mb, err := muxClientDownlink.Reader.ReadMultiBuffer()
+			if err != nil {
+				break
+			}
+			buf.ReleaseMulti(mb)
+		}
+	}()
+	ok := client.Dispatch(clientCtx, muxClientUplink)
+	if !ok {
+		b.Fatal("failed to dispatch")
+	}
+	data := buf.FromBytes(make([]byte, 8192))
+	b.SetBytes(int64(8192))
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		err := muxClientUplink.Writer.WriteMultiBuffer(buf.MultiBuffer{data})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/common/mux/client_test.go
+++ b/common/mux/client_test.go
@@ -58,7 +58,7 @@ func TestClientWorkerClose(t *testing.T) {
 		Writer: w1,
 	}, mux.ClientStrategy{
 		MaxConcurrency: 4,
-		MaxConnection:  4,
+		MaxReuseTimes:  4,
 	})
 	common.Must(err)
 
@@ -68,7 +68,7 @@ func TestClientWorkerClose(t *testing.T) {
 		Writer: w2,
 	}, mux.ClientStrategy{
 		MaxConcurrency: 4,
-		MaxConnection:  4,
+		MaxReuseTimes:  4,
 	})
 	common.Must(err)
 

--- a/common/mux/server_test.go
+++ b/common/mux/server_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func newLinkPair() (*transport.Link, *transport.Link) {
-	opt := pipe.WithoutSizeLimit()
+	opt := pipe.WithSizeLimit(512 * 1024)
 	uplinkReader, uplinkWriter := pipe.New(opt)
 	downlinkReader, downlinkWriter := pipe.New(opt)
 

--- a/common/mux/session.go
+++ b/common/mux/session.go
@@ -56,7 +56,7 @@ func (m *SessionManager) Allocate(Strategy *ClientStrategy) *Session {
 	defer m.Unlock()
 
 	MaxConcurrency := int(Strategy.MaxConcurrency)
-	MaxConnection := uint16(Strategy.MaxConnection)
+	MaxConnection := uint16(Strategy.MaxReuseTimes)
 
 	if m.closed || (MaxConcurrency > 0 && len(m.sessions) >= MaxConcurrency) || (MaxConnection > 0 && m.count >= MaxConnection) {
 		return nil

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -101,6 +101,7 @@ func (c *SniffingConfig) Build() (*proxyman.SniffingConfig, error) {
 type MuxConfig struct {
 	Enabled         bool   `json:"enabled"`
 	Concurrency     int16  `json:"concurrency"`
+	MaxReuseTimes   int32  `json:"maxReuseTimes"`
 	XudpConcurrency int16  `json:"xudpConcurrency"`
 	XudpProxyUDP443 string `json:"xudpProxyUDP443"`
 }
@@ -117,6 +118,7 @@ func (m *MuxConfig) Build() (*proxyman.MultiplexingConfig, error) {
 	return &proxyman.MultiplexingConfig{
 		Enabled:         m.Enabled,
 		Concurrency:     int32(m.Concurrency),
+		MaxReuseTimes:   m.MaxReuseTimes,
 		XudpConcurrency: int32(m.XudpConcurrency),
 		XudpProxyUDP443: m.XudpProxyUDP443,
 	}, nil


### PR DESCRIPTION
字面意思
现 mux cool 逻辑:
MaxConcurrency 为一个连接里的最大活动子连接数
还有一个神秘的 MaxConnections 参数 硬编码为128 实际上就是最大复用次数 我不知道为什么叫这个 这个PR将其重命名了
我修改了一下 允许手动指定 maxReuseTimes 并把默认值变成了65535(mux.cool两位流ID允许的最大上限)

这些限制仅存在于客户端 服务端没有限制 旧的可以正常工作