### PR TITLE
Stats API: Return status "not found" instead of "unknown"

### DIFF
--- a/app/stats/command/command.go
+++ b/app/stats/command/command.go
@@ -12,6 +12,8 @@ import (
 	"github.com/xtls/xray-core/core"
 	feature_stats "github.com/xtls/xray-core/features/stats"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 )
 
 // statsServer is an implementation of StatsService.
@@ -30,7 +32,7 @@ func NewStatsServer(manager feature_stats.Manager) StatsServiceServer {
 func (s *statsServer) GetStats(ctx context.Context, request *GetStatsRequest) (*GetStatsResponse, error) {
 	c := s.stats.GetCounter(request.Name)
 	if c == nil {
-		return nil, errors.New(request.Name, " not found.")
+		return nil, status.Error(codes.NotFound, request.Name+" not found.")
 	}
 	var value int64
 	if request.Reset_ {
@@ -49,7 +51,7 @@ func (s *statsServer) GetStats(ctx context.Context, request *GetStatsRequest) (*
 func (s *statsServer) GetStatsOnline(ctx context.Context, request *GetStatsRequest) (*GetStatsResponse, error) {
 	c := s.stats.GetOnlineMap(request.Name)
 	if c == nil {
-		return nil, errors.New(request.Name, " not found.")
+		return nil, status.Error(codes.NotFound, request.Name+" not found.")
 	}
 	value := int64(c.Count())
 	return &GetStatsResponse{
@@ -64,7 +66,7 @@ func (s *statsServer) GetStatsOnlineIpList(ctx context.Context, request *GetStat
 	c := s.stats.GetOnlineMap(request.Name)
 
 	if c == nil {
-		return nil, errors.New(request.Name, " not found.")
+		return nil, status.Error(codes.NotFound, request.Name+" not found.")
 	}
 
 	ips := make(map[string]int64)


### PR DESCRIPTION
currently when we request a stat and is not available, we get Unknown in return, this is not right and we should get NotFound status.