### PR TITLE
Commands: Output certificate chain's total length in `tls ping`

### DIFF
--- a/main/commands/all/tls/ping.go
+++ b/main/commands/all/tls/ping.go
@@ -130,7 +130,7 @@ func printCertificates(certs []*x509.Certificate) {
 			leaf = cert
 		}
 	}
-	fmt.Println("Certificate chain length: ", length, "(cert count:", strconv.Itoa(len(certs))+")")
+	fmt.Println("Certificate chain's total length: ", length, "(certs count: "+strconv.Itoa(len(certs))+")")
 	if leaf != nil {
 		fmt.Println("Cert's signature algorithm: ", leaf.SignatureAlgorithm.String())
 		fmt.Println("Cert's publicKey algorithm: ", leaf.PublicKeyAlgorithm.String())


### PR DESCRIPTION
tls ping 显示整个证书链长度 用于寻找比较长的证书
(如果如之前讨论所述只找到一个证书也会有注释)