### PR TITLE
API: Fix issue with inbounduser not finding emails with uppercase letters

### DIFF
--- a/proxy/trojan/validator.go
+++ b/proxy/trojan/validator.go
@@ -53,6 +53,7 @@ func (v *Validator) Get(hash string) *protocol.MemoryUser {
 
 // Get a trojan user with hashed key, nil if user doesn't exist.
 func (v *Validator) GetByEmail(email string) *protocol.MemoryUser {
+	email = strings.ToLower(email)
 	u, _ := v.email.Load(email)
 	if u != nil {
 		return u.(*protocol.MemoryUser)

--- a/proxy/vless/validator.go
+++ b/proxy/vless/validator.go
@@ -63,6 +63,7 @@ func (v *MemoryValidator) Get(id uuid.UUID) *protocol.MemoryUser {
 
 // Get a VLESS user with email, nil if user doesn't exist.
 func (v *MemoryValidator) GetByEmail(email string) *protocol.MemoryUser {
+	email = strings.ToLower(email)
 	u, _ := v.email.Load(email)
 	if u != nil {
 		return u.(*protocol.MemoryUser)


### PR DESCRIPTION
Fixes #3644. 
In the VLESS and Trojan protocols, GetByEmail did not account for the fact that emails are stored in lowercase, so the `api inbounduser` could not find a user if the email was written using uppercase letters.
<img width="634" alt="image" src="https://github.com/user-attachments/assets/2965b2f0-8a94-4457-9601-09d883348c2b" />