### PR TITLE
Metrics: Export last_try_time and last_seen_time of burst observatory.

### DIFF
--- a/app/observatory/burst/burstobserver.go
+++ b/app/observatory/burst/burstobserver.go
@@ -36,21 +36,23 @@ func (o *Observer) createResult() []*observatory.OutboundStatus {
 	var result []*observatory.OutboundStatus
 	o.hp.access.Lock()
 	defer o.hp.access.Unlock()
+
 	for name, value := range o.hp.Results {
+		curStat := value.getStatistics()
 		status := observatory.OutboundStatus{
-			Alive:           value.getStatistics().All != value.getStatistics().Fail,
-			Delay:           value.getStatistics().Average.Milliseconds(),
+			Alive:           curStat.All != curStat.Fail,
+			Delay:           curStat.Average.Milliseconds(),
 			LastErrorReason: "",
 			OutboundTag:     name,
-			LastSeenTime:    0,
-			LastTryTime:     0,
+			LastSeenTime:    curStat.LastSeenTime,
+			LastTryTime:     curStat.LastTryTime,
 			HealthPing: &observatory.HealthPingMeasurementResult{
-				All:       int64(value.getStatistics().All),
-				Fail:      int64(value.getStatistics().Fail),
-				Deviation: int64(value.getStatistics().Deviation),
-				Average:   int64(value.getStatistics().Average),
-				Max:       int64(value.getStatistics().Max),
-				Min:       int64(value.getStatistics().Min),
+				All:       int64(curStat.All),
+				Fail:      int64(curStat.Fail),
+				Deviation: int64(curStat.Deviation),
+				Average:   int64(curStat.Average),
+				Max:       int64(curStat.Max),
+				Min:       int64(curStat.Min),
 			},
 		}
 		result = append(result, &status)

--- a/app/observatory/burst/healthping_result.go
+++ b/app/observatory/burst/healthping_result.go
@@ -7,12 +7,14 @@ import (
 
 // HealthPingStats is the statistics of HealthPingRTTS
 type HealthPingStats struct {
-	All       int
-	Fail      int
-	Deviation time.Duration
-	Average   time.Duration
-	Max       time.Duration
-	Min       time.Duration
+	All          int
+	Fail         int
+	Deviation    time.Duration
+	Average      time.Duration
+	Max          time.Duration
+	Min          time.Duration
+	LastSeenTime int64
+	LastTryTime  int64
 }
 
 // HealthPingRTTS holds ping rtts for health Checker
@@ -87,12 +89,19 @@ func (h *HealthPingRTTS) getStatistics() *HealthPingStats {
 	cnt := 0
 	validRTTs := make([]time.Duration, 0)
 	for _, rtt := range h.rtts {
+		timestamp := rtt.time.Unix()
+		if timestamp > stats.LastTryTime {
+			stats.LastTryTime = timestamp
+		}
 		switch {
 		case rtt.value == 0 || time.Since(rtt.time) > h.validity:
 			continue
 		case rtt.value == rttFailed:
 			stats.Fail++
 			continue
+		}
+		if timestamp > stats.LastSeenTime {
+			stats.LastSeenTime = timestamp
 		}
 		cnt++
 		sum += rtt.value


### PR DESCRIPTION
这个 PR 和 https://github.com/XTLS/Xray-core/issues/5121 https://github.com/XTLS/Xray-core/discussions/3171 有关。作用是把 burstObservatory 的 last_try_time 和 last_seen_time 导出到 metrics。

实际效果：
```json
{
    "cmdline": [
    ],
    "memstats": {
    },
    "observatory": {
        "proxy1": {
            "alive": true,
            "delay": 578,
            "outbound_tag": "proxy1",
            "last_seen_time": 1757649242, // 服务器能 ping 通
            "last_try_time": 1757649242,
            "health_ping": {
                "all": 2,
                "deviation": 244388950,
                "average": 578955950,
                "max": 823344900,
                "min": 334567000
            }
        },
        "proxy9": {
            "outbound_tag": "proxy9",
            "last_try_time": 1757649241,  // ping 不通
            "health_ping": {
                "all": 2,
                "fail": 2
            }
        }
    },
    "stats": null
}
```