### PR TITLE
fix `MultiBuffer` `Compact` function

### DIFF
--- a/common/buf/buffer.go
+++ b/common/buf/buffer.go
@@ -258,6 +258,9 @@ func (b *Buffer) IsFull() bool {
 func (b *Buffer) Write(data []byte) (int, error) {
 	nBytes := copy(b.v[b.end:], data)
 	b.end += int32(nBytes)
+	if nBytes != len(data) {
+		return nBytes, errors.New("incomplete write")
+	}
 	return nBytes, nil
 }
 
@@ -306,10 +309,11 @@ func (b *Buffer) Read(data []byte) (int, error) {
 	nBytes := copy(data, b.v[b.start:b.end])
 	if int32(nBytes) == b.Len() {
 		b.Clear()
+		return nBytes, nil
 	} else {
 		b.start += int32(nBytes)
+		return nBytes, errors.New("incomplete read")
 	}
-	return nBytes, nil
 }
 
 // ReadFrom implements io.ReaderFrom.

--- a/common/buf/multi_buffer.go
+++ b/common/buf/multi_buffer.go
@@ -141,12 +141,22 @@ func Compact(mb MultiBuffer) MultiBuffer {
 
 	mb2 := make(MultiBuffer, 0, len(mb))
 	last := mb[0]
+	if last.start != 0 {
+		b := New()
+		common.Must2(b.ReadFrom(last))
+		last = b
+	}
 
 	for i := 1; i < len(mb); i++ {
 		curr := mb[i]
 		if last.Len()+curr.Len() > Size {
 			mb2 = append(mb2, last)
 			last = curr
+			if last.start != 0 {
+				b := New()
+				common.Must2(b.ReadFrom(last))
+				last = b
+			}
 		} else {
 			common.Must2(last.ReadFrom(curr))
 			curr.Release()


### PR DESCRIPTION
Unfortunately, the lack of error return in the two functions `read` and `write` (in `buffer.go`) caused the author to write the function `Compact` (in `multi_buffer.go`) incorrectly and no one has noticed until now.

///

`common.Must2(last.ReadFrom(curr))` does not necessarily append `curr` to `last`, also `common.Must2` has no effect here, because `ReadFrom` does not return any error on failure.

///

for example suppose:

in `Compact` function `for` loop, `last` == `mb[0]` and `curr` == `mb[1]`
and `last.start` == `2` and `last.end` == `8192`
and `curr.start` == `0` and `curr.end` == `2`
so `last.Len() + curr.Len() <= 8192`
but `common.Must2(last.ReadFrom(curr))`  doesn't actually do anything!!!

///

**`Compact` function is used in `tls` and `websocket`, and this caused the Xray-core to occasionally send corrupted data!!! Whoa!!!**

thanks to @Vdu6n1XMrq6694a8 for his/her great Reproduction.
