### PR TITLE
DNS-Hosts: return only first matched-result

### DIFF
--- a/app/dns/hosts.go
+++ b/app/dns/hosts.go
@@ -6,6 +6,7 @@ import (
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/strmatcher"
 	"github.com/xtls/xray-core/features/dns"
+	"sort"
 )
 
 // StaticHosts represents static domain-ip mapping in DNS server.
@@ -59,16 +60,14 @@ func filterIP(ips []net.Address, option dns.IPOption) []net.Address {
 }
 
 func (h *StaticHosts) lookupInternal(domain string) []net.Address {
-	ips := make([]net.Address, 0)
-	found := false
-	for _, id := range h.matchers.Match(domain) {
-		ips = append(ips, h.ips[id]...)
-		found = true
-	}
-	if !found {
+	MatchSlice := h.matchers.Match(domain)
+	sort.Slice(MatchSlice, func(i, j int) bool {
+		return MatchSlice[i] < MatchSlice[j]
+	})
+	if len(MatchSlice) == 0 {
 		return nil
 	}
-	return ips
+	return h.ips[MatchSlice[0]]
 }
 
 func (h *StaticHosts) lookup(domain string, option dns.IPOption, maxDepth int) []net.Address {


### PR DESCRIPTION
we should not append matched-results in `hosts`, reason: https://github.com/XTLS/Xray-core/pull/4673#issue-3028985227

///

I tried to solve this problem in https://github.com/XTLS/Xray-core/pull/4673 but it didn't work, because `json.Unmarshal` had messed up the order and the first matched-result was not necessarily the first matched-result to appear in the json.

///

**but now I changed `json.Unmarshal` as well and the problem is completely solved.**

(In fact, if I knew I could solve "json.Unmarshal" problem so soon, I wouldn't have opened https://github.com/XTLS/Xray-core/pull/4702 at all)