### PR TITLE
Reverse: portal-worker should not be closed before making sure there is at least one other active worker

### DIFF
--- a/app/reverse/config.go
+++ b/app/reverse/config.go
@@ -9,6 +9,7 @@ import (
 
 func (c *Control) FillInRandom() {
 	randomLength := dice.Roll(64)
+	randomLength++
 	c.Random = make([]byte, randomLength)
 	io.ReadFull(rand.Reader, c.Random)
 }


### PR DESCRIPTION
when a portal-worker is draining, heartbeat-reader/writer is immediately closed, this causes some problems, let explain why:

suppose we only have one active portal-worker and it starts draining.

also support the only sub-connection(session) of this worker is heartbeat-sub-connection and it has no client-sub-connection.

after heartbeat-sub-connection is closed, the number of sub-connection(session) of the worker reaches 0,

worker check every 16 seconds if there is no session(sub-connection), It closes itself.

**So there is a chance that the worker will be closed after heartbeat-sub-connection is closed and before the new worker arrives from bridge-side.**

**So during this time, until a new worker is created and arrives from bridge-side, our connection with bridge-side will be completely broken, so if new sub-connection is received from the client-side, we can't connect it to the bridge-side.**

**so we need to check that there is at least one other active worker before closing heartbeat-sub-connection.**

///

also, apart from the fact that our connection to the bridge-side can be interrupted for a moment, there is another reason for this change:

during Iran-Israel 12 days war, some Iran-servers become "Iran-Access", means they only accept connection from Iran-IP, but if the connection is established before becoming "Iran-Access" from foreign-IP, the connection wouldn't disconnect after becoming "Iran-Access".

so Xray-core should not disconnect a connection(worker), before making sure there is at least one other active connection (worker).

///

also, when worker is not draining, heartbeat period increase to 10 seconds.
