### PR TITLE
Freedom: Don't use rawConn copy when using utls

### DIFF
--- a/proxy/freedom/freedom.go
+++ b/proxy/freedom/freedom.go
@@ -266,6 +266,9 @@ func isTLSConn(conn stat.Connection) bool {
 		if _, ok := conn.(*tls.Conn); ok {
 			return true
 		}
+		if _, ok := conn.(*tls.UConn); ok {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
之前 @yuhan6665 修改了freedom让它不要在使用tls执行 rawcopy 方法是尝试将conn断言为tls.Conn 成功则跳过 但是从某个更新之后默认utls导致这里变成了 tls.UConn 致使断言失败