### PR TITLE
Workflows: Fix Actions' manual dispatch for assets update

### DIFF
--- a/.github/workflows/scheduled-assets-update.yml
+++ b/.github/workflows/scheduled-assets-update.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   geodat:
-    if: github.event.schedule == '30 22 * * *' || github.event_name == 'push'|| github.event_name == 'pull_request'
+    if: github.event.schedule == '30 22 * * *' || github.event_name == 'push'|| github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Restore Geodat Cache


### PR DESCRIPTION
现在应该可以正常手动触发 assets 更新了，比如 geodata

应该可以解决莫名其妙的 cache 清空导致其它依赖 actions 失败的问题

应用 pr 后需要在 Actions 页面左侧选择对应 action，然后右侧可以手动 Run workflow