### PR TITLE
REALITY client: Fix log when printing "is using X25519MLKEM768..."

### DIFF
--- a/transport/internet/reality/reality.go
+++ b/transport/internet/reality/reality.go
@@ -77,7 +77,8 @@ func (c *UConn) HandshakeAddress() net.Address {
 func (c *UConn) VerifyPeerCertificate(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 	if c.Config.Show {
 		localAddr := c.LocalAddr().String()
-		fmt.Printf("REALITY localAddr: %v\tis using X25519MLKEM768 for TLS' communication: %v\n", localAddr, c.HandshakeState.ServerHello.SelectedGroup == utls.X25519MLKEM768)
+		curveID := *(*utls.CurveID)(unsafe.Pointer(reflect.ValueOf(c).Elem().FieldByName("curveID").UnsafeAddr()))
+		fmt.Printf("REALITY localAddr: %v\tis using X25519MLKEM768 for TLS' communication: %v\n", localAddr, curveID == utls.X25519MLKEM768)
 		fmt.Printf("REALITY localAddr: %v\tis using ML-DSA-65 for cert's extra verification: %v\n", localAddr, len(c.Config.Mldsa65Verify) > 0)
 	}
 	p, _ := reflect.TypeOf(c.Conn).Elem().FieldByName("peerCertificates")


### PR DESCRIPTION
难道以前一直没人看这个输出吗 我看的时候服务端输出true客户端输出false一头雾水(
selectedGroup 不是服务端选择的group(不同于selected alpn 它确实是服务端给出的alpn协商结果) 这个东西是HelloRetryRequest里用的 服务端想用这个keyshare重新进行协商 而不是说本次握手协商出的keyshare 它直接被编码在 server hello 的keyshare.group 里 所以要像我之前 tls ping 那样反射出来(