### PR TITLE
UDP listener: Allow listening on "localhost"

### DIFF
--- a/transport/internet/udp/hub.go
+++ b/transport/internet/udp/hub.go
@@ -40,6 +40,14 @@ func ListenUDP(ctx context.Context, address net.Address, port net.Port, streamSe
 		opt(hub)
 	}
 
+	if address.Family().IsDomain() && address.Domain() == "localhost" {
+		address = net.LocalHostIP
+	}
+
+	if address.Family().IsDomain() {
+		return nil, errors.New("domain address is not allowed for listening: ", address.Domain())
+	}
+
 	var sockopt *internet.SocketConfig
 	if streamSettings != nil {
 		sockopt = streamSettings.SocketSettings


### PR DESCRIPTION
从 tcp listener 抄来的 没啥技术含量 tcp listener 给localhost开了小灶 这个更改从v2ray继承来的不过 udp listener 没写 顺便localhost外的域名监听也是禁止的 更改纯粹是为了同步行为 当然也可以改成如果是域名就解析一次 个人觉得没必要 谁有什么事听个公网地址
close #4939