### PR TITLE
Sockopt: Windows `IPV6_MULTICAST_IF` & `IP_MULTICAST_IF` failed No return

### DIFF
--- a/transport/internet/sockopt_windows.go
+++ b/transport/internet/sockopt_windows.go
@@ -48,7 +48,7 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_UNICAST_IF, int(idx)); err != nil {
 				return errors.New("failed to set IP_UNICAST_IF").Base(err)
 			}
-			if ip := net.ParseDestination(address); ip.IsMulticast() {
+			if ip := net.ParseDestination(address); ip.Address.IP().IsMulticast() {
 				if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_MULTICAST_IF, int(idx)); err != nil {
 					return errors.New("failed to set IP_MULTICAST_IF").Base(err)
 				}
@@ -57,7 +57,7 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_UNICAST_IF, inf.Index); err != nil {
 				return errors.New("failed to set IPV6_UNICAST_IF").Base(err)
 			}
-			if ip := net.ParseDestination(address); ip.IsMulticast() {
+			if ip := net.ParseDestination(address); ip.Address.IP().IsMulticast() {
 				if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_MULTICAST_IF, inf.Index); err != nil {
 					return errors.New("failed to set IPV6_MULTICAST_IF").Base(err)
 				}

--- a/transport/internet/sockopt_windows.go
+++ b/transport/internet/sockopt_windows.go
@@ -49,7 +49,7 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_UNICAST_IF, int(idx)); err != nil {
 				return errors.New("failed to set IP_UNICAST_IF").Base(err)
 			}
-			if ip, _ := xrnet.ParseDestination(address); ip.IsMulticast() {
+			if ip, _ := xrnet.ParseDestination(address); ip.Address.IP().IsMulticast() {
 				if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_MULTICAST_IF, int(idx)); err != nil {
 					return errors.New("failed to set IP_MULTICAST_IF").Base(err)
 				}
@@ -58,7 +58,7 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_UNICAST_IF, inf.Index); err != nil {
 				return errors.New("failed to set IPV6_UNICAST_IF").Base(err)
 			}
-			if ip, _ := xrnet.ParseDestination(address); ip.IsMulticast() {
+			if ip, _ := xrnet.ParseDestination(address); ip.Address.IP().IsMulticast() {
 				if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_MULTICAST_IF, inf.Index); err != nil {
 					return errors.New("failed to set IPV6_MULTICAST_IF").Base(err)
 				}

--- a/transport/internet/sockopt_windows.go
+++ b/transport/internet/sockopt_windows.go
@@ -48,7 +48,7 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_UNICAST_IF, int(idx)); err != nil {
 				return errors.New("failed to set IP_UNICAST_IF").Base(err)
 			}
-			if ip := net.ParseIP(address); ip != nil && ip.IsMulticast() {
+			if ip := net.ParseDestination(address); ip.IsMulticast() {
 				if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_MULTICAST_IF, int(idx)); err != nil {
 					return errors.New("failed to set IP_MULTICAST_IF").Base(err)
 				}
@@ -57,7 +57,7 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_UNICAST_IF, inf.Index); err != nil {
 				return errors.New("failed to set IPV6_UNICAST_IF").Base(err)
 			}
-			if ip := net.ParseIP(address); ip != nil && ip.IsMulticast() {
+			if ip := net.ParseDestination(address); ip.IsMulticast() {
 				if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_MULTICAST_IF, inf.Index); err != nil {
 					return errors.New("failed to set IPV6_MULTICAST_IF").Base(err)
 				}

--- a/transport/internet/sockopt_windows.go
+++ b/transport/internet/sockopt_windows.go
@@ -48,16 +48,12 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_UNICAST_IF, int(idx)); err != nil {
 				return errors.New("failed to set IP_UNICAST_IF").Base(err)
 			}
-			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_MULTICAST_IF, int(idx)); err != nil {
-				errors.New("failed to set IP_MULTICAST_IF").Base(err)
-			}
+			syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_MULTICAST_IF, int(idx))
 		} else {
 			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_UNICAST_IF, inf.Index); err != nil {
 				return errors.New("failed to set IPV6_UNICAST_IF").Base(err)
 			}
