### PR TITLE
Sniffer-destOverride: Remove `fakedns+others` option

### DIFF
--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -69,10 +69,8 @@ func (c *SniffingConfig) Build() (*proxyman.SniffingConfig, error) {
 				p = append(p, "tls")
 			case "quic":
 				p = append(p, "quic")
-			case "fakedns":
+			case "fakedns", "fakedns+others":
 				p = append(p, "fakedns")
-			case "fakedns+others":
-				p = append(p, "fakedns+others")
 			default:
 				return nil, errors.New("unknown protocol: ", protocol)
 			}


### PR DESCRIPTION
The documentation description about ‍`fakedns+others` is completely wrong: https://github.com/XTLS/Xray-core/pull/4733#issuecomment-2888134773.

and even if we fix it, it will just be an redundant option.

So I agree with  @yuhan6665  and  @Fangliding  and i did [this](https://github.com/XTLS/Xray-core/pull/4726#issuecomment-2886494540).
