### PR TITLE
perf(router): adjust the order of rules to optimize performance

### DIFF
--- a/app/router/condition.go
+++ b/app/router/condition.go
@@ -47,20 +47,6 @@ var matcherTypeMap = map[Domain_Type]strmatcher.Type{
 	Domain_Full:   strmatcher.Full,
 }
 
-func domainToMatcher(domain *Domain) (strmatcher.Matcher, error) {
-	matcherType, f := matcherTypeMap[domain.Type]
-	if !f {
-		return nil, errors.New("unsupported domain type", domain.Type)
-	}
-
-	matcher, err := matcherType.New(domain.Value)
-	if err != nil {
-		return nil, errors.New("failed to create domain matcher").Base(err)
-	}
-
-	return matcher, nil
-}
-
 type DomainMatcher struct {
 	matchers strmatcher.IndexMatcher
 }

--- a/app/router/config.go
+++ b/app/router/config.go
@@ -32,25 +32,16 @@ func (r *Rule) Apply(ctx routing.Context) bool {
 func (rr *RoutingRule) BuildCondition() (Condition, error) {
 	conds := NewConditionChan()
 
-	if len(rr.Domain) > 0 {
-		matcher, err := NewMphMatcherGroup(rr.Domain)
-		if err != nil {
-			return nil, errors.New("failed to build domain condition with MphDomainMatcher").Base(err)
-		}
-		errors.LogDebug(context.Background(), "MphDomainMatcher is enabled for ", len(rr.Domain), " domain rule(s)")
-		conds.Add(matcher)
-	}
-
-	if len(rr.UserEmail) > 0 {
-		conds.Add(NewUserMatcher(rr.UserEmail))
-	}
-
-	if rr.VlessRouteList != nil {
-		conds.Add(NewPortMatcher(rr.VlessRouteList, MatcherAsType_VlessRoute))
-	}
-
 	if len(rr.InboundTag) > 0 {
 		conds.Add(NewInboundTagMatcher(rr.InboundTag))
+	}
+
+	if len(rr.Networks) > 0 {
+		conds.Add(NewNetworkMatcher(rr.Networks))
+	}
+
+	if len(rr.Protocol) > 0 {
+		conds.Add(NewProtocolMatcher(rr.Protocol))
 	}
 
 	if rr.PortList != nil {
@@ -65,8 +56,20 @@ func (rr *RoutingRule) BuildCondition() (Condition, error) {
 		conds.Add(NewPortMatcher(rr.LocalPortList, MatcherAsType_Local))
 	}
 
-	if len(rr.Networks) > 0 {
-		conds.Add(NewNetworkMatcher(rr.Networks))
+	if rr.VlessRouteList != nil {
+		conds.Add(NewPortMatcher(rr.VlessRouteList, MatcherAsType_VlessRoute))
+	}
+
+	if len(rr.UserEmail) > 0 {
+		conds.Add(NewUserMatcher(rr.UserEmail))
+	}
+
+	if len(rr.Attributes) > 0 {
+		configuredKeys := make(map[string]*regexp.Regexp)
+		for key, value := range rr.Attributes {
+			configuredKeys[strings.ToLower(key)] = regexp.MustCompile(value)
+		}
+		conds.Add(&AttributeMatcher{configuredKeys})
 	}
 
 	if len(rr.Geoip) > 0 {
@@ -94,16 +97,13 @@ func (rr *RoutingRule) BuildCondition() (Condition, error) {
 		errors.LogWarning(context.Background(), "Due to some limitations, in UDP connections, localIP is always equal to listen interface IP, so \"localIP\" rule condition does not work properly on UDP inbound connections that listen on all interfaces")
 	}
 
-	if len(rr.Protocol) > 0 {
-		conds.Add(NewProtocolMatcher(rr.Protocol))
-	}
-
-	if len(rr.Attributes) > 0 {
-		configuredKeys := make(map[string]*regexp.Regexp)
-		for key, value := range rr.Attributes {
-			configuredKeys[strings.ToLower(key)] = regexp.MustCompile(value)
+	if len(rr.Domain) > 0 {
+		matcher, err := NewMphMatcherGroup(rr.Domain)
+		if err != nil {
+			return nil, errors.New("failed to build domain condition with MphDomainMatcher").Base(err)
 		}
-		conds.Add(&AttributeMatcher{configuredKeys})
+		errors.LogDebug(context.Background(), "MphDomainMatcher is enabled for ", len(rr.Domain), " domain rule(s)")
+		conds.Add(matcher)
 	}
 
 	if conds.Len() == 0 {


### PR DESCRIPTION
- 当 rule 有多种约束混一起时，应该先 apply 开销低的，可以降低 cpu 占用

  其实这里最好是做个隐式 order 字段以遵守配置文件顺序，供追求极限性能的~赔钱机场~高级用户使用

- 删了一个废弃的函数

---

此 PR 和 #5289 冲突
如果两个全部接受，应该先合 #5289 我再 rebase 这个

此 PR rebase 后的 diff
https://github.com/Meo597/Xray-core/compare/perf-geoip-matcher..rebased-geoip-matcher/perf-route