### PR TITLE
Commands: Add adu/rmu inbound user management to API

### DIFF
--- a/main/commands/all/api/api.go
+++ b/main/commands/all/api/api.go
@@ -23,6 +23,8 @@ var CmdAPI = &base.Command{
 		cmdRemoveOutbounds,
 		cmdListInbounds,
 		cmdListOutbounds,
+		cmdAddInboundUsers,
+		cmdRemoveInboundUsers,
 		cmdInboundUser,
 		cmdInboundUserCount,
 		cmdAddRules,

--- a/main/commands/all/api/inbound_user_add.go
+++ b/main/commands/all/api/inbound_user_add.go
@@ -67,11 +67,11 @@ func addInboundUserAction(ctx context.Context, client handlerService.HandlerServ
 	return err
 }
 
-func extractInboundUsers(i *core.InboundHandlerConfig) []*protocol.User {
-	if i == nil {
+func extractInboundUsers(inb *core.InboundHandlerConfig) []*protocol.User {
+	if inb == nil {
 		return nil
 	}
-	inst, err := i.ProxySettings.GetInstance()
+	inst, err := inb.ProxySettings.GetInstance()
 	if err != nil || inst == nil {
 		fmt.Println("failed to get inbound instance:", err)
 		return nil
@@ -109,7 +109,6 @@ func extractInboundsConfig(unnamedArgs []string) []conf.InboundDetourConfig {
 	return ins
 }
 
-// inbound_user_remove.go require this function too
 func executeInboundUserAction(ctx context.Context, client handlerService.HandlerServiceClient, inb conf.InboundDetourConfig, action func(ctx context.Context, client handlerService.HandlerServiceClient, tag string, user *protocol.User) error) int {
 	success := 0
 

--- a/main/commands/all/api/inbound_user_add.go
+++ b/main/commands/all/api/inbound_user_add.go
@@ -1,0 +1,145 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/xtls/xray-core/common/protocol"
+
+	handlerService "github.com/xtls/xray-core/app/proxyman/command"
+	cserial "github.com/xtls/xray-core/common/serial"
+
+	"github.com/xtls/xray-core/core"
+	"github.com/xtls/xray-core/infra/conf"
+	"github.com/xtls/xray-core/infra/conf/serial"
+	"github.com/xtls/xray-core/proxy/shadowsocks"
+	"github.com/xtls/xray-core/proxy/shadowsocks_2022"
+	"github.com/xtls/xray-core/proxy/trojan"
+	vlessin "github.com/xtls/xray-core/proxy/vless/inbound"
+	vmessin "github.com/xtls/xray-core/proxy/vmess/inbound"
+
+	"github.com/xtls/xray-core/main/commands/base"
+)
+
+var cmdAddInboundUsers = &base.Command{
+	CustomFlags: true,
+	UsageLine:   "{{.Exec}} api adu [--server=127.0.0.1:8080] <c1.json> [c2.json]...",
+	Short:       "Add users to inbounds",
+	Long: `
+Add users to inbounds.
+Arguments:
+	-s, -server
+		The API server address. Default 127.0.0.1:8080
+	-t, -timeout
+		Timeout seconds to call API. Default 3
+Example:
+    {{.Exec}} {{.LongName}} --server=127.0.0.1:8080  c1.json c2.json
+`,
+	Run: executeAddInboundUsers,
+}
+
+func executeAddInboundUsers(cmd *base.Command, args []string) {
+	setSharedFlags(cmd)
+	cmd.Flag.Parse(args)
+	unnamedArgs := cmd.Flag.Args()
+	inbs := extractInboundsConfig(unnamedArgs)
+
+	conn, ctx, close := dialAPIServer()
+	defer close()
+	client := handlerService.NewHandlerServiceClient(conn)
+
+	success := 0
+	for _, inb := range inbs {
+		success += executeInboundUserAction(ctx, client, inb, addInboundUserAction)
+	}
+	fmt.Println("Added", success, "user(s) in total.")
+}
+
+func addInboundUserAction(ctx context.Context, client handlerService.HandlerServiceClient, tag string, user *protocol.User) error {
+	fmt.Println("add user:", user.Email)
+	_, err := client.AlterInbound(ctx, &handlerService.AlterInboundRequest{
+		Tag: tag,
+		Operation: cserial.ToTypedMessage(
+			&handlerService.AddUserOperation{
+				User: user,
+			}),
+	})
+	return err
+}
+
+func extractInboundUsers(i *core.InboundHandlerConfig) []*protocol.User {
+	if i == nil {
+		return nil
+	}
+	inst, err := i.ProxySettings.GetInstance()
+	if err != nil || inst == nil {
+		fmt.Println("failed to get inbound instance:", err)
+		return nil
+	}
+	switch ty := inst.(type) {
+	case *vmessin.Config:
+		return ty.User
+	case *vlessin.Config:
+		return ty.Clients
+	case *trojan.ServerConfig:
+		return ty.Users
+	case *shadowsocks.ServerConfig:
+		return ty.Users
+	case *shadowsocks_2022.MultiUserServerConfig:
+		return ty.Users
+	default:
+		fmt.Println("unsupported inbound type")
+	}
+	return nil
+}
+
+func extractInboundsConfig(unnamedArgs []string) []conf.InboundDetourConfig {
+	ins := make([]conf.InboundDetourConfig, 0)
+	for _, arg := range unnamedArgs {
+		r, err := loadArg(arg)
+		if err != nil {
+			base.Fatalf("failed to load %s: %s", arg, err)
+		}
+		conf, err := serial.DecodeJSONConfig(r)
+		if err != nil {
+			base.Fatalf("failed to decode %s: %s", arg, err)
+		}
+		ins = append(ins, conf.InboundConfigs...)
+	}
+	return ins
+}
+
+// inbound_user_remove.go require this function too
+func executeInboundUserAction(ctx context.Context, client handlerService.HandlerServiceClient, inb conf.InboundDetourConfig, action func(ctx context.Context, client handlerService.HandlerServiceClient, tag string, user *protocol.User) error) int {
+	success := 0
+
+	tag := inb.Tag
+	if len(tag) < 1 {
+		return success
+	}
+
+	fmt.Println("processing inbound:", tag)
+	built, err := inb.Build()
+	if err != nil {
+		fmt.Println("failed to build config:", err)
+		return success
+	}
+
+	users := extractInboundUsers(built)
+	if users == nil {
+		return success
+	}
+
+	for _, user := range users {
+		if len(user.Email) < 1 {
+			continue
+		}
+		if err := action(ctx, client, inb.Tag, user); err == nil {
+			fmt.Println("result: ok")
+			success += 1
+		} else {
+			fmt.Println(err)
+		}
+	}
+	return success
+}

--- a/main/commands/all/api/inbound_user_remove.go
+++ b/main/commands/all/api/inbound_user_remove.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/xtls/xray-core/common/protocol"
+
+	handlerService "github.com/xtls/xray-core/app/proxyman/command"
+	cserial "github.com/xtls/xray-core/common/serial"
+
+	"github.com/xtls/xray-core/main/commands/base"
+)
+
+var cmdRemoveInboundUsers = &base.Command{
+	CustomFlags: true,
+	UsageLine:   "{{.Exec}} api rmu [--server=127.0.0.1:8080] <c1.json> [c2.json]...",
+	Short:       "Remove users from inbounds",
+	Long: `
+Remove users from inbounds.
+Arguments:
+	-s, -server
+		The API server address. Default 127.0.0.1:8080
+	-t, -timeout
+		Timeout seconds to call API. Default 3
+Example:
+    {{.Exec}} {{.LongName}} --server=127.0.0.1:8080  c1.json c2.json
+`,
+	Run: executeRemoveUsers,
+}
+
+func executeRemoveUsers(cmd *base.Command, args []string) {
+	setSharedFlags(cmd)
+	cmd.Flag.Parse(args)
+	unnamedArgs := cmd.Flag.Args()
+	inbs := extractInboundsConfig(unnamedArgs)
+
+	conn, ctx, close := dialAPIServer()
+	defer close()
+	client := handlerService.NewHandlerServiceClient(conn)
+
+	success := 0
+	for _, inb := range inbs {
+		success += executeInboundUserAction(ctx, client, inb, removeInboundUserAction)
+	}
+	fmt.Println("Removed", success, "user(s) in total.")
+}
+
+func removeInboundUserAction(ctx context.Context, client handlerService.HandlerServiceClient, tag string, user *protocol.User) error {
+	fmt.Println("remove user:", user.Email)
+	_, err := client.AlterInbound(ctx, &handlerService.AlterInboundRequest{
+		Tag: tag,
+		Operation: cserial.ToTypedMessage(
+			&handlerService.RemoveUserOperation{
+				Email: user.Email,
+			}),
+	})
+	return err
+}

--- a/main/commands/all/api/inbound_user_remove.go
+++ b/main/commands/all/api/inbound_user_remove.go
@@ -1,10 +1,7 @@
 package api
 
 import (
-	"context"
 	"fmt"
-
-	"github.com/xtls/xray-core/common/protocol"
 
 	handlerService "github.com/xtls/xray-core/app/proxyman/command"
 	cserial "github.com/xtls/xray-core/common/serial"
@@ -14,7 +11,7 @@ import (
 
 var cmdRemoveInboundUsers = &base.Command{
 	CustomFlags: true,
-	UsageLine:   "{{.Exec}} api rmu [--server=127.0.0.1:8080] <c1.json> [c2.json]...",
+	UsageLine:   "{{.Exec}} api rmu [--server=127.0.0.1:8080] -tag=tag <email1> [email2]...",
 	Short:       "Remove users from inbounds",
 	Long: `
 Remove users from inbounds.
@@ -23,37 +20,43 @@ Arguments:
 		The API server address. Default 127.0.0.1:8080
 	-t, -timeout
 		Timeout seconds to call API. Default 3
+	-tag
+		Inbound tag
 Example:
-    {{.Exec}} {{.LongName}} --server=127.0.0.1:8080  c1.json c2.json
+    {{.Exec}} {{.LongName}} --server=127.0.0.1:8080 -tag="vless-in" "xray@love.com" ...
 `,
 	Run: executeRemoveUsers,
 }
 
 func executeRemoveUsers(cmd *base.Command, args []string) {
 	setSharedFlags(cmd)
+	var tag string
+	cmd.Flag.StringVar(&tag, "tag", "", "")
 	cmd.Flag.Parse(args)
-	unnamedArgs := cmd.Flag.Args()
-	inbs := extractInboundsConfig(unnamedArgs)
+	emails := cmd.Flag.Args()
+	if len(tag) < 1 {
+		base.Fatalf("inbound tag not specified")
+	}
 
 	conn, ctx, close := dialAPIServer()
 	defer close()
 	client := handlerService.NewHandlerServiceClient(conn)
 
 	success := 0
-	for _, inb := range inbs {
-		success += executeInboundUserAction(ctx, client, inb, removeInboundUserAction)
+	for _, email := range emails {
+		fmt.Println("remove user:", email)
+		_, err := client.AlterInbound(ctx, &handlerService.AlterInboundRequest{
+			Tag: tag,
+			Operation: cserial.ToTypedMessage(
+				&handlerService.RemoveUserOperation{
+					Email: email,
+				}),
+		})
+		if err == nil {
+			success += 1
+		} else {
+			fmt.Println(err)
+		}
 	}
 	fmt.Println("Removed", success, "user(s) in total.")
-}
-
-func removeInboundUserAction(ctx context.Context, client handlerService.HandlerServiceClient, tag string, user *protocol.User) error {
-	fmt.Println("remove user:", user.Email)
-	_, err := client.AlterInbound(ctx, &handlerService.AlterInboundRequest{
-		Tag: tag,
-		Operation: cserial.ToTypedMessage(
-			&handlerService.RemoveUserOperation{
-				Email: user.Email,
-			}),
-	})
-	return err
 }


### PR DESCRIPTION
这个 PR 添加 adu 和 rmu 两个管理 inbound 用户的命令行 API。支持 vless, vmess, trojan, ss 四种协议。  
主要给个人使用，机场有自己的面板应该不需要这个功能。  

```bash
$ ./xray help api adu
usage: xray api adu [--server=127.0.0.1:8080] <c1.json> [c2.json]...

Add users to inbounds.
Arguments:
        -s, -server
                The API server address. Default 127.0.0.1:8080
        -t, -timeout
                Timeout seconds to call API. Default 3
Example:
    xray api adu --server=127.0.0.1:8080  c1.json c2.json
```
```bash
$ ./xray help api rmu
usage: xray api rmu [--server=127.0.0.1:8080] -tag=tag <email1> [email2]...

Remove users from inbounds.
Arguments:
        -s, -server
                The API server address. Default 127.0.0.1:8080
        -t, -timeout
                Timeout seconds to call API. Default 3
        -tag
                Inbound tag
Example:
    xray api rmu --server=127.0.0.1:8080 -tag="vless-in" "xray@love.com" ...
```

<details><summary>详细用法示例：</summary><p>

config.json
```json
{
    "api": {
        "tag": "api",
        "listen": "127.0.0.1:2025",
        "services": [
            "HandlerService"
        ]
    },
    "inbounds": [
        {
            "tag": "serv",
            "protocol": "vless",
            "listen": "127.0.0.1",
            "port": 2000,
            "settings": {
                "decryption": "none",
                "clients": [
                    {
                        "email": "user1@xray.com",
                        "id": "74641c58-9e0b-41d4-8a24-78c48c54152f"
                    }
                ]
            }
        }
    ]
}
```

user2.json
```json
{
    "inbounds": [
        {
            "tag": "serv",
            "protocol": "vless",
            "listen": "127.0.0.1",
            "port": 2000,
            "settings": {
                "decryption": "none",
                "clients": [
                    {
                        "email": "user2@xray.com",
                        "id": "64bf49d6-4179-47fc-8e08-d8f5d8d0dd47"
                    }
                ]
            }
        }
    ]
}
```

首次添加用户2
```bash
$ ./xray api adu -s 127.0.0.1:2025 user2.json
processing inbound: serv
add user: user2@xray.com
result: ok
Added 1 user(s) in total.
```

再次添加用户2
```bash
$ cat user2.json | ./xray api adu -s 127.0.0.1:2025 stdin:
processing inbound: serv
add user: user2@xray.com
rpc error: code = Unknown desc = proxy/vless: User user2@xray.com already exists.
Added 0 user(s) in total.
```

查询当前用户
```bash
$ ./xray api inbounduser -s 127.0.0.1:2025 -tag "serv"
{
    "users": [
        {
            "account": {
                "_TypedMessage_": "xray.proxy.vless.Account",
                "id": "74641c58-9e0b-41d4-8a24-78c48c54152f"
            },
            "email": "user1@xray.com"
        },
        {
            "account": {
                "_TypedMessage_": "xray.proxy.vless.Account",
                "id": "64bf49d6-4179-47fc-8e08-d8f5d8d0dd47"
            },
            "email": "user2@xray.com"
        }
    ]
}
```

删除用户2
```bash
$ ./xray api rmu -s 127.0.0.1:2025 -tag="serv" "user2@xray.com"
remove user: user2@xray.com
Removed 1 user(s) in total.
```

再次查询
```bash
$ ./xray api inbounduser -s 127.0.0.1:2025 -tag "serv"
{
    "users": [
        {
            "account": {
                "_TypedMessage_": "xray.proxy.vless.Account",
                "id": "74641c58-9e0b-41d4-8a24-78c48c54152f"
            },
            "email": "user1@xray.com"
        }
    ]
}
```

</p></details>
