### PR TITLE
Commands: Display Post-Quantum key exchange in `tls ping`

### DIFF
--- a/main/commands/all/tls/ping.go
+++ b/main/commands/all/tls/ping.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strconv"
 	"unsafe"
 
 	"github.com/xtls/xray-core/main/commands/base"
@@ -38,8 +39,13 @@ func executePing(cmd *base.Command, args []string) {
 		base.Fatalf("domain not specified")
 	}
 
-	domain := cmdPing.Flag.Arg(0)
-	fmt.Println("Tls ping: ", domain)
+	domainWithPort := cmdPing.Flag.Arg(0)
+	fmt.Println("Tls ping: ", domainWithPort)
+	TargetPort := 443
+	domain, port, err := net.SplitHostPort(domainWithPort)
+	if err == nil {
+		TargetPort, _ = strconv.Atoi(port)
+	}
 
 	var ip net.IP
 	if len(*pingIPStr) > 0 {
@@ -60,7 +66,7 @@ func executePing(cmd *base.Command, args []string) {
 	fmt.Println("-------------------")
 	fmt.Println("Pinging without SNI")
 	{
-		tcpConn, err := net.DialTCP("tcp", nil, &net.TCPAddr{IP: ip, Port: 443})
+		tcpConn, err := net.DialTCP("tcp", nil, &net.TCPAddr{IP: ip, Port: TargetPort})
 		if err != nil {
 			base.Fatalf("Failed to dial tcp: %s", err)
 		}

--- a/main/commands/all/tls/ping.go
+++ b/main/commands/all/tls/ping.go
@@ -129,10 +129,9 @@ func printTLSConnDetail(tlsConn *gotls.Conn) {
 		tlsVersion = "TLS 1.2"
 	}
 	fmt.Println("TLS Version:", tlsVersion)
-	p, _ := reflect.TypeOf(tlsConn).Elem().FieldByName("curveID")
-	curveID := (*gotls.CurveID)(unsafe.Pointer(uintptr(unsafe.Pointer(tlsConn)) + p.Offset))
-	if curveID != nil {
-		PostQuantum := (*curveID == gotls.X25519MLKEM768)
+	curveID := *(*gotls.CurveID)(unsafe.Pointer(reflect.ValueOf(tlsConn).Elem().FieldByName("curveID").UnsafeAddr()))
+	if curveID != 0 {
+		PostQuantum := (curveID == gotls.X25519MLKEM768)
 		fmt.Println("Post-Quantum key exchange:", PostQuantum, "("+curveID.String()+")")
 	} else {
 		fmt.Println("Post-Quantum key exchange: false (RSA Exchange)")

--- a/transport/internet/tls/config.go
+++ b/transport/internet/tls/config.go
@@ -486,11 +486,11 @@ func ConfigFromStreamSettings(settings *internet.MemoryStreamConfig) *Config {
 
 func ParseCurveName(curveNames []string) []tls.CurveID {
 	curveMap := map[string]tls.CurveID{
-		"curvep256":             tls.CurveP256,
-		"curvep384":             tls.CurveP384,
-		"curvep521":             tls.CurveP521,
-		"x25519":                tls.X25519,
-		"x25519kyber768draft00": 0x6399,
+		"curvep256":      tls.CurveP256,
+		"curvep384":      tls.CurveP384,
+		"curvep521":      tls.CurveP521,
+		"x25519":         tls.X25519,
+		"x25519mlkem768": tls.X25519MLKEM768,
 	}
 
 	var curveIDs []tls.CurveID


### PR DESCRIPTION
为 xray tls ping 新增密钥交换算法显示 方便查看一个地址是否支持后量子 配合reality
```
./xray tls ping cloudflare.com
Tls ping:  cloudflare.com
Using IP:  104.16.132.229
-------------------
Pinging without SNI
Handshake succeeded
TLS Version: TLS 1.3
Post-Quantum key exchange: true (X25519MLKEM768)
Allowed domains:  [cloudflare.com *.amp.cloudflare.com *.cloudflare.com *.dns.cloudflare.com *.staging.cloudflare.com]
-------------------
Pinging with SNI
handshake succeeded
TLS Version: TLS 1.3
Post-Quantum key exchange: true (X25519MLKEM768)
Allowed domains:  [cloudflare.com *.amp.cloudflare.com *.cloudflare.com *.dns.cloudflare.com *.staging.cloudflare.com]
Tls ping finished
```