### PR TITLE
TUN inbound: Close connection when handling is done

### DIFF
--- a/proxy/tun/handler.go
+++ b/proxy/tun/handler.go
@@ -102,6 +102,10 @@ func (t *Handler) Init(ctx context.Context, pm policy.Manager, dispatcher routin
 
 // HandleConnection pass the connection coming from the ip stack to the routing dispatcher
 func (t *Handler) HandleConnection(conn net.Conn, destination net.Destination) {
+	// when handling is done with any outcome, always signal back to the incoming connection
+	// to close, send completion packets back to the network, and cleanup
+	defer conn.Close()
+
 	sid := session.NewID()
 	ctx := c.ContextWithID(t.ctx, sid)
 


### PR DESCRIPTION
dispatcher.DispatchLink calls conn.Close() (or rather common.Interrupt()) on incoming connection only if error occurs.
conn.Close() is not called in case of successful handling (connection finishes or completes by outbound policy idle timeout), when DispatchLink return with no error and HandleConnection function just ends.
This breaks lifecycle handling, and leave connections (both TCP/UDP) dangling in gVisor while already closed from upstream side.
Add defer conn.Close(), always signalling handled connection to close to the input (tun) side, send finish packets (TCP) and cleanup handling (UDP).
