### PR TITLE
DNS: Use cache for NXDOMAIN (rcode 3)

### DIFF
--- a/app/dns/nameserver_doh.go
+++ b/app/dns/nameserver_doh.go
@@ -357,7 +357,7 @@ func (s *DoHNameServer) QueryIP(ctx context.Context, domain string, clientIP net
 		errors.LogDebug(ctx, "DNS cache is disabled. Querying IP for ", domain, " at ", s.name)
 	} else {
 		ips, ttl, err := s.findIPsForDomain(fqdn, option)
-		if err == nil || err == dns_feature.ErrEmptyResponse {
+		if err == nil || err == dns_feature.ErrEmptyResponse || dns_feature.RCodeFromError(err) == 3 {
 			errors.LogDebugInner(ctx, err, s.name, " cache HIT ", domain, " -> ", ips)
 			log.Record(&log.DNSLog{Server: s.name, Domain: domain, Result: ips, Status: log.DNSCacheHit, Elapsed: 0, Error: err})
 			return ips, ttl, err

--- a/app/dns/nameserver_quic.go
+++ b/app/dns/nameserver_quic.go
@@ -300,7 +300,7 @@ func (s *QUICNameServer) QueryIP(ctx context.Context, domain string, clientIP ne
 		errors.LogDebug(ctx, "DNS cache is disabled. Querying IP for ", domain, " at ", s.name)
 	} else {
 		ips, ttl, err := s.findIPsForDomain(fqdn, option)
-		if err == nil || err == dns_feature.ErrEmptyResponse {
+		if err == nil || err == dns_feature.ErrEmptyResponse || dns_feature.RCodeFromError(err) == 3 {
 			errors.LogDebugInner(ctx, err, s.name, " cache HIT ", domain, " -> ", ips)
 			log.Record(&log.DNSLog{Server: s.name, Domain: domain, Result: ips, Status: log.DNSCacheHit, Elapsed: 0, Error: err})
 			return ips, ttl, err

--- a/app/dns/nameserver_tcp.go
+++ b/app/dns/nameserver_tcp.go
@@ -325,7 +325,7 @@ func (s *TCPNameServer) QueryIP(ctx context.Context, domain string, clientIP net
 		errors.LogDebug(ctx, "DNS cache is disabled. Querying IP for ", domain, " at ", s.name)
 	} else {
 		ips, ttl, err := s.findIPsForDomain(fqdn, option)
-		if err == nil || err == dns_feature.ErrEmptyResponse {
+		if err == nil || err == dns_feature.ErrEmptyResponse || dns_feature.RCodeFromError(err) == 3 {
 			errors.LogDebugInner(ctx, err, s.name, " cache HIT ", domain, " -> ", ips)
 			log.Record(&log.DNSLog{Server: s.name, Domain: domain, Result: ips, Status: log.DNSCacheHit, Elapsed: 0, Error: err})
 			return ips, ttl, err

--- a/app/dns/nameserver_udp.go
+++ b/app/dns/nameserver_udp.go
@@ -282,7 +282,7 @@ func (s *ClassicNameServer) QueryIP(ctx context.Context, domain string, clientIP
 		errors.LogDebug(ctx, "DNS cache is disabled. Querying IP for ", domain, " at ", s.name)
 	} else {
 		ips, ttl, err := s.findIPsForDomain(fqdn, option)
-		if err == nil || err == dns_feature.ErrEmptyResponse {
+		if err == nil || err == dns_feature.ErrEmptyResponse || dns_feature.RCodeFromError(err) == 3 {
 			errors.LogDebugInner(ctx, err, s.name, " cache HIT ", domain, " -> ", ips)
 			log.Record(&log.DNSLog{Server: s.name, Domain: domain, Result: ips, Status: log.DNSCacheHit, Elapsed: 0, Error: err})
 			return ips, ttl, err


### PR DESCRIPTION
First, I have to thank @Fangliding for his guidance on https://github.com/XTLS/Xray-core/pull/4558#issuecomment-2759007356.

I mistakenly think that the problem is related to log, but in fact log is just log and has nothing to do with performance.

in https://github.com/XTLS/Xray-core/pull/3784 @Fangliding change the original code `err != errRecordNotFound` to `err == nil || err == dns_feature.ErrEmptyResponse` To be more accurate.

but in android some apps send thousands of requests in a matter of seconds, that return `NXDOMAIN`.

This causes performance to drop drastically, and many people have complained about this.

So I also added `NXDOMAIN` to the modes that should use `cache`.

![photo_2025-03-28_02-10-14](https://github.com/user-attachments/assets/8a2cd61c-917d-4f09-b054-c4d2a94dc3e0)
