### PR TITLE
Chore: Migrate to Go 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/xtls/xray-core
 
-go 1.24
+go 1.25
 
 require (
 	github.com/cloudflare/circl v1.6.1

--- a/main/commands/all/tls/ping.go
+++ b/main/commands/all/tls/ping.go
@@ -6,9 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net"
-	"reflect"
 	"strconv"
-	"unsafe"
 
 	"github.com/xtls/xray-core/main/commands/base"
 	. "github.com/xtls/xray-core/transport/internet/tls"
@@ -139,14 +137,15 @@ func printCertificates(certs []*x509.Certificate) {
 }
 
 func printTLSConnDetail(tlsConn *gotls.Conn) {
+	connectionState := tlsConn.ConnectionState()
 	var tlsVersion string
-	if tlsConn.ConnectionState().Version == gotls.VersionTLS13 {
+	if connectionState.Version == gotls.VersionTLS13 {
 		tlsVersion = "TLS 1.3"
-	} else if tlsConn.ConnectionState().Version == gotls.VersionTLS12 {
+	} else if connectionState.Version == gotls.VersionTLS12 {
 		tlsVersion = "TLS 1.2"
 	}
 	fmt.Println("TLS Version: ", tlsVersion)
-	curveID := *(*gotls.CurveID)(unsafe.Pointer(reflect.ValueOf(tlsConn).Elem().FieldByName("curveID").UnsafeAddr()))
+	curveID := connectionState.CurveID
 	if curveID != 0 {
 		PostQuantum := (curveID == gotls.X25519MLKEM768)
 		fmt.Println("TLS Post-Quantum key exchange: ", PostQuantum, "("+curveID.String()+")")


### PR DESCRIPTION
什么都没发生 好像不像前几次那么艰难
扫了一下更新日志 移除了tls ping使用unsafe获取未导出的密钥交换算法 因为现在connectionstate提供了
看有人说实验性GC的事 它不会被包含在内(因为需要构建时GOEXPERIMENT) 而且它不会减少内存占用 一段内存该不该回收在GC开始时就确定了 能降低的CPU占用也有限因为这个算法优化的是回收碎片内存 xray的大头buffer都是new出来的整块内存 而且是有一个pool管理的(