### PR TITLE
Add GoXRay GUI client to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,17 @@
 - iOS & macOS arm64
   - [FoXray](https://apps.apple.com/app/foxray/id6448898396)
   - [Streisand](https://apps.apple.com/app/streisand/id6450534064)
+  - [GoXRay](https://github.com/goxray/desktop)
 - macOS arm64 & x64
   - [V2rayU](https://github.com/yanue/V2rayU)
   - [V2RayXS](https://github.com/tzmax/V2RayXS)
   - [Furious](https://github.com/LorenEteval/Furious)
   - [FoXray](https://apps.apple.com/app/foxray/id6448898396)
+  - [GoXRay](https://github.com/goxray/desktop)
 - Linux
   - [v2rayA](https://github.com/v2rayA/v2rayA)
   - [Furious](https://github.com/LorenEteval/Furious)
+  - [GoXRay](https://github.com/goxray/desktop)
 
 ## Others that support VLESS, XTLS, REALITY, XUDP, PLUX...
 


### PR DESCRIPTION
I've implemented a fully functional client in Go for macOS/Linux: https://github.com/goxray/desktop. It would be nice to add it to README.