### PR TITLE
common/signal/timer.go: Refator to use sync.Once

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -160,7 +160,6 @@ func CloseIfExists(obj any) error {
 	if obj != nil {
 		v := reflect.ValueOf(obj)
 		if !v.IsNil() {
-			fmt.Println("closing", obj)
 			return Close(obj)
 		}
 	}


### PR DESCRIPTION
fix #5051 
移除了烦人难懂的空指针检查 改为显式的once操作 finish() 无论如何只执行一次
settimeout在once被消耗后不再执行操作
mutex匿名结构体被重新修改为未导出字段 mutex相关功能不应该允许外部调用
so