### PR TITLE
修复task泄露

### DIFF
--- a/common/signal/timer.go
+++ b/common/signal/timer.go
@@ -67,9 +67,9 @@ func (t *ActivityTimer) SetTimeout(timeout time.Duration) {
 		t.checkTask.Close()
 	}
 	t.checkTask = checkTask
-	t.Unlock()
 	t.Update()
 	common.Must(checkTask.Start())
+	t.Unlock()
 }
 
 func CancelAfterInactivity(ctx context.Context, cancel context.CancelFunc, timeout time.Duration) *ActivityTimer {


### PR DESCRIPTION
signal包里面SetTimeout方法并发时可能会出现task close以后执行start导致泄露