### PR TITLE
VLESS Encryption: Check 17~17000 -> Check 17~16640

### DIFF
--- a/proxy/vless/encryption/common.go
+++ b/proxy/vless/encryption/common.go
@@ -107,7 +107,7 @@ func (c *CommonConn) Read(b []byte) (int, error) {
 	if _, err := io.ReadFull(c.Conn, peerHeader[:]); err != nil {
 		return 0, err
 	}
-	l, err := DecodeHeader(peerHeader[:]) // l: 17~17000
+	l, err := DecodeHeader(peerHeader[:]) // l: 17~16640
 	if err != nil {
 		if c.Client != nil && strings.Contains(err.Error(), "invalid header: ") { // client's 0-RTT
 			c.Client.RWLock.Lock()
@@ -214,7 +214,7 @@ func DecodeHeader(h []byte) (l int, err error) {
 	if h[0] != 23 || h[1] != 3 || h[2] != 3 {
 		l = 0
 	}
-	if l < 17 || l > 17000 { // TODO: TLSv1.3 max length
+	if l < 17 || l > 16640 { // TLS 1.3 max record: 16384 + 256 (RFC 8446 §5.2)
 		err = errors.New("invalid header: " + fmt.Sprintf("%v", h[:5])) // DO NOT CHANGE: relied by client's Read()
 	}
 	return


### PR DESCRIPTION
## Description

The internal Vision encryption layer previously accepted TLS records up to **17,000 bytes**. This exceeds the TLS 1.3 maximum `TLSCiphertext` length defined in [RFC 8446 §5.2](https://www.rfc-editor.org/rfc/rfc8446#section-5.2), which mandates a hard limit of **16,640 bytes** (`2^14 + 256`).

## Problem

Records between 16,641 and 17,000 bytes are **never** produced by any compliant TLS implementation (Go `crypto/tls`, OpenSSL, BoringSSL, etc.). Accepting them creates a detectable fingerprint that DPI systems can use to identify VLESS Vision (PQ/decryption mode) traffic via active probing.

Per the RFC:

> _"The length MUST NOT exceed 2^14 + 256. An endpoint that receives a record that exceeds this length MUST terminate the connection with a `record_overflow` alert."_

## Impact

| Area              | Detail                                                                                                                                 |
| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
| **Security**      | Eliminates a fingerprinting vector usable by DPI/active probing                                                                        |
| **Compatibility** | Fully backward compatible — `Write()` already fragments at ~8192 bytes, well below the new limit                                       |
| **Scope**         | Only affects VLESS configurations with `decryption` enabled. Standard TLS/REALITY transport is unaffected (handled by Go `crypto/tls`) |