-			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_MULTICAST_IF, inf.Index); err != nil {
-				errors.New("failed to set IPV6_MULTICAST_IF").Base(err)
-			}
+			syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_MULTICAST_IF, inf.Index)
 		}
 	}
 

--- a/transport/internet/sockopt_windows.go
+++ b/transport/internet/sockopt_windows.go
@@ -49,7 +49,7 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_UNICAST_IF, int(idx)); err != nil {
 				return errors.New("failed to set IP_UNICAST_IF").Base(err)
 			}
-			if ip := xrnet.ParseDestination(address); ip.IsMulticast() {
+			if ip, _ := xrnet.ParseDestination(address); ip.IsMulticast() {
 				if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_MULTICAST_IF, int(idx)); err != nil {
 					return errors.New("failed to set IP_MULTICAST_IF").Base(err)
 				}
@@ -58,7 +58,7 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_UNICAST_IF, inf.Index); err != nil {
 				return errors.New("failed to set IPV6_UNICAST_IF").Base(err)
 			}
-			if ip := xrnet.ParseDestination(address); ip.IsMulticast() {
+			if ip, _ := xrnet.ParseDestination(address); ip.IsMulticast() {
 				if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_MULTICAST_IF, inf.Index); err != nil {
 					return errors.New("failed to set IPV6_MULTICAST_IF").Base(err)
 				}

--- a/transport/internet/sockopt_windows.go
+++ b/transport/internet/sockopt_windows.go
@@ -48,7 +48,7 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_UNICAST_IF, int(idx)); err != nil {
 				return errors.New("failed to set IP_UNICAST_IF").Base(err)
 			}
-			if ip := net.ParseDestination(address); ip.Address.IP().IsMulticast() {
+			if ip := net.destination.ParseDestination(address); ip.IsMulticast() {
 				if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_MULTICAST_IF, int(idx)); err != nil {
 					return errors.New("failed to set IP_MULTICAST_IF").Base(err)
 				}
@@ -57,7 +57,7 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_UNICAST_IF, inf.Index); err != nil {
 				return errors.New("failed to set IPV6_UNICAST_IF").Base(err)
 			}
-			if ip := net.ParseDestination(address); ip.Address.IP().IsMulticast() {
+			if ip := net.destination.ParseDestination(address); ip.IsMulticast() {
 				if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_MULTICAST_IF, inf.Index); err != nil {
 					return errors.New("failed to set IPV6_MULTICAST_IF").Base(err)
 				}

--- a/transport/internet/sockopt_windows.go
+++ b/transport/internet/sockopt_windows.go
@@ -11,7 +11,6 @@ import (
 	"unsafe"
 
 	"github.com/xtls/xray-core/common/errors"
-	xrnet "github.com/xtls/xray-core/common/net"
 )
 
 const (
@@ -49,19 +48,15 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_UNICAST_IF, int(idx)); err != nil {
 				return errors.New("failed to set IP_UNICAST_IF").Base(err)
 			}
-			if ip, _ := xrnet.ParseDestination(address); ip.Address.IP().IsMulticast() {
-				if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_MULTICAST_IF, int(idx)); err != nil {
-					return errors.New("failed to set IP_MULTICAST_IF").Base(err)
-				}
+			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_MULTICAST_IF, int(idx)); err != nil {
+				errors.New("failed to set IP_MULTICAST_IF").Base(err)
 			}
 		} else {
 			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_UNICAST_IF, inf.Index); err != nil {
 				return errors.New("failed to set IPV6_UNICAST_IF").Base(err)
 			}
-			if ip, _ := xrnet.ParseDestination(address); ip.Address.IP().IsMulticast() {
-				if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_MULTICAST_IF, inf.Index); err != nil {
-					return errors.New("failed to set IPV6_MULTICAST_IF").Base(err)
-				}
+			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_MULTICAST_IF, inf.Index); err != nil {
+				errors.New("failed to set IPV6_MULTICAST_IF").Base(err)
 			}
 		}
 	}

