### PR TITLE
Timer: prevent creating redundant check task

### DIFF
--- a/common/signal/timer.go
+++ b/common/signal/timer.go
@@ -56,12 +56,15 @@ func (t *ActivityTimer) SetTimeout(timeout time.Duration) {
 		return
 	}
 
+	t.Lock()
+	defer t.Unlock()
+	if t.onTimeout == nil {
+		return
+	}
 	checkTask := &task.Periodic{
 		Interval: timeout,
 		Execute:  t.check,
 	}
-
-	t.Lock()
 
 	if t.checkTask != nil {
 		t.checkTask.Close()
@@ -69,7 +72,6 @@ func (t *ActivityTimer) SetTimeout(timeout time.Duration) {
 	t.checkTask = checkTask
 	t.Update()
 	common.Must(checkTask.Start())
-	t.Unlock()
 }
 
 func CancelAfterInactivity(ctx context.Context, cancel context.CancelFunc, timeout time.Duration) *ActivityTimer {


### PR DESCRIPTION
```
requestDone := func() error {
		defer timer.SetTimeout(plcy.Timeouts.DownlinkOnly)
                ...
}

responseDone := func() error {
		defer timer.SetTimeout(plcy.Timeouts.UplinkOnly)
                ...
}

```
after one timeout is set, another one will be set after timeout and return, but it is redundant.

//////////////////////////////////////////////////////////////////////////////////////////////

also, if UplinkOnly/DownlinkOnly timeout is already set , splice-timeout should not be set, and I will fix it soon.

https://github.com/XTLS/Xray-core/blob/33272a04994e81509fbd713c8dc1217c39f1e461/proxy/proxy.go#L599-L602