### PR TITLE
modify udp-listen-address and dialer-connect-timeout

### DIFF
--- a/transport/internet/system_dialer.go
+++ b/transport/internet/system_dialer.go
@@ -53,10 +53,10 @@ func (d *DefaultSystemDialer) Dial(ctx context.Context, src net.Address, dest ne
 
 	if dest.Network == net.Network_UDP && !hasBindAddr(sockopt) {
 		srcAddr := resolveSrcAddr(net.Network_UDP, src)
-		listenHostPort := ":0"
+		listenAddress := ":0"
 		listenNetwork := "udp"
 		if srcAddr != nil {
-			listenHostPort = srcAddr.String()
+			listenAddress = srcAddr.String()
 			listenNetwork = srcAddr.Network()
 		}
 		var lc net.ListenConfig
@@ -78,7 +78,7 @@ func (d *DefaultSystemDialer) Dial(ctx context.Context, src net.Address, dest ne
 				}
 			})
 		}
-		packetConn, err := lc.ListenPacket(ctx, listenNetwork, listenHostPort)
+		packetConn, err := lc.ListenPacket(ctx, listenNetwork, listenAddress)
 		if err != nil {
 			return nil, err
 		}

--- a/transport/internet/system_dialer.go
+++ b/transport/internet/system_dialer.go
@@ -53,11 +53,11 @@ func (d *DefaultSystemDialer) Dial(ctx context.Context, src net.Address, dest ne
 
 	if dest.Network == net.Network_UDP && !hasBindAddr(sockopt) {
 		srcAddr := resolveSrcAddr(net.Network_UDP, src)
-		if srcAddr == nil {
-			srcAddr = &net.UDPAddr{
-				IP:   []byte{0, 0, 0, 0},
-				Port: 0,
-			}
+		listenHostPort := ":0"
+		listenNetwork := "udp"
+		if srcAddr != nil {
+			listenHostPort = srcAddr.String()
+			listenNetwork = srcAddr.Network()
 		}
 		var lc net.ListenConfig
 		destAddr, err := net.ResolveUDPAddr("udp", dest.NetAddr())
@@ -78,7 +78,7 @@ func (d *DefaultSystemDialer) Dial(ctx context.Context, src net.Address, dest ne
 				}
 			})
 		}
-		packetConn, err := lc.ListenPacket(ctx, srcAddr.Network(), srcAddr.String())
+		packetConn, err := lc.ListenPacket(ctx, listenNetwork, listenHostPort)
 		if err != nil {
 			return nil, err
 		}
@@ -92,7 +92,7 @@ func (d *DefaultSystemDialer) Dial(ctx context.Context, src net.Address, dest ne
 		goStdKeepAlive = time.Duration(-1)
 	}
 	dialer := &net.Dialer{
-		Timeout:   time.Second * 16,
+		Timeout:   time.Second * 21, // chrome tcp connect timeout is 21 seconds
 		LocalAddr: resolveSrcAddr(dest.Network, src),
 		KeepAlive: goStdKeepAlive,
 	}


### PR DESCRIPTION
During implementing "happy eyeballs", I encountered a strange thing:

in https://github.com/XTLS/Xray-core/blob/0995fa41fe692e332412670665bd934e4c734caa/transport/internet/system_dialer.go#L56-L60

the "0.0.0.0" set for udp listen-IP, even when the dest address is IPv6 !

This affects the `ListenPacket` function.

although, it seems golang ignore type of "0.0.0.0" when network type is udp(= udp4 & udp6)

anyway, i think it is better to set ":0" for listen address.

///

also, chrome tcp connect timeout is 21 seconds, so it is better set dialer timeout to 21 seconds like chrome.
