### PR TITLE
修复ss2022内存泄露

### DIFF
--- a/common/singbridge/pipe.go
+++ b/common/singbridge/pipe.go
@@ -51,9 +51,9 @@ func (w *PipeConnWrapper) Read(b []byte) (n int, err error) {
 	case result := <-c:
 		return result.n, result.err
 	case <-time.After(300 * time.Second):
-		common.Interrupt(w.R)
 		common.Close(w.R)
-		return 0, io.EOF
+		common.Interrupt(w.R)
+		return 0, buf.ErrReadTimeout
 	}
 }
 

--- a/common/singbridge/pipe.go
+++ b/common/singbridge/pipe.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"io"
 	"net"
+	"time"
 
 	"github.com/sagernet/sing/common/bufio"
+	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/buf"
 	"github.com/xtls/xray-core/transport"
 )
@@ -33,8 +35,26 @@ func (w *PipeConnWrapper) Close() error {
 	return nil
 }
 
+// This Read implemented a timeout to avoid goroutine leak.
+// as a temporarily solution
 func (w *PipeConnWrapper) Read(b []byte) (n int, err error) {
-	return w.R.Read(b)
+	type readResult struct {
+		n   int
+		err error
+	}
+	c := make(chan readResult, 1)
+	go func() {
+		n, err := w.R.Read(b)
+		c <- readResult{n: n, err: err}
+	}()
+	select {
+	case result := <-c:
+		return result.n, result.err
+	case <-time.After(300 * time.Second):
+		common.Interrupt(w.R)
+		common.Close(w.R)
+		return 0, io.EOF
+	}
 }
 
 func (w *PipeConnWrapper) Write(p []byte) (n int, err error) {


### PR DESCRIPTION
sing里的task包和ray里的不一样它会等待并收集所有tast的错误才会结束并执行清理参数
考虑到sing包没法再动 只能往被卡住的函数里添加一个内置的超时机制来处理了
虽然说理论上这东西是要删的不过当前这样可以勉强解决问题
close #5163  