### PR TITLE
Routing: fix router select wrong outbound when failed to resolve domain to ip

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -2,6 +2,7 @@ package dispatcher
 
 import (
 	"context"
+	go_errors "errors"
 	"regexp"
 	"strings"
 	"sync"
@@ -488,6 +489,12 @@ func (d *DefaultDispatcher) routedDispatch(ctx context.Context, link *transport.
 				return // DO NOT CHANGE: the traffic shouldn't be processed by default outbound if the specified outbound tag doesn't exist (yet), e.g., VLESS Reverse Proxy
 			}
 		} else {
+			if !go_errors.Is(err, common.ErrNoClue) {
+				errors.LogWarningInner(ctx, err, "get error during route pick ")
+				common.Close(link.Writer)
+				common.Interrupt(link.Reader)
+				return
+			}
 			errors.LogInfo(ctx, "default route for ", destination)
 		}
 	}

--- a/app/router/command/config.go
+++ b/app/router/command/config.go
@@ -51,6 +51,10 @@ func (c routingContext) GetSkipDNSResolve() bool {
 	return false
 }
 
+func (c routingContext) GetError() error {
+	return nil
+}
+
 // AsRoutingContext converts a protobuf RoutingContext into an implementation of routing.Context.
 func AsRoutingContext(r *RoutingContext) routing.Context {
 	return routingContext{r}

--- a/app/router/router.go
+++ b/app/router/router.go
@@ -195,6 +195,9 @@ func (r *Router) pickRouteInternal(ctx routing.Context) (*Rule, routing.Context,
 		if rule.Apply(ctx) {
 			return rule, ctx, nil
 		}
+		if err := ctx.GetError(); err != nil {
+			return nil, ctx, err
+		}
 	}
 
 	if r.domainStrategy != Config_IpIfNonMatch || len(ctx.GetTargetDomain()) == 0 || skipDNSResolve {
@@ -207,6 +210,9 @@ func (r *Router) pickRouteInternal(ctx routing.Context) (*Rule, routing.Context,
 	for _, rule := range r.rules {
 		if rule.Apply(ctx) {
 			return rule, ctx, nil
+		}
+		if err := ctx.GetError(); err != nil {
+			return nil, ctx, err
 		}
 	}
 

--- a/features/routing/context.go
+++ b/features/routing/context.go
@@ -49,4 +49,7 @@ type Context interface {
 
 	// GetSkipDNSResolve returns a flag switch for weather skip dns resolve during route pick.
 	GetSkipDNSResolve() bool
+
+	// GetError returns errors during route pick, e.g., built-in-dns fail to resolve domain to IP
+	GetError() error
 }

--- a/features/routing/session/context.go
+++ b/features/routing/session/context.go
@@ -152,6 +152,11 @@ func (ctx *Context) GetSkipDNSResolve() bool {
 	return ctx.Content.SkipDNSResolve
 }
 
+// GetError implements routing.Context.
+func (ctx *Context) GetError() error {
+	return nil
+}
+
 // AsRoutingContext creates a context from context.context with session info.
 func AsRoutingContext(ctx context.Context) routing.Context {
 	outbounds := session.OutboundsFromContext(ctx)


### PR DESCRIPTION
suppose we want to route domains with range-A IPs to outbound-1, and route others to outbound-2,
and domains with range-A IPs should not be routed to outbound-2 under any circumstances.

so the config is:

```
"domainStrategy": "IPOnDemand",
    "rules": [
           {"outboundTag": "outbound-1", // rule-1
            "ip": ["range-A"]
           },
           {"outboundTag": "outbound-2", // rule-2
            "network": "tcp,udp"
           }
    ]
```

suppose the domain "example.com" has ip in range-A, but built-in-dns-servers are unavailable for a while(for any reason), so domain failed to resolve to ip and rule-1 does not apply and rule-2 apply and "example.com" route to outbound-2!!! but "example.com" has range-A ip and should not route to outbound-2.

there are many examples where domains with certain range IPs should not be routed to a specific outbound.

///

As a result, in "IPOnDemand"/"IPIfNonMatch" mode, when a domain failed to resolve to ip(after encountering an ip-rule), router should return error immediately and should not select any outbound.


