### PR TITLE
VLESS inbound: Add option to set default `flow`

### DIFF
--- a/infra/conf/vless.go
+++ b/infra/conf/vless.go
@@ -40,7 +40,7 @@ func (c *VLessInboundConfig) Build() (proto.Message, error) {
 	config := new(inbound.Config)
 	config.Clients = make([]*protocol.User, len(c.Clients))
 	switch c.Flow {
-	case "", vless.XRV:
+	case "", vless.XRV, vless.NO_FLOW:
 	default:
 		return nil, errors.New(`VLESS "settings.flow" doesn't support "` + c.Flow + `" in this version`)
 	}
@@ -63,6 +63,8 @@ func (c *VLessInboundConfig) Build() (proto.Message, error) {
 		switch account.Flow {
 		case "":
 			account.Flow = c.Flow
+		case vless.NO_FLOW:
+			account.Flow = ""
 		case vless.XRV:
 		default:
 			return nil, errors.New(`VLESS clients: "flow" doesn't support "` + account.Flow + `" in this version`)

--- a/infra/conf/vless.go
+++ b/infra/conf/vless.go
@@ -29,9 +29,10 @@ type VLessInboundFallback struct {
 }
 
 type VLessInboundConfig struct {
-	Clients    []json.RawMessage       `json:"clients"`
-	Decryption string                  `json:"decryption"`
-	Fallbacks  []*VLessInboundFallback `json:"fallbacks"`
+	Clients     []json.RawMessage       `json:"clients"`
+	Decryption  string                  `json:"decryption"`
+	Fallbacks   []*VLessInboundFallback `json:"fallbacks"`
+	DefaultFlow string                  `json:"defaultFlow"`
 }
 
 // Build implements Buildable
@@ -55,7 +56,9 @@ func (c *VLessInboundConfig) Build() (proto.Message, error) {
 		account.Id = u.String()
 
 		switch account.Flow {
-		case "", vless.XRV:
+		case "":
+			account.Flow = c.DefaultFlow
+		case vless.XRV:
 		default:
 			return nil, errors.New(`VLESS clients: "flow" doesn't support "` + account.Flow + `" in this version`)
 		}

--- a/infra/conf/vless.go
+++ b/infra/conf/vless.go
@@ -58,7 +58,7 @@ func (c *VLessInboundConfig) Build() (proto.Message, error) {
 		switch c.Flow {
 		case "", vless.XRV:
 		default:
-			return nil, errors.New(`VLESS clients: "settings.flow" doesn't support "` + account.Flow + `" in this version`)
+			return nil, errors.New(`VLESS "settings.flow" doesn't support "` + c.Flow + `" in this version`)
 		}
 
 		switch account.Flow {

--- a/infra/conf/vless.go
+++ b/infra/conf/vless.go
@@ -29,10 +29,10 @@ type VLessInboundFallback struct {
 }
 
 type VLessInboundConfig struct {
-	Clients     []json.RawMessage       `json:"clients"`
-	Decryption  string                  `json:"decryption"`
-	Fallbacks   []*VLessInboundFallback `json:"fallbacks"`
-	DefaultFlow string                  `json:"defaultFlow"`
+	Clients    []json.RawMessage       `json:"clients"`
+	Decryption string                  `json:"decryption"`
+	Fallbacks  []*VLessInboundFallback `json:"fallbacks"`
+	Flow       string                  `json:"flow"`
 }
 
 // Build implements Buildable
@@ -57,7 +57,7 @@ func (c *VLessInboundConfig) Build() (proto.Message, error) {
 
 		switch account.Flow {
 		case "":
-			account.Flow = c.DefaultFlow
+			account.Flow = c.Flow
 		case vless.XRV:
 		default:
 			return nil, errors.New(`VLESS clients: "flow" doesn't support "` + account.Flow + `" in this version`)

--- a/infra/conf/vless.go
+++ b/infra/conf/vless.go
@@ -40,7 +40,7 @@ func (c *VLessInboundConfig) Build() (proto.Message, error) {
 	config := new(inbound.Config)
 	config.Clients = make([]*protocol.User, len(c.Clients))
 	switch c.Flow {
-	case "", vless.XRV, vless.NO_FLOW:
+	case "", vless.XRV, vless.NoFLow:
 	default:
 		return nil, errors.New(`VLESS "settings.flow" doesn't support "` + c.Flow + `" in this version`)
 	}
@@ -63,7 +63,7 @@ func (c *VLessInboundConfig) Build() (proto.Message, error) {
 		switch account.Flow {
 		case "":
 			account.Flow = c.Flow
-		case vless.NO_FLOW:
+		case vless.NoFLow:
 			account.Flow = ""
 		case vless.XRV:
 		default:

--- a/infra/conf/vless.go
+++ b/infra/conf/vless.go
@@ -39,6 +39,11 @@ type VLessInboundConfig struct {
 func (c *VLessInboundConfig) Build() (proto.Message, error) {
 	config := new(inbound.Config)
 	config.Clients = make([]*protocol.User, len(c.Clients))
+	switch c.Flow {
+	case "", vless.XRV:
+	default:
+		return nil, errors.New(`VLESS "settings.flow" doesn't support "` + c.Flow + `" in this version`)
+	}
 	for idx, rawUser := range c.Clients {
 		user := new(protocol.User)
 		if err := json.Unmarshal(rawUser, user); err != nil {
@@ -54,12 +59,6 @@ func (c *VLessInboundConfig) Build() (proto.Message, error) {
 			return nil, err
 		}
 		account.Id = u.String()
-
-		switch c.Flow {
-		case "", vless.XRV:
-		default:
-			return nil, errors.New(`VLESS "settings.flow" doesn't support "` + c.Flow + `" in this version`)
-		}
 
 		switch account.Flow {
 		case "":

--- a/infra/conf/vless.go
+++ b/infra/conf/vless.go
@@ -55,6 +55,12 @@ func (c *VLessInboundConfig) Build() (proto.Message, error) {
 		}
 		account.Id = u.String()
 
+		switch c.Flow {
+		case "", vless.XRV:
+		default:
+			return nil, errors.New(`VLESS clients: "settings.flow" doesn't support "` + account.Flow + `" in this version`)
+		}
+
 		switch account.Flow {
 		case "":
 			account.Flow = c.Flow

--- a/infra/conf/vless.go
+++ b/infra/conf/vless.go
@@ -40,7 +40,9 @@ func (c *VLessInboundConfig) Build() (proto.Message, error) {
 	config := new(inbound.Config)
 	config.Clients = make([]*protocol.User, len(c.Clients))
 	switch c.Flow {
-	case "", vless.XRV, vless.NoFLow:
+	case vless.NoFLow:
+		c.Flow = ""
+	case "", vless.XRV:
 	default:
 		return nil, errors.New(`VLESS "settings.flow" doesn't support "` + c.Flow + `" in this version`)
 	}

--- a/infra/conf/vless.go
+++ b/infra/conf/vless.go
@@ -40,7 +40,7 @@ func (c *VLessInboundConfig) Build() (proto.Message, error) {
 	config := new(inbound.Config)
 	config.Clients = make([]*protocol.User, len(c.Clients))
 	switch c.Flow {
-	case vless.NoFLow:
+	case vless.None:
 		c.Flow = ""
 	case "", vless.XRV:
 	default:
@@ -65,7 +65,7 @@ func (c *VLessInboundConfig) Build() (proto.Message, error) {
 		switch account.Flow {
 		case "":
 			account.Flow = c.Flow
-		case vless.NoFLow:
+		case vless.None:
 			account.Flow = ""
 		case vless.XRV:
 		default:

--- a/proxy/vless/vless.go
+++ b/proxy/vless/vless.go
@@ -6,6 +6,6 @@
 package vless
 
 const (
-	XRV     = "xtls-rprx-vision"
-	NO_FLOW = "none"
+	XRV    = "xtls-rprx-vision"
+	NoFLow = "none"
 )

--- a/proxy/vless/vless.go
+++ b/proxy/vless/vless.go
@@ -7,5 +7,5 @@ package vless
 
 const (
 	XRV     = "xtls-rprx-vision"
-	NO_FLOW = "no-flow"
+	NO_FLOW = "none"
 )

--- a/proxy/vless/vless.go
+++ b/proxy/vless/vless.go
@@ -6,6 +6,6 @@
 package vless
 
 const (
-	XRV  = "xtls-rprx-vision"
 	None = "none"
+	XRV  = "xtls-rprx-vision"
 )

--- a/proxy/vless/vless.go
+++ b/proxy/vless/vless.go
@@ -6,5 +6,6 @@
 package vless
 
 const (
-	XRV = "xtls-rprx-vision"
+	XRV     = "xtls-rprx-vision"
+	NO_FLOW = "no-flow"
 )

--- a/proxy/vless/vless.go
+++ b/proxy/vless/vless.go
@@ -6,6 +6,6 @@
 package vless
 
 const (
-	XRV    = "xtls-rprx-vision"
-	NoFLow = "none"
+	XRV  = "xtls-rprx-vision"
+	None = "none"
 )


### PR DESCRIPTION
https://github.com/XTLS/Xray-core/issues/4994

Implementation for fr.

How it work.

If defaultFlow isn't set than defaultFlow is "" and all core logic work like in previous versions. But, when we set defaultFlow, then if client don't have flow, then will be set flow from defaultFlow. Its optional parameter.

```json
"settings": {
        "defaultFlow": "xtls-rprx-vision",
        "clients": [
          {
            "id": "c481e5e7-2796-491d-ac55-00e3c1e0acc3",
            "email": "sOoqSgPC2rHuTWRCPLt3"
          }
        ],
        "decryption": "none"
      }

```