### PR TITLE
Fix nil pointer dereference in CreateObject

### DIFF
--- a/core/functions.go
+++ b/core/functions.go
@@ -14,9 +14,11 @@ import (
 
 // CreateObject creates a new object based on the given Xray instance and config. The Xray instance may be nil.
 func CreateObject(v *Instance, config interface{}) (interface{}, error) {
-	ctx := v.ctx
+	var ctx context.Context
 	if v != nil {
 		ctx = toContext(v.ctx, v)
+	} else {
+		ctx = context.Background()
 	}
 	return common.CreateObject(ctx, config)
 }


### PR DESCRIPTION
#### Problem
The original implementation of the `CreateObject` function directly accessed `v.ctx` before checking if `v` was `nil`. This could lead to a runtime panic due to a nil pointer dereference when `v` is `nil`.

#### Solution
- Reordered the logic to check `v != nil` before accessing `v.ctx`.
- Added a fallback to `context.Background()` when `v` is `nil`, ensuring the function handles this edge case gracefully.
- Updated the `ctx` assignment to use `toContext(v.ctx, v)` only when `v` is non-nil.

#### Changes
- Modified `CreateObject` in `core/functions.go` to safely handle nil `v` values.
- Previous code:
  ```go
  ctx := v.ctx
  if v != nil {
      ctx = toContext(v.ctx, v)
  }