### PR TITLE
Config: Implement missing MarshalJSON for structs having custom UnmarshalJSON

### DIFF
--- a/infra/conf/cfgcommon/duration/duration.go
+++ b/infra/conf/cfgcommon/duration/duration.go
@@ -8,11 +8,13 @@ import (
 
 type Duration int64
 
+// MarshalJSON implements encoding/json.Marshaler.MarshalJSON
 func (d *Duration) MarshalJSON() ([]byte, error) {
 	dr := time.Duration(*d)
 	return json.Marshal(dr.String())
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.UnmarshalJSON
 func (d *Duration) UnmarshalJSON(b []byte) error {
 	var v interface{}
 	if err := json.Unmarshal(b, &v); err != nil {

--- a/infra/conf/common.go
+++ b/infra/conf/common.go
@@ -169,6 +169,19 @@ func (v *PortRange) Build() *net.PortRange {
 	}
 }
 
+// MarshalJSON implements encoding/json.Marshaler.MarshalJSON
+func (v *PortRange) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.String())
+}
+
+func (port *PortRange) String() string {
+	if port.From == port.To {
+		return strconv.Itoa(int(port.From))
+	} else {
+		return fmt.Sprintf("%d-%d", port.From, port.To)
+	}
+}
+
 // UnmarshalJSON implements encoding/json.Unmarshaler.UnmarshalJSON
 func (v *PortRange) UnmarshalJSON(data []byte) error {
 	port, err := parseIntPort(data)
@@ -203,20 +216,21 @@ func (list *PortList) Build() *net.PortList {
 	return portList
 }
 
-func (v PortList) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.String())
+// MarshalJSON implements encoding/json.Marshaler.MarshalJSON
+func (v *PortList) MarshalJSON() ([]byte, error) {
+	portStr := v.String()
+	port, err := strconv.Atoi(portStr)
+	if err == nil {
+		return json.Marshal(port)
+	} else {
+		return json.Marshal(portStr)
+	}
 }
 
 func (v PortList) String() string {
 	ports := []string{}
 	for _, port := range v.Range {
-		if port.From == port.To {
-			p := strconv.Itoa(int(port.From))
-			ports = append(ports, p)
-		} else {
-			p := fmt.Sprintf("%d-%d", port.From, port.To)
-			ports = append(ports, p)
-		}
+		ports = append(ports, port.String())
 	}
 	return strings.Join(ports, ",")
 }

--- a/infra/conf/common.go
+++ b/infra/conf/common.go
@@ -23,6 +23,7 @@ func (v StringList) Len() int {
 	return len(v)
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.UnmarshalJSON
 func (v *StringList) UnmarshalJSON(data []byte) error {
 	var strarray []string
 	if err := json.Unmarshal(data, &strarray); err == nil {
@@ -43,10 +44,12 @@ type Address struct {
 	net.Address
 }
 
-func (v Address) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements encoding/json.Marshaler.MarshalJSON
+func (v *Address) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.Address.String())
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.UnmarshalJSON
 func (v *Address) UnmarshalJSON(data []byte) error {
 	var rawStr string
 	if err := json.Unmarshal(data, &rawStr); err != nil {
@@ -81,6 +84,7 @@ func (v Network) Build() net.Network {
 
 type NetworkList []Network
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.UnmarshalJSON
 func (v *NetworkList) UnmarshalJSON(data []byte) error {
 	var strarray []Network
 	if err := json.Unmarshal(data, &strarray); err == nil {
@@ -291,7 +295,8 @@ type Int32Range struct {
 	To    int32
 }
 
-func (v Int32Range) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements encoding/json.Marshaler.MarshalJSON
+func (v *Int32Range) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.String())
 }
 
@@ -303,6 +308,7 @@ func (v Int32Range) String() string {
 	}
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.UnmarshalJSON
 func (v *Int32Range) UnmarshalJSON(data []byte) error {
 	defer v.ensureOrder()
 	var str string

--- a/infra/conf/dns.go
+++ b/infra/conf/dns.go
@@ -163,6 +163,18 @@ type HostAddress struct {
 	addrs []*Address
 }
 
+// MarshalJSON implements encoding/json.Marshaler.MarshalJSON
+func (h *HostAddress) MarshalJSON() ([]byte, error) {
+	if (h.addr != nil) != (h.addrs != nil) {
+		if h.addr != nil {
+			return json.Marshal(h.addr)
+		} else if h.addrs != nil {
+			return json.Marshal(h.addrs)
+		}
+	}
+	return nil, errors.New("unexpected config state")
+}
+
 // UnmarshalJSON implements encoding/json.Unmarshaler.UnmarshalJSON
 func (h *HostAddress) UnmarshalJSON(data []byte) error {
 	addr := new(Address)
@@ -206,6 +218,11 @@ func getHostMapping(ha *HostAddress) *dns.Config_HostMapping {
 	return &dns.Config_HostMapping{
 		Ip: ips,
 	}
+}
+
+// MarshalJSON implements encoding/json.Marshaler.MarshalJSON
+func (m *HostsWrapper) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.Hosts)
 }
 
 // UnmarshalJSON implements encoding/json.Unmarshaler.UnmarshalJSON

--- a/infra/conf/dns.go
+++ b/infra/conf/dns.go
@@ -25,6 +25,7 @@ type NameServerConfig struct {
 	TimeoutMs          uint64     `json:"timeoutMs"`
 }
 
+// UnmarshalJSON implements encoding/json.Unmarshaler.UnmarshalJSON
 func (c *NameServerConfig) UnmarshalJSON(data []byte) error {
 	var address Address
 	if err := json.Unmarshal(data, &address); err == nil {

--- a/infra/conf/fakedns.go
+++ b/infra/conf/fakedns.go
@@ -20,6 +20,18 @@ type FakeDNSConfig struct {
 	pools []*FakeDNSPoolElementConfig
 }
 
+// MarshalJSON implements encoding/json.Marshaler.MarshalJSON
+func (f *FakeDNSConfig) MarshalJSON() ([]byte, error) {
+	if (f.pool != nil) != (f.pools != nil) {
+		if f.pool != nil {
+			return json.Marshal(f.pool)
+		} else if f.pools != nil {
+			return json.Marshal(f.pools)
+		}
+	}
+	return nil, errors.New("unexpected config state")
+}
+
 // UnmarshalJSON implements encoding/json.Unmarshaler.UnmarshalJSON
 func (f *FakeDNSConfig) UnmarshalJSON(data []byte) error {
 	var pool FakeDNSPoolElementConfig


### PR DESCRIPTION
Added `MarshalJSON` for the below structs
- `FakeDNSConfig`
- `HostAddress`
- `PortRange`

Rewritten `MarshalJSON` for
- `PortList`

Also adds comments and prefers pointer receivers.
