### PR TITLE
README.md: Update links for PassWall & PassWall 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@
 ## GUI Clients
 
 - OpenWrt
-  - [PassWall](https://github.com/xiaorouji/openwrt-passwall), [PassWall 2](https://github.com/xiaorouji/openwrt-passwall2)
+  - [PassWall](https://github.com/Openwrt-Passwall/openwrt-passwall), [PassWall 2](https://github.com/Openwrt-Passwall/openwrt-passwall2)
   - [ShadowSocksR Plus+](https://github.com/fw876/helloworld)
   - [luci-app-xray](https://github.com/yichya/luci-app-xray) ([openwrt-xray](https://github.com/yichya/openwrt-xray))
 - Asuswrt-Merlin


### PR DESCRIPTION
在passwall和passwall2迁移仓库之后点击之前的仓库链接会显示404