### PR TITLE
mKCP: Fix key derivation for obfuscation

### DIFF
--- a/transport/internet/kcp/cryptreal.go
+++ b/transport/internet/kcp/cryptreal.go
@@ -9,5 +9,5 @@ import (
 
 func NewAEADAESGCMBasedOnSeed(seed string) cipher.AEAD {
 	hashedSeed := sha256.Sum256([]byte(seed))
-	return crypto.NewAesGcm(hashedSeed[:])
+	return crypto.NewAesGcm(hashedSeed[:16])
 }


### PR DESCRIPTION
改函数的时候复制错了 本来是取32位数组的前16位作为切片的不小心都丢进去了
这样还不会坏test 因为它直接根据切片长度返回具体算法(16字节128 32字节256) 导致导出相同的AEAD函数并且没有break任何东西从而可以正常解密 约等于把KCP加密的AES128GCM换成了AES256GCM 新版本倒新版本都可以联通 只有混用新旧或者用其他实现才会爆炸