### PR TITLE
Add Xray-exporter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@
 - Xray Tools
   - [xray-knife](https://github.com/lilendian0x00/xray-knife)
   - [xray-checker](https://github.com/kutovoys/xray-checker)
+  - [xray-exporter](https://github.com/compassvpn/xray-exporter)
 - Xray Wrapper
   - [XTLS/libXray](https://github.com/XTLS/libXray)
   - [xtls-sdk](https://github.com/remnawave/xtls-sdk)


### PR DESCRIPTION
Add xray-exporter.
An updated exporter for Xray with extended features such as approximation of user counts, outbound distillation, and top requested domains/IPs.
A refactor and major update from https://github.com/wi1dcard/v2ray-exporter