### PR TITLE
Freedom: Fix noises delay

### DIFF
--- a/infra/conf/freedom.go
+++ b/infra/conf/freedom.go
@@ -187,8 +187,8 @@ func ParseNoise(noise *Noise) (*freedom.Noise, error) {
 		if noise.Delay.From != 0 && noise.Delay.To != 0 {
 			NConfig.DelayMin = uint64(noise.Delay.From)
 			NConfig.DelayMax = uint64(noise.Delay.To)
-			if NConfig.DelayMin > NConfig.LengthMax {
-				NConfig.DelayMin, NConfig.DelayMax = NConfig.LengthMax, NConfig.DelayMin
+			if NConfig.DelayMin > NConfig.DelayMax {
+				NConfig.DelayMin, NConfig.DelayMax = NConfig.DelayMax, NConfig.DelayMin
 			}
 		} else {
 			return nil, errors.New("DelayMin or DelayMax cannot be zero")


### PR DESCRIPTION
fix a typo in noise delay parsing
that always set DelayMin to 0

and thus udp noise delay never executed
https://github.com/XTLS/Xray-core/blob/main/proxy/freedom/freedom.go#L422