### PR TITLE
REALITY protocol: fallback for chrome fingerprint (X25519MLKEM768)

### DIFF
--- a/transport/internet/reality/reality.go
+++ b/transport/internet/reality/reality.go
@@ -245,6 +245,14 @@ func UClient(c net.Conn, config *Config, ctx context.Context, dest net.Destinati
 			// Do not close the connection
 		}()
 		time.Sleep(time.Duration(crypto.RandBetween(config.SpiderY[8], config.SpiderY[9])) * time.Millisecond) // return
+
+		// temporary fallback for server core that not upgrade to X25519MLKEM768 yet
+		if config.Fingerprint == "chrome" {
+			config.Fingerprint = "chromeNormal"
+			if config.Show {
+				errors.LogInfo(ctx, fmt.Sprintf("REALITY Fingerprint: set to: %v\n", config.Fingerprint))
+			}
+		}
 		return nil, errors.New("REALITY: processed invalid connection").AtWarning()
 	}
 	return uConn, nil

--- a/transport/internet/tls/tls.go
+++ b/transport/internet/tls/tls.go
@@ -191,6 +191,9 @@ var PresetFingerprints = map[string]*utls.ClientHelloID{
 	"randomized":       nil,
 	"randomizednoalpn": nil,
 	"unsafe":           nil,
+
+	// temporary
+	"chromeNormal": &utls.HelloChrome_120,
 }
 
 var ModernFingerprints = map[string]*utls.ClientHelloID{


### PR DESCRIPTION
If the client is using version v25.5.16 and the server is on an older version, some Reality configurations using targets that don't support `X25519MLKEM768` will fail. To address this, I've added a temporary `chromeNormal` fallback, which will remain in place for the next few versions until server side's updated to a supported version.

https://github.com/XTLS/Xray-core/pull/3813#issuecomment-2919224335

