### PR TITLE
Docker: Fix geodata directory permissions issue

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -45,6 +45,7 @@ RUN mkdir -p /tmp/var/log/xray && touch \
 FROM gcr.io/distroless/static:nonroot
 
 COPY --from=build --chown=0:0 --chmod=755 /src/xray /usr/local/bin/xray
+COPY --from=build --chown=0:0 --chmod=755 /tmp/empty /usr/local/share/xray
 COPY --from=build --chown=0:0 --chmod=644 /tmp/geodat/*.dat /usr/local/share/xray/
 COPY --from=build --chown=0:0 --chmod=755 /tmp/empty /usr/local/etc/xray
 COPY --from=build --chown=0:0 --chmod=644 /tmp/usr/local/etc/xray/*.json /usr/local/etc/xray/

--- a/.github/docker/Dockerfile.usa
+++ b/.github/docker/Dockerfile.usa
@@ -54,6 +54,7 @@ RUN mkdir -p /tmp/var/log/xray && touch \
 FROM --platform=linux/amd64 gcr.io/distroless/static:nonroot
 
 COPY --from=build --chown=0:0 --chmod=755 /src/xray /usr/local/bin/xray
+COPY --from=build --chown=0:0 --chmod=755 /tmp/empty /usr/local/share/xray
 COPY --from=build --chown=0:0 --chmod=644 /tmp/geodat/*.dat /usr/local/share/xray/
 COPY --from=build --chown=0:0 --chmod=755 /tmp/empty /usr/local/etc/xray
 COPY --from=build --chown=0:0 --chmod=644 /tmp/usr/local/etc/xray/*.json /usr/local/etc/xray/


### PR DESCRIPTION
解决`/usr/local/share/xray`目录缺少x权限，导致geodata无法加载的问题