### PR TITLE
tcp-brutal

### DIFF
--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -112,6 +112,8 @@ func (c *KCPConfig) Build() (proto.Message, error) {
 type TCPConfig struct {
 	HeaderConfig        json.RawMessage `json:"header"`
 	AcceptProxyProtocol bool            `json:"acceptProxyProtocol"`
+	Rate                uint64          `json:"rate"`
+	Cwnd                uint32          `json:"cwnd"`
 }
 
 // Build implements Buildable.
@@ -131,6 +133,8 @@ func (c *TCPConfig) Build() (proto.Message, error) {
 	if c.AcceptProxyProtocol {
 		config.AcceptProxyProtocol = c.AcceptProxyProtocol
 	}
+	config.Rate = c.Rate
+	config.Cwnd = c.Cwnd
 	return config, nil
 }
 

--- a/transport/internet/tcp/config.pb.go
+++ b/transport/internet/tcp/config.pb.go
@@ -26,6 +26,8 @@ type Config struct {
 	state               protoimpl.MessageState `protogen:"open.v1"`
 	HeaderSettings      *serial.TypedMessage   `protobuf:"bytes,2,opt,name=header_settings,json=headerSettings,proto3" json:"header_settings,omitempty"`
 	AcceptProxyProtocol bool                   `protobuf:"varint,3,opt,name=accept_proxy_protocol,json=acceptProxyProtocol,proto3" json:"accept_proxy_protocol,omitempty"`
+	Rate                uint64                 `protobuf:"varint,4,opt,name=rate,proto3" json:"rate,omitempty"`
+	Cwnd                uint32                 `protobuf:"varint,5,opt,name=cwnd,proto3" json:"cwnd,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }
@@ -74,14 +76,30 @@ func (x *Config) GetAcceptProxyProtocol() bool {
 	return false
 }
 
+func (x *Config) GetRate() uint64 {
+	if x != nil {
+		return x.Rate
+	}
+	return 0
+}
+
+func (x *Config) GetCwnd() uint32 {
+	if x != nil {
+		return x.Cwnd
+	}
+	return 0
+}
+
 var File_transport_internet_tcp_config_proto protoreflect.FileDescriptor
 
 const file_transport_internet_tcp_config_proto_rawDesc = "" +
 	"\n" +
-	"#transport/internet/tcp/config.proto\x12\x1bxray.transport.internet.tcp\x1a!common/serial/typed_message.proto\"\x8d\x01\n" +
+	"#transport/internet/tcp/config.proto\x12\x1bxray.transport.internet.tcp\x1a!common/serial/typed_message.proto\"\xb5\x01\n" +
 	"\x06Config\x12I\n" +
 	"\x0fheader_settings\x18\x02 \x01(\v2 .xray.common.serial.TypedMessageR\x0eheaderSettings\x122\n" +
-	"\x15accept_proxy_protocol\x18\x03 \x01(\bR\x13acceptProxyProtocolJ\x04\b\x01\x10\x02Bs\n" +
+	"\x15accept_proxy_protocol\x18\x03 \x01(\bR\x13acceptProxyProtocol\x12\x12\n" +
+	"\x04rate\x18\x04 \x01(\x04R\x04rate\x12\x12\n" +
+	"\x04cwnd\x18\x05 \x01(\rR\x04cwndJ\x04\b\x01\x10\x02Bs\n" +
 	"\x1fcom.xray.transport.internet.tcpP\x01Z0github.com/xtls/xray-core/transport/internet/tcp\xaa\x02\x1bXray.Transport.Internet.Tcpb\x06proto3"
 
 var (

--- a/transport/internet/tcp/config.proto
+++ b/transport/internet/tcp/config.proto
@@ -12,4 +12,6 @@ message Config {
   reserved 1;
   xray.common.serial.TypedMessage header_settings = 2;
   bool accept_proxy_protocol = 3;
+  uint64 rate = 4;
+  uint32 cwnd = 5;
 }

--- a/transport/internet/tcp/hub.go
+++ b/transport/internet/tcp/hub.go
@@ -108,6 +108,12 @@ func (v *Listener) keepAccepting() {
 			}
 			continue
 		}
+		if v.config.Rate > 0 {
+			err := SetBrutalRate(conn, v.config.Rate, v.config.Cwnd)
+			if err != nil {
+				errors.LogDebugInner(context.Background(), err, "failed to apply socket options to incoming connection")
+			}
+		}
 		go func() {
 			if v.tlsConfig != nil {
 				conn = tls.Server(conn, v.tlsConfig)

--- a/transport/internet/tcp/sockopt_darwin.go
+++ b/transport/internet/tcp/sockopt_darwin.go
@@ -24,3 +24,7 @@ func GetOriginalDestination(conn stat.Connection) (net.Destination, error) {
 	}
 	return dest, nil
 }
+
+func SetBrutalRate(conn stat.Connection, rate uint64, cwnd uint32) error {
+	return nil
+}

--- a/transport/internet/tcp/sockopt_freebsd.go
+++ b/transport/internet/tcp/sockopt_freebsd.go
@@ -24,3 +24,7 @@ func GetOriginalDestination(conn stat.Connection) (net.Destination, error) {
 	}
 	return dest, nil
 }
+
+func SetBrutalRate(conn stat.Connection, rate uint64, cwnd uint32) error {
+	return nil
+}

--- a/transport/internet/tcp/sockopt_linux_test.go
+++ b/transport/internet/tcp/sockopt_linux_test.go
@@ -4,9 +4,13 @@
 package tcp_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
+	"fmt"
 	"strings"
 	"testing"
+	unsafe "unsafe"
 
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/testing/servers/tcp"
@@ -29,5 +33,33 @@ func TestGetOriginalDestination(t *testing.T) {
 	originalDest, err := GetOriginalDestination(conn)
 	if !(dest == originalDest || strings.Contains(err.Error(), "failed to call getsockopt")) {
 		t.Error("unexpected state")
+	}
+}
+
+func TestSockoptParams(t *testing.T) {
+	type BrutalParams struct {
+		rate      uint64
+		cwnd_gain uint32
+	}
+
+	params := BrutalParams{
+		rate:      15 * 1024 * 1024 / 8,
+		cwnd_gain: 15,
+	}
+
+	raw := unsafe.Slice(
+		(*byte)(unsafe.Pointer(&params)),
+		unsafe.Sizeof(params),
+	)
+
+	buf := make([]byte, 16)
+	binary.LittleEndian.PutUint64(buf, 15*1024*1024/8)
+	binary.LittleEndian.PutUint32(buf[8:], 15)
+
+	fmt.Println(len(raw), raw)
+	fmt.Println(len(buf), buf)
+
+	if !bytes.Equal(raw, buf) {
+		t.Fatal("!bytes.Equal(raw, buf)")
 	}
 }

--- a/transport/internet/tcp/sockopt_other.go
+++ b/transport/internet/tcp/sockopt_other.go
@@ -11,3 +11,7 @@ import (
 func GetOriginalDestination(conn stat.Connection) (net.Destination, error) {
 	return net.Destination{}, nil
 }
+
+func SetBrutalRate(conn stat.Connection, rate uint64, cwnd uint32) error {
+	return nil
+}


### PR DESCRIPTION
既然引入了 hy，~那么再补个 tcp brutal~

xray 中使用 tcp-brutal

前置准备

- linux
- kvm vps
- 安装了对应内核的 linux header，快速检查软件源是否有对应 header `apt-cache show "linux-headers-$(uname -r)"`

```shell
curl -fsSL -O https://raw.githubusercontent.com/apernet/tcp-brutal/204aeea3437a83599c1c1fa1b97e4425cfdfc49d/scripts/install_dkms.sh
curl -fsSL -O https://github.com/apernet/tcp-brutal/releases/download/v1.0.3/tcp-brutal.dkms.tar.gz
bash install_dkms.sh --local tcp-brutal.dkms.tar.gz
```

参考配置，可自由搭配传输安全

```jsonc
"inbounds": [
  {
    // "listen": "127.0.0.1",
    "port": 1081,
    "protocol": "vless",
    "settings": {
      "clients": [
        {
          "id": "5783a3e7-e373-51cd-8642-c83782b807c5"
        }
      ],
      "decryption": "none"
    },
    "streamSettings": {
      "netword": "tcp",
      "tcpSettings": {
        "rate": 19660800, // 150mbps
        "cwnd": 15
      }
    }
  }
]
```

目前的 CustomSockopt 只会在监听的时候设置一次
而 inet_csk_ca 是面向连接的，要在连接建立后设置 brutal rate
https://github.com/apernet/tcp-brutal/blob/204aeea3437a83599c1c1fa1b97e4425cfdfc49d/brutal.c#L88

测试下来提升有限，bbr 只能跑 1mbps 的设置了 150mbps 也才提升到 50mbps