### PR TITLE
HTTPUpgrade server: Fix certain stuck in Handle()

### DIFF
--- a/transport/internet/httpupgrade/hub.go
+++ b/transport/internet/httpupgrade/hub.go
@@ -31,7 +31,18 @@ func (s *server) Addr() net.Addr {
 	return nil
 }
 
-func (s *server) Handle(conn net.Conn) (stat.Connection, error) {
+func (s *server) Handle(conn net.Conn) {
+	upgradedConn, err := s.upgrade(conn)
+	if err != nil {
+		common.CloseIfExists(conn)
+		errors.LogInfoInner(context.Background(), err, "failed to handle request")
+		return
+	}
+	s.addConn(upgradedConn)
+}
+
+// upgrade execute a fake websocket upgrade process and return the available connection
+func (s *server) upgrade(conn net.Conn) (stat.Connection, error) {
 	connReader := bufio.NewReader(conn)
 	req, err := http.ReadRequest(connReader)
 	if err != nil {
@@ -52,7 +63,6 @@ func (s *server) Handle(conn net.Conn) (stat.Connection, error) {
 	connection := strings.ToLower(req.Header.Get("Connection"))
 	upgrade := strings.ToLower(req.Header.Get("Upgrade"))
 	if connection != "upgrade" || upgrade != "websocket" {
-		_ = conn.Close()
 		return nil, errors.New("unrecognized request")
 	}
 	resp := &http.Response{
@@ -67,7 +77,6 @@ func (s *server) Handle(conn net.Conn) (stat.Connection, error) {
 	resp.Header.Set("Upgrade", "websocket")
 	err = resp.Write(conn)
 	if err != nil {
-		_ = conn.Close()
 		return nil, err
 	}
 
@@ -99,14 +108,7 @@ func (s *server) keepAccepting() {
 		if err != nil {
 			return
 		}
-		go func() {
-			handledConn, err := s.Handle(conn)
-			if err != nil {
-				errors.LogInfoInner(context.Background(), err, "failed to handle request")
-				return
-			}
-			s.addConn(handledConn)
-		}()
+		go s.Handle(conn)
 	}
 }
 


### PR DESCRIPTION
这两天莫名其妙卡死 抓包显示 GET 请求发送后响应一个 ACK 就卡死了 我还以为是被墙了 发现只有发送到 httpupgrade 的路径会卡死 其他回复都是正常 后来在VPS端抓包发现VPS收到GET也是响应一个ACK再无响应 随手重启一下发现就好了 连续遇到了两三次 检查代码的时候发现这个 httpupgrade 升级过程竟然是串行阻塞的 只要有一个占着监听器升级流程的连接它就会一直阻塞整个监听器导致其他连接都不能升级 特征就是收到一个 GET 就没有响应了