### PR TITLE
Add a boolean option `ignoreClientIp` to allow overriding the client-requested target with the DNS-resolved IP during sniffing

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -293,8 +293,8 @@ func (d *DefaultDispatcher) Dispatch(ctx context.Context, destination net.Destin
 					ob.RouteTarget = destination
 					if sniffingRequest.IgnoreClientIp {
 						ips, err := d.dns.LookupIP(domain, dns.IPOption{
-							IPv4Enable: ob.OriginalTarget.Address.Family().IsIPv4(),
-							IPv6Enable: !ob.OriginalTarget.Address.Family().IsIPv4(),
+							IPv4Enable: ob.OriginalTarget.Address.Family().IsIPv4() || ob.OriginalTarget.Address.Family().IsDomain(),
+							IPv6Enable: ob.OriginalTarget.Address.Family().IsIPv6(),
 							FakeEnable: false,
 						})
 						if len(ips) == 0 || err != nil {
@@ -360,8 +360,8 @@ func (d *DefaultDispatcher) DispatchLink(ctx context.Context, destination net.De
 				ob.RouteTarget = destination
 				if sniffingRequest.IgnoreClientIp {
 					ips, err := d.dns.LookupIP(domain, dns.IPOption{
-						IPv4Enable: ob.OriginalTarget.Address.Family().IsIPv4(),
-						IPv6Enable: !ob.OriginalTarget.Address.Family().IsIPv4(),
+						IPv4Enable: ob.OriginalTarget.Address.Family().IsIPv4() || ob.OriginalTarget.Address.Family().IsDomain(),
+						IPv6Enable: ob.OriginalTarget.Address.Family().IsIPv6(),
 						FakeEnable: false,
 					})
 					if len(ips) == 0 || err != nil {

--- a/app/proxyman/config.pb.go
+++ b/app/proxyman/config.pb.go
@@ -192,7 +192,7 @@ type SniffingConfig struct {
 	// message.
 	MetadataOnly bool `protobuf:"varint,4,opt,name=metadata_only,json=metadataOnly,proto3" json:"metadata_only,omitempty"`
 	RouteOnly    bool `protobuf:"varint,5,opt,name=route_only,json=routeOnly,proto3" json:"route_only,omitempty"`
-	IgnoreClientIp    bool `protobuf:"varint,6,opt,name=ignore_client_ip,json=ignoreClientIp,proto3" json:"ignoreClientIp,omitempty"`
+	IgnoreClientIp    bool `protobuf:"varint,6,opt,name=ignore_client_ip,json=ignoreClientIp,proto3" json:"ignore_client_ip,omitempty"`
 }
 
 func (x *SniffingConfig) Reset() {

--- a/app/proxyman/config.pb.go
+++ b/app/proxyman/config.pb.go
@@ -192,6 +192,7 @@ type SniffingConfig struct {
 	// message.
 	MetadataOnly bool `protobuf:"varint,4,opt,name=metadata_only,json=metadataOnly,proto3" json:"metadata_only,omitempty"`
 	RouteOnly    bool `protobuf:"varint,5,opt,name=route_only,json=routeOnly,proto3" json:"route_only,omitempty"`
+	IgnoreClientIp    bool `protobuf:"varint,6,opt,name=ignore_client_ip,json=ignoreClientIp,proto3" json:"ignoreClientIp,omitempty"`
 }
 
 func (x *SniffingConfig) Reset() {
@@ -255,6 +256,13 @@ func (x *SniffingConfig) GetMetadataOnly() bool {
 func (x *SniffingConfig) GetRouteOnly() bool {
 	if x != nil {
 		return x.RouteOnly
+	}
+	return false
+}
+
+func (x *SniffingConfig) GetIgnoreClientIp() bool {
+	if x != nil {
+		return x.IgnoreClientIp
 	}
 	return false
 }

--- a/app/proxyman/inbound/worker.go
+++ b/app/proxyman/inbound/worker.go
@@ -103,6 +103,7 @@ func (w *tcpWorker) callback(conn stat.Connection) {
 		content.SniffingRequest.ExcludeForDomain = w.sniffingConfig.DomainsExcluded
 		content.SniffingRequest.MetadataOnly = w.sniffingConfig.MetadataOnly
 		content.SniffingRequest.RouteOnly = w.sniffingConfig.RouteOnly
+		content.SniffingRequest.IgnoreClientIp = w.sniffingConfig.IgnoreClientIp
 	}
 	ctx = session.ContextWithContent(ctx, content)
 
@@ -326,6 +327,7 @@ func (w *udpWorker) callback(b *buf.Buffer, source net.Destination, originalDest
 				content.SniffingRequest.OverrideDestinationForProtocol = w.sniffingConfig.DestinationOverride
 				content.SniffingRequest.MetadataOnly = w.sniffingConfig.MetadataOnly
 				content.SniffingRequest.RouteOnly = w.sniffingConfig.RouteOnly
+				content.SniffingRequest.IgnoreClientIp = w.sniffingConfig.IgnoreClientIp
 			}
 			ctx = session.ContextWithContent(ctx, content)
 			if err := w.proxy.Process(ctx, net.Network_UDP, conn, w.dispatcher); err != nil {
@@ -477,6 +479,7 @@ func (w *dsWorker) callback(conn stat.Connection) {
 		content.SniffingRequest.ExcludeForDomain = w.sniffingConfig.DomainsExcluded
 		content.SniffingRequest.MetadataOnly = w.sniffingConfig.MetadataOnly
 		content.SniffingRequest.RouteOnly = w.sniffingConfig.RouteOnly
+		content.SniffingRequest.IgnoreClientIp = w.sniffingConfig.IgnoreClientIp
 	}
 	ctx = session.ContextWithContent(ctx, content)
 

--- a/common/session/session.go
+++ b/common/session/session.go
@@ -80,6 +80,7 @@ type SniffingRequest struct {
 	Enabled                        bool
 	MetadataOnly                   bool
 	RouteOnly                      bool
+	IgnoreClientIp                 bool
 }
 
 // Content is the metadata of the connection content.

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -55,6 +55,7 @@ type SniffingConfig struct {
 	DomainsExcluded *StringList `json:"domainsExcluded"`
 	MetadataOnly    bool        `json:"metadataOnly"`
 	RouteOnly       bool        `json:"routeOnly"`
+	IgnoreClientIp  bool        `json:"ignoreClientIp"`
 }
 
 // Build implements Buildable.
@@ -92,6 +93,7 @@ func (c *SniffingConfig) Build() (*proxyman.SniffingConfig, error) {
 		DomainsExcluded:     d,
 		MetadataOnly:        c.MetadataOnly,
 		RouteOnly:           c.RouteOnly,
+		IgnoreClientIp:      c.IgnoreClientIp,
 	}, nil
 }
 


### PR DESCRIPTION
📄 What’s Changed

    Introduced a new boolean option ignoreClientIp in the sniffing module.
    When routeOnly is set to true and ignoreClientIp is enabled, the client-requested target IP will be overridden with the IP resolved by the internal DNS module.
    The default value of ignoreClientIp is false to preserve backward compatibility and existing behavior.

💡 Why This Change Is Needed

This enhancement addresses the issue described in [Issue #4335](https://github.com/XTLS/Xray-core/issues/4335) by ensuring routing flexibility and robustness in scenarios where client-side DNS pollution may cause routing failures.

Key Behavior:

    When the client-requested target is a domain:
        ob.Target will be set to a trusted IPv4 address (resolved by the internal DNS).
        ob.RouteTarget will remain the original domain name.

    When the client-requested target is an IP address:
        ob.Target will be set to the trusted IP resolved by the internal DNS.
        ob.RouteTarget will be the corresponding domain name.

⚡ Benefits

    Ensures that both IP-based routing rules and domain-based routing rules remain consistently available at all times.
    Completely mitigates the impact of client-side DNS pollution without the need for manual intervention, such as blocking common DoH providers.
    Simplifies transparent proxy configurations, especially when Xray is acting as a gateway managing geo-based routing across multiple geographically distributed nodes.
