### PR TITLE
Sniffer bug: `fakedns` alone should not override domain for tls/http/quic (when there is no map-domain)

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -224,7 +224,7 @@ func (d *DefaultDispatcher) shouldOverride(ctx context.Context, result SniffResu
 		if strings.HasPrefix(protocolString, p) || strings.HasPrefix(p, protocolString) {
 			return true
 		}
-		if fkr0, ok := d.fdns.(dns.FakeDNSEngineRev0); ok && protocolString != "bittorrent" && p == "fakedns" &&
+		if fkr0, ok := d.fdns.(dns.FakeDNSEngineRev0); ok && protocolString != "bittorrent" && p == "fakedns+others" &&
 			fkr0.IsIPInIPPool(destination.Address) {
 			errors.LogInfo(ctx, "Using sniffer ", protocolString, " since the fake DNS missed")
 			return true


### PR DESCRIPTION
currently, `"destOverride": ["fakedns"]` override domain for tls/http/quic protocol when ip is in fake-pool-range and when we have no map-domain.

This shouldn't happen and this is `fakedns+others` job.

///

also, it seems `fakedns+others` has no practical use and can be removed later.
