### PR TITLE
Chore: Remove all double gonet import

### DIFF
--- a/app/dns/fakedns/fake.go
+++ b/app/dns/fakedns/fake.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"math"
 	"math/big"
-	gonet "net"
 	"sync"
 	"time"
 
@@ -17,7 +16,7 @@ import (
 
 type Holder struct {
 	domainToIP cache.Lru
-	ipRange    *gonet.IPNet
+	ipRange    *net.IPNet
 	mu         *sync.Mutex
 
 	config *FakeDnsPool
@@ -79,10 +78,10 @@ func (fkdns *Holder) initializeFromConfig() error {
 }
 
 func (fkdns *Holder) initialize(ipPoolCidr string, lruSize int) error {
-	var ipRange *gonet.IPNet
+	var ipRange *net.IPNet
 	var err error
 
-	if _, ipRange, err = gonet.ParseCIDR(ipPoolCidr); err != nil {
+	if _, ipRange, err = net.ParseCIDR(ipPoolCidr); err != nil {
 		return errors.New("Unable to parse CIDR for Fake DNS IP assignment").Base(err).AtError()
 	}
 

--- a/app/dns/fakedns/fakedns_test.go
+++ b/app/dns/fakedns/fakedns_test.go
@@ -1,7 +1,6 @@
 package fakedns
 
 import (
-	gonet "net"
 	"strconv"
 	"testing"
 
@@ -155,7 +154,7 @@ func TestFakeDNSMulti(t *testing.T) {
 			assert.True(t, inPool)
 		})
 		t.Run("ipv6", func(t *testing.T) {
-			ip, err := gonet.ResolveIPAddr("ip", "fddd:c5b4:ff5f:f4f0::5")
+			ip, err := net.ResolveIPAddr("ip", "fddd:c5b4:ff5f:f4f0::5")
 			assert.Nil(t, err)
 			inPool := fakeMulti.IsIPInIPPool(net.IPAddress(ip.IP))
 			assert.True(t, inPool)
@@ -165,7 +164,7 @@ func TestFakeDNSMulti(t *testing.T) {
 			assert.False(t, inPool)
 		})
 		t.Run("ipv6_inverse", func(t *testing.T) {
-			ip, err := gonet.ResolveIPAddr("ip", "fcdd:c5b4:ff5f:f4f0::5")
+			ip, err := net.ResolveIPAddr("ip", "fcdd:c5b4:ff5f:f4f0::5")
 			assert.Nil(t, err)
 			inPool := fakeMulti.IsIPInIPPool(net.IPAddress(ip.IP))
 			assert.False(t, inPool)

--- a/app/proxyman/inbound/worker.go
+++ b/app/proxyman/inbound/worker.go
@@ -2,7 +2,6 @@ package inbound
 
 import (
 	"context"
-	gonet "net"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -565,12 +564,12 @@ func (w *dsWorker) Close() error {
 }
 
 func IsLocal(ip net.IP) bool {
-	addrs, err := gonet.InterfaceAddrs()
+	addrs, err := net.InterfaceAddrs()
 	if err != nil {
 		return false
 	}
 	for _, addr := range addrs {
-		if ipnet, ok := addr.(*gonet.IPNet); ok {
+		if ipnet, ok := addr.(*net.IPNet); ok {
 			if ipnet.IP.Equal(ip) {
 				return true
 			}

--- a/app/proxyman/outbound/handler.go
+++ b/app/proxyman/outbound/handler.go
@@ -6,7 +6,6 @@ import (
 	goerrors "errors"
 	"io"
 	"math/big"
-	gonet "net"
 	"os"
 
 	"github.com/xtls/xray-core/common/dice"
@@ -398,7 +397,7 @@ func (h *Handler) ProxySettings() *serial.TypedMessage {
 
 func ParseRandomIP(addr net.Address, prefix string) net.Address {
 
-	_, ipnet, _ := gonet.ParseCIDR(addr.IP().String() + "/" + prefix)
+	_, ipnet, _ := net.ParseCIDR(addr.IP().String() + "/" + prefix)
 
 	ones, bits := ipnet.Mask.Size()
 	subnetSize := new(big.Int).Lsh(big.NewInt(1), uint(bits-ones))
@@ -412,5 +411,5 @@ func ParseRandomIP(addr net.Address, prefix string) net.Address {
 	padded := make([]byte, len(ipnet.IP))
 	copy(padded[len(padded)-len(rndBytes):], rndBytes)
 
-	return net.ParseAddress(gonet.IP(padded).String())
+	return net.ParseAddress(net.IP(padded).String())
 }

--- a/common/net/system.go
+++ b/common/net/system.go
@@ -12,6 +12,8 @@ var (
 
 type ListenConfig = net.ListenConfig
 
+type KeepAliveConfig = net.KeepAliveConfig
+
 var (
 	Listen     = net.Listen
 	ListenTCP  = net.ListenTCP
@@ -25,6 +27,12 @@ var FileConn = net.FileConn
 
 // ParseIP is an alias of net.ParseIP
 var ParseIP = net.ParseIP
+
+var ParseCIDR = net.ParseCIDR
+
+var ResolveIPAddr = net.ResolveIPAddr
+
+var InterfaceByName = net.InterfaceByName
 
 var SplitHostPort = net.SplitHostPort
 
@@ -50,6 +58,8 @@ type (
 	UnixAddr = net.UnixAddr
 	UnixConn = net.UnixConn
 )
+
+type IPAddr = net.IPAddr
 
 // IP is an alias for net.IP.
 type (
@@ -82,3 +92,11 @@ var (
 )
 
 type Resolver = net.Resolver
+
+var DefaultResolver = net.DefaultResolver
+
+var JoinHostPort = net.JoinHostPort
+
+var InterfaceAddrs = net.InterfaceAddrs
+
+var Interfaces = net.Interfaces

--- a/proxy/wireguard/bind.go
+++ b/proxy/wireguard/bind.go
@@ -3,14 +3,13 @@ package wireguard
 import (
 	"context"
 	"errors"
-	"net"
 	"net/netip"
 	"strconv"
 	"sync"
 
 	"golang.zx2c4.com/wireguard/conn"
 
-	xnet "github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/features/dns"
 	"github.com/xtls/xray-core/transport/internet"
 )
@@ -51,21 +50,21 @@ func (n *netBind) ParseEndpoint(s string) (conn.Endpoint, error) {
 		return nil, err
 	}
 
-	addr := xnet.ParseAddress(ipStr)
-	if addr.Family() == xnet.AddressFamilyDomain {
+	addr := net.ParseAddress(ipStr)
+	if addr.Family() == net.AddressFamilyDomain {
 		ips, _, err := n.dns.LookupIP(addr.Domain(), n.dnsOption)
 		if err != nil {
 			return nil, err
 		} else if len(ips) == 0 {
 			return nil, dns.ErrEmptyResponse
 		}
-		addr = xnet.IPAddress(ips[0])
+		addr = net.IPAddress(ips[0])
 	}
 
-	dst := xnet.Destination{
+	dst := net.Destination{
 		Address: addr,
-		Port:    xnet.Port(portNum),
-		Network: xnet.Network_UDP,
+		Port:    net.Port(portNum),
+		Network: net.Network_UDP,
 	}
 
 	return &netEndpoint{
@@ -214,7 +213,7 @@ func (bind *netBindServer) Send(buff [][]byte, endpoint conn.Endpoint) error {
 }
 
 type netEndpoint struct {
-	dst  xnet.Destination
+	dst  net.Destination
 	conn net.Conn
 }
 
@@ -247,7 +246,7 @@ func (e netEndpoint) SrcToString() string {
 	return ""
 }
 
-func toNetIpAddr(addr xnet.Address) netip.Addr {
+func toNetIpAddr(addr net.Address) netip.Addr {
 	if addr.Family().IsIPv4() {
 		ip := addr.IP()
 		return netip.AddrFrom4([4]byte{ip[0], ip[1], ip[2], ip[3]})

--- a/proxy/wireguard/tun.go
+++ b/proxy/wireguard/tun.go
@@ -3,7 +3,6 @@ package wireguard
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/netip"
 	"runtime"
 	"strconv"
@@ -13,7 +12,7 @@ import (
 
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/log"
-	xnet "github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/proxy/wireguard/gvisortun"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
@@ -28,7 +27,7 @@ import (
 
 type tunCreator func(localAddresses []netip.Addr, mtu int, handler promiscuousModeHandler) (Tunnel, error)
 
-type promiscuousModeHandler func(dest xnet.Destination, conn net.Conn)
+type promiscuousModeHandler func(dest net.Destination, conn net.Conn)
 
 type Tunnel interface {
 	BuildDevice(ipc string, bind conn.Bind) error
@@ -169,7 +168,7 @@ func createGVisorTun(localAddresses []netip.Addr, mtu int, handler promiscuousMo
 				ep.SocketOptions().SetKeepAlive(true)
 
 				// local address is actually destination
-				handler(xnet.TCPDestination(xnet.IPAddress(id.LocalAddress.AsSlice()), xnet.Port(id.LocalPort)), gonet.NewTCPConn(&wq, ep))
+				handler(net.TCPDestination(net.IPAddress(id.LocalAddress.AsSlice()), net.Port(id.LocalPort)), gonet.NewTCPConn(&wq, ep))
 			}(r)
 		})
 		stack.SetTransportProtocolHandler(tcp.ProtocolNumber, tcpForwarder.HandlePacket)
@@ -194,7 +193,7 @@ func createGVisorTun(localAddresses []netip.Addr, mtu int, handler promiscuousMo
 					Timeout: 15 * time.Second,
 				})
 
-				handler(xnet.UDPDestination(xnet.IPAddress(id.LocalAddress.AsSlice()), xnet.Port(id.LocalPort)), gonet.NewUDPConn(&wq, ep))
+				handler(net.UDPDestination(net.IPAddress(id.LocalAddress.AsSlice()), net.Port(id.LocalPort)), gonet.NewUDPConn(&wq, ep))
 			}(r)
 		})
 		stack.SetTransportProtocolHandler(udp.ProtocolNumber, udpForwarder.HandlePacket)

--- a/transport/internet/dialer.go
+++ b/transport/internet/dialer.go
@@ -3,7 +3,6 @@ package internet
 import (
 	"context"
 	"fmt"
-	gonet "net"
 	"strings"
 
 	"github.com/xtls/xray-core/common"
@@ -183,7 +182,7 @@ func checkAddressPortStrategy(ctx context.Context, dest net.Destination, sockopt
 		if len(parts) != 3 {
 			return nil, errors.New("invalid address format", dest.Address.String())
 		}
-		_, srvRecords, err := gonet.DefaultResolver.LookupSRV(context.Background(), parts[0][1:], parts[1][1:], parts[2])
+		_, srvRecords, err := net.DefaultResolver.LookupSRV(context.Background(), parts[0][1:], parts[1][1:], parts[2])
 		if err != nil {
 			return nil, errors.New("failed to lookup SRV record").Base(err)
 		}
@@ -198,7 +197,7 @@ func checkAddressPortStrategy(ctx context.Context, dest net.Destination, sockopt
 	}
 	if OverrideBy == "txt" {
 		errors.LogDebug(ctx, "query TXT record for "+dest.Address.String())
-		txtRecords, err := gonet.DefaultResolver.LookupTXT(ctx, dest.Address.String())
+		txtRecords, err := net.DefaultResolver.LookupTXT(ctx, dest.Address.String())
 		if err != nil {
 			errors.LogError(ctx, "failed to lookup SRV record: "+err.Error())
 			return nil, errors.New("failed to lookup SRV record").Base(err)

--- a/transport/internet/grpc/dial.go
+++ b/transport/internet/grpc/dial.go
@@ -2,7 +2,6 @@ package grpc
 
 import (
 	"context"
-	gonet "net"
 	"sync"
 	"time"
 
@@ -99,7 +98,7 @@ func getGrpcClient(ctx context.Context, dest net.Destination, streamSettings *in
 			},
 			MinConnectTimeout: 5 * time.Second,
 		}),
-		grpc.WithContextDialer(func(gctx context.Context, s string) (gonet.Conn, error) {
+		grpc.WithContextDialer(func(gctx context.Context, s string) (net.Conn, error) {
 			select {
 			case <-gctx.Done():
 				return nil, gctx.Err()
@@ -180,7 +179,7 @@ func getGrpcClient(ctx context.Context, dest net.Destination, streamSettings *in
 	}
 
 	conn, err := grpc.Dial(
-		gonet.JoinHostPort(grpcDestHost, dest.Port.String()),
+		net.JoinHostPort(grpcDestHost, dest.Port.String()),
 		dialOptions...,
 	)
 	globalDialerMap[dialerConf{dest, streamSettings}] = conn

--- a/transport/internet/grpc/encoding/hunkconn.go
+++ b/transport/internet/grpc/encoding/hunkconn.go
@@ -3,11 +3,10 @@ package encoding
 import (
 	"context"
 	"io"
-	"net"
 
 	"github.com/xtls/xray-core/common/buf"
 	"github.com/xtls/xray-core/common/errors"
-	xnet "github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/net/cnc"
 	"github.com/xtls/xray-core/common/signal/done"
 	"google.golang.org/grpc/metadata"
@@ -55,7 +54,7 @@ func NewHunkConn(hc HunkConn, cancel context.CancelFunc) net.Conn {
 	if ok {
 		header := md.Get("x-real-ip")
 		if len(header) > 0 {
-			realip := xnet.ParseAddress(header[0])
+			realip := net.ParseAddress(header[0])
 			if realip.Family().IsIP() {
 				rAddr = &net.TCPAddr{
 					IP:   realip.IP(),

--- a/transport/internet/sockopt_darwin.go
+++ b/transport/internet/sockopt_darwin.go
@@ -2,7 +2,6 @@ package internet
 
 import (
 	"context"
-	gonet "net"
 	"os"
 	"runtime"
 	"strconv"
@@ -135,7 +134,7 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 	}
 
 	if config.Interface != "" {
-		iface, err := gonet.InterfaceByName(config.Interface)
+		iface, err := net.InterfaceByName(config.Interface)
 
 		if err != nil {
 			return errors.New("failed to get interface ", config.Interface).Base(err)
@@ -226,7 +225,7 @@ func applyInboundSocketOptions(network string, fd uintptr, config *SocketConfig)
 	}
 
 	if config.Interface != "" {
-		iface, err := gonet.InterfaceByName(config.Interface)
+		iface, err := net.InterfaceByName(config.Interface)
 
 		if err != nil {
 			return errors.New("failed to get interface ", config.Interface).Base(err)

--- a/transport/internet/splithttp/browser_client.go
+++ b/transport/internet/splithttp/browser_client.go
@@ -3,9 +3,9 @@ package splithttp
 import (
 	"context"
 	"io"
-	gonet "net"
 
 	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/transport/internet/browser_dialer"
 	"github.com/xtls/xray-core/transport/internet/websocket"
 )
@@ -19,13 +19,13 @@ func (c *BrowserDialerClient) IsClosed() bool {
 	panic("not implemented yet")
 }
 
-func (c *BrowserDialerClient) OpenStream(ctx context.Context, url string, body io.Reader, uploadOnly bool) (io.ReadCloser, gonet.Addr, gonet.Addr, error) {
+func (c *BrowserDialerClient) OpenStream(ctx context.Context, url string, body io.Reader, uploadOnly bool) (io.ReadCloser, net.Addr, net.Addr, error) {
 	if body != nil {
 		return nil, nil, nil, errors.New("bidirectional streaming for browser dialer not implemented yet")
 	}
 
 	conn, err := browser_dialer.DialGet(url, c.transportConfig.GetRequestHeader(url))
-	dummyAddr := &gonet.IPAddr{}
+	dummyAddr := &net.IPAddr{}
 	if err != nil {
 		return nil, dummyAddr, dummyAddr, err
 	}

--- a/transport/internet/splithttp/client.go
+++ b/transport/internet/splithttp/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	gonet "net"
 	"net/http"
 	"net/http/httptrace"
 	"sync"
@@ -42,7 +41,7 @@ func (c *DefaultDialerClient) IsClosed() bool {
 	return c.closed
 }
 
-func (c *DefaultDialerClient) OpenStream(ctx context.Context, url string, body io.Reader, uploadOnly bool) (wrc io.ReadCloser, remoteAddr, localAddr gonet.Addr, err error) {
+func (c *DefaultDialerClient) OpenStream(ctx context.Context, url string, body io.Reader, uploadOnly bool) (wrc io.ReadCloser, remoteAddr, localAddr net.Addr, err error) {
 	// this is done when the TCP/UDP connection to the server was established,
 	// and we can unblock the Dial function and print correct net addresses in
 	// logs

--- a/transport/internet/system_dialer.go
+++ b/transport/internet/system_dialer.go
@@ -3,7 +3,6 @@ package internet
 import (
 	"context"
 	"math/rand"
-	gonet "net"
 	"syscall"
 	"time"
 
@@ -89,7 +88,7 @@ func (d *DefaultSystemDialer) Dial(ctx context.Context, src net.Address, dest ne
 		}, nil
 	}
 	// Chrome defaults
-	keepAliveConfig := gonet.KeepAliveConfig{
+	keepAliveConfig := net.KeepAliveConfig{
 		Enable:   true,
 		Idle:     45 * time.Second,
 		Interval: 45 * time.Second,

--- a/transport/internet/system_listener.go
+++ b/transport/internet/system_listener.go
@@ -2,7 +2,6 @@ package internet
 
 import (
 	"context"
-	gonet "net"
 	"os"
 	"runtime"
 	"strconv"
@@ -95,7 +94,7 @@ func (dl *DefaultListener) Listen(ctx context.Context, addr net.Addr, sockopt *S
 			if sockopt.TcpKeepAliveIdle*sockopt.TcpKeepAliveInterval < 0 {
 				return nil, errors.New("invalid TcpKeepAliveIdle or TcpKeepAliveInterval value: ", sockopt.TcpKeepAliveIdle, " ", sockopt.TcpKeepAliveInterval)
 			}
-			lc.KeepAliveConfig = gonet.KeepAliveConfig{
+			lc.KeepAliveConfig = net.KeepAliveConfig{
 				Enable:   false,
 				Idle:     -1,
 				Interval: -1,

--- a/transport/internet/websocket/dialer.go
+++ b/transport/internet/websocket/dialer.go
@@ -5,7 +5,6 @@ import (
 	_ "embed"
 	"encoding/base64"
 	"io"
-	gonet "net"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -64,7 +63,7 @@ func dialWebSocket(ctx context.Context, dest net.Destination, streamSettings *in
 		tlsConfig := tConfig.GetTLSConfig(tls.WithDestination(dest), tls.WithNextProto("http/1.1"))
 		dialer.TLSClientConfig = tlsConfig
 		if fingerprint := tls.GetFingerprint(tConfig.Fingerprint); fingerprint != nil {
-			dialer.NetDialTLSContext = func(_ context.Context, _, addr string) (gonet.Conn, error) {
+			dialer.NetDialTLSContext = func(_ context.Context, _, addr string) (net.Conn, error) {
 				// Like the NetDial in the dialer
 				pconn, err := internet.DialSystem(ctx, dest, streamSettings.SocketSettings)
 				if err != nil {


### PR DESCRIPTION
common/net 包的说法是 "drop-in replacement to Golang's net package" 它应该可以完全替换掉 go 的 net 包 代码中很多部分遇到没有 alias 的东西都是直接导入 gonet "net" 之类的东西 这里一并移除掉了 代码可以更清爽一点