### PR TITLE
WireGuard outbound: Fix close closed

### DIFF
--- a/proxy/wireguard/client.go
+++ b/proxy/wireguard/client.go
@@ -129,7 +129,8 @@ func (h *Handler) processWireGuard(ctx context.Context, dialer internet.Dialer) 
 	}
 	defer func() {
 		if err != nil {
-			_ = h.bind.Close()
+			h.bind.Close()
+			h.bind = nil
 		}
 	}()
 


### PR DESCRIPTION
close #5053 
跟我说的一样wg实现很怪 甚至用 `_ =` 来忽略全部返回值 这个defer整一个就是坏的 h.bind 也很不合适 暂时糊一个上去吧