### PR TITLE
DNS: Retry with EDNS0 when response is truncated 

### DIFF
--- a/app/dns/dnscommon.go
+++ b/app/dns/dnscommon.go
@@ -35,6 +35,9 @@ type IPRecord struct {
 	IP     []net.Address
 	Expire time.Time
 	RCode  dnsmessage.RCode
+
+	// Truncated is for udp dns to indicates if the response is truncated and needs to be retried
+	Truncated bool
 }
 
 func (r *IPRecord) getIPs() ([]net.Address, error) {
@@ -65,6 +68,7 @@ type dnsRequest struct {
 	start   time.Time
 	expire  time.Time
 	msg     *dnsmessage.Message
+	ctx     context.Context
 }
 
 func genEDNS0Options(clientIP net.IP) *dnsmessage.Resource {
@@ -179,9 +183,10 @@ func parseResponse(payload []byte) (*IPRecord, error) {
 
 	now := time.Now()
 	ipRecord := &IPRecord{
-		ReqID:  h.ID,
-		RCode:  h.RCode,
-		Expire: now.Add(time.Second * 600),
+		ReqID:     h.ID,
+		RCode:     h.RCode,
+		Expire:    now.Add(time.Second * 600),
+		Truncated: h.Truncated,
 	}
 
 L:

--- a/app/dns/dnscommon.go
+++ b/app/dns/dnscommon.go
@@ -31,13 +31,11 @@ type record struct {
 
 // IPRecord is a cacheable item for a resolved domain
 type IPRecord struct {
-	ReqID  uint16
-	IP     []net.Address
-	Expire time.Time
-	RCode  dnsmessage.RCode
-
-	// Truncated is for udp dns to indicates if the response is truncated and needs to be retried
-	Truncated bool
+	ReqID     uint16
+	IP        []net.Address
+	Expire    time.Time
+	RCode     dnsmessage.RCode
+	RawHeader *dnsmessage.Header
 }
 
 func (r *IPRecord) getIPs() ([]net.Address, error) {
@@ -68,7 +66,6 @@ type dnsRequest struct {
 	start   time.Time
 	expire  time.Time
 	msg     *dnsmessage.Message
-	ctx     context.Context
 }
 
 func genEDNS0Options(clientIP net.IP) *dnsmessage.Resource {
@@ -186,7 +183,7 @@ func parseResponse(payload []byte) (*IPRecord, error) {
 		ReqID:     h.ID,
 		RCode:     h.RCode,
 		Expire:    now.Add(time.Second * 600),
-		Truncated: h.Truncated,
+		RawHeader: &h,
 	}
 
 L:

--- a/app/dns/dnscommon_test.go
+++ b/app/dns/dnscommon_test.go
@@ -85,8 +85,9 @@ func Test_parseResponse(t *testing.T) {
 			}
 
 			if got != nil {
-				// reset the time
+				// reset the time and RawHeader
 				got.Expire = time.Time{}
+				got.RawHeader = nil
 			}
 			if cmp.Diff(got, tt.want) != "" {
 				t.Error(cmp.Diff(got, tt.want))

--- a/app/dns/dnscommon_test.go
+++ b/app/dns/dnscommon_test.go
@@ -51,7 +51,7 @@ func Test_parseResponse(t *testing.T) {
 	}{
 		{
 			"empty",
-			&IPRecord{0, []net.Address(nil), time.Time{}, dnsmessage.RCodeSuccess},
+			&IPRecord{0, []net.Address(nil), time.Time{}, dnsmessage.RCodeSuccess, nil},
 			false,
 		},
 		{
@@ -66,12 +66,13 @@ func Test_parseResponse(t *testing.T) {
 				[]net.Address{net.ParseAddress("8.8.8.8"), net.ParseAddress("8.8.4.4")},
 				time.Time{},
 				dnsmessage.RCodeSuccess,
+				nil,
 			},
 			false,
 		},
 		{
 			"aaaa record",
-			&IPRecord{2, []net.Address{net.ParseAddress("2001::123:8888"), net.ParseAddress("2001::123:8844")}, time.Time{}, dnsmessage.RCodeSuccess},
+			&IPRecord{2, []net.Address{net.ParseAddress("2001::123:8888"), net.ParseAddress("2001::123:8844")}, time.Time{}, dnsmessage.RCodeSuccess, nil},
 			false,
 		},
 	}

--- a/app/dns/nameserver_udp.go
+++ b/app/dns/nameserver_udp.go
@@ -147,7 +147,7 @@ func (s *ClassicNameServer) HandleResponse(ctx context.Context, packet *udp_prot
 			newMsg.ID = s.newReqID()
 			newReq.msg = &newMsg
 			s.addPendingRequest(&newReq)
-			b, _ := dns.PackMessage(req.msg)
+			b, _ := dns.PackMessage(newReq.msg)
 			s.udpServer.Dispatch(toDnsContext(newReq.ctx, s.address.String()), *s.address, b)
 			return
 		}

--- a/app/dns/nameserver_udp.go
+++ b/app/dns/nameserver_udp.go
@@ -141,6 +141,7 @@ func (s *ClassicNameServer) HandleResponse(ctx context.Context, packet *udp_prot
 			// and add EDNS0 option
 			opt := new(dnsmessage.Resource)
 			common.Must(opt.Header.SetEDNS0(1350, 0xfe00, true))
+			opt.Body = &dnsmessage.OPTResource{}
 			newMsg := *req.msg
 			newReq := *req
 			newMsg.Additionals = append(newMsg.Additionals, *opt)


### PR DESCRIPTION
RT 如果DNS消息回复被截断则再次发送带EDNS的请求并把大小扩展到1350