### PR TITLE
Easier Configuration: add 3 alias, add default tag for inbounds and outbounds

### DIFF
--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -22,6 +22,7 @@ import (
 var (
 	inboundConfigLoader = NewJSONConfigLoader(ConfigCreatorCache{
 		"dokodemo-door": func() interface{} { return new(DokodemoConfig) },
+		"tunnel":        func() interface{} { return new(DokodemoConfig) },
 		"http":          func() interface{} { return new(HTTPServerConfig) },
 		"shadowsocks":   func() interface{} { return new(ShadowsocksServerConfig) },
 		"mixed":         func() interface{} { return new(SocksServerConfig) },
@@ -34,8 +35,10 @@ var (
 
 	outboundConfigLoader = NewJSONConfigLoader(ConfigCreatorCache{
 		"blackhole":   func() interface{} { return new(BlackholeConfig) },
+		"block":       func() interface{} { return new(BlackholeConfig) },
 		"loopback":    func() interface{} { return new(LoopbackConfig) },
 		"freedom":     func() interface{} { return new(FreedomConfig) },
+		"direct":      func() interface{} { return new(FreedomConfig) },
 		"http":        func() interface{} { return new(HTTPClientConfig) },
 		"shadowsocks": func() interface{} { return new(ShadowsocksClientConfig) },
 		"socks":       func() interface{} { return new(SocksClientConfig) },


### PR DESCRIPTION
### add alias:
`tunnel` for `dokodemo-door`
`direct` for `freedom`
`block` for `blackhole`

### add default inbounds and outbounds tag:

**outbounds:**

```
	if c.Tag == "" {
		switch strings.ToLower(c.Protocol) {
		case "vless", "vmess", "trojan", "shadowsocks", "wireguard":
			c.Tag = "proxy"
		case "freedom", "direct":
			c.Tag = "direct"
		case "blackhole", "block":
			c.Tag = "block"
		case "dns":
			c.Tag = "dns-out"
		default:
			id := uuid.New()
			c.Tag = "xray.outbound." + id.String()
		}
	}

```

**inbounds:**

```
	if c.Tag == "" {
		id := uuid.New()
		c.Tag = "xray.inbound." + id.String()
	}

```

    
 