### PR TITLE
core/core.go: Replace "Custom" with vcs info if available

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -12,6 +12,7 @@ package core
 import (
 	"fmt"
 	"runtime"
+	"runtime/debug"
 
 	"github.com/xtls/xray-core/common/serial"
 )
@@ -27,6 +28,34 @@ var (
 	codename = "Xray, Penetrates Everything."
 	intro    = "A unified platform for anti-censorship."
 )
+
+func init() {
+	// Manually injected
+	if build != "Custom" {
+		return
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	var isDirty bool
+	var foundBuild bool
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			if len(setting.Value) < 7 {
+				return
+			}
+			build = setting.Value[:7]
+			foundBuild = true
+		case "vcs.modified":
+			isDirty = setting.Value == "true"
+		}
+	}
+	if isDirty && foundBuild {
+		build += "-dirty"
+	}
+}
 
 // Version returns Xray's version as a string, in the form of "x.y.z" where x, y and z are numbers.
 // ".z" part may be omitted in regular releases.


### PR DESCRIPTION
把之前的 buildvcs=flase 加回来（实测它省下的地方不到1kb 没有意义）
直接使用vcs信息展示build信息 不再需要手动git调整