### PR TITLE
Freedom: Fix UDP reply mismatch-address

### DIFF
--- a/proxy/freedom/freedom.go
+++ b/proxy/freedom/freedom.go
@@ -314,6 +314,8 @@ func (r *PacketReader) ReadMultiBuffer() (buf.MultiBuffer, error) {
 		return nil, err
 	}
 	b.Resize(0, int32(n))
+	// if udp dest addr is changed, we are unable to get the correct src addr
+	// so we don't attach src info to udp packet, break cone behavior, assuming the dial dest is the expected scr addr
 	if !r.IsAddrChanged {
 		b.UDP = &net.Destination{
 			Address: net.IPAddress(d.(*net.UDPAddr).IP),

--- a/proxy/freedom/freedom.go
+++ b/proxy/freedom/freedom.go
@@ -175,6 +175,7 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 	var newCancel context.CancelFunc
 	if session.TimeoutOnlyFromContext(ctx) {
 		newCtx, newCancel = context.WithCancel(context.Background())
+		newCtx = session.ContextWithOutbounds(newCtx, session.OutboundsFromContext(ctx))
 	}
 
 	plcy := h.policy()


### PR DESCRIPTION
### the problem:

the problem https://github.com/XTLS/Xray-core/issues/4800#issue-3132409092 is because after browser sending UDP-data(quic initial packet) the packet correctly reaches to the final-target but the response-data does not reach to the browser, this problem happen when target-address is domain, let's explain why:

**code-A (freedom.go > ReadMultiBuffer):**

https://github.com/XTLS/Xray-core/blob/fbae89d017aee5947598d0a82945b316fdc688ab/proxy/freedom/freedom.go#L309-L313

**code-B (udp/dispatcher.go > handleInput):**

https://github.com/XTLS/Xray-core/blob/fbae89d017aee5947598d0a82945b316fdc688ab/transport/internet/udp/dispatcher.go#L135-L138

**code-C (socks/server.go):**

https://github.com/XTLS/Xray-core/blob/fbae89d017aee5947598d0a82945b316fdc688ab/proxy/socks/server.go#L237-L243


suppose browser send UDP-socks-request(UDP-associate) and target is cloudflare-quic.com:443.

each request packet consists of header+payload and header is "cloudflare-quic:443".

the response packet is also consists header+payload, **the response-header must also be "cloudflare-quic.com", otherwise browser does not accept the received data**.

to sending packet to "cloudflare-quic.com", Xray-core must resolve it to IP, suppose resolved-IP is "188.114.98.0".
after sending data, `ReadMultiBuffer` function receive response-data and because packet received from "188.114.98.0", it set `b.UDP`(buffer-UDP) address to "188.114.98.0" ---> **code-A**

after udp-dispatcher call a "callback" and pass the buffer(`b`) to that  ---> **code-B**

if for example inbound is socks-protocol the 'callback" is "udpServer" in "socks/server.go > handleUDPPayload".

because `payload.UDP` is not `nil` and is equal to "188.114.98.0:443", **the response-header-address overridden by "188.114.98.0:443", but the request-header was "cloudflare-quic.com" so the browser reject the response.** ---> **code-C**

### In short:

**in short, the request and response header must be same but if address is domain(or fakedns) Xray-core send resolved-IP as a response header and this causes the browser to reject the packet.**

**so if the address is domain or fakedns or changed by `redirect` settings, Xray-core should ignore response-IP-address and send request-header-address as a response-header-address**.
