### PR TITLE
Fix issues related to android client

### DIFF
--- a/app/proxyman/outbound/handler.go
+++ b/app/proxyman/outbound/handler.go
@@ -325,6 +325,7 @@ func (h *Handler) Start() error {
 // Close implements common.Closable.
 func (h *Handler) Close() error {
 	common.Close(h.mux)
+	common.Close(h.proxy)
 	return nil
 }
 

--- a/proxy/wireguard/client.go
+++ b/proxy/wireguard/client.go
@@ -77,6 +77,20 @@ func New(ctx context.Context, conf *DeviceConfig) (*Handler, error) {
 	}, nil
 }
 
+func (h *Handler) Close() (err error) {
+	go func() {
+		h.wgLock.Lock()
+		defer h.wgLock.Unlock()
+
+		if h.net != nil {
+			_ = h.net.Close()
+			h.net = nil
+		}
+	}()
+
+	return nil
+}
+
 func (h *Handler) processWireGuard(ctx context.Context, dialer internet.Dialer) (err error) {
 	h.wgLock.Lock()
 	defer h.wgLock.Unlock()

--- a/transport/internet/system_dialer.go
+++ b/transport/internet/system_dialer.go
@@ -61,6 +61,11 @@ func (d *DefaultSystemDialer) Dial(ctx context.Context, src net.Address, dest ne
 		}
 		var lc net.ListenConfig
 		lc.Control = func(network, address string, c syscall.RawConn) error {
+			for _, ctl := range d.controllers {
+				if err := ctl(network, address, c); err != nil {
+					errors.LogInfoInner(ctx, err, "failed to apply external controller")
+				}
+			}
 			return c.Control(func(fd uintptr) {
 				if sockopt != nil {
 					if err := applyOutboundSocketOptions(network, "", fd, sockopt); err != nil {


### PR DESCRIPTION
Commit https://github.com/Cl-He-O/Xray-core/commit/690d76fb9ea87fcb18ee50a6d938df99de1c4117 fix the issue described in https://github.com/XTLS/Xray-core/issues/4613.
Commit https://github.com/Cl-He-O/Xray-core/commit/115fa4449b36e81751637600d9254ac11c21d500 fix issue that dialer controllers are not called, introduced by https://github.com/XTLS/Xray-core/commit/8284a0ef8f1ee3774982cb6e53f53848401fa3a5. Dialer controllers are used in an android client to protect socket from looping back.