### PR TITLE
XHTTP XMUX: Abandon `client` if `client.Do(req)` failed

### DIFF
--- a/transport/internet/splithttp/config.go
+++ b/transport/internet/splithttp/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/xtls/xray-core/common"
+	"github.com/xtls/xray-core/core"
 	"github.com/xtls/xray-core/transport/internet"
 )
 
@@ -36,10 +37,11 @@ func (c *Config) GetNormalizedQuery() string {
 	if query != "" {
 		query += "&"
 	}
+	query += "x_version=" + core.Version()
 
 	paddingLen := c.GetNormalizedXPaddingBytes().rand()
 	if paddingLen > 0 {
-		query += "x_padding=" + strings.Repeat("0", int(paddingLen))
+		query += "&x_padding=" + strings.Repeat("0", int(paddingLen))
 	}
 
 	return query
@@ -58,6 +60,7 @@ func (c *Config) WriteResponseHeader(writer http.ResponseWriter) {
 	// CORS headers for the browser dialer
 	writer.Header().Set("Access-Control-Allow-Origin", "*")
 	writer.Header().Set("Access-Control-Allow-Methods", "GET, POST")
+	writer.Header().Set("X-Version", core.Version())
 	paddingLen := c.GetNormalizedXPaddingBytes().rand()
 	if paddingLen > 0 {
 		writer.Header().Set("X-Padding", strings.Repeat("0", int(paddingLen)))

--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -372,14 +372,14 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 		if xmuxClient != nil {
 			xmuxClient.LeftRequests.Add(-1)
 		}
-		conn.reader, conn.remoteAddr, conn.localAddr, _ = httpClient.OpenStream(context.WithoutCancel(ctx), requestURL.String(), reader, false)
+		conn.reader, conn.remoteAddr, conn.localAddr, _ = httpClient.OpenStream(ctx, requestURL.String(), reader, false)
 		return stat.Connection(&conn), nil
 	} else { // stream-down
 		var err error
 		if xmuxClient2 != nil {
 			xmuxClient2.LeftRequests.Add(-1)
 		}
-		conn.reader, conn.remoteAddr, conn.localAddr, err = httpClient2.OpenStream(context.WithoutCancel(ctx), requestURL2.String(), nil, false)
+		conn.reader, conn.remoteAddr, conn.localAddr, err = httpClient2.OpenStream(ctx, requestURL2.String(), nil, false)
 		if err != nil { // browser dialer only
 			return nil, err
 		}
@@ -454,7 +454,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 
 			go func() {
 				err := httpClient.PostPacket(
-					context.WithoutCancel(ctx),
+					ctx,
 					url.String(),
 					&buf.MultiBufferContainer{MultiBuffer: chunk},
 					int64(chunk.Len()),


### PR DESCRIPTION
最近对 [XHTTP](https://github.com/XTLS/Xray-core/discussions/4113) 进行了“换网测试”，**发现 H2 仍存在切换网络后“断流”的问题**（只能等保活检查），而 H3 有一定概率不会断，应该是连接迁移了。尚未研究“多少秒不活跃触发保活检查”的对象是否包含“未响应”，时间是否就是 `hKeepAlivePeriod`。

所以这个 PR 继承了 https://github.com/XTLS/Xray-core/pull/4163 未竟的事业，重新引入了 https://github.com/XTLS/Xray-core/commit/51769fdde1ca663dcb08d942618e480bee13109f ：**任一 HTTP 请求返回 err 就不再分配新请求。**
（context.WithoutCancel(ctx) 确保了不是客户端引发的 err，此前 stream-up 上行没加它，再加上服务端迟迟未响应，疯狂报错）

由于 stream-up 上行旧服务端迟迟未响应、导致最后返回了 err，这个 PR 类似 [REALITY](https://github.com/XTLS/REALITY) 会把客户端版本发给服务端，**所以新服务端会向新客户端及时响应 200**，这解决了 stream-up 上行状态码为 400/499、被 CDN 掐断 https://github.com/XTLS/Xray-core/discussions/4113#discussioncomment-11682833 的问题。

还有 https://github.com/XTLS/Xray-core/commit/836e84b8510a9478bc00dd8690cb71a51a607d11 我不确定要不要引入，似乎 Go 已经没这问题了？

- ETH/USDT/USDC: `0xDc3Fe44F0f25D13CACb1C4896CD0D321df3146Ee`
- **Project X NFT: https://github.com/XTLS/Xray-core/discussions/3633**
- REALITY NFT: https://opensea.io/assets/ethereum/0x5ee362866001613093361eb8569d59c4141b76d1/2
