### PR TITLE
Wireguard: Decouple server endpoint DNS from address option

### DIFF
--- a/proxy/wireguard/client.go
+++ b/proxy/wireguard/client.go
@@ -300,14 +300,14 @@ func (h *Handler) createIPCRequest() string {
 				errors.LogInfo(h.bind.ctx, "createIPCRequest use dialer dest ip: ", addr)
 			} else {
 				ips, _, err := h.dns.LookupIP(addr.Domain(), dns.IPOption{
-					IPv4Enable:/*h.hasIPv4 &&*/ h.conf.preferIP4(),
-					IPv6Enable:/*h.hasIPv6 &&*/ h.conf.preferIP6(),
+					IPv4Enable: h.conf.preferIP4(),
+					IPv6Enable: h.conf.preferIP6(),
 				})
 				{ // Resolve fallback
 					if (len(ips) == 0 || err != nil) && h.conf.hasFallback() {
 						ips, _, err = h.dns.LookupIP(addr.Domain(), dns.IPOption{
-							IPv4Enable:/*h.hasIPv4 &&*/ h.conf.fallbackIP4(),
-							IPv6Enable:/*h.hasIPv6 &&*/ h.conf.fallbackIP6(),
+							IPv4Enable: h.conf.fallbackIP4(),
+							IPv6Enable: h.conf.fallbackIP6(),
 						})
 					}
 				}


### PR DESCRIPTION
Previously, Wireguard server endpoint's domain resolution was incorrectly constrained by the local `address` option. For example, `ForceIPv6v4` might fail to resolve AAAA records for the server domain if no IPv6 was explicitly configured in the `address` option.

This commit decouples the server endpoint's domain resolution from the local `address` configuration. It ensures the Wireguard server address is resolved independently, allowing its `domainStrategy` to function correctly without being limited by the client's local network or `address` settings.