### PR TITLE
DNS: change error loglevel for DOH for NXDOMAIN

### DIFF
--- a/app/dns/nameserver_doh.go
+++ b/app/dns/nameserver_doh.go
@@ -260,7 +260,7 @@ func (s *DoHNameServer) sendQuery(ctx context.Context, domain string, clientIP n
 			}
 			resp, err := s.dohHTTPSContext(dnsCtx, b.Bytes())
 			if err != nil {
-				errors.LogErrorInner(ctx, err, "failed to retrieve response for ", domain)
+				errors.LogInfoInner(ctx, err, "failed to retrieve response for ", domain)
 				return
 			}
 			rec, err := parseResponse(resp)


### PR DESCRIPTION
dns-query-answer for some domains contains no ip, NXDOMAIN
```
nslookup jkasssahdjashdjh.com

-> server can't find jkasssahdjashdjh.com: NXDOMAIN
```

in Xray-core when dns is DOH and and dns-query answer has no ip (NXDOMAIN), an error-log is created and printed:

`2025/03/27 17:09:46.372277 [Error] app/dns: failed to retrieve response for jkasssahdjashdjh.com. > Post "https://free.shecan.ir/dns-query": context canceled`

**this log is only shown for DOH-dns, and we have no log for other types of dns.**

///

some apps in android constantly asking for IP of an invalid domain(NXDOMAIN), this causes thousands of unnecessary logs in v2rayNG and slows down the app.

///

this is only a temporary solution.(and only for log)