### PR TITLE
refactor: use bytes.HasPrefix for SniffBittorrent prefix check

### DIFF
--- a/common/protocol/bittorrent/bittorrent.go
+++ b/common/protocol/bittorrent/bittorrent.go
@@ -1,6 +1,7 @@
 package bittorrent
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"math"
@@ -22,12 +23,14 @@ func (h *SniffHeader) Domain() string {
 
 var errNotBittorrent = errors.New("not bittorrent header")
 
+var btPrefix = []byte("BitTorrent protocol")
+
 func SniffBittorrent(b []byte) (*SniffHeader, error) {
-	if len(b) < 20 {
+	if len(b) < 1+len(btPrefix) {
 		return nil, common.ErrNoClue
 	}
 
-	if b[0] == 19 && string(b[1:20]) == "BitTorrent protocol" {
+	if b[0] == byte(len(btPrefix)) && bytes.HasPrefix(b[1:], btPrefix) {
 		return &SniffHeader{}, nil
 	}
 


### PR DESCRIPTION
- Replace string(b[1:20]) == "BitTorrent protocol" with bytes.HasPrefix(b[1:], btPrefix) to eliminate allocations.
- Tie length check to 1 + len(btPrefix) instead of magic number 20.