### PR TITLE
fix: use defer for properly close connection.

### DIFF
--- a/app/proxyman/inbound/worker.go
+++ b/app/proxyman/inbound/worker.go
@@ -2,7 +2,6 @@ package inbound
 
 import (
 	"context"
-	"log/slog"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -62,7 +61,7 @@ func (w *tcpWorker) callback(conn stat.Connection) {
 	ctx, cancel := context.WithCancel(w.ctx)
 	defer func() {
 		if err := conn.Close(); err != nil {
-			slog.Error("conn.Close() failed: %v", err)
+			errors.LogError(ctx, "conn.Close() failed: %v", err)
 		}
 	}()
 	defer cancel()


### PR DESCRIPTION
```func (w *tcpWorker) callback(conn stat.Connection) {
  ctx, cancel := context.WithCancel(w.ctx)
  sid := session.NewID()
  ctx = c.ContextWithID(ctx, sid)

  outbounds := []*session.Outbound{{}}
  if w.recvOrigDest {
    var dest net.Destination
    switch getTProxyType(w.stream) {
    case internet.SocketConfig_Redirect:
      d, err := tcp.GetOriginalDestination(conn)
      if err != nil {
        errors.LogInfoInner(ctx, err, "failed to get original destination")
      } else {
        dest = d
      }
    case internet.SocketConfig_TProxy:
      dest = net.DestinationFromAddr(conn.LocalAddr())
    }
    if dest.IsValid() {
      outbounds[0].Target = dest
    }
  }
  ctx = session.ContextWithOutbounds(ctx, outbounds)

  if w.uplinkCounter != nil || w.downlinkCounter != nil {
    conn = &stat.CounterConnection{
      Connection:   conn,
      ReadCounter:  w.uplinkCounter,
      WriteCounter: w.downlinkCounter,
    }
  }
  ctx = session.ContextWithInbound(ctx, &session.Inbound{
    Source:  net.DestinationFromAddr(conn.RemoteAddr()),
    Gateway: net.TCPDestination(w.address, w.port),
    Tag:     w.tag,
    Conn:    conn,
  })

  content := new(session.Content)
  if w.sniffingConfig != nil {
    content.SniffingRequest.Enabled = w.sniffingConfig.Enabled
    content.SniffingRequest.OverrideDestinationForProtocol = w.sniffingConfig.DestinationOverride
    content.SniffingRequest.ExcludeForDomain = w.sniffingConfig.DomainsExcluded
    content.SniffingRequest.MetadataOnly = w.sniffingConfig.MetadataOnly
    content.SniffingRequest.RouteOnly = w.sniffingConfig.RouteOnly
  }
  ctx = session.ContextWithContent(ctx, content)

  if err := w.proxy.Process(ctx, net.Network_TCP, conn, w.dispatcher); err != nil {
    errors.LogInfoInner(ctx, err, "connection ends")
  }
  cancel() <---- may not be invoked if we get error in middle
  conn.Close() <---- may not be invoked if we get error in middle 
}
```
