### PR TITLE
Buffer-upd

### DIFF
--- a/common/buf/buffer.go
+++ b/common/buf/buffer.go
@@ -14,9 +14,6 @@ const (
 )
 
 var ErrBufferFull = errors.New("buffer is full")
-
-var zero = [Size * 10]byte{0}
-
 var pool = bytespool.GetPool(Size)
 
 // ownership represents the data owner of the buffer.
@@ -41,60 +38,67 @@ type Buffer struct {
 
 // New creates a Buffer with 0 length and 8K capacity, managed.
 func New() *Buffer {
-	buf := pool.Get().([]byte)
-	if cap(buf) >= Size {
-		buf = buf[:Size]
-	} else {
-		buf = make([]byte, Size)
+	v := pool.Get()
+	b, ok := v.([]byte)
+	if !ok || cap(b) < Size {
+		b = make([]byte, Size)
 	}
-
-	return &Buffer{
-		v: buf,
-	}
+	b = b[:Size:Size]
+	return &Buffer{v: b}
 }
 
-// NewExisted creates a standard size Buffer with an existed bytearray, managed.
+// NewExisted creates a standard size Buffer with an existed bytearray, managed
+// Panics if cap(b) < Size or len(b) overflows int32.
 func NewExisted(b []byte) *Buffer {
 	if cap(b) < Size {
 		panic("Invalid buffer")
 	}
 
 	oLen := len(b)
+	oLen32 := int32(oLen)
+	if int(oLen32) != oLen {
+		panic("Invalid buffer length")
+	}
+
 	if oLen < Size {
-		b = b[:Size]
+		b = b[:Size:Size]
 	}
 
 	return &Buffer{
 		v:   b,
-		end: int32(oLen),
+		end: oLen32,
 	}
 }
 
 // FromBytes creates a Buffer with an existed bytearray, unmanaged.
+// Panics if len(b) exceeds int32; capacity is fixed via b[:n:n].
 func FromBytes(b []byte) *Buffer {
+	const maxInt32 = 1<<31 - 1
+	n := len(b)
+	if n > maxInt32 {
+		panic("buffer too large")
+	}
+	v := b[:n:n]
 	return &Buffer{
-		v:         b,
-		end:       int32(len(b)),
+		v:         v,
+		end:       int32(n),
 		ownership: unmanaged,
 	}
 }
 
 // StackNew creates a new Buffer object on stack, managed.
-// This method is for buffers that is released in the same function.
+// This method is for buffers that are released in the same function.
 func StackNew() Buffer {
-	buf := pool.Get().([]byte)
-	if cap(buf) >= Size {
-		buf = buf[:Size]
-	} else {
-		buf = make([]byte, Size)
+	v := pool.Get()
+	b, ok := v.([]byte)
+	if !ok || cap(b) < Size {
+		b = make([]byte, Size)
 	}
-
-	return Buffer{
-		v: buf,
-	}
+	b = b[:Size:Size]
+	return Buffer{v: b}
 }
 
-// NewWithSize creates a Buffer with 0 length and capacity with at least the given size, bytespool's.
+// NewWithSize creates a Buffer with 0 length and capacity at least size, bytespool-backed.
 func NewWithSize(size int32) *Buffer {
 	return &Buffer{
 		v:         bytespool.Alloc(size),
@@ -103,16 +107,28 @@ func NewWithSize(size int32) *Buffer {
 }
 
 // Release recycles the buffer into an internal buffer pool.
+// Zeroes the used range; no-op for nil or unmanaged.
 func (b *Buffer) Release() {
-	if b == nil || b.v == nil || b.ownership == unmanaged {
+	if b == nil {
+		return
+	}
+	p := b.v
+	o := b.ownership
+	usedStart, usedEnd := b.start, b.end
+
+	b.v = nil
+	b.start, b.end = 0, 0
+	b.UDP = nil
+
+	if p == nil || o == unmanaged {
 		return
 	}
 
-	p := b.v
-	b.v = nil
-	b.Clear()
+	if usedEnd > usedStart && int(usedEnd) <= len(p) {
+		clear(p[usedStart:usedEnd])
+	}
 
-	switch b.ownership {
+	switch o {
 	case managed:
 		if cap(p) == Size {
 			pool.Put(p)
@@ -120,14 +136,15 @@ func (b *Buffer) Release() {
 	case bytespools:
 		bytespool.Free(p)
 	}
-	b.UDP = nil
 }
 
-// Clear clears the content of the buffer, results an empty buffer with
-// Len() = 0.
+// Clear clears the content of the buffer, results an empty buffer with Len() = 0.
+// No-op for nil.
 func (b *Buffer) Clear() {
-	b.start = 0
-	b.end = 0
+	if b == nil {
+		return
+	}
+	b.start, b.end = 0, 0
 }
 
 // Byte returns the bytes at index.
@@ -146,86 +163,108 @@ func (b *Buffer) Bytes() []byte {
 }
 
 // Extend increases the buffer size by n bytes, and returns the extended part.
-// It panics if result size is larger than buf.Size.
+// Panics on negative n or if capacity is exceeded.
 func (b *Buffer) Extend(n int32) []byte {
-	end := b.end + n
-	if end > int32(len(b.v)) {
-		panic("extending out of bound")
+	if n == 0 {
+		return b.v[b.end:b.end]
 	}
-	ext := b.v[b.end:end]
-	b.end = end
-	copy(ext, zero[:])
-	return ext
+	if n < 0 {
+		panic("extending out of bounds")
+	}
+	avail := int32(len(b.v)) - b.end
+	if n > avail {
+		panic("extending out of bounds")
+	}
+	oldEnd := b.end
+	b.end += n
+	return b.v[oldEnd:b.end]
 }
 
 // BytesRange returns a slice of this buffer with given from and to boundary.
+// Negative indices are clamped and from ≤ to is enforced.
 func (b *Buffer) BytesRange(from, to int32) []byte {
+	l := b.Len()
+
 	if from < 0 {
-		from += b.Len()
+		from += l
 	}
 	if to < 0 {
-		to += b.Len()
+		to += l
 	}
-	return b.v[b.start+from : b.start+to]
+	from = min(max(from, 0), l)
+	to = min(max(to, 0), l)
+
+	if to < from {
+		to = from
+	}
+
+	start := b.start + from
+	end := b.start + to
+	return b.v[start:end]
 }
 
 // BytesFrom returns a slice of this Buffer starting from the given position.
+// Negative index is clamped.
 func (b *Buffer) BytesFrom(from int32) []byte {
-	if from < 0 {
-		from += b.Len()
-	}
-	return b.v[b.start+from : b.end]
+	return b.BytesRange(from, b.Len())
 }
 
 // BytesTo returns a slice of this Buffer from start to the given position.
+// Negative index is clamped.
 func (b *Buffer) BytesTo(to int32) []byte {
-	if to < 0 {
-		to += b.Len()
-	}
-	if to < 0 {
-		to = 0
-	}
-	return b.v[b.start : b.start+to]
+	return b.BytesRange(0, to)
 }
 
-// Check makes sure that 0 <= b.start <= b.end.
+// Check makes sure that 0 <= b.start <= b.end <= int32(len(b.v)).
+// No-op for nil.
 func (b *Buffer) Check() {
-	if b.start < 0 {
-		b.start = 0
+	if b == nil {
+		return
 	}
-	if b.end < 0 {
-		b.end = 0
-	}
-	if b.start > b.end {
-		b.start = b.end
+	cap32 := int32(len(b.v))
+	e := min(max(b.end, 0), cap32)
+	s := min(max(b.start, 0), e)
+	if s != b.start || e != b.end {
+		b.start, b.end = s, e
 	}
 }
 
-// Resize cuts the buffer at the given position.
+// Resize cuts the buffer to [from:to] relative to current content (negative indices allowed).
+// Panics if to < from or capacity is exceeded.
+// Zeroes any newly exposed region.
 func (b *Buffer) Resize(from, to int32) {
 	oldEnd := b.end
+	l := b.Len()
 	if from < 0 {
-		from += b.Len()
+		from += l
 	}
 	if to < 0 {
-		to += b.Len()
+		to += l
 	}
 	if to < from {
 		panic("Invalid slice")
 	}
-	b.end = b.start + to
-	b.start += from
+	newStart := b.start + from
+	newEnd := b.start + to
+	if newEnd > int32(len(b.v)) {
+		panic("extending out of bound")
+	}
+	b.start = newStart
+	b.end = newEnd
 	b.Check()
 	if b.end > oldEnd {
-		copy(b.v[oldEnd:b.end], zero[:])
+		clear(b.v[oldEnd:b.end])
 	}
 }
 
-// Advance cuts the buffer at the given position.
+// Advance cuts the buffer by moving start by from relative to current length.
+// Negative allowed and clamped.
 func (b *Buffer) Advance(from int32) {
+	l := b.end - b.start
 	if from < 0 {
-		from += b.Len()
+		from += l
 	}
+	from = min(max(from, 0), l)
 	b.start += from
 	b.Check()
 }
@@ -265,28 +304,46 @@ func (b *Buffer) IsFull() bool {
 }
 
 // Write implements Write method in io.Writer.
+// Returns ErrBufferFull on short write.
+// Returns 0, nil on empty input.
 func (b *Buffer) Write(data []byte) (int, error) {
-	nBytes := copy(b.v[b.end:], data)
-	b.end += int32(nBytes)
-	if nBytes < len(data) {
-		return nBytes, ErrBufferFull
+	if len(data) == 0 {
+		return 0, nil
 	}
-	return nBytes, nil
+	end := b.end
+	n := copy(b.v[end:], data)
+	b.end = end + int32(n)
+	if n != len(data) {
+		return n, ErrBufferFull
+	}
+	return n, nil
 }
 
 // WriteByte writes a single byte into the buffer.
 func (b *Buffer) WriteByte(v byte) error {
-	if b.IsFull() {
+	if b.end == int32(len(b.v)) {
 		return ErrBufferFull
 	}
-	b.v[b.end] = v
-	b.end++
+	i := b.end
+	b.v[i] = v
+	b.end = i + 1
 	return nil
 }
 
 // WriteString implements io.StringWriter.
+// Returns ErrBufferFull on short write.
+// Returns 0, nil on empty input.
 func (b *Buffer) WriteString(s string) (int, error) {
-	return b.Write([]byte(s))
+	if len(s) == 0 {
+		return 0, nil
+	}
+	end := b.end
+	n := copy(b.v[end:], s)
+	b.end = end + int32(n)
+	if n != len(s) {
+		return n, ErrBufferFull
+	}
+	return n, nil
 }
 
 // ReadByte implements io.ByteReader
@@ -294,53 +351,85 @@ func (b *Buffer) ReadByte() (byte, error) {
 	if b.start == b.end {
 		return 0, io.EOF
 	}
-
-	nb := b.v[b.start]
-	b.start++
-	return nb, nil
+	i := b.start
+	v := b.v[i]
+	b.start = i + 1
+	return v, nil
 }
 
-// ReadBytes implements bufio.Reader.ReadBytes
+// ReadBytes implements bufio.Reader.ReadBytes.
+// Panics if length < 0.
+// Returns io.EOF if insufficient data.
 func (b *Buffer) ReadBytes(length int32) ([]byte, error) {
-	if b.end-b.start < length {
+	if length < 0 {
+		panic("invalid length")
+	}
+	avail := b.end - b.start
+	if avail < length {
 		return nil, io.EOF
 	}
-
-	nb := b.v[b.start : b.start+length]
-	b.start += length
-	return nb, nil
+	start := b.start
+	end := start + length
+	b.start = end
+	return b.v[start:end], nil
 }
 
 // Read implements io.Reader.Read().
 func (b *Buffer) Read(data []byte) (int, error) {
 	if b.Len() == 0 {
+		if len(data) == 0 {
+			return 0, nil
+		}
 		return 0, io.EOF
 	}
 	nBytes := copy(data, b.v[b.start:b.end])
-	if int32(nBytes) == b.Len() {
+	b.start += int32(nBytes)
+	if b.start == b.end {
 		b.Clear()
-	} else {
-		b.start += int32(nBytes)
 	}
 	return nBytes, nil
 }
 
 // ReadFrom implements io.ReaderFrom.
+// Reads into remaining capacity and suppresses io.EOF when n > 0.
+// Returns (0, nil) if no capacity remains.
 func (b *Buffer) ReadFrom(reader io.Reader) (int64, error) {
-	n, err := reader.Read(b.v[b.end:])
-	b.end += int32(n)
-	return int64(n), err
+	dst := b.v[b.end:]
+	if len(dst) == 0 {
+		return 0, nil
+	}
+
+	n, err := reader.Read(dst)
+	if n > 0 {
+		b.end += int32(n)
+		if err == io.EOF {
+			return int64(n), nil
+		}
+		return int64(n), err
+	}
+
+	return 0, err
 }
 
 // ReadFullFrom reads exact size of bytes from given reader, or until error occurs.
+// Panics if size < 0.
+// Returns an error if size exceeds Available().
 func (b *Buffer) ReadFullFrom(reader io.Reader, size int32) (int64, error) {
-	end := b.end + size
-	if end > int32(len(b.v)) {
-		v := end
+	if size == 0 {
+		return 0, nil
+	}
+	if size < 0 {
+		panic("invalid size")
+	}
+	if size > b.Available() {
+		v := int64(b.end) + int64(size)
 		return 0, errors.New("out of bound: ", v)
 	}
-	n, err := io.ReadFull(reader, b.v[b.end:end])
-	b.end += int32(n)
+
+	start := b.end
+	end := start + size
+	n, err := io.ReadFull(reader, b.v[start:end])
+	b.end = start + int32(n)
 	return int64(n), err
 }
 


### PR DESCRIPTION
# 🇬🇧 English
## Buffers: pinning cap, zeroing via clear, safe io semantics, fewer allocations in WriteString
**Goal:** Improve predictability, safety, and performance without changing the public API

**What’s done**
1. Pinned slice capacity via full slice expressions `[:n:n]` (in `New`/`StackNew`/`NewExisted`/`FromBytes`)
2. Switched data zeroing to the built-in `clear`. Removed the global zero array. The grown segment is zeroed in `Resize`, and the consumed range is zeroed in `Release`
3. Removed allocation in `WriteString` (copying from `string` directly into `[]byte`)
4. io methods aligned with the `io` contracts (`Write`/`WriteString`/`Read`/`ReadFrom`/`ReadFullFrom`/`ReadByte`/`ReadBytes`)
5. Added explicit checks for indices, sizes, and length representability in `int32`. Methods are made `nil`-safe. Offsets and ranges are normalized

**How this is achieved**
- **Cap pinning:** full slice expressions `b = b[:n:n]` prevent implicit growth and make it straightforward to return buffers to the pool with exactly the required capacity
- **Zeroing:** `clear(p[i:j])` instead of copying from a global buffer; `clear` zeroes slice elements and is a no-op for `nil`
- **Strings/bytes:** `WriteString` copies directly from `string` to `[]byte` (without the intermediate `[]byte(s)`), enabling `copy`
- **io contracts:**
    - `Write`/`WriteString`: on a short write, return an error (required by `io.Writer`)
    - `Read`: when `len(p) == 0` - return `(0, nil)`; clear the buffer upon full consumption
    - `ReadFrom`: when `n > 0 && err == io.EOF` - return `(n, nil)`
    - `ReadFullFrom`: pre-check `size <= Available()` and read via `io.ReadFull`
    - `ReadByte`/`ReadBytes`: explicit length validation; return `EOF` when data is insufficient
- **Bounds checks:** normalize indices/offsets (`BytesRange`/`BytesFrom`/`BytesTo`/`Advance`/`Check`); forbid `end > len(v)` in `Resize`; apply strict checks in `Extend`
- **Conversions:** guard conversions to `int32` (in `NewExisted`/`FromBytes`) according to numeric conversion rules.

#

# 🇷🇺 Russian
## Буферы: фиксация cap, обнуление через clear, безопасная io семантика, меньше аллокаций в WriteString

**Цель:** Повысить предсказуемость, безопасность и производительность без изменения публичного API

**Что сделано**
1. Зафиксирована вместимость срезов через полные выражения `[:n:n]` (в `New`/`StackNew`/`NewExisted`/`FromBytes`)
2. Обнуление данных переведено на встроенный `clear`. Удалён глобальный нулевой массив. Обнуляется прирост в `Resize` и использованный диапазон в `Release`.
3. Убрана аллокация в `WriteString` (копирование из `string` напрямую в `byte`)
4. Методы io выровнены по контрактам `io` (`Write`/`WriteString`/`Read`/`ReadFrom`/`ReadFullFrom`/`ReadByte`/`ReadBytes`)
5. Добавлены явные проверки индексов, размеров и представимости длины в `int32`. Методы приведены к `nil`-safe. Сдвиги и диапазоны нормализуются.

**Как достигнуто**
- **Фиксация `cap`:** полные выражения среза `b = b[:n:n]` исключают неявный рост и упрощают возврат в пул ровно нужной ёмкости
- **Обнуление:** `clear(p[i:j])` вместо копирования из глобального буфера. `clear` обнуляет элементы среза и является noop для `nil`
- **Строки/байты:** `WriteString` копирует напрямую из `string` в `byte`
- **Контракты io**
    - `Write`/`WriteString`: при частичной записи возвращается ошибка
    - `Read`: при `len(p)==0` - `(0, nil)`; очистка буфера при полном потреблении
    - `ReadFrom`: при `n>0 && err==io.EOF` - `(n, nil)`
    - `ReadFullFrom`: предварительная проверка `size <= Available` и чтение через `ReadFull`
    - `ReadByte`/`ReadBytes`: явная валидация длины, `EOF`
- **Проверки границ:** нормализация индексов/сдвигов (`BytesRange`/`BytesFrom`/`BytesTo`/`Advance`/`Check`), запрет выхода `end > len(v)` в `Resize`, строгие проверки в `Extend`
- **Преобразования:** защита преобразований к `int32` (в `NewExisted`/`FromBytes`)