### PR TITLE
feat: optional DNS pinning for XHTTP w/ downloadSettings

### DIFF
--- a/transport/internet/dns_pin.go
+++ b/transport/internet/dns_pin.go
@@ -1,0 +1,77 @@
+package internet
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/xtls/xray-core/common/net"
+)
+
+// DNS pinning is an opt-in, per-context mechanism to keep repeated dials to the
+// same domain using a stable chosen IP (e.g. for XHTTP upload/download legs).
+
+type dnsPinKey struct{}
+
+type dnsPinStore struct {
+	mu sync.Mutex
+	m  map[string]net.IP // normalized domain -> pinned IP
+}
+
+func normalizePinDomain(domain string) string {
+	d := strings.ToLower(strings.TrimSpace(domain))
+	return strings.TrimSuffix(d, ".")
+}
+
+// ContextWithDNSPin returns a derived context that enables DNS pinning.
+// DialSystem will only honor pins when the context carries a pin store.
+func ContextWithDNSPin(ctx context.Context) context.Context {
+	if ctx.Value(dnsPinKey{}) != nil {
+		return ctx
+	}
+	return context.WithValue(ctx, dnsPinKey{}, &dnsPinStore{m: make(map[string]net.IP)})
+}
+
+func getDNSPin(ctx context.Context, domain string) (net.IP, bool) {
+	store, ok := ctx.Value(dnsPinKey{}).(*dnsPinStore)
+	if !ok || store == nil {
+		return nil, false
+	}
+	d := normalizePinDomain(domain)
+	if d == "" {
+		return nil, false
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	ip, ok := store.m[d]
+	if !ok || len(ip) == 0 {
+		return nil, false
+	}
+	out := make(net.IP, len(ip))
+	copy(out, ip)
+	return out, true
+}
+
+// SetDNSPinIfAbsent pins domain -> ip if no pin exists yet.
+// Returns true if it was stored.
+func SetDNSPinIfAbsent(ctx context.Context, domain string, ip net.IP) bool {
+	store, ok := ctx.Value(dnsPinKey{}).(*dnsPinStore)
+	if !ok || store == nil {
+		return false
+	}
+	d := normalizePinDomain(domain)
+	if d == "" || len(ip) == 0 {
+		return false
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if existing, ok := store.m[d]; ok && len(existing) > 0 {
+		return false
+	}
+	ipCopy := make(net.IP, len(ip))
+	copy(ipCopy, ip)
+	store.m[d] = ipCopy
+	return true
+}
+
+

--- a/transport/internet/dns_pin_test.go
+++ b/transport/internet/dns_pin_test.go
@@ -1,0 +1,107 @@
+package internet
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	cnet "github.com/xtls/xray-core/common/net"
+	feature_dns "github.com/xtls/xray-core/features/dns"
+)
+
+type fakeDNSClient struct {
+	ips []cnet.IP
+}
+
+func (f *fakeDNSClient) Type() interface{} { return feature_dns.ClientType() }
+func (f *fakeDNSClient) Start() error      { return nil }
+func (f *fakeDNSClient) Close() error      { return nil }
+func (f *fakeDNSClient) LookupIP(domain string, option feature_dns.IPOption) ([]cnet.IP, uint32, error) {
+	return append([]cnet.IP(nil), f.ips...), 60, nil
+}
+
+type recordDialer struct {
+	dests []cnet.Destination
+}
+
+func (d *recordDialer) Type() interface{} { return (*recordDialer)(nil) }
+func (d *recordDialer) DestIpAddress() cnet.IP {
+	return nil
+}
+func (d *recordDialer) Dial(ctx context.Context, source cnet.Address, destination cnet.Destination, sockopt *SocketConfig) (cnet.Conn, error) {
+	d.dests = append(d.dests, destination)
+	return &noopConn{remote: destination}, nil
+}
+
+type noopConn struct {
+	remote cnet.Destination
+	closed bool
+}
+
+func (c *noopConn) Read([]byte) (int, error)  { return 0, errors.New("noop") }
+func (c *noopConn) Write([]byte) (int, error) { return 0, errors.New("noop") }
+func (c *noopConn) Close() error              { c.closed = true; return nil }
+func (c *noopConn) LocalAddr() cnet.Addr      { return &cnet.TCPAddr{IP: []byte{0, 0, 0, 0}, Port: 0} }
+func (c *noopConn) RemoteAddr() cnet.Addr {
+	return &cnet.TCPAddr{IP: c.remote.Address.IP(), Port: int(c.remote.Port)}
+}
+func (c *noopConn) SetDeadline(time.Time) error      { return nil }
+func (c *noopConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *noopConn) SetWriteDeadline(time.Time) error { return nil }
+
+func TestDialSystem_DNSPin_OptInPinsChosenIPAcrossDials(t *testing.T) {
+	// Arrange: mock DNS returns two IPs; mock dialer records destinations instead of dialing.
+	oldDNS := dnsClient
+	oldDialer := effectiveSystemDialer
+	defer func() {
+		dnsClient = oldDNS
+		effectiveSystemDialer = oldDialer
+	}()
+
+	sockopt := &SocketConfig{DomainStrategy: DomainStrategy_USE_IP}
+	dest443 := cnet.TCPDestination(cnet.DomainAddress("example.com"), 443)
+	dest8443 := cnet.TCPDestination(cnet.DomainAddress("example.com"), 8443)
+
+	// Without pin store: DialSystem should respect current DNS results (deterministic with 1 IP).
+	{
+		rd := &recordDialer{}
+		effectiveSystemDialer = rd
+		dnsClient = &fakeDNSClient{ips: []cnet.IP{{1, 1, 1, 1}}}
+		_, _ = DialSystem(context.Background(), dest443, sockopt)
+		dnsClient = &fakeDNSClient{ips: []cnet.IP{{2, 2, 2, 2}}}
+		_, _ = DialSystem(context.Background(), dest443, sockopt)
+		if len(rd.dests) != 2 {
+			t.Fatalf("expected 2 dials, got %d", len(rd.dests))
+		}
+		if rd.dests[0].Address.String() != "1.1.1.1" {
+			t.Fatalf("expected first dial to use 1.1.1.1, got %s", rd.dests[0].Address)
+		}
+		if rd.dests[1].Address.String() != "2.2.2.2" {
+			t.Fatalf("expected second dial to use 2.2.2.2 after DNS change, got %s", rd.dests[1].Address)
+		}
+	}
+
+	// With pin store: second call must reuse the first chosen IP even if DNS changes and port differs.
+	{
+		rd := &recordDialer{}
+		effectiveSystemDialer = rd
+		ctx := ContextWithDNSPin(context.Background())
+		dnsClient = &fakeDNSClient{ips: []cnet.IP{{1, 1, 1, 1}}}
+		_, _ = DialSystem(ctx, dest443, sockopt)
+		dnsClient = &fakeDNSClient{ips: []cnet.IP{{2, 2, 2, 2}}}
+		_, _ = DialSystem(ctx, dest8443, sockopt)
+		if len(rd.dests) != 2 {
+			t.Fatalf("expected 2 dials, got %d", len(rd.dests))
+		}
+		if rd.dests[0].Address.String() != "1.1.1.1" {
+			t.Fatalf("expected first dial to use 1.1.1.1, got %s", rd.dests[0].Address)
+		}
+		if rd.dests[1].Address.String() != "1.1.1.1" {
+			t.Fatalf("expected pinned IP to be reused after DNS change, got %s", rd.dests[1].Address)
+		}
+		if rd.dests[0].Port == rd.dests[1].Port {
+			t.Fatalf("expected ports to differ to prove pinning is independent of port, got %s", rd.dests[0].Port)
+		}
+	}
+}

--- a/transport/internet/splithttp/download_settings.go
+++ b/transport/internet/splithttp/download_settings.go
@@ -1,0 +1,53 @@
+package splithttp
+
+import (
+	"strings"
+
+	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/transport/internet"
+)
+
+func xhttpDownloadEnableDNSPin(downloadCfg *internet.StreamConfig) bool {
+	if downloadCfg == nil {
+		return false
+	}
+	if downloadCfg.Address == nil {
+		return true
+	}
+	if dom, ok := downloadCfg.Address.Address.(*net.IPOrDomain_Domain); ok {
+		return dom.Domain == "" || strings.EqualFold(dom.Domain, "same")
+	}
+	return false
+}
+
+// xhttpApplyDownloadSameAddress mutates memory2.Destination when downloadSettings.address is
+// missing/""/"same", inheriting the primary destination's address while keeping the download
+// port (or falling back to primary port).
+func xhttpApplyDownloadSameAddress(primary net.Destination, downloadCfg *internet.StreamConfig, memory2 *internet.MemoryStreamConfig) {
+	if !xhttpDownloadEnableDNSPin(downloadCfg) {
+		return
+	}
+	if memory2 == nil {
+		return
+	}
+
+	// Figure out the desired port (downloadCfg.Port wins if provided).
+	port := primary.Port
+	if downloadCfg != nil && downloadCfg.Port != 0 {
+		port = net.Port(downloadCfg.Port)
+	}
+
+	if memory2.Destination == nil {
+		memory2.Destination = &net.Destination{Address: primary.Address, Port: port, Network: net.Network_TCP}
+		return
+	}
+
+	if memory2.Destination.Address.Family().IsDomain() {
+		dom := memory2.Destination.Address.Domain()
+		if dom == "" || strings.EqualFold(dom, "same") {
+			*memory2.Destination = net.Destination{Address: primary.Address, Port: port, Network: net.Network_TCP}
+		}
+	}
+}
+
+

--- a/transport/internet/splithttp/download_settings_test.go
+++ b/transport/internet/splithttp/download_settings_test.go
@@ -1,0 +1,78 @@
+package splithttp
+
+import (
+	"testing"
+
+	cnet "github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/transport/internet"
+)
+
+func TestXHTTPDownloadEnableDNSPin(t *testing.T) {
+	if xhttpDownloadEnableDNSPin(nil) {
+		t.Fatal("expected false for nil downloadCfg")
+	}
+	if !xhttpDownloadEnableDNSPin(&internet.StreamConfig{Address: nil}) {
+		t.Fatal("expected true for nil address")
+	}
+	if !xhttpDownloadEnableDNSPin(&internet.StreamConfig{Address: cnet.NewIPOrDomain(cnet.DomainAddress(""))}) {
+		t.Fatal("expected true for empty domain")
+	}
+	if !xhttpDownloadEnableDNSPin(&internet.StreamConfig{Address: cnet.NewIPOrDomain(cnet.DomainAddress("same"))}) {
+		t.Fatal(`expected true for domain "same"`)
+	}
+	if !xhttpDownloadEnableDNSPin(&internet.StreamConfig{Address: cnet.NewIPOrDomain(cnet.DomainAddress("SAME"))}) {
+		t.Fatal(`expected true for domain "SAME" (case-insensitive)`)
+	}
+	if xhttpDownloadEnableDNSPin(&internet.StreamConfig{Address: cnet.NewIPOrDomain(cnet.DomainAddress("other.example"))}) {
+		t.Fatal("expected false for non-same domain")
+	}
+}
+
+func TestXHTTPApplyDownloadSameAddress_InheritsPrimaryAddressAndKeepsPort(t *testing.T) {
+	primary := cnet.TCPDestination(cnet.DomainAddress("example.com"), 443)
+
+	// Case: downloadCfg has nil address; memory2 has no destination.
+	{
+		downloadCfg := &internet.StreamConfig{Port: 8443, Address: nil}
+		memory2 := &internet.MemoryStreamConfig{}
+		xhttpApplyDownloadSameAddress(primary, downloadCfg, memory2)
+		if memory2.Destination == nil {
+			t.Fatal("expected destination to be filled")
+		}
+		if memory2.Destination.Address.String() != primary.Address.String() {
+			t.Fatalf("expected inherited address %s, got %s", primary.Address, memory2.Destination.Address)
+		}
+		if memory2.Destination.Port != cnet.Port(8443) {
+			t.Fatalf("expected port 8443, got %s", memory2.Destination.Port)
+		}
+	}
+
+	// Case: downloadCfg address is "same"; memory2 destination initially points to "same".
+	{
+		downloadCfg := &internet.StreamConfig{Port: 8443, Address: cnet.NewIPOrDomain(cnet.DomainAddress("same"))}
+		memory2 := &internet.MemoryStreamConfig{
+			Destination: &cnet.Destination{Address: cnet.DomainAddress("same"), Port: 1, Network: cnet.Network_TCP},
+		}
+		xhttpApplyDownloadSameAddress(primary, downloadCfg, memory2)
+		if memory2.Destination.Address.String() != primary.Address.String() {
+			t.Fatalf("expected inherited address %s, got %s", primary.Address, memory2.Destination.Address)
+		}
+		if memory2.Destination.Port != cnet.Port(8443) {
+			t.Fatalf("expected port 8443, got %s", memory2.Destination.Port)
+		}
+	}
+
+	// Case: downloadCfg address is explicit other domain -> should not override.
+	{
+		downloadCfg := &internet.StreamConfig{Port: 8443, Address: cnet.NewIPOrDomain(cnet.DomainAddress("other.example"))}
+		memory2 := &internet.MemoryStreamConfig{
+			Destination: &cnet.Destination{Address: cnet.DomainAddress("other.example"), Port: 8443, Network: cnet.Network_TCP},
+		}
+		xhttpApplyDownloadSameAddress(primary, downloadCfg, memory2)
+		if memory2.Destination.Address.String() != "other.example" {
+			t.Fatalf("expected address to remain other.example, got %s", memory2.Destination.Address)
+		}
+	}
+}
+
+


### PR DESCRIPTION
This PR fixes XHTTP issue when main XHTTPSettings and it's downloadSettings have the same domain but DNS returns different A records that points to different servers, for example when using DNS Load Balancing.

- Add opt-in per-context DNS “pin” so repeated dials to the same domain reuse the first chosen IP (transport/internet).
- Enable pinning only for XHTTP when downloadSettings.address is missing / empty  or "same" value, and allow downloadSettings to inherit the primary address while keeping other settings (transport/internet/splithttp).
- Handle reused HTTP connections (pin based on actual remote IP once a connection is obtained).
- Add unit tests for pinning and for different values ("same" or empty address).