### PR TITLE
Sockopt: Fix some domainStrategy & dialerProxy bugs

### DIFF
--- a/transport/internet/dialer.go
+++ b/transport/internet/dialer.go
@@ -104,13 +104,13 @@ func lookupIP(domain string, strategy DomainStrategy, localAddr net.Address) ([]
 	}
 
 	if err == nil && len(ips) == 0 {
-		err = dns.ErrEmptyResponse
+		return nil, dns.ErrEmptyResponse
 	}
 	return ips, err
 }
 
 func canLookupIP(dst net.Destination, sockopt *SocketConfig) bool {
-	if dst.Address.Family().IsIP() || dnsClient == nil {
+	if dst.Address.Family().IsIP() {
 		return false
 	}
 	return sockopt.DomainStrategy.hasStrategy()


### PR DESCRIPTION
i fixed these bugs with "happy eyeballs" PR, but @RPRX  said to seperate the PRs.

so, after this PR merged, i open new PR for "happy eyeballs".

///

### bugs:

1. You forgot to return error for `ForceIP` mode when no ip is found, and wrongly, `ForceIP` mode was no different from `useIP` mode.(for sockopt-domainStrategy)
[also, when `forceIP` is set, it shouldn't use `AsIs` in any situation (when `dnsClient == nil`) and should return error instead]
3. you forgot to return error when user misspelled the outbound-tag-name in `dialerProxy`.(wrongly, you ignore `dialerProxy` in such a situation and the user mistakenly thought everything was working properly).
