### PR TITLE
Removing code that was not being executed and should not be executed.

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -96,7 +96,6 @@ type DefaultDispatcher struct {
 	router routing.Router
 	policy policy.Manager
 	stats  stats.Manager
-	dns    dns.Client
 	fdns   dns.FakeDNSEngine
 }
 
@@ -107,7 +106,7 @@ func init() {
 			core.OptionalFeatures(ctx, func(fdns dns.FakeDNSEngine) {
 				d.fdns = fdns
 			})
-			return d.Init(config.(*Config), om, router, pm, sm, dc)
+			return d.Init(config.(*Config), om, router, pm, sm)
 		}); err != nil {
 			return nil, err
 		}
@@ -116,12 +115,11 @@ func init() {
 }
 
 // Init initializes DefaultDispatcher.
-func (d *DefaultDispatcher) Init(config *Config, om outbound.Manager, router routing.Router, pm policy.Manager, sm stats.Manager, dns dns.Client) error {
+func (d *DefaultDispatcher) Init(config *Config, om outbound.Manager, router routing.Router, pm policy.Manager, sm stats.Manager) error {
 	d.ohm = om
 	d.router = router
 	d.policy = pm
 	d.stats = sm
-	d.dns = dns
 	return nil
 }
 

--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -407,18 +407,6 @@ func sniffer(ctx context.Context, cReader *cachedReader, metadataOnly bool, netw
 func (d *DefaultDispatcher) routedDispatch(ctx context.Context, link *transport.Link, destination net.Destination) {
 	outbounds := session.OutboundsFromContext(ctx)
 	ob := outbounds[len(outbounds)-1]
-	if hosts, ok := d.dns.(dns.HostsLookup); ok && destination.Address.Family().IsDomain() {
-		proxied := hosts.LookupHosts(ob.Target.String())
-		if proxied != nil {
-			ro := ob.RouteTarget == destination
-			destination.Address = *proxied
-			if ro {
-				ob.RouteTarget = destination
-			} else {
-				ob.Target = destination
-			}
-		}
-	}
 
 	var handler outbound.Handler
 

--- a/app/dns/dns.go
+++ b/app/dns/dns.go
@@ -243,22 +243,6 @@ func (s *DNS) LookupIP(domain string, option dns.IPOption) ([]net.IP, uint32, er
 	return nil, 0, dns.ErrEmptyResponse
 }
 
-// LookupHosts implements dns.HostsLookup.
-func (s *DNS) LookupHosts(domain string) *net.Address {
-	domain = strings.TrimSuffix(domain, ".")
-	if domain == "" {
-		return nil
-	}
-	// Normalize the FQDN form query
-	addrs := s.hosts.Lookup(domain, *s.ipOption)
-	if len(addrs) > 0 {
-		errors.LogInfo(s.ctx, "domain replaced: ", domain, " -> ", addrs[0].String())
-		return &addrs[0]
-	}
-
-	return nil
-}
-
 func (s *DNS) sortClients(domain string) []*Client {
 	clients := make([]*Client, 0, len(s.clients))
 	clientUsed := make([]bool, len(s.clients))

--- a/features/dns/client.go
+++ b/features/dns/client.go
@@ -24,10 +24,6 @@ type Client interface {
 	LookupIP(domain string, option IPOption) ([]net.IP, uint32, error)
 }
 
-type HostsLookup interface {
-	LookupHosts(domain string) *net.Address
-}
-
 // ClientType returns the type of Client interface. Can be used for implementing common.HasType.
 //
 // xray:api:beta


### PR DESCRIPTION
during reading dispatcher codes, I encountered a strange code:

https://github.com/XTLS/Xray-core/blob/72170d8b6be0d83af1624f6d31b81cf73f1a189c/app/dispatcher/default.go#L410-L421


First, **fortunately** this code was not executed at all, because `ob.Target.String()` has prefix("tcp:"/"udp:") and `hosts.LookupHosts(ob.Target.String())` always returned `nil` and as a result `proxied` was always `nil` and the code was not executed at all !!!

Second, this code should not be executed at all, because the logic of this code is **completely wrong**, and we should not use `built-in-dns-hosts` to replace the `ob.Target` and change the destination, because suppose we are in client-side and we want to use `built-in-dns‍` only in client-side, and destination is used in server-side, so we should not change the destination and ob.Target by using `built-in-dns-hosts`, also if we have multiple-ip for a domain this code only replaces one IP.

///

fortunately, this code was not executed at all, and removing it is just to clean up the code.
