### PR TITLE
TLS ECH: Increase DOH timeout

### DIFF
--- a/transport/internet/tls/ech.go
+++ b/transport/internet/tls/ech.go
@@ -245,12 +245,8 @@ func dnsQuery(server string, domain string, sockopt *internet.SocketConfig) ([]b
 					return conn, nil
 				},
 			}
-			timeout := 5 * time.Second
-			if sockopt != nil && len(sockopt.DialerProxy) > 0 {
-				timeout = 10 * time.Second
-			}
 			c := &http.Client{
-				Timeout:   timeout,
+				Timeout:   30 * time.Second,
 				Transport: tr,
 			}
 			client, _ = clientForECHDOH.LoadOrStore(serverKey, c)


### PR DESCRIPTION
because most DOH are blocked, we should use fragment/domainFronting/other-proxy dialer for DOH to obtain the ech key.

but using fragment/other-proxy dialer causes more delay, so 5 seconds timeout may not be enough.

~According to some reports in the Persian group, using fragment with less than 2 seconds delay does not work on some ISPs in Iran.~
