### PR TITLE
Commands: Add `-outpbfile` for `convert pb`

### DIFF
--- a/main/commands/all/convert/protobuf.go
+++ b/main/commands/all/convert/protobuf.go
@@ -63,7 +63,7 @@ func executeConvertConfigsToProtobuf(cmd *base.Command, args []string) {
 	if len(optFile) > 0 {
 		switch core.GetFormatByExtension(getFileExtension(optFile)){
 		case "protobuf", "":
-			fmt.Println("Output ProtoBuf file is %s.", optFile)
+			fmt.Println("Output ProtoBuf file is ", optFile)
 		default:
 			base.Fatalf("-outpbfile followed by a possible original config.")
 		}

--- a/main/commands/all/convert/protobuf.go
+++ b/main/commands/all/convert/protobuf.go
@@ -89,7 +89,7 @@ func executeConvertConfigsToProtobuf(cmd *base.Command, args []string) {
 		}
 		defer f.Close()
 
-		if _, err := f.Write(bytesConfig); err!= nil {
+		if _, err := f.Write(bytesConfig); err != nil {
 			base.Fatalf("failed to write proto file: %s", err)
 		}
 	} else {

--- a/main/commands/all/convert/protobuf.go
+++ b/main/commands/all/convert/protobuf.go
@@ -66,7 +66,7 @@ func executeConvertConfigsToProtobuf(cmd *base.Command, args []string) {
 
 	if len(optFile) > 0 {
 		fileFormat := core.GetFormatByExtension(getFileExtension(optFile))
-		if fileFormat != "protobuf" || fileFormat != "" {
+		if (fileFormat != "protobuf") || (fileFormat != "") {
 			base.Fatalf("-outpbfile followed by a possible original config.")
 		}
 	} else if !optDump {

--- a/main/commands/all/convert/protobuf.go
+++ b/main/commands/all/convert/protobuf.go
@@ -60,19 +60,19 @@ func executeConvertConfigsToProtobuf(cmd *base.Command, args []string) {
 		unnamedArgs.Set(v)
 	}
 
-	if len(unnamedArgs) < 1 {
-		base.Fatalf("invalid config list length: %d", len(unnamedArgs))
-	}
-
 	if len(optFile) > 0 {
 		switch core.GetFormatByExtension(getFileExtension(optFile)){
 		case "protobuf", "":
-			fmt.Printf("Output ProtoBuf file is %s.", optFile)
+			fmt.Println("Output ProtoBuf file is %s.", optFile)
 		default:
 			base.Fatalf("-outpbfile followed by a possible original config.")
 		}
 	} else if !optDump {
 		base.Fatalf("-outpbfile not specified")
+	}
+
+	if len(unnamedArgs) < 1 {
+		base.Fatalf("invalid config list length: %d", len(unnamedArgs))
 	}
 
 	pbConfig, err := core.LoadConfig("auto", unnamedArgs)

--- a/main/commands/all/convert/protobuf.go
+++ b/main/commands/all/convert/protobuf.go
@@ -18,7 +18,7 @@ var cmdProtobuf = &base.Command{
 	UsageLine:   "{{.Exec}} convert pb [-outpbfile file] [-debug] [-type] [json file] [json file] ...",
 	Short:       "Convert multiple json configs to protobuf",
 	Long: `
-Convert multiple configs to protobuf. JSON, YAML and TOML can be used.
+Convert multiple configs to ProtoBuf. JSON, YAML and TOML can be used.
 
 Arguments:
 
@@ -65,8 +65,10 @@ func executeConvertConfigsToProtobuf(cmd *base.Command, args []string) {
 	}
 
 	if len(optFile) > 0 {
-		fileFormat := core.GetFormatByExtension(getFileExtension(optFile))
-		if (fileFormat != "protobuf") || (fileFormat != "") {
+		switch core.GetFormatByExtension(getFileExtension(optFile)){
+		case "protobuf", "":
+			fmt.Printf("Output ProtoBuf file is %s.", optFile)
+		default:
 			base.Fatalf("-outpbfile followed by a possible original config.")
 		}
 	} else if !optDump {


### PR DESCRIPTION
~~这么久了似乎没人发现用 `xray convert pb config.json c1.json c2.json c3.json > mix.pb` 这个方式出来的 proto 文件没法正常用的吗，看来现在用 proto 配置的没几个了~~

用 `xray convert pb config.json c1.json c2.json c3.json > mix.pb` 转换配置文件到 proto 文件的时候，这个操作其实是将控制台输出写到文件（期望的 proto），但是会将读取配置文件产生的 log （写到控制台）也一并写进文件，导致产生的文件不能用。 ~~其实用十六进制编辑器或者什么的把头部的 log 去掉就好，但是依然比较麻烦~~

现增加一个选项 -outpbfile，直接将生成的 proto 直接写到指定文件位置，出来的 proto 文件直接就能用。
比如： `xray convert pb -outpbfile output.pb config.json c1.json c2.json c3.json` 将 config.json c1.json c2.json c3.json 合并后转换成 proto 并直接写入到 output.pb

~~功能描述要不要再调整，调用 `core.LoadConfig` 可以使用 JSON(C) YAML TOML 格式的配置~~