### PR TITLE
UDP worker: `conn.updateActivity()` should be executed in Lock

### DIFF
--- a/app/proxyman/inbound/worker.go
+++ b/app/proxyman/inbound/worker.go
@@ -259,6 +259,7 @@ func (w *udpWorker) getConnection(id connID) (*udpConn, bool) {
 	defer w.Unlock()
 
 	if conn, found := w.activeConn[id]; found && !conn.done.Done() {
+		conn.updateActivity()
 		return conn, true
 	}
 


### PR DESCRIPTION
https://github.com/XTLS/Xray-core/pull/4909#issuecomment-3092297015

because updateActivity() runs out of udpworker-Lock:

suppose exactly after 2 minutes of inactivity a packet is received from inbound, so it is possible we create a new-outbound-connection for that but we don't update udpconn-activity and close that.

this cause we ignore the active-outbound-connection by mistake and create new one for next-received-packet.



///

possible is possible, even with a very low probability.
