### PR TITLE
XICMP finalmask: Refine seq

### DIFF
--- a/transport/internet/finalmask/xicmp/client.go
+++ b/transport/internet/finalmask/xicmp/client.go
@@ -189,7 +189,9 @@ func (c *xicmpConnClient) recvLoop() {
 		}
 
 		if len(echo.Data) > 0 {
+			c.mutex.Lock()
 			delete(c.seqStatus, echo.Seq)
+			c.mutex.Unlock()
 
 			buf := make([]byte, len(echo.Data))
 			copy(buf, echo.Data)


### PR DESCRIPTION
给 seq 加个超时机制，~聊胜于无~

本来想用 time.Time，但是一想到每次 read 都 time.Now 一下就有点难崩，~那还是用窗口模拟吧~

~之前还想除了回复的第一个随机字节后面再加四字节 crc32 校验，想了想还是算了，是不是合法数据还是交给上层，而且 hash 验证也只能缓解~