### PR TITLE
Commands: Fix ambiguous printing of private x25519 key

### DIFF
--- a/main/commands/all/curve25519.go
+++ b/main/commands/all/curve25519.go
@@ -42,7 +42,8 @@ func Curve25519Genkey(StdEncoding bool, input_base64 string) {
 	// Modify random bytes using algorithm described at:
 	// https://cr.yp.to/ecdh.html.
 	privateKey[0] &= 248
-	privateKey[31] &= 127 | 64
+	privateKey[31] &= 127
+	privateKey[31] |= 64
 
 	if publicKey, err = curve25519.X25519(privateKey, curve25519.Basepoint); err != nil {
 		output = err.Error()


### PR DESCRIPTION
This transformation was originally added in https://github.com/XTLS/Xray-core/pull/1747.
And then https://github.com/XTLS/Xray-core/pull/2794 changed it to `127 | 64`.

But `x & (127 | 64)` is not the same as `(x & 127) | 64`. For example:

`0 & (127 | 64) = 0`
`(0 & 127) | 64 = 64`

### Reproduction:

in main:
```sh
$ ./xray x25519 -i AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
Private key: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
Public key: L-V9o0fNYkMVKNqsX7spBzD_9oSvxM_C7ZCZX1jLO3Q

$ ./xray x25519 -i AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEA
Private key: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEA
Public key: L-V9o0fNYkMVKNqsX7spBzD_9oSvxM_C7ZCZX1jLO3Q
```

in this PR:
```sh
$ ./xray x25519 -i AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
Private key: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEA
Public key: L-V9o0fNYkMVKNqsX7spBzD_9oSvxM_C7ZCZX1jLO3Q

$ ./xray x25519 -i AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEA
Private key: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEA
Public key: L-V9o0fNYkMVKNqsX7spBzD_9oSvxM_C7ZCZX1jLO3Q
```

(note the last two letters of private key)