### PR TITLE
inbounds & outbounds: TCP KeepAlive off By default

### DIFF
--- a/transport/internet/system_dialer.go
+++ b/transport/internet/system_dialer.go
@@ -87,14 +87,10 @@ func (d *DefaultSystemDialer) Dial(ctx context.Context, src net.Address, dest ne
 			Dest: destAddr,
 		}, nil
 	}
-	goStdKeepAlive := time.Duration(0)
-	if sockopt != nil && (sockopt.TcpKeepAliveInterval != 0 || sockopt.TcpKeepAliveIdle != 0) {
-		goStdKeepAlive = time.Duration(-1)
-	}
 	dialer := &net.Dialer{
 		Timeout:   time.Second * 16,
 		LocalAddr: resolveSrcAddr(dest.Network, src),
-		KeepAlive: goStdKeepAlive,
+		KeepAlive: time.Duration(-1),
 	}
 
 	if sockopt != nil || len(d.controllers) > 0 {

--- a/transport/internet/system_listener.go
+++ b/transport/internet/system_listener.go
@@ -88,10 +88,8 @@ func (dl *DefaultListener) Listen(ctx context.Context, addr net.Addr, sockopt *S
 		network = addr.Network()
 		address = addr.String()
 		lc.Control = getControlFunc(ctx, sockopt, dl.controllers)
+		lc.KeepAlive = time.Duration(-1)
 		if sockopt != nil {
-			if sockopt.TcpKeepAliveInterval != 0 || sockopt.TcpKeepAliveIdle != 0 {
-				lc.KeepAlive = time.Duration(-1)
-			}
 			if sockopt.TcpMptcp {
 				lc.SetMultipathTCP(true)
 			}


### PR DESCRIPTION
ISP NAT 会话老化时间，一般是 5 分钟（或者不少于）；Xray 空闲连接超时（老化）时间 `connIdle` ，也是 5 分钟。
因此，我认为：开启 TCP KeepAlive 后，golang 默认每隔 15 秒，发送一次“TCP KeepAlive 探针”是不必要的。应该尽可能保持无线电静默。

https://t.me/projectXray/4134023?thread=4133903
https://t.me/projectXray/4375781?thread=4375765