### PR TITLE
UDS: Keep valid source addr

### DIFF
--- a/app/proxyman/inbound/worker.go
+++ b/app/proxyman/inbound/worker.go
@@ -2,6 +2,7 @@ package inbound
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -463,9 +464,19 @@ func (w *dsWorker) callback(conn stat.Connection) {
 			WriteCounter: w.downlinkCounter,
 		}
 	}
+	// For most of time, unix obviously have no source addr. But if we leave it empty, it will cause panic.
+	// So we use gateway as source for log.
+	// However, there are some special situations where a valid source address might be available.
+	// Such as the source address parsed from X-Forwarded-For in websocket.
+	// In that case, we keep it.
+	var source net.Destination
+	if !strings.Contains(conn.RemoteAddr().String(), "unix") {
+		source = net.DestinationFromAddr(conn.RemoteAddr())
+	} else {
+		source = net.UnixDestination(w.address)
+	}
 	ctx = session.ContextWithInbound(ctx, &session.Inbound{
-		// Unix have no source addr, so we use gateway as source for log.
-		Source:  net.UnixDestination(w.address),
+		Source:  source,
 		Gateway: net.UnixDestination(w.address),
 		Tag:     w.tag,
 		Conn:    conn,


### PR DESCRIPTION
close #4324 
之前因为UDS的source留空会导致panic 所以写了具体的 uds 地址作为占位符
但是UDS监听不一定代表源地址是无效的 当时没有考虑到 源地址可能被传输协议专有的方法比如从 `X-Forwarded-For` 中读取出来 这种情况下源地址是有效的 所以稍微做一下校验
至于issue里有的情况没法复现 因为各入站实现不同 有的是从 conn 中读取源地址 这种可以正常读到 有的是从 ctx 读取 填入uds作为占位的情况只填到了 ctx 里面