### PR TITLE
REALITY client: Clearer log when receiving real certificate

### DIFF
--- a/transport/internet/reality/reality.go
+++ b/transport/internet/reality/reality.go
@@ -180,7 +180,7 @@ func UClient(c net.Conn, config *Config, ctx context.Context, dest net.Destinati
 		fmt.Printf("REALITY localAddr: %v\tuConn.Verified: %v\n", localAddr, uConn.Verified)
 	}
 	if !uConn.Verified {
-		errors.LogError(ctx, "REALITY: peer verification failed (potential MITM or redirection)")
+		errors.LogError(ctx, "REALITY: received real certificate (potential MITM or redirection)")
 		go func() {
 			client := &http.Client{
 				Transport: &http2.Transport{


### PR DESCRIPTION
The fmt.Printf call inside UClient's DialTLSContext was executing unconditionally.
This caused log pollution when using xray-core as a library dependency, printing to stdout even when debug mode was disabled.(REALITY localAddr: xxx	DialTLSContext)

This patch wraps the print statement with `if config.Show`, consistent with other debug logs in the file.
This cleans up the output when using the package as a library.