### PR TITLE
XHTTP transport: Bugfixes for obfuscations

### DIFF
--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -230,7 +230,7 @@ type SplitHTTPConfig struct {
 	SeqKey               string            `json:"seqKey"`
 	UplinkDataPlacement  string            `json:"uplinkDataPlacement"`
 	UplinkDataKey        string            `json:"uplinkDataKey"`
-	UplinkChunkSize      uint32            `json:"uplinkChunkSize"`
+	UplinkChunkSize      Int32Range        `json:"uplinkChunkSize"`
 	NoGRPCHeader         bool              `json:"noGRPCHeader"`
 	NoSSEHeader          bool              `json:"noSSEHeader"`
 	ScMaxEachPostBytes   Int32Range        `json:"scMaxEachPostBytes"`
@@ -379,17 +379,6 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 		}
 	}
 
-	if c.UplinkChunkSize == 0 {
-		switch c.UplinkDataPlacement {
-		case splithttp.PlacementCookie:
-			c.UplinkChunkSize = 3 * 1024 // 3KiB
-		case splithttp.PlacementHeader:
-			c.UplinkChunkSize = 4 * 1000 // 4KB
-		}
-	} else if c.UplinkChunkSize < 64 {
-		c.UplinkChunkSize = 64
-	}
-
 	if c.ServerMaxHeaderBytes < 0 {
 		return nil, errors.New("invalid negative value of maxHeaderBytes")
 	}
@@ -424,7 +413,7 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 		SeqKey:               c.SeqKey,
 		UplinkDataPlacement:  c.UplinkDataPlacement,
 		UplinkDataKey:        c.UplinkDataKey,
-		UplinkChunkSize:      c.UplinkChunkSize,
+		UplinkChunkSize:      newRangeConfig(c.UplinkChunkSize),
 		NoGRPCHeader:         c.NoGRPCHeader,
 		NoSSEHeader:          c.NoSSEHeader,
 		ScMaxEachPostBytes:   newRangeConfig(c.ScMaxEachPostBytes),

--- a/transport/internet/browser_dialer/dialer.html
+++ b/transport/internet/browser_dialer/dialer.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 	<title>Browser Dialer</title>
+	<link rel="icon" href="data:">
 </head>
 <body>
 	<script>

--- a/transport/internet/browser_dialer/dialer.html
+++ b/transport/internet/browser_dialer/dialer.html
@@ -29,7 +29,35 @@
 				requestInit.headers = extra.headers;
 			}
 
+			if (extra.cookies) {
+				requestInit.credentials = 'include';
+			}
+
 			return requestInit;
