### PR TITLE
app/dispatcher/default.go: Close link when routedDispatch() failed

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -483,6 +483,8 @@ func (d *DefaultDispatcher) routedDispatch(ctx context.Context, link *transport.
 				handler = h
 			} else {
 				errors.LogWarning(ctx, "non existing outTag: ", outTag)
+				common.Close(link.Writer)
+				common.Interrupt(link.Reader)
 				return // DO NOT CHANGE: the traffic shouldn't be processed by default outbound if the specified outbound tag doesn't exist (yet), e.g., VLESS Reverse Proxy
 			}
 		} else {


### PR DESCRIPTION
`routedDispatch` is also used for `(pipe)Dispatch`(it is still used in some cases) so link should close immediately when `routedDispatch` failed.
otherwise, inbound/mux remain open without doing anything.
