### PR TITLE
DNS outbound: Fix some issues

### DIFF
--- a/proxy/dns/dns.go
+++ b/proxy/dns/dns.go
@@ -209,10 +209,7 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, d internet.
 				}
 				if isIPQuery {
 					b.Release()
-					err := h.handleIPQuery(id, qType, domain, writer)
-					if err != nil {
-						return err
-					}
+					go h.handleIPQuery(id, qType, domain, writer)
 					continue
 				}
 				if h.nonIPQuery == "drop" {

--- a/proxy/dns/dns.go
+++ b/proxy/dns/dns.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	go_errors "errors"
 	"io"
+	"strings"
 	"sync"
 	"time"
 
@@ -348,6 +349,10 @@ func (h *Handler) handleIPQuery(id uint16, qType dnsmessage.Type, domain string,
 }
 
 func (h *Handler) rejectNonIPQuery(id uint16, qType dnsmessage.Type, domain string, writer dns_proto.MessageWriter) error {
+	domainT := strings.TrimSuffix(domain, ".")
+	if domainT == "" {
+		return errors.New("empty domain name")
+	}
 	b := buf.New()
 	rawBytes := b.Extend(buf.Size)
 	builder := dnsmessage.NewBuilder(rawBytes[:0], dnsmessage.Header{

--- a/proxy/dns/dns.go
+++ b/proxy/dns/dns.go
@@ -422,9 +422,9 @@ func (c *outboundConn) Read(b []byte) (int, error) {
 		if !open {
 			return 0, io.EOF
 		}
-	} else {
-		c.access.Unlock()
+		return c.conn.Read(b)
 	}
+	c.access.Unlock()
 	return c.conn.Read(b)
 }
 


### PR DESCRIPTION
1. because we don't have `UplinkOnly/DownlinkOnly`, after outbound-connection is closed(`response` returned), `request` function(and as a result inbound-connection) remain open for a long time(especially when the network is TCP)

///

2. we have a weird code in:
https://github.com/XTLS/Xray-core/blob/4064f8dd8080b0e278df79e0a42c0b153b1d445e/proxy/dns/dns.go#L393

    it should be: `return 0, err`(dns-query is not sent but we are waiting for a response!)