### PR TITLE
🐞 fix(缓存异常): 当请求URL过长时，将异常中断连接

### DIFF
--- a/common/buf/buffer.go
+++ b/common/buf/buffer.go
@@ -266,9 +266,6 @@ func (b *Buffer) IsFull() bool {
 func (b *Buffer) Write(data []byte) (int, error) {
 	nBytes := copy(b.v[b.end:], data)
 	b.end += int32(nBytes)
-	if nBytes < len(data) {
-		return nBytes, ErrBufferFull
-	}
 	return nBytes, nil
 }
 


### PR DESCRIPTION
由于上层缓冲大小与下层不一致, 当请求URL过长时, 上层序列化后的内容将超过缓冲区并返回ErrBufferFull错误，导致请求转发失败. 由于golang的Write语义本来在写入已满的情况下应该阻塞而不是报错, 且上层有处理返回的int，故此处直接返回写入字节数即可