### PR TITLE
Fix prevent sensitive key material from leaking into logs and error messages

### DIFF
--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -933,7 +933,7 @@ func (c *REALITYConfig) Build() (proto.Message, error) {
 			return nil, errors.New(`empty "privateKey"`)
 		}
 		if config.PrivateKey, err = base64.RawURLEncoding.DecodeString(c.PrivateKey); err != nil || len(config.PrivateKey) != 32 {
-			return nil, errors.New(`invalid "privateKey": `, c.PrivateKey)
+			return nil, errors.New(`invalid "privateKey": decode error or incorrect length`)
 		}
 		if c.MinClientVer != "" {
 			config.MinClientVer = make([]byte, 3)
@@ -984,10 +984,10 @@ func (c *REALITYConfig) Build() (proto.Message, error) {
 
 		if c.Mldsa65Seed != "" {
 			if c.Mldsa65Seed == c.PrivateKey {
-				return nil, errors.New(`"mldsa65Seed" and "privateKey" can not be the same value: `, c.Mldsa65Seed)
+				return nil, errors.New(`"mldsa65Seed" and "privateKey" can not be the same value`)
 			}
 			if config.Mldsa65Seed, err = base64.RawURLEncoding.DecodeString(c.Mldsa65Seed); err != nil || len(config.Mldsa65Seed) != 32 {
-				return nil, errors.New(`invalid "mldsa65Seed": `, c.Mldsa65Seed)
+				return nil, errors.New(`invalid "mldsa65Seed": decode error or incorrect length`)
 			}
 		}
 
@@ -1017,7 +1017,7 @@ func (c *REALITYConfig) Build() (proto.Message, error) {
 			return nil, errors.New(`empty "password"`)
 		}
 		if config.PublicKey, err = base64.RawURLEncoding.DecodeString(c.PublicKey); err != nil || len(config.PublicKey) != 32 {
-			return nil, errors.New(`invalid "password": `, c.PublicKey)
+			return nil, errors.New(`invalid "password": decode error or incorrect length`)
 		}
 		if len(c.ShortIds) != 0 {
 			return nil, errors.New(`non-empty "shortIds", please use "shortId" instead`)
@@ -1031,7 +1031,7 @@ func (c *REALITYConfig) Build() (proto.Message, error) {
 		}
 		if c.Mldsa65Verify != "" {
 			if config.Mldsa65Verify, err = base64.RawURLEncoding.DecodeString(c.Mldsa65Verify); err != nil || len(config.Mldsa65Verify) != 1952 {
-				return nil, errors.New(`invalid "mldsa65Verify": `, c.Mldsa65Verify)
+				return nil, errors.New(`invalid "mldsa65Verify": decode error or incorrect length`)
 			}
 		}
 		if c.SpiderX == "" {


### PR DESCRIPTION
## Description

When the REALITY `Show` debug flag is enabled, the client-side handshake code in `reality.go` prints raw cryptographic key material to stdout via `fmt.Printf`. This includes the first 16 bytes of the ECDH-derived `AuthKey` (the session encryption key) and the `SessionId` field (which embeds the `ShortId`, Xray version, and a Unix timestamp).

Additionally, several error messages in `transport_internet.go` echo back raw `privateKey`, `mldsa65Seed`, and `password` values when config parsing fails, which can end up in log files.

This PR:

1. **Redacts all sensitive data** from debug output in `reality.go` — `AuthKey` bytes and `SessionId` bytes are no longer printed.
2. **Migrates all 10 `fmt.Printf` calls** in `reality.go` to the project's structured `errors.LogDebug()` logging system, ensuring debug output respects global log-level settings instead of always going to raw stdout.
3. **Removes raw key values** from 5 error messages in `transport_internet.go` — error messages now describe the problem without echoing the actual secret.
4. Removes the now-unused `"fmt"` import from `reality.go`.

## Problem

Two places in the codebase print sensitive key material in plain text:

### 1. `reality.go` — debug logs leak encryption keys

When `Show` is enabled, `fmt.Printf` prints the `AuthKey` (session encryption key) and `SessionId` (containing `ShortId` + timestamp) directly to stdout:

```go
fmt.Printf("REALITY localAddr: %v\thello.SessionId[:16]: %v\n", localAddr, hello.SessionId[:16])  // line 150
fmt.Printf("REALITY localAddr: %v\tuConn.AuthKey[:16]: %v\tAEAD: %T\n", localAddr, uConn.AuthKey[:16], aead)  // line 172
```

All 10 `fmt.Printf` calls in this file go directly to stdout, bypassing log-level control.

### 2. `transport_internet.go` — error messages echo raw keys

When config parsing fails, the raw key value is included in the error message:

```go
errors.New(`invalid "privateKey": `, c.PrivateKey)            // line 936
errors.New(`"mldsa65Seed" and "privateKey" can not be the same value: `, c.Mldsa65Seed)  // line 987
errors.New(`invalid "mldsa65Seed": `, c.Mldsa65Seed)          // line 990
errors.New(`invalid "password": `, c.PublicKey)                // line 1020
errors.New(`invalid "mldsa65Verify": `, c.Mldsa65Verify)      // line 1034
```

## Impact

- **Session decryption**: Anyone with access to logs (sysadmin, cloud log services, log backups) can extract `AuthKey` and decrypt the REALITY session.
- **Client fingerprinting**: Leaked `SessionId` contains the `ShortId` (unique client identifier), Xray version bytes, and connection timestamp — enabling user tracking.
- **Key exposure via error logs**: If a misconfigured server writes error output to a log file, `privateKey` and `mldsa65Seed` values are stored in plaintext on disk.