### PR TITLE
MUX: Prevent goroutine leak

### DIFF
--- a/common/mux/session_test.go
+++ b/common/mux/session_test.go
@@ -41,11 +41,11 @@ func TestSessionManagerClose(t *testing.T) {
 	m := NewSessionManager()
 	s := m.Allocate(&ClientStrategy{})
 
-	if m.CloseIfNoSession() {
+	if m.CloseIfNoSessionAndIdle(m.Size(), m.Count()) {
 		t.Error("able to close")
 	}
 	m.Remove(false, s.ID)
-	if !m.CloseIfNoSession() {
+	if !m.CloseIfNoSessionAndIdle(m.Size(), m.Count()) {
 		t.Error("not able to close")
 	}
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -678,10 +678,10 @@ func CopyRawConnIfExist(ctx context.Context, readerConn net.Conn, writerConn net
 			errors.LogInfo(ctx, "CopyRawConn splice")
 			statWriter, _ := writer.(*dispatcher.SizeStatWriter)
 			//runtime.Gosched() // necessary
-			time.Sleep(time.Millisecond)    // without this, there will be a rare ssl error for freedom splice
-			timer.SetTimeout(8 * time.Hour) // prevent leak, just in case
+			time.Sleep(time.Millisecond)     // without this, there will be a rare ssl error for freedom splice
+			timer.SetTimeout(24 * time.Hour) // prevent leak, just in case
 			if inTimer != nil {
-				inTimer.SetTimeout(8 * time.Hour)
+				inTimer.SetTimeout(24 * time.Hour)
 			}
 			w, err := tc.ReadFrom(readerConn)
 			if readCounter != nil {


### PR DESCRIPTION
fix problems:

1. after using `DispatchLink`, we may have goroutine-leak when connection between mux-client and mux-server cut.

2. in some cases in mux `dispatchLink` wait on wrong things and it cause code-stuck and goroutine leak.

3. for reverse, we may have goroutine-leak when a sub-client-connection cut

///

4. most NAT TCP translations time out is 24 hours, so change splice-timeout to 24 hours.
