### PR TITLE
Vless fallback: we shoud not create fallback-connection after inbound-connection is closed

### DIFF
--- a/proxy/vless/inbound/inbound.go
+++ b/proxy/vless/inbound/inbound.go
@@ -206,7 +206,10 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection s
 
 	first := buf.FromBytes(make([]byte, buf.Size))
 	first.Clear()
-	firstLen, _ := first.ReadFrom(connection)
+	firstLen, errR := first.ReadFrom(connection)
+	if errR != nil {
+		return errR
+	}
 	errors.LogInfo(ctx, "firstLen = ", firstLen)
 
 	reader := &buf.BufferedReader{


### PR DESCRIPTION
first do the following test to understand better:

1. run [this xray config](https://github.com/patterniha/bug-test/blob/main/vless_fallback_bug_proof.json)

2. sniff loopback port 8888 with wireshark 

3. run [this](https://github.com/patterniha/bug-test/blob/main/vless_fallback.py) python script
this script create a connection to xray-vless-inbound and close the connection after 1 seconds

you see after inbound-connection is closed, xray create a connection to fallback and then close it immediately!!!

this is just a waste and should be fixed.

<img width="2870" height="197" alt="Screenshot 2025-07-19 170558" src="https://github.com/user-attachments/assets/ca4fa173-d3f0-4f55-915a-926382e2f565" />


