### PR TITLE
Chore: Migrate to Go 1.26

### DIFF
--- a/.github/build/friendly-filenames.json
+++ b/.github/build/friendly-filenames.json
@@ -29,6 +29,5 @@
   "openbsd-arm7": { "friendlyName": "openbsd-arm32-v7a" },
   "windows-386": { "friendlyName": "windows-32" },
   "windows-amd64": { "friendlyName": "windows-64" },
-  "windows-arm64": { "friendlyName": "windows-arm64-v8a" },
-  "windows-arm7": { "friendlyName": "windows-arm32-v7a" }
+  "windows-arm64": { "friendlyName": "windows-arm64-v8a" }
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
               break
             fi
           done
-          LIST=('amd64' 'x86' 'arm64' 'arm')
+          LIST=('amd64' 'x86' 'arm64')
           for ARCHITECTURE in "${LIST[@]}"
           do
             echo -e "Checking wintun.dll for ${ARCHITECTURE}..."
@@ -114,9 +114,6 @@ jobs:
           # Windows ARM
           - goos: windows
             goarch: arm64
-          - goos: windows
-            goarch: arm
-            goarm: 7
           # BEGIN Other architectures
           # BEGIN riscv64 & ARM64 & LOONG64
           - goos: linux
@@ -249,9 +246,6 @@ jobs:
             fi
             if [[ ${GOARCH} == 'arm64' ]]; then
               mv resources/wintun/bin/arm64/wintun.dll build_assets/
-            fi
-            if [[ ${GOARCH} == 'arm' ]]; then
-              mv resources/wintun/bin/arm/wintun.dll build_assets/
             fi
             mv resources/wintun/LICENSE.txt build_assets/LICENSE-wintun.txt
           fi

--- a/.github/workflows/scheduled-assets-update.yml
+++ b/.github/workflows/scheduled-assets-update.yml
@@ -89,7 +89,7 @@ jobs:
           max_attempts: 60
           command: |
             [ -d 'resources' ] || mkdir resources
-            LIST=('amd64' 'x86' 'arm64' 'arm')
+            LIST=('amd64' 'x86' 'arm64')
             for ARCHITECTURE in "${LIST[@]}"
             do
               FILE_PATH="resources/wintun/bin/${ARCHITECTURE}/wintun.dll"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/xtls/xray-core
 
-go 1.25.7
+go 1.26
 
 require (
 	github.com/apernet/quic-go v0.57.2-0.20260111184307-eec823306178

--- a/transport/internet/tls/config.go
+++ b/transport/internet/tls/config.go
@@ -524,11 +524,13 @@ func ConfigFromStreamSettings(settings *internet.MemoryStreamConfig) *Config {
 
 func ParseCurveName(curveNames []string) []tls.CurveID {
 	curveMap := map[string]tls.CurveID{
-		"curvep256":      tls.CurveP256,
-		"curvep384":      tls.CurveP384,
-		"curvep521":      tls.CurveP521,
-		"x25519":         tls.X25519,
-		"x25519mlkem768": tls.X25519MLKEM768,
+		"curvep256":          tls.CurveP256,
+		"curvep384":          tls.CurveP384,
+		"curvep521":          tls.CurveP521,
+		"x25519":             tls.X25519,
+		"x25519mlkem768":     tls.X25519MLKEM768,
+		"secp256r1mlkem768":  tls.SecP256r1MLKEM768,
+		"secp384r1mlkem1024": tls.SecP384r1MLKEM1024,
 	}
 
 	var curveIDs []tls.CurveID

--- a/transport/internet/tls/ech.go
+++ b/transport/internet/tls/ech.go
@@ -3,8 +3,6 @@ package tls
 import (
 	"bytes"
 	"context"
-	"crypto/ecdh"
-	"crypto/rand"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/binary"
@@ -23,8 +21,6 @@ import (
 	"golang.org/x/net/http2"
 
 	"github.com/miekg/dns"
-	"github.com/xtls/reality"
-	"github.com/xtls/reality/hpke"
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/utils"
@@ -330,34 +326,6 @@ func dnsQuery(server string, domain string, sockopt *internet.SocketConfig) ([]b
 	return nil, dns2.DefaultTTL, nil
 }
 
-// reference github.com/OmarTariq612/goech
-func MarshalBinary(ech reality.EchConfig) ([]byte, error) {
-	var b cryptobyte.Builder
-	b.AddUint16(ech.Version)
-	b.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
-		child.AddUint8(ech.ConfigID)
-		child.AddUint16(ech.KemID)
-		child.AddUint16(uint16(len(ech.PublicKey)))
-		child.AddBytes(ech.PublicKey)
-		child.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
-			for _, cipherSuite := range ech.SymmetricCipherSuite {
-				child.AddUint16(cipherSuite.KDFID)
-				child.AddUint16(cipherSuite.AEADID)
-			}
-		})
-		child.AddUint8(ech.MaxNameLength)
-		child.AddUint8(uint8(len(ech.PublicName)))
-		child.AddBytes(ech.PublicName)
-		child.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
-			for _, extention := range ech.Extensions {
-				child.AddUint16(extention.Type)
-				child.AddBytes(extention.Data)
-			}
-		})
-	})
-	return b.Bytes()
-}
-
 var ErrInvalidLen = errors.New("goech: invalid length")
 
 func ConvertToGoECHKeys(data []byte) ([]tls.EncryptedClientHelloKey, error) {
@@ -391,42 +359,4 @@ func ConvertToGoECHKeys(data []byte) ([]tls.EncryptedClientHelloKey, error) {
 		})
 	}
 	return keys, nil
