### PR TITLE
Tests: Real fix for TestCommanderListHandlers

### DIFF
--- a/testing/scenarios/command_test.go
+++ b/testing/scenarios/command_test.go
@@ -286,7 +286,13 @@ func TestCommanderListHandlers(t *testing.T) {
 		t.Error("unexpected nil response")
 	}
 
-	if diff := cmp.Diff(inboundResp.Inbounds, clientConfig.Inbound, protocmp.Transform()); diff != "" {
+	if diff := cmp.Diff(
+		inboundResp.Inbounds,
+		clientConfig.Inbound,
+		protocmp.Transform(),
+		cmpopts.SortSlices(func(a, b *core.InboundHandlerConfig) bool {
+			return a.Tag < b.Tag
+		})); diff != "" {
 		t.Fatalf("inbound response doesn't match config (-want +got):\n%s", diff)
 	}
 
@@ -296,7 +302,13 @@ func TestCommanderListHandlers(t *testing.T) {
 		t.Error("unexpected nil response")
 	}
 
-	if diff := cmp.Diff(outboundResp.Outbounds, clientConfig.Outbound, protocmp.Transform()); diff != "" {
+	if diff := cmp.Diff(
+		outboundResp.Outbounds,
+		clientConfig.Outbound,
+		protocmp.Transform(),
+		cmpopts.SortSlices(func(a, b *core.InboundHandlerConfig) bool {
+			return a.Tag < b.Tag
+		})); diff != "" {
 		t.Fatalf("outbound response doesn't match config (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
错误是由 PR #4723 引入的

然后 PR #4789 是输出diff，以供后续定位问题

现在本PR根据抓到的日志来修复此错误

目前只抓到一条日志：
看起来像是protobuf序列化结果有时会顺序不一致导致测试不通过

```log
=== RUN   TestCommanderListHandlers
Xray 25.5.16 (Xray, Penetrates Everything.) Custom (go1.24.4 darwin/arm64)
A unified platform for anti-censorship.
2025/06/07 13:22:28.581087 [Debug] app/proxyman/inbound: creating stream worker on 127.0.0.1:49289
2025/06/07 13:22:28.581153 [Debug] app/proxyman/inbound: creating stream worker on 127.0.0.1:49290
2025/06/07 13:22:28.581157 [Info] transport/internet/tcp: listening TCP on 127.0.0.1:49289
2025/06/07 13:22:28.581159 [Info] transport/internet/tcp: listening TCP on 127.0.0.1:49290
Warning: 7 13:22:28.581364 [Warning] core: Xray 25.5.16 started
2025/06/07 13:22:30.575509 [Debug] [2378785008] proxy/dokodemo: processing connection from: 127.0.0.1:49291
2025/06/07 13:22:30.575539 [Info] [2378785008] proxy/dokodemo: received request for 127.0.0.1:49291
2025/06/07 13:22:30.575542 [Info] [2378785008] app/dispatcher: default route for tcp:127.0.0.1:49288
2025/06/07 13:22:30.575544 from 127.0.0.1:49291 accepted tcp:127.0.0.1:49288 [d >> default-outbound]
2025/06/07 13:22:30.575553 [Info] [2378785008] transport/internet/tcp: dialing TCP to tcp:127.0.0.1:49288
2025/06/07 13:22:30.575557 [Debug] [2378785008] transport/internet: dialing to tcp:127.0.0.1:49288
2025/06/07 13:22:30.575664 [Info] [2378785008] proxy/freedom: connection opened to tcp:127.0.0.1:49288, local endpoint 127.0.0.1:49292, remote endpoint 127.0.0.1:49288
2025/06/07 13:22:30.575670 [Info] [2378785008] proxy: CopyRawConn readv
testConn finishes: 0 ms	 <nil> 	Alloc = 1.93MB 	TotalAlloc = 1.93MB 	Sys = 8.52MB 	NumGC = 0
2025/06/07 13:22:30.576522 [Debug] [1952250006] proxy/dokodemo: processing connection from: 127.0.0.1:49293
2025/06/07 13:22:30.576528 [Info] [1952250006] proxy/dokodemo: received request for 127.0.0.1:49293
2025/06/07 13:22:30.576571 [Info] [1952250006] app/dispatcher: taking detour [api] for [tcp:127.0.0.1:49288]
2025/06/07 13:22:30.576575 from 127.0.0.1:49293 accepted tcp:127.0.0.1:49288 [api -> api]
    command_test.go:290: inbound response doesn't match config (-want +got):
          []*core.InboundHandlerConfig{
          	Inverse(protocmp.Transform, protocmp.Message{
          		"@type":          s"xray.core.InboundHandlerConfig",
          		"proxy_settings": protocmp.Message{"@type": s"xray.common.serial.TypedMessage", "type": string("xray.proxy.dokodemo.Config"), "value": []uint8{0x0a, 0x06, 0x0a, 0x04, ...}},
          		"receiver_settings": protocmp.Message{
          			"@type": s"xray.common.serial.TypedMessage",
          			"type":  string("xray.app.proxyman.ReceiverConfig"),
          			"value": []uint8{
          				... // 3 identical elements
          				0x08,
          				0x08,
        - 				0x8a,
        + 				0x89,
          				0x81,
          				0x03,
          				0x10,
        - 				0x8a,
        + 				0x89,
          				0x81,
          				0x03,
          				... // 8 identical elements
          			},
          		},
        - 		"tag": string("api"),
        + 		"tag": string("d"),
          	}),
          	Inverse(protocmp.Transform, protocmp.Message{
          		"@type":          s"xray.core.InboundHandlerConfig",
          		"proxy_settings": protocmp.Message{"@type": s"xray.common.serial.TypedMessage", "type": string("xray.proxy.dokodemo.Config"), "value": []uint8{0x0a, 0x06, 0x0a, 0x04, ...}},
          		"receiver_settings": protocmp.Message{
          			"@type": s"xray.common.serial.TypedMessage",
          			"type":  string("xray.app.proxyman.ReceiverConfig"),
          			"value": []uint8{
          				... // 3 identical elements
          				0x08,
          				0x08,
        - 				0x89,
        + 				0x8a,
          				0x81,
          				0x03,
          				0x10,
        - 				0x89,
        + 				0x8a,
          				0x81,
          				0x03,
          				... // 8 identical elements
          			},
          		},
        - 		"tag": string("d"),
        + 		"tag": string("api"),
          	}),
          }
2025/06/07 13:22:30.578778 [Info] Closing all servers.
Failed accept TCP connection: accept tcp 127.0.0.1:49288: use of closed network connection
--- FAIL: TestCommanderListHandlers (2.01s)
```