### PR TITLE
Workflows: Ensure Geodat exists

### DIFF
--- a/.github/workflows/release-win7.yml
+++ b/.github/workflows/release-win7.yml
@@ -9,7 +9,38 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  check-assets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Restore Geodat Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: resources
+          key: xray-geodat-
+
+      - name: Check Assets Existence
+        id: check-assets
+        run: |
+          [ -d 'resources' ] || mkdir resources
+          LIST=('geoip.dat' 'geosite.dat')
+          for FILE_NAME in "${LIST[@]}"
+          do
+            echo -e "Checking ${FILE_NAME}..."
+            if [ -s "./resources/${FILE_NAME}" ]; then
+              echo -e "${FILE_NAME} exists."
+            else
+              echo -e "${FILE_NAME} does not exist."
+              echo "missing=true" >> $GITHUB_OUTPUT
+              break
+            fi
+          done
+
+      - name: Sleep for 90 seconds if Assets Missing
+        if: steps.check-assets.outputs.missing == 'true'
+        run: sleep 90
+
   build:
+    needs: check-assets
     permissions:
       contents: write
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,53 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  check-assets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Restore Geodat Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: resources
+          key: xray-geodat-
+
+      - name: Check Assets Existence
+        id: check-assets
+        run: |
+          [ -d 'resources' ] || mkdir resources
+          LIST=('geoip.dat' 'geosite.dat')
+          for FILE_NAME in "${LIST[@]}"
+          do
+            echo -e "Checking ${FILE_NAME}..."
+            if [ -s "./resources/${FILE_NAME}" ]; then
+              echo -e "${FILE_NAME} exists."
+            else
+              echo -e "${FILE_NAME} does not exist."
+              echo "missing=true" >> $GITHUB_OUTPUT
+              break
+            fi
+          done
+
+      - name: Trigger Asset Update Workflow if Assets Missing
+        if: steps.check-assets.outputs.missing == 'true'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            await github.rest.actions.createWorkflowDispatch({
+              owner,
+              repo,
+              workflow_id: 'scheduled-assets-update.yml',
+              ref: context.ref
+            });
+            console.log('Triggered scheduled-assets-update.yml due to missing assets on branch:', context.ref);
+
+      - name: Sleep for 90 seconds if Assets Missing
+        if: steps.check-assets.outputs.missing == 'true'
+        run: sleep 90
+
   build:
+    needs: check-assets
     permissions:
       contents: write
     strategy:

--- a/.github/workflows/scheduled-assets-update.yml
+++ b/.github/workflows/scheduled-assets-update.yml
@@ -1,6 +1,6 @@
 name: Scheduled assets update
 
-# NOTE: This Github Actions is required by other actions, for preparing other packaging assets in a 
+# NOTE: This Github Actions is required by other actions, for preparing other packaging assets in a
 #       routine manner, for example: GeoIP/GeoSite.
 #       Currently updating:
 #       - Geodat (GeoIP/Geosite)
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
   schedule:
     # Update GeoData on every day (22:30 UTC)
-    - cron: '30 22 * * *'
+    - cron: "30 22 * * *"
   push:
     # Prevent triggering update request storm
     paths:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,36 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  check-assets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Restore Geodat Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: resources
+          key: xray-geodat-
+      - name: Check Assets Existence
+        id: check-assets
+        run: |
+          [ -d 'resources' ] || mkdir resources
+          LIST=('geoip.dat' 'geosite.dat')
+          for FILE_NAME in "${LIST[@]}"
+          do
+            echo -e "Checking ${FILE_NAME}..."
+            if [ -s "./resources/${FILE_NAME}" ]; then
+              echo -e "${FILE_NAME} exists."
+            else
+              echo -e "${FILE_NAME} does not exist."
+              echo "missing=true" >> $GITHUB_OUTPUT
+              break
+            fi
+          done
+      - name: Sleep for 90 seconds if Assets Missing
+        if: steps.check-assets.outputs.missing == 'true'
+        run: sleep 90
+
   test:
+    needs: check-assets
     permissions:
       contents: read
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
test和build流程依赖geodat，但无法确保它们存在，只是简单的从cache恢复

因为这些资源依赖`scheduled-assets-update.yml`定时下载，有时fork或开新分支时它没能被触发就会导致如下错误

![image](https://github.com/user-attachments/assets/3d96289e-db41-45e0-8c88-dbb8d9cd49d6)
