### PR TITLE
TUN inbound: Cancel ctx when handling is done

### DIFF
--- a/proxy/tun/handler.go
+++ b/proxy/tun/handler.go
@@ -108,8 +108,7 @@ func (t *Handler) HandleConnection(conn net.Conn, destination net.Destination) {
 
 	ctx, cancel := context.WithCancel(t.ctx)
 	defer cancel()
-	sid := session.NewID()
-	ctx = c.ContextWithID(ctx, sid)
+	ctx = c.ContextWithID(ctx, session.NewID())
 
 	source := net.DestinationFromAddr(conn.RemoteAddr())
 	inbound := session.Inbound{


### PR DESCRIPTION
after DispatchLink ends, in addition to conn, ctx must also be canceled:

https://github.com/XTLS/Xray-core/blob/7ff06f65eccdcd2f5722ee369d23b699aeb5cc0f/app/proxyman/inbound/worker.go#L61-L63

https://github.com/XTLS/Xray-core/blob/7ff06f65eccdcd2f5722ee369d23b699aeb5cc0f/app/proxyman/inbound/worker.go#L131-L132