### PR TITLE
Build: Remove Windows ARM 32-bit build

### DIFF
--- a/.github/build/friendly-filenames.json
+++ b/.github/build/friendly-filenames.json
@@ -29,6 +29,5 @@
   "openbsd-arm7": { "friendlyName": "openbsd-arm32-v7a" },
   "windows-386": { "friendlyName": "windows-32" },
   "windows-amd64": { "friendlyName": "windows-64" },
-  "windows-arm64": { "friendlyName": "windows-arm64-v8a" },
-  "windows-arm7": { "friendlyName": "windows-arm32-v7a" }
+  "windows-arm64": { "friendlyName": "windows-arm64-v8a" }
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,6 @@ jobs:
           # Windows ARM
           - goos: windows
             goarch: arm64
-          - goos: windows
-            goarch: arm
-            goarm: 7
           # BEGIN Other architectures
           # BEGIN riscv64 & ARM64 & LOONG64
           - goos: linux


### PR DESCRIPTION
根据 golang/go#71671 ，Go 官方已经数年没有可用的 Windows ARM 32 位 builder 以至于现在出来的 Windows ARM 32 工具链存在问题（**Go 1.24 中已经标记为 broken 并且没有提供对应的工具链下载**）**只能交叉编译**，并且已经确定**在 Go 1.26 移除对 Windows ARM 32 位的支持**。

因此不用太着急合并，可以最晚到 v26 才移除。

影响范围大概是 Windows 8.1 RT（如果能直接跑的话）、Windows 10 ARM 32 位（含 IoT 版本）、Windows Server Nano ARM 32 位，以及使用 Windows on ARM 64 位但是还在使用 ARM 32 位 Xray-core 的用户。基于 Windows 11 24H2 / Windows Server 2024 的用户不受此影响，因为这些版本已经移除运行 32 位 ARM 应用的支持。