### PR TITLE
Socks/https: Fix unexpected rawConn copy

### DIFF
--- a/proxy/http/server.go
+++ b/proxy/http/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/xtls/xray-core/core"
 	"github.com/xtls/xray-core/features/policy"
 	"github.com/xtls/xray-core/features/routing"
+	"github.com/xtls/xray-core/proxy"
 	"github.com/xtls/xray-core/transport/internet/stat"
 )
 
@@ -95,7 +96,7 @@ func (s *Server) ProcessWithFirstbyte(ctx context.Context, network net.Network, 
 	inbound.User = &protocol.MemoryUser{
 		Level: s.config.UserLevel,
 	}
-	if isTransportConn(conn) {
+	if !proxy.IsRAWTransport(conn) {
 		inbound.CanSpliceCopy = 3
 	}
 	var reader *bufio.Reader
@@ -373,20 +374,6 @@ func readResponseAndHandle100Continue(r *bufio.Reader, req *http.Request, writer
 		}
 	}
 	return http.ReadResponse(r, req)
-}
-
-// isTransportConn return false if the conn is a raw tcp conn without transport or tls, can process splice copy
-func isTransportConn(conn stat.Connection) bool {
-	if conn != nil {
-		statConn, ok := conn.(*stat.CounterConnection)
-		if ok {
-			conn = statConn.Connection
-		}
-		if _, ok := conn.(*net.TCPConn); ok {
-			return false
-		}
-	}
-	return true
 }
 
 func init() {

--- a/proxy/socks/server.go
+++ b/proxy/socks/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/xtls/xray-core/core"
 	"github.com/xtls/xray-core/features/policy"
 	"github.com/xtls/xray-core/features/routing"
+	"github.com/xtls/xray-core/proxy"
 	"github.com/xtls/xray-core/proxy/http"
 	"github.com/xtls/xray-core/transport/internet/stat"
 	"github.com/xtls/xray-core/transport/internet/udp"
@@ -75,7 +76,7 @@ func (s *Server) Process(ctx context.Context, network net.Network, conn stat.Con
 	inbound.User = &protocol.MemoryUser{
 		Level: s.config.UserLevel,
 	}
-	if isTransportConn(conn) {
+	if !proxy.IsRAWTransport(conn) {
 		inbound.CanSpliceCopy = 3
 	}
 
@@ -313,20 +314,6 @@ func (s *Server) handleUDPPayload(ctx context.Context, conn stat.Connection, dis
 			udpServer.Dispatch(currentPacketCtx, *dest, payload)
 		}
 	}
-}
-
-// isTransportConn return false if the conn is a raw tcp conn without transport or tls, can process splice copy
-func isTransportConn(conn stat.Connection) bool {
-	if conn != nil {
-		statConn, ok := conn.(*stat.CounterConnection)
-		if ok {
-			conn = statConn.Connection
-		}
-		if _, ok := conn.(*net.TCPConn); ok {
-			return false
-		}
-	}
-	return true
 }
 
 func init() {


### PR DESCRIPTION
close #5040
rt 防止socks5或者http在over tls或者ws之类的东西的时候被意外splice 不过我测试返回的错误不是bad record 是别的乱七八糟的
see https://github.com/XTLS/Xray-core/commit/eef74b2c7dd6d988b8baab6b5d15062e6497f372#diff-7e4a3669d1f89cd5bf18b4387841cabd1fcb156a8a632b8892ee3267359a1828
@yuhan6665 