### PR TITLE
Core: Export the running bool

### DIFF
--- a/core/xray.go
+++ b/core/xray.go
@@ -90,6 +90,11 @@ type Instance struct {
 	ctx context.Context
 }
 
+// Instance state
+func (server *Instance) IsRunning() bool {
+	return server.running
+}
+
 func AddInboundHandler(server *Instance, config *InboundHandlerConfig) error {
 	inboundManager := server.GetFeature(inbound.ManagerType()).(inbound.Manager)
 	rawHandler, err := CreateObject(server, config)


### PR DESCRIPTION
So in this contribution I did a small change and exported the running bool. code follows
```go
func (server *Instance) IsRunning() bool {
	return server.running
}
```

But why ? right?
the reason behind it is I wanted to implement this feature in [libXray](https://github.com/XTLS/libXray) but when I went on I saw `running` wasnt like exported and I cannot access that. So to have a api to check current core state in libXray we need it. For reference another xray wrapper like to mention [AndroidLibXrayLite](https://github.com/2dust/AndroidLibXrayLite) has the same feature to get core state. So choosed to have it also in libXray.