### PR TITLE
SocketConfig: Fail fast on unavailable network interface

### DIFF
--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"math"
+	gonet "net"
 	"net/url"
 	"runtime"
 	"strconv"
@@ -1214,6 +1215,12 @@ func (c *SocketConfig) Build() (*internet.SocketConfig, error) {
 		happyEyeballs.Interleave = c.HappyEyeballsSettings.Interleave
 		happyEyeballs.TryDelayMs = c.HappyEyeballsSettings.TryDelayMs
 		happyEyeballs.MaxConcurrentTry = c.HappyEyeballsSettings.MaxConcurrentTry
+	}
+
+	if c.Interface != "" {
+		if _, err := gonet.InterfaceByName(c.Interface); err != nil {
+			return nil, errors.New("invalid interface: ", c.Interface).Base(err)
+		}
 	}
 
 	return &internet.SocketConfig{


### PR DESCRIPTION
Validate interface at config load; return non-retryable error at runtime.

Fixes CPU/memory leak caused by infinite retry loop when bound interface is unavailable.
