### PR TITLE
UDP-dispatcher: fix activity timer cause connection disconnected every minutes

### DIFF
--- a/proxy/shadowsocks/server.go
+++ b/proxy/shadowsocks/server.go
@@ -128,6 +128,7 @@ func (s *Server) handleUDPPayload(ctx context.Context, conn stat.Connection, dis
 
 		conn.Write(data.Bytes())
 	})
+	defer udpServer.RemoveRay()
 
 	inbound := session.InboundFromContext(ctx)
 	var dest *net.Destination

--- a/proxy/socks/server.go
+++ b/proxy/socks/server.go
@@ -245,13 +245,15 @@ func (s *Server) handleUDPPayload(ctx context.Context, conn stat.Connection, dis
 		udpMessage, err := EncodeUDPPacket(request, payload.Bytes())
 		payload.Release()
 
-		defer udpMessage.Release()
 		if err != nil {
 			errors.LogWarningInner(ctx, err, "failed to write UDP response")
+			return
 		}
+		defer udpMessage.Release()
 
 		conn.Write(udpMessage.Bytes())
 	})
+	defer udpServer.RemoveRay()
 
 	inbound := session.InboundFromContext(ctx)
 	if inbound != nil && inbound.Source.IsValid() {

--- a/proxy/trojan/server.go
+++ b/proxy/trojan/server.go
@@ -259,6 +259,7 @@ func (s *Server) handleUDPPayload(ctx context.Context, clientReader *PacketReade
 			errors.LogWarningInner(ctx, err, "failed to write response")
 		}
 	})
+	defer udpServer.RemoveRay()
 
 	inbound := session.InboundFromContext(ctx)
 	user := inbound.User

--- a/transport/internet/udp/dispatcher.go
+++ b/transport/internet/udp/dispatcher.go
@@ -24,6 +24,15 @@ type connEntry struct {
 	link   *transport.Link
 	timer  signal.ActivityUpdater
 	cancel context.CancelFunc
+	closed bool
+}
+
+func (c *connEntry) Close() error {
+	c.closed = true
+	c.cancel()
+	common.Interrupt(c.link.Reader)
+	common.Close(c.link.Writer)
+	return nil
 }
 
 type Dispatcher struct {
@@ -45,8 +54,7 @@ func (v *Dispatcher) RemoveRay() {
 	v.Lock()
 	defer v.Unlock()
 	if v.conn != nil {
-		common.Interrupt(v.conn.link.Reader)
-		common.Close(v.conn.link.Writer)
+		v.conn.Close()
 		v.conn = nil
 	}
 }
@@ -56,28 +64,32 @@ func (v *Dispatcher) getInboundRay(ctx context.Context, dest net.Destination) (*
 	defer v.Unlock()
 
 	if v.conn != nil {
-		return v.conn, nil
+		if v.conn.closed {
+			v.conn = nil
+		} else {
+			return v.conn, nil
+		}
 	}
 
 	errors.LogInfo(ctx, "establishing new connection for ", dest)
 
 	ctx, cancel := context.WithCancel(ctx)
-	removeRay := func() {
-		cancel()
-		v.RemoveRay()
-	}
-	timer := signal.CancelAfterInactivity(ctx, removeRay, time.Minute)
 
 	link, err := v.dispatcher.Dispatch(ctx, dest)
 	if err != nil {
+		cancel()
 		return nil, errors.New("failed to dispatch request to ", dest).Base(err)
 	}
 
 	entry := &connEntry{
 		link:   link,
-		timer:  timer,
-		cancel: removeRay,
+		cancel: cancel,
 	}
+	entryClose := func() {
+		entry.Close()
+	}
+
+	entry.timer = signal.CancelAfterInactivity(ctx, entryClose, time.Minute)
 	v.conn = entry
 	go handleInput(ctx, entry, dest, v.callback, v.callClose)
 	return entry, nil
@@ -96,7 +108,7 @@ func (v *Dispatcher) Dispatch(ctx context.Context, destination net.Destination, 
 	if outputStream != nil {
 		if err := outputStream.WriteMultiBuffer(buf.MultiBuffer{payload}); err != nil {
 			errors.LogInfoInner(ctx, err, "failed to write first UDP payload")
-			conn.cancel()
+			conn.Close()
 			return
 		}
 	}
@@ -104,7 +116,7 @@ func (v *Dispatcher) Dispatch(ctx context.Context, destination net.Destination, 
 
 func handleInput(ctx context.Context, conn *connEntry, dest net.Destination, callback ResponseCallback, callClose func() error) {
 	defer func() {
-		conn.cancel()
+		conn.Close()
 		if callClose != nil {
 			callClose()
 		}


### PR DESCRIPTION
when target-connection is udp, after the first disconnection between xray-client and xray-server, the connection between xray-client and xray-server is disconnected every minute, Let's do the following reproduction-method to understand better:

1. you need python with `PySocks` package(pip install PySocks)
2. run [xray-client](https://github.com/patterniha/bug-test/blob/main/udp-test-client-config.json) and [xray-server](https://github.com/patterniha/bug-test/blob/main/udp-test-server-config.json) both on one PC
3. run [echo-server.py](https://github.com/patterniha/bug-test/blob/main/echo-server.py) with python(`python echo-server.py`)
this is a simple udp echo server
4. run [echo-socks-client.py](https://github.com/patterniha/bug-test/blob/main/echo-socks-client.py) with python
this is simple udp echo client that use socks5 protocol to connect

     echo-socks-client.py <-> xray-client <-> xray-server <-> echo-server.py

5. after a few seconds, terminate xray-**server** and then re-run xray-**server** (to disconnect connection between client-xray and server-xray, and re-established again)

6. sniff connection between xray-client and xray-server (loopback-adapter-port-1234)

**Then you see that every minute the connection between xray-client and xray-server is disconnected and then re-established.(while the connection is not idle and should not be closed)**

<img width="2826" height="613" alt="Screenshot 2025-07-15 032342" src="https://github.com/user-attachments/assets/b5ab3f78-c6f1-45be-b34d-53aea1e1bf83" />


///

**this is important issue, that causes us to have frequent disconnections between xray-client and xray-server(after first disconnecting with any reason)**

**Also, because we bind a new port(freedom-udp) in server-side every time, it can cause a lot of problems.**

///

### Why is this happening?

This is because of this wrong code:

https://github.com/XTLS/Xray-core/blob/1976d02ec9aaff3d34221a18b4ec8869437e2dc6/transport/internet/udp/dispatcher.go#L65-L69

**After previous-connection is closed, it's timer remains active, and after a minute it run `v.RemoveRay()` and `RemoveRay` close `v.conn`, but now `v.conn` is our new connection which is active and should not be closed !!!**

**And this process repeating...**

///

**other refine:**

in `worker.go` it is better to cancel ctx after udpConn is closed