### PR TITLE
Fix: XHTTP sessionPlacement unsupported path

### DIFF
--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -334,7 +334,7 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 	switch c.SessionPlacement {
 	case "":
 		c.SessionPlacement = "path"
-	case "cookie", "header", "query":
+	case "path", "cookie", "header", "query":
 	default:
 		return nil, errors.New("unsupported session placement: " + c.SessionPlacement)
 	}
@@ -342,7 +342,7 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 	switch c.SeqPlacement {
 	case "":
 		c.SeqPlacement = "path"
-	case "cookie", "header", "query":
+	case "path", "cookie", "header", "query":
 		if c.SessionPlacement == "path" {
 			return nil, errors.New("SeqPlacement must be path when SessionPlacement is path")
 		}


### PR DESCRIPTION
Fix for issue https://github.com/XTLS/Xray-core/issues/5631

# Cause

Config parser didn't expect that someone could explicitly set the `SessionPlacement` and `SeqPlacement` parameters to their default values (`path`).

# Fix

I added `path` to the list of allowed values for the `SessionPlacement` and `SeqPlacement` parameters.