### PR TITLE
API: Fix user online map remain 1 after connection dropped

### DIFF
--- a/app/stats/online_map.go
+++ b/app/stats/online_map.go
@@ -7,7 +7,6 @@ import (
 
 // OnlineMap is an implementation of stats.OnlineMap.
 type OnlineMap struct {
-	value         int
 	ipList        map[string]time.Time
 	access        sync.RWMutex
 	lastCleanup   time.Time
@@ -25,7 +24,7 @@ func NewOnlineMap() *OnlineMap {
 
 // Count implements stats.OnlineMap.
 func (c *OnlineMap) Count() int {
-	return c.value
+	return len(c.ipList)
 }
 
 // List implements stats.OnlineMap.
@@ -50,7 +49,6 @@ func (c *OnlineMap) AddIP(ip string) {
 		c.lastCleanup = time.Now()
 	}
 
-	c.value = len(list)
 	c.ipList = list
 }
 
@@ -80,12 +78,10 @@ func (c *OnlineMap) RemoveExpiredIPs(list map[string]time.Time) map[string]time.
 }
 
 func (c *OnlineMap) IpTimeMap() map[string]time.Time {
-	list := c.ipList
 	if time.Since(c.lastCleanup) > c.cleanupPeriod {
-		list = c.RemoveExpiredIPs(list)
+		c.RemoveExpiredIPs(c.ipList)
 		c.lastCleanup = time.Now()
 	}
-	
-	c.value = len(list)
+
 	return c.ipList
 }

--- a/app/stats/online_map.go
+++ b/app/stats/online_map.go
@@ -85,6 +85,7 @@ func (c *OnlineMap) IpTimeMap() map[string]time.Time {
 		list = c.RemoveExpiredIPs(list)
 		c.lastCleanup = time.Now()
 	}
-
+	
+	c.value = len(list)
 	return c.ipList
 }

--- a/app/stats/online_map.go
+++ b/app/stats/online_map.go
@@ -37,18 +37,16 @@ func (c *OnlineMap) List() []string {
 
 // AddIP implements stats.OnlineMap.
 func (c *OnlineMap) AddIP(ip string) {
-	list := c.ipList
-
 	if ip == "127.0.0.1" {
 		return
 	}
 	c.access.Lock()
-	if _, ok := list[ip]; !ok {
-		list[ip] = time.Now()
+	if _, ok := c.ipList[ip]; !ok {
+		c.ipList[ip] = time.Now()
 	}
 	c.access.Unlock()
 	if time.Since(c.lastCleanup) > c.cleanupPeriod {
-		c.RemoveExpiredIPs(list)
+		c.RemoveExpiredIPs(c.ipList)
 		c.lastCleanup = time.Now()
 	}
 }

--- a/app/stats/online_map.go
+++ b/app/stats/online_map.go
@@ -24,6 +24,9 @@ func NewOnlineMap() *OnlineMap {
 
 // Count implements stats.OnlineMap.
 func (c *OnlineMap) Count() int {
+	c.access.RLock()
+	defer c.access.RUnlock()
+
 	return len(c.ipList)
 }
 
@@ -45,11 +48,9 @@ func (c *OnlineMap) AddIP(ip string) {
 	}
 	c.access.Unlock()
 	if time.Since(c.lastCleanup) > c.cleanupPeriod {
-		list = c.RemoveExpiredIPs(list)
+		c.RemoveExpiredIPs(list)
 		c.lastCleanup = time.Now()
 	}
-
-	c.ipList = list
 }
 
 func (c *OnlineMap) GetKeys() []string {


### PR DESCRIPTION
修复在没有连接后 ip 数量一直为 1 的问题