### PR TITLE
XUDP client: Initialize Global ID's BaseKey correctly

### DIFF
--- a/common/xudp/xudp.go
+++ b/common/xudp/xudp.go
@@ -35,6 +35,7 @@ func init() {
 	if strings.ToLower(platform.NewEnvFlag(platform.XUDPLog).GetValue(func() string { return "" })) == "true" {
 		Show = true
 	}
+	BaseKey = make([]byte, 32)
 	rand.Read(BaseKey)
 	go func() {
 		time.Sleep(100 * time.Millisecond) // this is not nice, but need to give some time for Android to setup ENV


### PR DESCRIPTION
正确初始化basekey 避免相互夺舍xudp连接