### PR TITLE
Commands: Print leaf cert's SHA256 in `tls ping`

### DIFF
--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -639,9 +639,13 @@ func (c *TLSConfig) Build() (proto.Message, error) {
 			if v == "" {
 				continue
 			}
-			hashValue, err := hex.DecodeString(v)
+			// remove colons for OpenSSL format
+			hashValue, err := hex.DecodeString(strings.ReplaceAll(v, ":", ""))
 			if err != nil {
 				return nil, err
+			}
+			if len(hashValue) != 32 {
+				return nil, errors.New("incorrect pinnedPeerCertSha256 length: ", v)
 			}
 			config.PinnedPeerCertSha256 = append(config.PinnedPeerCertSha256, hashValue)
 		}

--- a/main/commands/all/tls/ping.go
+++ b/main/commands/all/tls/ping.go
@@ -75,8 +75,6 @@ func executePing(cmd *base.Command, args []string) {
 			NextProtos:         []string{"h2", "http/1.1"},
 			MaxVersion:         gotls.VersionTLS13,
 			MinVersion:         gotls.VersionTLS12,
-			// Do not release tool before v5's refactor
-			// VerifyPeerCertificate: showCert(),
 		})
 		err = tlsConn.Handshake()
 		if err != nil {
@@ -101,8 +99,6 @@ func executePing(cmd *base.Command, args []string) {
 			NextProtos: []string{"h2", "http/1.1"},
 			MaxVersion: gotls.VersionTLS13,
 			MinVersion: gotls.VersionTLS12,
-			// Do not release tool before v5's refactor
-			// VerifyPeerCertificate: showCert(),
 		})
 		err = tlsConn.Handshake()
 		if err != nil {
@@ -133,6 +129,7 @@ func printCertificates(certs []*x509.Certificate) {
 		fmt.Println("Cert's signature algorithm: ", leaf.SignatureAlgorithm.String())
 		fmt.Println("Cert's publicKey algorithm: ", leaf.PublicKeyAlgorithm.String())
 		fmt.Println("Cert's allowed domains: ", leaf.DNSNames)
+		fmt.Println("Cert's leaf hash: ", hex.EncodeToString(GenerateCertHash(leaf)))
 	}
 }
 
@@ -151,19 +148,5 @@ func printTLSConnDetail(tlsConn *gotls.Conn) {
 		fmt.Println("TLS Post-Quantum key exchange: ", PostQuantum, "("+curveID.String()+")")
 	} else {
 		fmt.Println("TLS Post-Quantum key exchange:  false (RSA Exchange)")
-	}
-}
-
-func showCert() func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-		var hash []byte
-		for _, asn1Data := range rawCerts {
-			cert, _ := x509.ParseCertificate(asn1Data)
-			if cert.IsCA {
-				hash = GenerateCertHash(cert)
-			}
-		}
-		fmt.Println("Certificate Leaf Hash: ", hex.EncodeToString(hash))
-		return nil
 	}
 }

--- a/main/commands/all/tls/ping.go
+++ b/main/commands/all/tls/ping.go
@@ -129,7 +129,7 @@ func printCertificates(certs []*x509.Certificate) {
 		fmt.Println("Cert's signature algorithm: ", leaf.SignatureAlgorithm.String())
 		fmt.Println("Cert's publicKey algorithm: ", leaf.PublicKeyAlgorithm.String())
 		fmt.Println("Cert's allowed domains: ", leaf.DNSNames)
-		fmt.Println("Cert's leaf hash: ", hex.EncodeToString(GenerateCertHash(leaf)))
+		fmt.Println("Cert's leaf SHA256: ", hex.EncodeToString(GenerateCertHash(leaf)))
 	}
 }
 


### PR DESCRIPTION
本来想说这种小改放 #5625 的 如果说被搁置了那就拆开了
<img width="803" height="231" alt="image" src="https://github.com/user-attachments/assets/404c4427-76bc-4071-a217-dfeaf918d69b" />
验证过了计算结果正确
然后还有一个小改动是自动移除PinnedPeerCertSha256里的冒号（openssl产生这种格式的输出 meta好像也用这种）