### PR TITLE
VMess: Returns clearer error in AuthIDDecoderHolder

### DIFF
--- a/proxy/vmess/aead/authid.go
+++ b/proxy/vmess/aead/authid.go
@@ -17,8 +17,10 @@ import (
 )
 
 var (
-	ErrNotFound = errors.New("user do not exist")
-	ErrReplay   = errors.New("replayed request")
+	ErrNotFound     = errors.New("user do not exist")
+	ErrNeagtiveTime = errors.New("timestamp is negative")
+	ErrInvalidTime  = errors.New("invalid timestamp, perhaps unsynchronized time")
+	ErrReplay       = errors.New("replayed request")
 )
 
 func CreateAuthID(cmdKey []byte, time int64) [16]byte {
@@ -102,11 +104,11 @@ func (a *AuthIDDecoderHolder) Match(authID [16]byte) (interface{}, error) {
 		}
 
 		if t < 0 {
-			continue
+			return nil, ErrNeagtiveTime
 		}
 
 		if math.Abs(math.Abs(float64(t))-float64(time.Now().Unix())) > 120 {
-			continue
+			return nil, ErrInvalidTime
 		}
 
 		if !a.filter.Check(authID[:]) {


### PR DESCRIPTION
对时错误返回的竟然是 user do not exist(解码成功对时错误竟然是continue下一个而不是直接错误 一直到遍历完返回不存在) 之前零零散散收到过一些报告还以为是decoder的问题