### PR TITLE
Increase HTTP/2 MaxReadFrameSize from 16KB to 1MB for improved efficiency

### DIFF
--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -209,8 +209,9 @@ func createHTTPClient(dest net.Destination, streamSettings *internet.MemoryStrea
 			DialTLSContext: func(ctxInner context.Context, network string, addr string, cfg *gotls.Config) (net.Conn, error) {
 				return dialContext(ctxInner)
 			},
-			IdleConnTimeout: net.ConnIdleTimeout,
-			ReadIdleTimeout: keepAlivePeriod,
+			IdleConnTimeout:  net.ConnIdleTimeout,
+			ReadIdleTimeout:  keepAlivePeriod,
+			MaxReadFrameSize: 1024 * 1024,
 		}
 	} else {
 		httpDialContext := func(ctxInner context.Context, network string, addr string) (net.Conn, error) {


### PR DESCRIPTION
By default, the **MaxReadFrameSize** for the HTTP/2 client is only **16KB**, which is insufficient for high-bandwidth scenarios. In contrast, the default value for HTTP/3 is **6MB**, allowing for more efficient data handling.  

Increasing the **HTTP/2 MaxReadFrameSize** from **16KB to 1MB** enables larger frames to be processed in a single operation, resulting in:  
- **Reduced Overhead**: Minimizing excessive fragmentation of large payloads.  
- **Enhanced Performance**: Improving efficiency when handling high-bandwidth data streams.  

Making this value configurable in the settings file would be a valuable enhancement, but the **Xray** codebase is quite complex, making it difficult to determine the optimal placement for this configuration. Nevertheless, **setting 1MB as the default** is a reasonable choice for proxy applications.