### PR TITLE
Hysteria transport: Fix speedtest issue

### DIFF
--- a/transport/internet/hysteria/conn.go
+++ b/transport/internet/hysteria/conn.go
@@ -24,6 +24,7 @@ func (i *interConn) Write(b []byte) (int, error) {
 }
 
 func (i *interConn) Close() error {
+	i.stream.CancelRead(0)
 	return i.stream.Close()
 }
 


### PR DESCRIPTION
close #5546

出于某种原因，客户端 close stream 后服务端那边可能还在 hold 这条 stream，如果短时间内开多 stream 而不 CancelRead 可能导致新开的 stream 可以上传但收不到服务端回写的消息，~可能是 http3 的特性？~

这也是为什么多线程测速才会出现下载完成后卡死上传的情况而单线程没有 

感谢 @hedsbj 与 @missyea 的反馈