### PR TITLE
Add "certificate" environment variable

### DIFF
--- a/common/platform/filesystem/file.go
+++ b/common/platform/filesystem/file.go
@@ -3,6 +3,7 @@ package filesystem
 import (
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/xtls/xray-core/common/buf"
 	"github.com/xtls/xray-core/common/platform"
@@ -26,6 +27,13 @@ func ReadFile(path string) ([]byte, error) {
 
 func ReadAsset(file string) ([]byte, error) {
 	return ReadFile(platform.GetAssetLocation(file))
+}
+
+func ReadCertificate(file string) ([]byte, error) {
+	if filepath.IsAbs(file) {
+		return ReadFile(file)
+	}
+	return ReadFile(platform.GetCertificateLocation(file))
 }
 
 func CopyFile(dst string, src string) error {

--- a/common/platform/others.go
+++ b/common/platform/others.go
@@ -42,3 +42,8 @@ func GetAssetLocation(file string) string {
 	// asset not found, let the caller throw out the error
 	return defPath
 }
+
+func GetCertificateLocation(file string) string {
+	certificatePath := NewEnvFlag(CertificateLocation).GetValue(getExecutableDir)
+	return filepath.Join(certificatePath, file)
+}

--- a/common/platform/platform.go
+++ b/common/platform/platform.go
@@ -8,11 +8,12 @@ import (
 )
 
 const (
-	PluginLocation  = "xray.location.plugin"
-	ConfigLocation  = "xray.location.config"
-	ConfdirLocation = "xray.location.confdir"
-	ToolLocation    = "xray.location.tool"
-	AssetLocation   = "xray.location.asset"
+	PluginLocation      = "xray.location.plugin"
+	ConfigLocation      = "xray.location.config"
+	ConfdirLocation     = "xray.location.confdir"
+	ToolLocation        = "xray.location.tool"
+	AssetLocation       = "xray.location.asset"
+	CertificateLocation = "xray.location.certificate"
 
 	UseReadV         = "xray.buf.readv"
 	UseFreedomSplice = "xray.buf.splice"

--- a/common/platform/windows.go
+++ b/common/platform/windows.go
@@ -24,3 +24,8 @@ func GetAssetLocation(file string) string {
 	assetPath := NewEnvFlag(AssetLocation).GetValue(getExecutableDir)
 	return filepath.Join(assetPath, file)
 }
+
+func GetCertificateLocation(file string) string {
+	certificatePath := NewEnvFlag(CertificateLocation).GetValue(getExecutableDir)
+	return filepath.Join(certificatePath, file)
+}

--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -334,7 +334,7 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 
 func readFileOrString(f string, s []string) ([]byte, error) {
 	if len(f) > 0 {
-		return filesystem.ReadFile(f)
+		return filesystem.ReadCertificate(f)
 	}
 	if len(s) > 0 {
 		return []byte(strings.Join(s, "\n")), nil

--- a/transport/internet/tls/config.go
+++ b/transport/internet/tls/config.go
@@ -109,12 +109,12 @@ func setupOcspTicker(entry *Certificate, callback func(isReloaded, isOcspstaplin
 		for {
 			var isReloaded bool
 			if entry.CertificatePath != "" && entry.KeyPath != "" {
-				newCert, err := filesystem.ReadFile(entry.CertificatePath)
+				newCert, err := filesystem.ReadCertificate(entry.CertificatePath)
 				if err != nil {
 					errors.LogErrorInner(context.Background(), err, "failed to parse certificate")
 					return
 				}
-				newKey, err := filesystem.ReadFile(entry.KeyPath)
+				newKey, err := filesystem.ReadCertificate(entry.KeyPath)
 				if err != nil {
 					errors.LogErrorInner(context.Background(), err, "failed to parse key")
 					return


### PR DESCRIPTION
Wrongly, the source of relative path for certificate files is "command-run" folder: https://github.com/XTLS/Xray-core/issues/4531

also, it is not elegant that we put all certificate files in exec folder, so we need environment-variable for certificate files.

therefore, gui/panel can create a folder for certificates files and set certificate-environment-variable to that folder.

also, v2rayNG only has one folder for asset files, so in v2rayNG we can set
geo-environment-variable=certificate-environment-variable and then we can add certificate files.

///

logic:

```
if cert/key path is absolute path:
    read from that path
else:
    if we have certificate-environment-variable:
        read from certificate-environment-variable folder
    else:
        read from exec folder
```