### PR TITLE
Outbound: Add outbound sendThrough origin behavior 

### DIFF
--- a/app/proxyman/outbound/handler.go
+++ b/app/proxyman/outbound/handler.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	gonet "net"
 	"os"
+	"strings"
 
 	"github.com/xtls/xray-core/app/proxyman"
 	"github.com/xtls/xray-core/common"

--- a/app/proxyman/outbound/handler.go
+++ b/app/proxyman/outbound/handler.go
@@ -8,7 +8,6 @@ import (
 	"math/big"
 	gonet "net"
 	"os"
-	"strings"
 
 	"github.com/xtls/xray-core/app/proxyman"
 	"github.com/xtls/xray-core/common"
@@ -275,8 +274,12 @@ func (h *Handler) Dial(ctx context.Context, dest net.Destination) (stat.Connecti
 			ob := outbounds[len(outbounds)-1]
 			if h.senderSettings.ViaCidr == "" {
 				if h.senderSettings.Via.AsAddress().Family().IsDomain() && h.senderSettings.Via.AsAddress().Domain() == "origin" {
-					inbound := session.InboundFromContext(ctx)
-					ob.Gateway = net.ParseAddress(strings.Split(inbound.Conn.LocalAddr().String(), ":")[0])
+					if inbound := session.InboundFromContext(ctx); inbound != nil {
+						origin, _, err := net.SplitHostPort(inbound.Conn.LocalAddr().String())
+						if err == nil {
+							ob.Gateway = net.ParseAddress(origin)
+						}
+					}
 				} else {
 					ob.Gateway = h.senderSettings.Via.AsAddress()
 				}

--- a/app/proxyman/outbound/handler.go
+++ b/app/proxyman/outbound/handler.go
@@ -273,7 +273,12 @@ func (h *Handler) Dial(ctx context.Context, dest net.Destination) (stat.Connecti
 			outbounds := session.OutboundsFromContext(ctx)
 			ob := outbounds[len(outbounds)-1]
 			if h.senderSettings.ViaCidr == "" {
-				ob.Gateway = h.senderSettings.Via.AsAddress()
+				if h.senderSettings.Via.AsAddress().Family().IsDomain() && h.senderSettings.Via.AsAddress().Domain() == "origin" {
+					inbound := session.InboundFromContext(ctx)
+					ob.Gateway = net.ParseAddress(strings.Split(inbound.Conn.LocalAddr().String(), ":")[0])
+				} else {
+					ob.Gateway = h.senderSettings.Via.AsAddress()
+				}
 			} else { //Get a random address.
 				ob.Gateway = ParseRandomIPv6(h.senderSettings.Via.AsAddress(), h.senderSettings.ViaCidr)
 			}

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -292,7 +292,9 @@ func (c *OutboundDetourConfig) Build() (*core.OutboundHandlerConfig, error) {
 			senderSettings.ViaCidr = strings.Split(*c.SendThrough, "/")[1]
 		} else {
 			if address.Family().IsDomain() {
-				return nil, errors.New("unable to send through: " + address.String())
+				if address.Address.Domain() != "origin" {
+					return nil, errors.New("unable to send through: " + address.String())
+				}
 			}
 		}
 		senderSettings.Via = address.Build()


### PR DESCRIPTION
In case when there are few IP-addresses on the server, it would be good for outbound to have behavior when it resolves origin IP address and then sends packets through it. Before the choice was delegated to OS.

This behavior can be used with explicit specification in the outbound config:

`{"outbounds":[
    {
      "protocol":"freedom",
      "tag":"DIRECT",
      "sendThrough": "origin"
    }
}`
