### PR TITLE
Simple Dockerfile & .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Binaries and build artifacts
+*.exe
+*.out
+*.test
+*.tmp
+
+# Go build/cache directories
+/bin
+/pkg
+/vendor
+*.log
+*.cache
+coverage.*
+
+# VCS and config noise
+.git
+.gitignore
+.dockerignore
+*.swp
+*.swo
+*.DS_Store
+.idea/
+.vscode/
+
+# Docker artifacts
+Dockerfile*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM golang:1.24-alpine AS builder
+
+LABEL org.opencontainers.image.source="https://github.com/XTLS/Xray-core" \
+      org.opencontainers.image.licenses="MPL-2.0" \
+      org.opencontainers.image.title="xray-core"
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go build -o xray -trimpath -buildvcs=false \
+    -ldflags="-s -w -buildid=" -v ./main
+
+FROM alpine:3.22.0
+
+COPY --from=builder /src/xray /usr/local/bin/xray
+RUN  adduser -D -u 10001 xray &&\
+     chmod +x /usr/local/bin/xray &&\
+     mkdir -p /etc/xray /var/log/xray &&\
+     echo {} > /etc/xray/config.json
+
+WORKDIR /etc/xray
+USER xray
+
+ENTRYPOINT ["xray", "-c", "/etc/xray/config.json"]


### PR DESCRIPTION
open to suggestion or critics
add minimal Dockerfile for xray-core build

- Multi-stage build using golang:1.24-alpine
- Module caching via go.mod/go.sum separation
- Installs binary into minimal alpine:3.22
- Includes optimized .dockerignore for clean builds