### PR TITLE
README.md: Add v2rayN to macOS & Linux Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,12 +108,14 @@
   - [OneXray](https://github.com/OneXray/OneXray)
   - [GoXRay](https://github.com/goxray/desktop)
   - [AnyPortal](https://github.com/AnyPortal/AnyPortal)
+  - [v2rayN](https://github.com/2dust/v2rayN)
 - Linux
   - [v2rayA](https://github.com/v2rayA/v2rayA)
   - [Furious](https://github.com/LorenEteval/Furious)
   - [GorzRay](https://github.com/ketetefid/GorzRay)
   - [GoXRay](https://github.com/goxray/desktop)
   - [AnyPortal](https://github.com/AnyPortal/AnyPortal)
+  - [v2rayN](https://github.com/2dust/v2rayN)
 
 ## Others that support VLESS, XTLS, REALITY, XUDP, PLUX...
 


### PR DESCRIPTION
This PR adds v2rayN to the macOS and Linux GUI client lists.
Upstream now states cross-platform support (Windows / Linux / macOS) and Xray compatibility:

v2rayN repo: “A GUI client for Windows, Linux and macOS, support Xray and sing-box and others.” 
[GitHub](https://github.com/2dust/v2rayN)