+		}
+
+		function setCookiesFromTask(task) {
+			if (!task.extra.cookies) {
+				return;
+			}
+
+			const url = new URL(task.url);
+
+			for (const [name, value] of Object.entries(task.extra.cookies)) {
+				document.cookie = encodeURIComponent(name) + '=' + encodeURIComponent(value) + '; path=' + url.pathname;
+			}
+		}
+
+		function clearCookiesFromTask(task) {
+			if (!task.extra.cookies) {
+				return;
+			}
+
+			const url = new URL(task.url);
+
+			for (const [name, value] of Object.entries(task.extra.cookies)) {
+				document.cookie = encodeURIComponent(name) + '=; path=' + url.pathname + '; Max-Age=0';
+			}
 		}
 
 		let check = function () {
@@ -48,116 +76,121 @@
 			ws.onmessage = function (event) {
 				clientIdleCount -= 1;
 				let task = JSON.parse(event.data);
-				switch (task.method) {
-					case "WS": {
-						upstreamWsCount += 1;
-						console.log("Dial WS", task.url, task.extra.protocol);
-						const wss = new WebSocket(task.url, task.extra.protocol);
-						wss.binaryType = "arraybuffer";
-						let opened = false;
-						ws.onmessage = function (event) {
-							wss.send(event.data)
-						};
-						wss.onopen = function (event) {
-							opened = true;
-							ws.send("ok")
-						};
-						wss.onmessage = function (event) {
-							ws.send(event.data)
-						};
-						wss.onclose = function (event) {
-							upstreamWsCount -= 1;
-							console.log("Dial WS DONE, remaining: ", upstreamWsCount);
-							ws.close()
-						};
-						wss.onerror = function (event) {
-							!opened && ws.send("fail")
-							wss.close()
-						};
-						ws.onclose = function (event) {
-							wss.close()
-						};
-						break;
-					}
-					case "GET": {
-						(async () => {
-							const requestInit = prepareRequestInit(task.extra);
-
-							console.log("Dial GET", task.url);
-							ws.send("ok");
-							const controller = new AbortController();
-
-							/*
-							Aborting a streaming response in JavaScript
-							requires two levers to be pulled:
-
-							First, the streaming read itself has to be cancelled using
-							reader.cancel(), only then controller.abort() will actually work.
-
-							If controller.abort() alone is called while a
-							reader.read() is ongoing, it will block until the server closes the
-							response, the page is refreshed or the network connection is lost.
-							*/
-
-							let reader = null;
-							ws.onclose = (event) => {
-								try {
-									reader && reader.cancel();
-								} catch(e) {}
-
-								try {
-									controller.abort();
-								} catch(e) {}
-							};
-
-							try {
-								upstreamGetCount += 1;
-
-								requestInit.signal = controller.signal;
-								const response = await fetch(task.url, requestInit);
-
-								const body = await response.body;
-								reader = body.getReader();
-
-								while (true) {
-									const { done, value } = await reader.read();
-									if (value) ws.send(value);  // don't send back "undefined" string when received nothing
-									if (done) break;
-								}
-							} finally {
-								upstreamGetCount -= 1;
-								console.log("Dial GET DONE, remaining: ", upstreamGetCount);
-								ws.close();
-							}
-						})();
-						break;
-					}
-					case "POST": {
-						upstreamPostCount += 1;
-
+				if (task.method == "WS") {
+					upstreamWsCount += 1;
+					console.log("Dial WS", task.url, task.extra.protocol);
+					const wss = new WebSocket(task.url, task.extra.protocol);
+					wss.binaryType = "arraybuffer";
+					let opened = false;
+					ws.onmessage = function (event) {
+						wss.send(event.data)
+					};
+					wss.onopen = function (event) {
+						opened = true;
+						ws.send("ok")
+					};
+					wss.onmessage = function (event) {
+						ws.send(event.data)
+					};
+					wss.onclose = function (event) {
+						upstreamWsCount -= 1;
+						console.log("Dial WS DONE, remaining: ", upstreamWsCount);
+						ws.close()
+					};
+					wss.onerror = function (event) {
+						!opened && ws.send("fail")
+						wss.close()
+					};
+					ws.onclose = function (event) {
+						wss.close()
+					};
+				}
+				else if (task.method == "GET" && task.streamResponse) {
+					(async () => {
 						const requestInit = prepareRequestInit(task.extra);
-						requestInit.method = "POST";
 
-						console.log("Dial POST", task.url);
+						console.log("Dial GET", task.url);
 						ws.send("ok");
-						ws.onmessage = async (event) => {
+						const controller = new AbortController();
+
+						/*
+						Aborting a streaming response in JavaScript
+						requires two levers to be pulled:
+
+						First, the streaming read itself has to be cancelled using
+						reader.cancel(), only then controller.abort() will actually work.
+
+						If controller.abort() alone is called while a
+						reader.read() is ongoing, it will block until the server closes the
+						response, the page is refreshed or the network connection is lost.
+						*/
+
+						let reader = null;
+						ws.onclose = (event) => {
 							try {
-								requestInit.body = event.data;
-								const response = await fetch(task.url, requestInit);
-								if (response.ok) {
-									ws.send("ok");
-								} else {
-									console.error("bad status code");
-									ws.send("fail");
-								}
-							} finally {
-								upstreamPostCount -= 1;
-								console.log("Dial POST DONE, remaining: ", upstreamPostCount);
-								ws.close();
-							}
+								reader && reader.cancel();
+							} catch(e) {}
+
+							try {
+								controller.abort();
+							} catch(e) {}
 						};
-						break;
-					}
+
+						try {
+							upstreamGetCount += 1;
+
+							requestInit.signal = controller.signal;
+							setCookiesFromTask(task);
+							const response = await fetch(task.url, requestInit);
+							clearCookiesFromTask(task);
+
+							const body = await response.body;
+							reader = body.getReader();
+
+							while (true) {
+								const { done, value } = await reader.read();
+								if (value) ws.send(value);  // don't send back "undefined" string when received nothing
+								if (done) break;
+							}
+						} finally {
+							upstreamGetCount -= 1;
+							console.log("Dial GET DONE, remaining: ", upstreamGetCount);
+							ws.close();
+						}
+					})();
+				}
+				else if (!task.streamResponse) {
+					upstreamPostCount += 1;
+
+					const requestInit = prepareRequestInit(task.extra);
+					requestInit.method = task.method;
+
+					console.log("Dial", task.method, task.url);
+					ws.send("ok");
+					ws.onmessage = async (event) => {
+						try {
+							if (["POST", "PUT", "PATCH"].includes(task.method)) {
+								requestInit.body = event.data;
+							}
+							setCookiesFromTask(task);
+							const response = await fetch(task.url, requestInit);
+							clearCookiesFromTask(task);
+							if (response.ok) {
+								ws.send("ok");
+							} else {
+								console.error("bad status code");
+								ws.send("fail");
+							}
+						} finally {
+							upstreamPostCount -= 1;
+							console.log("Dial", task.method, "packet DONE, remaining: ", upstreamPostCount);
+							ws.close();
+						}
+					};
+				}
+				else {
+					console.error(`Incorrect task method=${task.method} streamResponse=${task.streamResponse}.`);
+					ws.close();
 				}
 
 				check();

--- a/transport/internet/browser_dialer/dialer.html
+++ b/transport/internet/browser_dialer/dialer.html
@@ -170,7 +170,7 @@
 					ws.send("ok");
 					ws.onmessage = async (event) => {
 						try {
-							if (["POST", "PUT", "PATCH"].includes(task.method)) {
+							if (event.data.byteLength > 0) {
 								requestInit.body = event.data;
 							}
 							setCookiesFromTask(task);

--- a/transport/internet/splithttp/browser_client.go
+++ b/transport/internet/splithttp/browser_client.go
@@ -30,29 +30,7 @@ func (c *BrowserDialerClient) OpenStream(ctx context.Context, url string, sessio
 		return nil, nil, nil, err
 	}
 
-	request.Header = c.transportConfig.GetRequestHeader()
-	length := int(c.transportConfig.GetNormalizedXPaddingBytes().rand())
-	config := XPaddingConfig{Length: length}
-
-	if c.transportConfig.XPaddingObfsMode {
-		config.Placement = XPaddingPlacement{
-			Placement: c.transportConfig.XPaddingPlacement,
-			Key:       c.transportConfig.XPaddingKey,
-			Header:    c.transportConfig.XPaddingHeader,
-			RawURL:    url,
-		}
-		config.Method = PaddingMethod(c.transportConfig.XPaddingMethod)
-	} else {
-		config.Placement = XPaddingPlacement{
-			Placement: PlacementQueryInHeader,
-			Key:       "x_padding",
-			Header:    "Referer",
-			RawURL:    url,
-		}
-	}
-
-	c.transportConfig.ApplyXPaddingToRequest(request, config)
-	c.transportConfig.ApplyMetaToRequest(request, sessionId, "")
+	c.transportConfig.FillStreamRequest(request, sessionId, "")
 
 	conn, err := browser_dialer.DialGet(request.URL.String(), request.Header, request.Cookies())
 	dummyAddr := &net.IPAddr{}
@@ -64,57 +42,25 @@ func (c *BrowserDialerClient) OpenStream(ctx context.Context, url string, sessio
 }
 
 func (c *BrowserDialerClient) PostPacket(ctx context.Context, url string, sessionId string, seqStr string, body io.Reader, contentLength int64) error {
-	bytes, err := io.ReadAll(body)
-	if err != nil {
-		return err
-	}
-
 	method := c.transportConfig.GetNormalizedUplinkHTTPMethod()
-	request, err := http.NewRequest(method, url, nil)
+	request, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return err
 	}
 
-	dataPlacement := c.transportConfig.GetNormalizedUplinkDataPlacement()
-
-	if dataPlacement == PlacementBody || dataPlacement == PlacementAuto {
-		request.Header = c.transportConfig.GetRequestHeader()
-	} else {
-		switch dataPlacement {
-		case PlacementHeader:
-			request.Header = c.transportConfig.GetRequestHeaderWithPayload(bytes)
-		case PlacementCookie:
-			request.Header = c.transportConfig.GetRequestHeader()
-			for _, cookie := range c.transportConfig.GetRequestCookiesWithPayload(bytes) {
-				request.AddCookie(cookie)
-			}
-		}
-		bytes = nil
+	request.ContentLength = contentLength
+	err = c.transportConfig.FillPacketRequest(request, sessionId, seqStr)
+	if err != nil {
+		return err
 	}
 
-
-	length := int(c.transportConfig.GetNormalizedXPaddingBytes().rand())
-	config := XPaddingConfig{Length: length}
-
-	if c.transportConfig.XPaddingObfsMode {
-		config.Placement = XPaddingPlacement{
-			Placement: c.transportConfig.XPaddingPlacement,
-			Key:       c.transportConfig.XPaddingKey,
-			Header:    c.transportConfig.XPaddingHeader,
-			RawURL:    url,
-		}
-		config.Method = PaddingMethod(c.transportConfig.XPaddingMethod)
-	} else {
-		config.Placement = XPaddingPlacement{
-			Placement: PlacementQueryInHeader,
-			Key:       "x_padding",
-			Header:    "Referer",
-			RawURL:    url,
+	var bytes []byte
+	if (request.Body != nil) {
+		bytes, err = io.ReadAll(request.Body)
+		if err != nil {
+			return err
 		}
 	}
-
-	c.transportConfig.ApplyXPaddingToRequest(request, config)
-	c.transportConfig.ApplyMetaToRequest(request, sessionId, seqStr)
 
 	err = browser_dialer.DialPacket(method, request.URL.String(), request.Header, request.Cookies(), bytes)
 	if err != nil {

--- a/transport/internet/splithttp/common.go
+++ b/transport/internet/splithttp/common.go
@@ -7,4 +7,5 @@ const (
 	PlacementQuery         = "query"
 	PlacementPath          = "path"
 	PlacementBody          = "body"
+	PlacementAuto          = "auto"
 )

--- a/transport/internet/splithttp/config.go
+++ b/transport/internet/splithttp/config.go
@@ -102,27 +102,27 @@ func (c *Config) WriteResponseHeader(writer http.ResponseWriter, requestMethod s
 		writer.Header().Set("Access-Control-Allow-Origin", origin)
 	}
 
-	requestedMethod := requestHeader.Get("Access-Control-Request-Method")
-	if requestedMethod != "" {
-		writer.Header().Set("Access-Control-Allow-Methods", requestedMethod)
-	} else if requestMethod != "" && requestMethod != "OPTIONS" {
-		writer.Header().Set("Access-Control-Allow-Methods", requestMethod)
-	} else {
-		writer.Header().Set("Access-Control-Allow-Methods", "*")
-	}
-
-	requestedHeaders := requestHeader.Get("Access-Control-Request-Headers")
-	if requestedHeaders == "" {
-		writer.Header().Set("Access-Control-Allow-Headers", "*")
-	} else {
-		writer.Header().Set("Access-Control-Allow-Headers", requestedHeaders)
-	}
-
 	if c.GetNormalizedSessionPlacement() == PlacementCookie ||
 	   c.GetNormalizedSeqPlacement() == PlacementCookie ||
 	   c.XPaddingPlacement == PlacementCookie ||
 	   c.GetNormalizedUplinkDataPlacement() == PlacementCookie {
 		writer.Header().Set("Access-Control-Allow-Credentials", "true")
+	}
+
+	if requestMethod == "OPTIONS" {
+		requestedMethod := requestHeader.Get("Access-Control-Request-Method")
+		if requestedMethod != "" {
+			writer.Header().Set("Access-Control-Allow-Methods", requestedMethod)
+		} else {
+			writer.Header().Set("Access-Control-Allow-Methods", "*")
+		}
+
+		requestedHeaders := requestHeader.Get("Access-Control-Request-Headers")
+		if requestedHeaders == "" {
+			writer.Header().Set("Access-Control-Allow-Headers", "*")
+		} else {
+			writer.Header().Set("Access-Control-Allow-Headers", requestedHeaders)
+		}
 	}
 }
 

--- a/transport/internet/splithttp/config.go
+++ b/transport/internet/splithttp/config.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/crypto"
-	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/utils"
 	"github.com/xtls/xray-core/transport/internet"
 )
@@ -349,14 +348,6 @@ func (c *Config) FillPacketRequest(request *http.Request, sessionId string, seqS
 			for _, cookie := range c.GetRequestCookiesWithPayload(data) {
 				request.AddCookie(cookie)
 			}
-		}
-	}
-
-	switch request.Method {
-	case "POST", "PUT", "PATCH":
-	default:
-		if request.Body != nil {
-			return errors.New("Can't make " + request.Method + " with body")
 		}
 	}
 

--- a/transport/internet/splithttp/config.pb.go
+++ b/transport/internet/splithttp/config.pb.go
@@ -186,6 +186,7 @@ type Config struct {
 	UplinkDataPlacement  string                 `protobuf:"bytes,24,opt,name=uplinkDataPlacement,proto3" json:"uplinkDataPlacement,omitempty"`
 	UplinkDataKey        string                 `protobuf:"bytes,25,opt,name=uplinkDataKey,proto3" json:"uplinkDataKey,omitempty"`
 	UplinkChunkSize      uint32                 `protobuf:"varint,26,opt,name=uplinkChunkSize,proto3" json:"uplinkChunkSize,omitempty"`
+	ServerMaxHeaderBytes int32                  `protobuf:"varint,27,opt,name=serverMaxHeaderBytes,proto3" json:"serverMaxHeaderBytes,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
@@ -402,6 +403,13 @@ func (x *Config) GetUplinkChunkSize() uint32 {
 	return 0
 }
 
+func (x *Config) GetServerMaxHeaderBytes() int32 {
+	if x != nil {
+		return x.ServerMaxHeaderBytes
+	}
+	return 0
+}
+
 var File_transport_internet_splithttp_config_proto protoreflect.FileDescriptor
 
 const file_transport_internet_splithttp_config_proto_rawDesc = "" +
@@ -417,8 +425,7 @@ const file_transport_internet_splithttp_config_proto_rawDesc = "" +
 	"\x0ecMaxReuseTimes\x18\x03 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x0ecMaxReuseTimes\x12Z\n" +
 	"\x10hMaxRequestTimes\x18\x04 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x10hMaxRequestTimes\x12Z\n" +
 	"\x10hMaxReusableSecs\x18\x05 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x10hMaxReusableSecs\x12*\n" +
-	"\x10hKeepAlivePeriod\x18\x06 \x01(\x03R\x10hKeepAlivePeriod\"\xde\n" +
-	"\n" +
+	"\x10hKeepAlivePeriod\x18\x06 \x01(\x03R\x10hKeepAlivePeriod\"\x92\v\n" +
 	"\x06Config\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
 	"\x04path\x18\x02 \x01(\tR\x04path\x12\x12\n" +
@@ -448,7 +455,8 @@ const file_transport_internet_splithttp_config_proto_rawDesc = "" +
 	"\x06seqKey\x18\x17 \x01(\tR\x06seqKey\x120\n" +
 	"\x13uplinkDataPlacement\x18\x18 \x01(\tR\x13uplinkDataPlacement\x12$\n" +
 	"\ruplinkDataKey\x18\x19 \x01(\tR\ruplinkDataKey\x12(\n" +
-	"\x0fuplinkChunkSize\x18\x1a \x01(\rR\x0fuplinkChunkSize\x1a:\n" +
+	"\x0fuplinkChunkSize\x18\x1a \x01(\rR\x0fuplinkChunkSize\x122\n" +
+	"\x14serverMaxHeaderBytes\x18\x1b \x01(\x05R\x14serverMaxHeaderBytes\x1a:\n" +
 	"\fHeadersEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x85\x01\n" +

--- a/transport/internet/splithttp/config.pb.go
+++ b/transport/internet/splithttp/config.pb.go
@@ -185,7 +185,7 @@ type Config struct {
 	SeqKey               string                 `protobuf:"bytes,23,opt,name=seqKey,proto3" json:"seqKey,omitempty"`
 	UplinkDataPlacement  string                 `protobuf:"bytes,24,opt,name=uplinkDataPlacement,proto3" json:"uplinkDataPlacement,omitempty"`
 	UplinkDataKey        string                 `protobuf:"bytes,25,opt,name=uplinkDataKey,proto3" json:"uplinkDataKey,omitempty"`
-	UplinkChunkSize      uint32                 `protobuf:"varint,26,opt,name=uplinkChunkSize,proto3" json:"uplinkChunkSize,omitempty"`
+	UplinkChunkSize      *RangeConfig           `protobuf:"bytes,26,opt,name=uplinkChunkSize,proto3" json:"uplinkChunkSize,omitempty"`
 	ServerMaxHeaderBytes int32                  `protobuf:"varint,27,opt,name=serverMaxHeaderBytes,proto3" json:"serverMaxHeaderBytes,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
@@ -396,11 +396,11 @@ func (x *Config) GetUplinkDataKey() string {
 	return ""
 }
 
-func (x *Config) GetUplinkChunkSize() uint32 {
+func (x *Config) GetUplinkChunkSize() *RangeConfig {
 	if x != nil {
 		return x.UplinkChunkSize
 	}
-	return 0
+	return nil
 }
 
 func (x *Config) GetServerMaxHeaderBytes() int32 {
@@ -425,7 +425,7 @@ const file_transport_internet_splithttp_config_proto_rawDesc = "" +
 	"\x0ecMaxReuseTimes\x18\x03 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x0ecMaxReuseTimes\x12Z\n" +
 	"\x10hMaxRequestTimes\x18\x04 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x10hMaxRequestTimes\x12Z\n" +
 	"\x10hMaxReusableSecs\x18\x05 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x10hMaxReusableSecs\x12*\n" +
-	"\x10hKeepAlivePeriod\x18\x06 \x01(\x03R\x10hKeepAlivePeriod\"\x92\v\n" +
+	"\x10hKeepAlivePeriod\x18\x06 \x01(\x03R\x10hKeepAlivePeriod\"\xc2\v\n" +
 	"\x06Config\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
 	"\x04path\x18\x02 \x01(\tR\x04path\x12\x12\n" +
@@ -454,8 +454,8 @@ const file_transport_internet_splithttp_config_proto_rawDesc = "" +
 	"\fseqPlacement\x18\x16 \x01(\tR\fseqPlacement\x12\x16\n" +
 	"\x06seqKey\x18\x17 \x01(\tR\x06seqKey\x120\n" +
 	"\x13uplinkDataPlacement\x18\x18 \x01(\tR\x13uplinkDataPlacement\x12$\n" +
-	"\ruplinkDataKey\x18\x19 \x01(\tR\ruplinkDataKey\x12(\n" +
-	"\x0fuplinkChunkSize\x18\x1a \x01(\rR\x0fuplinkChunkSize\x122\n" +
+	"\ruplinkDataKey\x18\x19 \x01(\tR\ruplinkDataKey\x12X\n" +
+	"\x0fuplinkChunkSize\x18\x1a \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x0fuplinkChunkSize\x122\n" +
 	"\x14serverMaxHeaderBytes\x18\x1b \x01(\x05R\x14serverMaxHeaderBytes\x1a:\n" +
 	"\fHeadersEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
@@ -495,11 +495,12 @@ var file_transport_internet_splithttp_config_proto_depIdxs = []int32{
 	0,  // 9: xray.transport.internet.splithttp.Config.scStreamUpServerSecs:type_name -> xray.transport.internet.splithttp.RangeConfig
 	1,  // 10: xray.transport.internet.splithttp.Config.xmux:type_name -> xray.transport.internet.splithttp.XmuxConfig
 	4,  // 11: xray.transport.internet.splithttp.Config.downloadSettings:type_name -> xray.transport.internet.StreamConfig
-	12, // [12:12] is the sub-list for method output_type
-	12, // [12:12] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	0,  // 12: xray.transport.internet.splithttp.Config.uplinkChunkSize:type_name -> xray.transport.internet.splithttp.RangeConfig
+	13, // [13:13] is the sub-list for method output_type
+	13, // [13:13] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_transport_internet_splithttp_config_proto_init() }

--- a/transport/internet/splithttp/config.proto
+++ b/transport/internet/splithttp/config.proto
@@ -49,4 +49,5 @@ message Config {
   string uplinkDataPlacement = 24;
   string uplinkDataKey = 25;
   uint32 uplinkChunkSize = 26;
+  int32 serverMaxHeaderBytes = 27;
 }

--- a/transport/internet/splithttp/config.proto
+++ b/transport/internet/splithttp/config.proto
@@ -48,6 +48,6 @@ message Config {
   string seqKey = 23;
   string uplinkDataPlacement = 24;
   string uplinkDataKey = 25;
-  uint32 uplinkChunkSize = 26;
+  RangeConfig uplinkChunkSize = 26;
   int32 serverMaxHeaderBytes = 27;
 }

--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -101,7 +101,7 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		return
 	}
 
-	h.config.WriteResponseHeader(writer, request.Header)
+	h.config.WriteResponseHeader(writer, request.Method, request.Header)
 	length := int(h.config.GetNormalizedXPaddingBytes().rand())
 	config := XPaddingConfig{Length: length}
 

--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -254,13 +254,12 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		var headerPayload []byte
 		if dataPlacement == PlacementAuto || dataPlacement == PlacementHeader {
 			var headerPayloadChunks [] string
-			for i := 0; true; {
+			for i := 0; true; i++ {
 				chunk := request.Header.Get(fmt.Sprintf("%s-%d", uplinkDataKey, i))
 				if chunk == "" {
 					break
 				}
 				headerPayloadChunks = append(headerPayloadChunks, chunk)
-				i++
 			}
 			headerPayloadEncoded := strings.Join(headerPayloadChunks, "")
 			headerPayload, err = base64.RawURLEncoding.DecodeString(headerPayloadEncoded)
@@ -274,11 +273,10 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		var cookiePayload []byte
 		if dataPlacement == PlacementAuto || dataPlacement == PlacementCookie {
 			var cookiePayloadChunks []string
-			for i := 0; true; {
+			for i := 0; true; i++ {
 				cookieName := fmt.Sprintf("%s_%d", uplinkDataKey, i)
 				if c, _ := request.Cookie(cookieName); c != nil {
 					cookiePayloadChunks = append(cookiePayloadChunks, c.Value)
-					i++
 				} else {
 					break
 				}

--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -100,7 +101,7 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		return
 	}
 
-	h.config.WriteResponseHeader(writer)
+	h.config.WriteResponseHeader(writer, request.Header)
 	length := int(h.config.GetNormalizedXPaddingBytes().rand())
 	config := XPaddingConfig{Length: length}
 
@@ -118,7 +119,12 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		}
 	}
 
-	h.config.ApplyXPaddingToHeader(writer.Header(), config)
+	h.config.ApplyXPaddingToResponse(writer, config)
+
+	if request.Method == "OPTIONS" {
+		writer.WriteHeader(http.StatusOK)
+		return
+	}
 
 	/*
 		clientVer := []int{0, 0, 0}
@@ -183,26 +189,16 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		currentSession = h.upsertSession(sessionId)
 	}
 	scMaxEachPostBytes := int(h.ln.config.GetNormalizedScMaxEachPostBytes().To)
-	uplinkHTTPMethod := h.config.GetNormalizedUplinkHTTPMethod()
 	isUplinkRequest := false
 
-	if uplinkHTTPMethod != "GET" && request.Method == uplinkHTTPMethod {
+	switch request.Method {
+	case "GET":
+		isUplinkRequest = seqStr != ""
+	default:
 		isUplinkRequest = true
 	}
 
-	uplinkDataPlacement := h.config.GetNormalizedUplinkDataPlacement()
 	uplinkDataKey := h.config.UplinkDataKey
-
-	switch uplinkDataPlacement {
-	case PlacementHeader:
-		if request.Header.Get(uplinkDataKey+"-Upstream") == "1" {
-			isUplinkRequest = true
-		}
-	case PlacementCookie:
-		if c, _ := request.Cookie(uplinkDataKey + "_upstream"); c != nil && c.Value == "1" {
-			isUplinkRequest = true
-		}
-	}
 
 	if isUplinkRequest && sessionId != "" { // stream-up, packet-up
 		if seqStr == "" {
@@ -254,72 +250,63 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 			return
 		}
 
-		var payload []byte
-
-		if uplinkDataPlacement != PlacementBody {
-			var encodedStr string
-			switch uplinkDataPlacement {
-			case PlacementHeader:
-				dataLenStr := request.Header.Get(uplinkDataKey + "-Length")
-
-				if dataLenStr != "" {
-					dataLen, _ := strconv.Atoi(dataLenStr)
-					var chunks []string
-					i := 0
-
-					for {
-						chunk := request.Header.Get(fmt.Sprintf("%s-%d", uplinkDataKey, i))
-						if chunk == "" {
-							break
-						}
-						chunks = append(chunks, chunk)
-						i++
-					}
-
-					encodedStr = strings.Join(chunks, "")
-					if len(encodedStr) != dataLen {
-						encodedStr = ""
-					}
+		dataPlacement := h.config.GetNormalizedUplinkDataPlacement()
+		var headerPayload []byte
+		if dataPlacement == PlacementAuto || dataPlacement == PlacementHeader {
+			var headerPayloadChunks [] string
+			for i := 0; true; {
+				chunk := request.Header.Get(fmt.Sprintf("%s-%d", uplinkDataKey, i))
+				if chunk == "" {
+					break
 				}
-			case PlacementCookie:
-				var chunks []string
-				i := 0
+				headerPayloadChunks = append(headerPayloadChunks, chunk)
+				i++
+			}
+			headerPayloadEncoded := strings.Join(headerPayloadChunks, "")
+			headerPayload, err = base64.RawURLEncoding.DecodeString(headerPayloadEncoded)
+			if err != nil {
+				errors.LogInfo(context.Background(), "Invalid base64 in header's payload: ", err.Error())
+				writer.WriteHeader(http.StatusBadRequest)
+				return
+			}
+		}
 
-				for {
-					cookieName := fmt.Sprintf("%s_%d", uplinkDataKey, i)
-					if c, _ := request.Cookie(cookieName); c != nil {
-						chunks = append(chunks, c.Value)
-						i++
-					} else {
-						break
-					}
-				}
-
-				if len(chunks) > 0 {
-					encodedStr = strings.Join(chunks, "")
+		var cookiePayload []byte
+		if dataPlacement == PlacementAuto || dataPlacement == PlacementCookie {
+			var cookiePayloadChunks []string
+			for i := 0; true; {
+				cookieName := fmt.Sprintf("%s_%d", uplinkDataKey, i)
+				if c, _ := request.Cookie(cookieName); c != nil {
+					cookiePayloadChunks = append(cookiePayloadChunks, c.Value)
+					i++
+				} else {
+					break
 				}
 			}
+			cookiePayloadEncoded := strings.Join(cookiePayloadChunks, "")
+			cookiePayload, err = base64.RawURLEncoding.DecodeString(cookiePayloadEncoded)
+			if err != nil {
+				errors.LogInfo(context.Background(), "Invalid base64 in cookies' payload: ", err.Error())
+				writer.WriteHeader(http.StatusBadRequest)
+				return
+			}
+		}
 
-			if encodedStr != "" {
-				payload, err = base64.RawURLEncoding.DecodeString(encodedStr)
-			} else {
-				errors.LogInfoInner(context.Background(), err, "failed to extract data from key "+uplinkDataKey+" placed in "+uplinkDataPlacement)
+		var bodyPayload []byte
+		if dataPlacement == PlacementAuto || dataPlacement == PlacementBody {
+			bodyPayload, err = io.ReadAll(io.LimitReader(request.Body, int64(scMaxEachPostBytes)+1))
+			if err != nil {
+				errors.LogInfoInner(context.Background(), err, "failed to upload (ReadAll)")
 				writer.WriteHeader(http.StatusInternalServerError)
 				return
 			}
-		} else {
-			payload, err = io.ReadAll(io.LimitReader(request.Body, int64(scMaxEachPostBytes)+1))
 		}
+
+		payload := slices.Concat(headerPayload, cookiePayload, bodyPayload)
 
 		if len(payload) > scMaxEachPostBytes {
 			errors.LogInfo(context.Background(), "Too large upload. scMaxEachPostBytes is set to ", scMaxEachPostBytes, "but request size exceed it. Adjust scMaxEachPostBytes on the server to be at least as large as client.")
 			writer.WriteHeader(http.StatusRequestEntityTooLarge)
-			return
-		}
-
-		if err != nil {
-			errors.LogInfoInner(context.Background(), err, "failed to upload (ReadAll)")
-			writer.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 
@@ -339,6 +326,12 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 			errors.LogInfoInner(context.Background(), err, "failed to upload (PushPayload)")
 			writer.WriteHeader(http.StatusInternalServerError)
 			return
+		}
+
+		switch request.Method {
+		case "POST", "PUT", "PATCH":
+		default:
+			writer.Header().Set("Cache-Control", "no-store")
 		}
 
 		writer.WriteHeader(http.StatusOK)
@@ -519,7 +512,7 @@ func ListenXH(ctx context.Context, address net.Address, port net.Port, streamSet
 		l.server = http.Server{
 			Handler:           handler,
 			ReadHeaderTimeout: time.Second * 4,
-			MaxHeaderBytes:    8192,
+			MaxHeaderBytes:    l.config.GetNormalizedServerMaxHeaderBytes(),
 			Protocols:         protocols,
 		}
 		go func() {

--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -326,9 +326,8 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 			return
 		}
 
-		switch request.Method {
-		case "POST", "PUT", "PATCH":
-		default:
+		if len(bodyPayload) == 0 {
+			// Methods without a body are usually cached by default.
 			writer.Header().Set("Cache-Control", "no-store")
 		}
 

--- a/transport/internet/splithttp/xpadding.go
+++ b/transport/internet/splithttp/xpadding.go
@@ -156,6 +156,17 @@ func ApplyPaddingToCookie(req *http.Request, name, value string) {
 	})
 }
 
+func ApplyPaddingToResponseCookie(writer http.ResponseWriter, name, value string) {
+	if name == "" || value == "" {
+		return
+	}
+	http.SetCookie(writer, &http.Cookie{
+		Name:  name,
+		Value: value,
+		Path:  "/",
+	})
+}
+
 func ApplyPaddingToQuery(u *url.URL, key, value string) {
 	if u == nil || key == "" || value == "" {
 		return
@@ -218,6 +229,22 @@ func (c *Config) ApplyXPaddingToRequest(req *http.Request, config XPaddingConfig
 		ApplyPaddingToCookie(req, config.Placement.Key, paddingValue)
 	case PlacementQuery:
 		ApplyPaddingToQuery(req.URL, config.Placement.Key, paddingValue)
+	}
+}
+
+func (c *Config) ApplyXPaddingToResponse(writer http.ResponseWriter, config XPaddingConfig) {
+	placement := config.Placement.Placement
+
+	if placement == PlacementHeader || placement == PlacementQueryInHeader {
+		c.ApplyXPaddingToHeader(writer.Header(), config)
+		return
+	}
+
+	paddingValue := GeneratePadding(config.Method, config.Length)
+
+	switch placement {
+	case PlacementCookie:
+		ApplyPaddingToResponseCookie(writer, config.Placement.Key, paddingValue)
 	}
 }
 


### PR DESCRIPTION
1. Browser Dialer was broken in XHTTP. I fixed it and added support for the new HTTP methods and cookies.
Added OPTIONS support and some Access-Control-Allow-* headers for browser dialer on the server side.
To reduce the number of OPTIONS requests one can access browser dialer from the XHTTP domain (e.g. cdn.example.com). To hide content of the dialer from the CDN one can create simple loader script, e.g. htt<span>ps://cdn.example.com/loader.html</span>, which will load dialer from the specified url and replaces itself by dialer's content.

2. Nginx by default has very small limits for header buffers (client_header_buffer_size 1k and large_client_header_buffers 4 8k). And "A request header field cannot exceed the size of **one** buffer". So it is crucial to strictly follow this limits with the help of scMaxEachPostBytes and uplinkChunkSize settings when using packet-up via GET with payload in headers. But pipe.WriteMultiBuffer in Dial can write any amount of data when pipe isn't full, so after merging ReadMultiBuffer can return more data than allowed by scMaxEachPostBytes. So this data must be split into chunks after reading from pipe in Dial.
Also reduce the default value for the UplinkDataKey from 4 KiB to 4 KB, because 2x(header name + colon and space + 4 KiB + CRLF) will not fit into the default 8 KiB buffer.
Also select uplinkChunkSize randomly from some range to reduce detection.

3. Allow scMaxEachPostBytes less than 8 KiB and allow to increase MaxHeaderBytes from 8 KiB. Their defaults where contradictive.

4. Get rid of *-Upstream and *-Length headers and *_upstream cookie which may be used as a signature for the XHTTP detection. Length is not needed, it can be determined from data. Upstream is not needed because it could be determined from the sequence number presence in the packet-up via GET and is true in all other methods like POST, PUT, PATCH, etc.

5. Added UplinkDataPlacement=auto to support different placements through different CDN's in the single inbound on the server side. (Similar to Mode=auto)

6. Fix XPadding in cookies on the server side. It was not added at all when xPaddingPlacement=cookie.

7. Allow the only one of the sessionPlacement or the seqPlacement to be path.

P.S. It is better to view diff without whitespace changes.