### PR TITLE
Fix: resolve data races in splithttp transport

### DIFF
--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -500,11 +500,12 @@ func (w uploadWriter) Write(b []byte) (int, error) {
 
 	var writed int
 	for _, buff := range buffer.MultiBuffer {
+		l := int(buff.Len()) // capture length before ownership transfer
 		err := w.WriteMultiBuffer(buf.MultiBuffer{buff})
 		if err != nil {
 			return writed, err
 		}
-		writed += int(buff.Len())
+		writed += l
 	}
 	return writed, nil
 }


### PR DESCRIPTION
## Description

Fixes three critical data races in the `splithttp` package identified through static analysis and `go test -race`. All three affect connection stability under concurrent workloads.

---

### 1. `WaitReadCloser` race — `client.go`

- **Problem:** `ReadCloser` was read/written across goroutines without synchronization, causing undefined read behavior and potential nil dereference.
- **Fix:** Guarded `ReadCloser` with `sync.Mutex`; used `sync.Once` for safe channel close.

### 2. Upload buffer use-after-handoff — `dialer.go`

- **Problem:** `buff.Len()` was called after buffer ownership was transferred to the pipe, racing with the consumer goroutine.
- **Fix:** Captured buffer length _before_ `WriteMultiBuffer` call.

### 3. `uploadQueue` unguarded fields — `upload_queue.go`

- **Problem:** `closed` and `reader` were read in `Read()` without lock, while `Close()` mutated them under lock.
- **Fix:** Extended `writeCloseMutex` scope to cover the `Read()` path.

## Impact

- Eliminates undefined behavior, potential panics, and flaky connection drops under load
- No API or config changes — drop-in safe

## Test

```bash
go test -race ./transport/internet/splithttp/...
```