### PR TITLE
Sniffer: Fix potential infinite loop

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -2,7 +2,6 @@ package dispatcher
 
 import (
 	"context"
-	"io"
 	"regexp"
 	"strings"
 	"sync"
@@ -374,14 +373,7 @@ func sniffer(ctx context.Context, cReader *cachedReader, metadataOnly bool, netw
 				return nil, ctx.Err()
 			default:
 				cachingStartingTimeStamp := time.Now()
-				payloadLen := payload.Len()
 				cacheErr := cReader.Cache(payload, cacheDeadline)
-				if cacheErr != nil {
-					return nil, cacheErr
-				}
-				if payload.Len() == payloadLen {
-					return nil, io.EOF
-				}
 				cachingTimeElapsed := time.Since(cachingStartingTimeStamp)
 				cacheDeadline -= cachingTimeElapsed
 
@@ -391,12 +383,14 @@ func sniffer(ctx context.Context, cReader *cachedReader, metadataOnly bool, netw
 					case common.ErrNoClue: // No Clue: protocol not matches, and sniffer cannot determine whether there will be a match or not
 						totalAttempt++
 					case protocol.ErrProtoNeedMoreData: // Protocol Need More Data: protocol matches, but need more data to complete sniffing
-						break
+						if cacheErr != nil { // Cache error (e.g. timeout) counts for failed attempt
+							totalAttempt++
+						}
 					default:
 						return result, err
 					}
 				} else {
-					return nil, io.EOF
+					totalAttempt++
 				}
 				if totalAttempt >= 2 || cacheDeadline <= 0 {
 					return nil, errSniffingTimeout

--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -226,7 +226,7 @@ func (d *DefaultDispatcher) shouldOverride(ctx context.Context, result SniffResu
 		if strings.HasPrefix(protocolString, p) || strings.HasPrefix(p, protocolString) {
 			return true
 		}
-		if fkr0, ok := d.fdns.(dns.FakeDNSEngineRev0); ok && protocolString != "bittorrent" && p == "fakedns+others" &&
+		if fkr0, ok := d.fdns.(dns.FakeDNSEngineRev0); ok && protocolString != "bittorrent" && p == "fakedns" &&
 			fkr0.IsIPInIPPool(destination.Address) {
 			errors.LogInfo(ctx, "Using sniffer ", protocolString, " since the fake DNS missed")
 			return true

--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -391,14 +391,14 @@ func sniffer(ctx context.Context, cReader *cachedReader, metadataOnly bool, netw
 					case common.ErrNoClue: // No Clue: protocol not matches, and sniffer cannot determine whether there will be a match or not
 						totalAttempt++
 					case protocol.ErrProtoNeedMoreData: // Protocol Need More Data: protocol matches, but need more data to complete sniffing
-						totalAttempt++
+						break
 					default:
 						return result, err
 					}
 				} else {
 					return nil, io.EOF
 				}
-				if totalAttempt >= 32 || cacheDeadline <= 0 {
+				if totalAttempt >= 2 || cacheDeadline <= 0 {
 					return nil, errSniffingTimeout
 				}
 			}

--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -226,7 +226,7 @@ func (d *DefaultDispatcher) shouldOverride(ctx context.Context, result SniffResu
 		if strings.HasPrefix(protocolString, p) || strings.HasPrefix(p, protocolString) {
 			return true
 		}
-		if fkr0, ok := d.fdns.(dns.FakeDNSEngineRev0); ok && protocolString != "bittorrent" && p == "fakedns" &&
+		if fkr0, ok := d.fdns.(dns.FakeDNSEngineRev0); ok && protocolString != "bittorrent" && p == "fakedns+others" &&
 			fkr0.IsIPInIPPool(destination.Address) {
 			errors.LogInfo(ctx, "Using sniffer ", protocolString, " since the fake DNS missed")
 			return true


### PR DESCRIPTION
during reading sniffer code, i found two bugs and fixed them:

### 1. infinite-loop bug:

https://github.com/XTLS/Xray-core/blob/72170d8b6be0d83af1624f6d31b81cf73f1a189c/app/dispatcher/default.go#L376

if ` cacheErr != buf.ErrReadTimeout` (cacheDeadline not exceed) and `payload.IsEmpty()`, The code gets stuck in infinite loop, and CPU usage reaches 100%, and the app crashes !

(also if `cacheErr == nil` and `payload` doesn't change and `ErrProtoNeedMoreData`, the same thing happens)

**This bug is probably the main reason for https://github.com/XTLS/Xray-core/issues/3914.**

### 2. fakedns+others:

After reviewing the code, I realized that `"destOverride": ["fakedns+others"]` is no different from `"destOverride": ["fakedns"]`, That means `"destOverride": ["fakedns+others"]` behaves exactly like `"destOverride": ["fakedns"]`.

I also tested this to make sure.