--- a/transport/internet/sockopt_windows.go
+++ b/transport/internet/sockopt_windows.go
@@ -11,6 +11,7 @@ import (
 	"unsafe"
 
 	"github.com/xtls/xray-core/common/errors"
+	xrnet "github.com/xtls/xray-core/common/net"
 )
 
 const (
@@ -48,7 +49,7 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_UNICAST_IF, int(idx)); err != nil {
 				return errors.New("failed to set IP_UNICAST_IF").Base(err)
 			}
-			if ip := net.destination.ParseDestination(address); ip.IsMulticast() {
+			if ip := xrnet.ParseDestination(address); ip.IsMulticast() {
 				if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_MULTICAST_IF, int(idx)); err != nil {
 					return errors.New("failed to set IP_MULTICAST_IF").Base(err)
 				}
@@ -57,7 +58,7 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_UNICAST_IF, inf.Index); err != nil {
 				return errors.New("failed to set IPV6_UNICAST_IF").Base(err)
 			}
-			if ip := net.destination.ParseDestination(address); ip.IsMulticast() {
+			if ip := xrnet.ParseDestination(address); ip.IsMulticast() {
 				if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_MULTICAST_IF, inf.Index); err != nil {
 					return errors.New("failed to set IPV6_MULTICAST_IF").Base(err)
 				}

--- a/transport/internet/sockopt_windows.go
+++ b/transport/internet/sockopt_windows.go
@@ -48,7 +48,7 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_UNICAST_IF, int(idx)); err != nil {
 				return errors.New("failed to set IP_UNICAST_IF").Base(err)
 			}
-			if address.Address.IP().IsMulticast() {
+			if ip := net.ParseIP(address); ip != nil && ip.IsMulticast() {
 				if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_MULTICAST_IF, int(idx)); err != nil {
 					return errors.New("failed to set IP_MULTICAST_IF").Base(err)
 				}
@@ -57,7 +57,7 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_UNICAST_IF, inf.Index); err != nil {
 				return errors.New("failed to set IPV6_UNICAST_IF").Base(err)
 			}
-			if address.Address.IP().IsMulticast() {
+			if ip := net.ParseIP(address); ip != nil && ip.IsMulticast() {
 				if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_MULTICAST_IF, inf.Index); err != nil {
 					return errors.New("failed to set IPV6_MULTICAST_IF").Base(err)
 				}

--- a/transport/internet/sockopt_windows.go
+++ b/transport/internet/sockopt_windows.go
@@ -61,7 +61,7 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 				if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_MULTICAST_IF, inf.Index); err != nil {
 					return errors.New("failed to set IPV6_MULTICAST_IF").Base(err)
 				}
-			)
+			}
 		}
 	}
 

--- a/transport/internet/sockopt_windows.go
+++ b/transport/internet/sockopt_windows.go
@@ -48,16 +48,20 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_UNICAST_IF, int(idx)); err != nil {
 				return errors.New("failed to set IP_UNICAST_IF").Base(err)
 			}
-			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_MULTICAST_IF, int(idx)); err != nil {
-				return errors.New("failed to set IP_MULTICAST_IF").Base(err)
+			if address.Address.IP().IsMulticast() {
+				if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IP, IP_MULTICAST_IF, int(idx)); err != nil {
+					return errors.New("failed to set IP_MULTICAST_IF").Base(err)
+				}
 			}
 		} else {
 			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_UNICAST_IF, inf.Index); err != nil {
 				return errors.New("failed to set IPV6_UNICAST_IF").Base(err)
 			}
-			if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_MULTICAST_IF, inf.Index); err != nil {
-				return errors.New("failed to set IPV6_MULTICAST_IF").Base(err)
-			}
+			if address.Address.IP().IsMulticast() {
+				if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_IPV6, IPV6_MULTICAST_IF, inf.Index); err != nil {
+					return errors.New("failed to set IPV6_MULTICAST_IF").Base(err)
+				}
+			)
 		}
 	}
 


### PR DESCRIPTION
`IP(V6)_MULTICAST_IF` 通常会失败，导致之后的代码，没有执行