### PR TITLE
Inbounds & Outbounds: TCP KeepAlive better default value

### DIFF
--- a/transport/internet/sockopt_linux.go
+++ b/transport/internet/sockopt_linux.go
@@ -64,26 +64,6 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 			}
 		}
 
-		if config.TcpKeepAliveInterval > 0 || config.TcpKeepAliveIdle > 0 {
-			if config.TcpKeepAliveInterval > 0 {
-				if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPINTVL, int(config.TcpKeepAliveInterval)); err != nil {
-					return errors.New("failed to set TCP_KEEPINTVL", err)
-				}
-			}
-			if config.TcpKeepAliveIdle > 0 {
-				if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPIDLE, int(config.TcpKeepAliveIdle)); err != nil {
-					return errors.New("failed to set TCP_KEEPIDLE", err)
-				}
-			}
-			if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_KEEPALIVE, 1); err != nil {
-				return errors.New("failed to set SO_KEEPALIVE", err)
-			}
-		} else if config.TcpKeepAliveInterval < 0 || config.TcpKeepAliveIdle < 0 {
-			if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_KEEPALIVE, 0); err != nil {
-				return errors.New("failed to unset SO_KEEPALIVE", err)
-			}
-		}
-
 		if config.TcpCongestion != "" {
 			if err := syscall.SetsockoptString(int(fd), syscall.SOL_TCP, syscall.TCP_CONGESTION, config.TcpCongestion); err != nil {
 				return errors.New("failed to set TCP_CONGESTION", err)


### PR DESCRIPTION
from #4927
重写了一下 tcp keepalive 的逻辑 删除了 sockopt_linux 里的操作 移到了 listener/dialer 中 这样可以跨平台
现在的逻辑
客户端 打开 TCP 连接使用和 Chrome 相同的 idle 和 interval (45秒) sockopt中两个数字任一为负则禁用 为正则覆盖默认值
服务端 监听默认不启用 任一大于 0 的 idle 或 interval 启用keepalive 并把相关数字设置成对应值 如果没设置 则为系统默认(而不是golang默认)
由于两个参数任一大于0启用和任一小于0禁用 一个正一个负会逻辑错误 如果发生这样的事直接返回错误