-}
-
-const ExtensionEncryptedClientHello = 0xfe0d
-const KDF_HKDF_SHA384 = 0x0002
-const KDF_HKDF_SHA512 = 0x0003
-
-func GenerateECHKeySet(configID uint8, domain string, kem uint16) (reality.EchConfig, []byte, error) {
-	config := reality.EchConfig{
-		Version:    ExtensionEncryptedClientHello,
-		ConfigID:   configID,
-		PublicName: []byte(domain),
-		KemID:      kem,
-		SymmetricCipherSuite: []reality.EchCipher{
-			{KDFID: hpke.KDF_HKDF_SHA256, AEADID: hpke.AEAD_AES_128_GCM},
-			{KDFID: hpke.KDF_HKDF_SHA256, AEADID: hpke.AEAD_AES_256_GCM},
-			{KDFID: hpke.KDF_HKDF_SHA256, AEADID: hpke.AEAD_ChaCha20Poly1305},
-			{KDFID: KDF_HKDF_SHA384, AEADID: hpke.AEAD_AES_128_GCM},
-			{KDFID: KDF_HKDF_SHA384, AEADID: hpke.AEAD_AES_256_GCM},
-			{KDFID: KDF_HKDF_SHA384, AEADID: hpke.AEAD_ChaCha20Poly1305},
-			{KDFID: KDF_HKDF_SHA512, AEADID: hpke.AEAD_AES_128_GCM},
-			{KDFID: KDF_HKDF_SHA512, AEADID: hpke.AEAD_AES_256_GCM},
-			{KDFID: KDF_HKDF_SHA512, AEADID: hpke.AEAD_ChaCha20Poly1305},
-		},
-		MaxNameLength: 0,
-		Extensions:    nil,
-	}
-	// if kem == hpke.DHKEM_X25519_HKDF_SHA256 {
-	curve := ecdh.X25519()
-	priv := make([]byte, 32) //x25519
-	_, err := io.ReadFull(rand.Reader, priv)
-	if err != nil {
-		return config, nil, err
-	}
-	privKey, _ := curve.NewPrivateKey(priv)
-	config.PublicKey = privKey.PublicKey().Bytes()
-	return config, priv, nil
-	// }
-	// TODO: add mlkem768 (former kyber768 draft00). The golang mlkem private key is 64 bytes seed?
 }


### PR DESCRIPTION
可能有用的透明改动

绿茶gc

其他

因为已经有官方 hpke 包 遂移除 ech 解析对 reality 中导出的hpke依赖
因为 win arm32 已经滚了 应用了 #4584 的内容（不然 CI 会炸掉）（commit作者已正确标注）