### PR TITLE
MUX: Refine and Fix some occasional problems

### DIFF
--- a/common/mux/client.go
+++ b/common/mux/client.go
@@ -296,7 +296,7 @@ func (m *ClientWorker) Dispatch(ctx context.Context, link *transport.Link) bool 
 	}
 
 	sm := m.sessionManager
-	s := sm.Allocate(m.strategy)
+	s := sm.Allocate(&m.strategy)
 	if s == nil {
 		return false
 	}

--- a/common/mux/client.go
+++ b/common/mux/client.go
@@ -174,6 +174,7 @@ type ClientWorker struct {
 	link           transport.Link
 	done           *done.Instance
 	strategy       ClientStrategy
+	access         sync.Mutex
 }
 
 var (
@@ -289,7 +290,9 @@ func (m *ClientWorker) IsFull() bool {
 }
 
 func (m *ClientWorker) Dispatch(ctx context.Context, link *transport.Link) bool {
-	if m.IsFull() || m.Closed() {
+	m.access.Lock()
+	defer m.access.Unlock()
+	if m.IsFull() {
 		return false
 	}
 

--- a/common/mux/client.go
+++ b/common/mux/client.go
@@ -296,7 +296,7 @@ func (m *ClientWorker) Dispatch(ctx context.Context, link *transport.Link) bool 
 	}
 
 	sm := m.sessionManager
-	s := sm.Allocate(int(m.strategy.MaxConcurrency))
+	s := sm.Allocate(m.strategy)
 	if s == nil {
 		return false
 	}

--- a/common/mux/client_test.go
+++ b/common/mux/client_test.go
@@ -1,51 +1,116 @@
 package mux_test
 
 import (
+	"context"
 	"testing"
+	"time"
 
-	. "github.com/xtls/xray-core/common/mux"
+	"github.com/golang/mock/gomock"
+	"github.com/xtls/xray-core/common"
+	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/common/mux"
+	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/session"
+	"github.com/xtls/xray-core/testing/mocks"
+	"github.com/xtls/xray-core/transport"
+	"github.com/xtls/xray-core/transport/pipe"
 )
 
-func TestSessionManagerAdd(t *testing.T) {
-	m := NewSessionManager()
+func TestIncrementalPickerFailure(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
 
-	s := m.Allocate(0)
-	if s.ID != 1 {
-		t.Error("id: ", s.ID)
-	}
-	if m.Size() != 1 {
-		t.Error("size: ", m.Size())
-	}
+	mockWorkerFactory := mocks.NewMuxClientWorkerFactory(mockCtl)
+	mockWorkerFactory.EXPECT().Create().Return(nil, errors.New("test"))
 
-	s = m.Allocate(0)
-	if s.ID != 2 {
-		t.Error("id: ", s.ID)
-	}
-	if m.Size() != 2 {
-		t.Error("size: ", m.Size())
+	picker := mux.IncrementalWorkerPicker{
+		Factory: mockWorkerFactory,
 	}
 
-	s = &Session{
-		ID: 4,
-	}
-	m.Add(s)
-	if s.ID != 4 {
-		t.Error("id: ", s.ID)
-	}
-	if m.Size() != 3 {
-		t.Error("size: ", m.Size())
+	_, err := picker.PickAvailable()
+	if err == nil {
+		t.Error("expected error, but nil")
 	}
 }
 
-func TestSessionManagerClose(t *testing.T) {
-	m := NewSessionManager()
-	s := m.Allocate(0)
+func TestClientWorkerEOF(t *testing.T) {
+	reader, writer := pipe.New(pipe.WithoutSizeLimit())
+	common.Must(writer.Close())
 
-	if m.CloseIfNoSession() {
-		t.Error("able to close")
+	worker, err := mux.NewClientWorker(transport.Link{Reader: reader, Writer: writer}, mux.ClientStrategy{})
+	common.Must(err)
+
+	time.Sleep(time.Millisecond * 500)
+
+	f := worker.Dispatch(context.Background(), nil)
+	if f {
+		t.Error("expected failed dispatching, but actually not")
 	}
-	m.Remove(false, s.ID)
-	if !m.CloseIfNoSession() {
-		t.Error("not able to close")
+}
+
+func TestClientWorkerClose(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+
+	r1, w1 := pipe.New(pipe.WithoutSizeLimit())
+	worker1, err := mux.NewClientWorker(transport.Link{
+		Reader: r1,
+		Writer: w1,
+	}, mux.ClientStrategy{
+		MaxConcurrency: 4,
+		MaxConnection:  4,
+	})
+	common.Must(err)
+
+	r2, w2 := pipe.New(pipe.WithoutSizeLimit())
+	worker2, err := mux.NewClientWorker(transport.Link{
+		Reader: r2,
+		Writer: w2,
+	}, mux.ClientStrategy{
+		MaxConcurrency: 4,
+		MaxConnection:  4,
+	})
+	common.Must(err)
+
+	factory := mocks.NewMuxClientWorkerFactory(mockCtl)
+	gomock.InOrder(
+		factory.EXPECT().Create().Return(worker1, nil),
+		factory.EXPECT().Create().Return(worker2, nil),
+	)
+
+	picker := &mux.IncrementalWorkerPicker{
+		Factory: factory,
 	}
+	manager := &mux.ClientManager{
+		Picker: picker,
+	}
+
+	tr1, tw1 := pipe.New(pipe.WithoutSizeLimit())
+	ctx1 := session.ContextWithOutbounds(context.Background(), []*session.Outbound{{
+		Target: net.TCPDestination(net.DomainAddress("www.example.com"), 80),
+	}})
+	common.Must(manager.Dispatch(ctx1, &transport.Link{
+		Reader: tr1,
+		Writer: tw1,
+	}))
+	defer tw1.Close()
+
+	common.Must(w1.Close())
+
+	time.Sleep(time.Millisecond * 500)
+	if !worker1.Closed() {
+		t.Error("worker1 is not finished")
+	}
+
+	tr2, tw2 := pipe.New(pipe.WithoutSizeLimit())
+	ctx2 := session.ContextWithOutbounds(context.Background(), []*session.Outbound{{
+		Target: net.TCPDestination(net.DomainAddress("www.example.com"), 80),
+	}})
+	common.Must(manager.Dispatch(ctx2, &transport.Link{
+		Reader: tr2,
+		Writer: tw2,
+	}))
+	defer tw2.Close()
+
+	common.Must(w2.Close())
 }

--- a/common/mux/server.go
+++ b/common/mux/server.go
@@ -201,11 +201,12 @@ func (w *ServerWorker) handleStatusNew(ctx context.Context, meta *FrameMetadata,
 			transferType: protocol.TransferTypePacket,
 			XUDP:         x,
 		}
-		go handle(ctx, x.Mux, w.link.Writer)
 		x.Status = Active
 		if !w.sessionManager.Add(x.Mux) {
 			x.Mux.Close(false)
+			return errors.New("failed to add new session")
 		}
+		go handle(ctx, x.Mux, w.link.Writer)
 		return nil
 	}
 
@@ -226,18 +227,23 @@ func (w *ServerWorker) handleStatusNew(ctx context.Context, meta *FrameMetadata,
 	if meta.Target.Network == net.Network_UDP {
 		s.transferType = protocol.TransferTypePacket
 	}
-	w.sessionManager.Add(s)
+	if !w.sessionManager.Add(s) {
+		s.Close(false)
+		return errors.New("failed to add new session")
+	}
 	go handle(ctx, s, w.link.Writer)
 	if !meta.Option.Has(OptionData) {
 		return nil
 	}
 
 	rr := s.NewReader(reader, &meta.Target)
-	if err := buf.Copy(rr, s.output); err != nil {
-		buf.Copy(rr, buf.Discard)
-		return s.Close(false)
+	err = buf.Copy(rr, s.output)
+
+	if err != nil && buf.IsWriteError(err) {
+		s.Close(false)
+		return buf.Copy(rr, buf.Discard)
 	}
-	return nil
+	return err
 }
 
 func (w *ServerWorker) handleStatusKeep(meta *FrameMetadata, reader *buf.BufferedReader) error {
@@ -304,10 +310,11 @@ func (w *ServerWorker) handleFrame(ctx context.Context, reader *buf.BufferedRead
 }
 
 func (w *ServerWorker) run(ctx context.Context) {
-	input := w.link.Reader
-	reader := &buf.BufferedReader{Reader: input}
+	reader := &buf.BufferedReader{Reader: w.link.Reader}
 
 	defer w.sessionManager.Close()
+	defer common.Close(w.link.Writer)
+	defer common.Interrupt(w.link.Reader)
 
 	for {
 		select {
@@ -318,7 +325,6 @@ func (w *ServerWorker) run(ctx context.Context) {
 			if err != nil {
 				if errors.Cause(err) != io.EOF {
 					errors.LogInfoInner(ctx, err, "unexpected EOF")
-					common.Interrupt(input)
 				}
 				return
 			}

--- a/common/mux/session.go
+++ b/common/mux/session.go
@@ -50,11 +50,12 @@ func (m *SessionManager) Count() int {
 	return int(m.count)
 }
 
-func (m *SessionManager) Allocate(Strategy ClientStrategy) *Session {
-	MaxConcurrency := int(Strategy.MaxConcurrency)
-	MaxConnection := uint16(Strategy.MaxConnection)
+func (m *SessionManager) Allocate(Strategy *ClientStrategy) *Session {
 	m.Lock()
 	defer m.Unlock()
+	
+	MaxConcurrency := int(Strategy.MaxConcurrency)
+	MaxConnection := uint16(Strategy.MaxConnection)
 
 	if m.closed || (MaxConcurrency > 0 && len(m.sessions) >= MaxConcurrency) || (MaxConnection > 0 && m.count >= MaxConnection) {
 		return nil

--- a/common/mux/session.go
+++ b/common/mux/session.go
@@ -50,11 +50,13 @@ func (m *SessionManager) Count() int {
 	return int(m.count)
 }
 
-func (m *SessionManager) Allocate(MaxConcurrency int) *Session {
+func (m *SessionManager) Allocate(Strategy ClientStrategy) *Session {
+	MaxConcurrency := int(Strategy.MaxConcurrency)
+	MaxConnection := uint16(Strategy.MaxConnection)
 	m.Lock()
 	defer m.Unlock()
 
-	if m.closed || (MaxConcurrency > 0 && len(m.sessions) >= MaxConcurrency) {
+	if m.closed || (MaxConcurrency > 0 && len(m.sessions) >= MaxConcurrency) || (MaxConnection > 0 && m.count >= MaxConnection) {
 		return nil
 	}
 

--- a/common/mux/session.go
+++ b/common/mux/session.go
@@ -50,11 +50,11 @@ func (m *SessionManager) Count() int {
 	return int(m.count)
 }
 
-func (m *SessionManager) Allocate() *Session {
+func (m *SessionManager) Allocate(MaxConcurrency int) *Session {
 	m.Lock()
 	defer m.Unlock()
 
-	if m.closed {
+	if m.closed || (MaxConcurrency > 0 && len(m.sessions) >= MaxConcurrency) {
 		return nil
 	}
 

--- a/common/mux/session_test.go
+++ b/common/mux/session_test.go
@@ -9,7 +9,7 @@ import (
 func TestSessionManagerAdd(t *testing.T) {
 	m := NewSessionManager()
 
-	s := m.Allocate(0)
+	s := m.Allocate(ClientStrategy{})
 	if s.ID != 1 {
 		t.Error("id: ", s.ID)
 	}
@@ -17,7 +17,7 @@ func TestSessionManagerAdd(t *testing.T) {
 		t.Error("size: ", m.Size())
 	}
 
-	s = m.Allocate(0)
+	s = m.Allocate(ClientStrategy{})
 	if s.ID != 2 {
 		t.Error("id: ", s.ID)
 	}
@@ -39,7 +39,7 @@ func TestSessionManagerAdd(t *testing.T) {
 
 func TestSessionManagerClose(t *testing.T) {
 	m := NewSessionManager()
-	s := m.Allocate(0)
+	s := m.Allocate(ClientStrategy{})
 
 	if m.CloseIfNoSession() {
 		t.Error("able to close")

--- a/common/mux/session_test.go
+++ b/common/mux/session_test.go
@@ -9,7 +9,7 @@ import (
 func TestSessionManagerAdd(t *testing.T) {
 	m := NewSessionManager()
 
-	s := m.Allocate()
+	s := m.Allocate(0)
 	if s.ID != 1 {
 		t.Error("id: ", s.ID)
 	}
@@ -17,7 +17,7 @@ func TestSessionManagerAdd(t *testing.T) {
 		t.Error("size: ", m.Size())
 	}
 
-	s = m.Allocate()
+	s = m.Allocate(0)
 	if s.ID != 2 {
 		t.Error("id: ", s.ID)
 	}
@@ -39,7 +39,7 @@ func TestSessionManagerAdd(t *testing.T) {
 
 func TestSessionManagerClose(t *testing.T) {
 	m := NewSessionManager()
-	s := m.Allocate()
+	s := m.Allocate(0)
 
 	if m.CloseIfNoSession() {
 		t.Error("able to close")

--- a/common/mux/session_test.go
+++ b/common/mux/session_test.go
@@ -9,7 +9,7 @@ import (
 func TestSessionManagerAdd(t *testing.T) {
 	m := NewSessionManager()
 
-	s := m.Allocate(ClientStrategy{})
+	s := m.Allocate(&ClientStrategy{})
 	if s.ID != 1 {
 		t.Error("id: ", s.ID)
 	}
@@ -17,7 +17,7 @@ func TestSessionManagerAdd(t *testing.T) {
 		t.Error("size: ", m.Size())
 	}
 
-	s = m.Allocate(ClientStrategy{})
+	s = m.Allocate(&ClientStrategy{})
 	if s.ID != 2 {
 		t.Error("id: ", s.ID)
 	}
@@ -39,7 +39,7 @@ func TestSessionManagerAdd(t *testing.T) {
 
 func TestSessionManagerClose(t *testing.T) {
 	m := NewSessionManager()
-	s := m.Allocate(ClientStrategy{})
+	s := m.Allocate(&ClientStrategy{})
 
 	if m.CloseIfNoSession() {
 		t.Error("able to close")


### PR DESCRIPTION
https://github.com/XTLS/Xray-core/blob/cb1afb33e68c56bf4510ad658ab86a0468b8c36c/common/mux/client.go#L291-L297


**if this function run concurrent from two goroutine, some problems may arise, let explain why:**

suppose `m.strategy.MaxConcurrency` is set to 4, and currently we have 3 sessions for `m.sessionManager`.

suppose goroutine-A and goroutine-B run this function concurrency, because we have 3 sessions and `MaxCuncurrency` is set to 4, `m.IsFull()` is `false` for both goroutine, so both goroutine will run `sm.Allocate()`.



although `sessionManager` has it's own Lock, but it does not help in this situation, and `sm.Allocate()`  create a new session for each goroutine. 

**so after running this two goroutine two new sessions created and the number of sessions reach to 5, but `MaxConcurrency` is set to 4, so we exceeded the value of `MaxConcurrency` !!!**

///

**so we need another `sync.Mutex` lock for running this dispatch, to  make sure we never exceed the `MaxConcurrency`/`MaxConnection`.**

also, `m.IsFull()` contain `m.Closed()`, so there is no need to check it again.