### PR TITLE
Fix: restrict MasterKeyLog file permissions

### DIFF
--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -787,6 +787,9 @@ func (c *TLSConfig) Build() (proto.Message, error) {
 	}
 	config.RejectUnknownSni = c.RejectUnknownSNI
 	config.MasterKeyLog = c.MasterKeyLog
+	if c.MasterKeyLog != "" && c.MasterKeyLog != "none" {
+		errors.LogWarning(context.Background(), "SECURITY: \"masterKeyLog\" is set in TLS config — TLS pre-master secrets will be written to disk at \""+c.MasterKeyLog+"\". This should ONLY be used for temporary debugging. Disable in production!")
+	}
 
 	if c.AllowInsecure {
 		if time.Now().After(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)) {
@@ -889,6 +892,9 @@ type REALITYConfig struct {
 func (c *REALITYConfig) Build() (proto.Message, error) {
 	config := new(reality.Config)
 	config.MasterKeyLog = c.MasterKeyLog
+	if c.MasterKeyLog != "" && c.MasterKeyLog != "none" {
+		errors.LogWarning(context.Background(), "SECURITY: \"masterKeyLog\" is set in REALITY config — TLS pre-master secrets will be written to disk at \""+c.MasterKeyLog+"\". This should ONLY be used for temporary debugging. Disable in production!")
+	}
 	config.Show = c.Show
 	var err error
 	if c.Target != nil {

--- a/transport/internet/reality/config.go
+++ b/transport/internet/reality/config.go
@@ -63,9 +63,14 @@ func KeyLogWriterFromConfig(c *Config) io.Writer {
 		return nil
 	}
 
-	writer, err := os.OpenFile(c.MasterKeyLog, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0644)
+	errors.LogWarning(context.Background(), "MasterKeyLog enabled — TLS secrets written to disk!")
+	writer, err := os.OpenFile(c.MasterKeyLog, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
 	if err != nil {
 		errors.LogErrorInner(context.Background(), err, "failed to open ", c.MasterKeyLog, " as master key log")
+		return nil
+	}
+	if chmodErr := os.Chmod(c.MasterKeyLog, 0o600); chmodErr != nil {
+		errors.LogWarningInner(context.Background(), chmodErr, "failed to enforce permissions on ", c.MasterKeyLog)
 	}
 
 	return writer

--- a/transport/internet/tls/config.go
+++ b/transport/internet/tls/config.go
@@ -459,10 +459,14 @@ func (c *Config) GetTLSConfig(opts ...Option) *tls.Config {
 	}
 
 	if len(c.MasterKeyLog) > 0 && c.MasterKeyLog != "none" {
-		writer, err := os.OpenFile(c.MasterKeyLog, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0644)
+		errors.LogWarning(context.Background(), "MasterKeyLog enabled — TLS secrets written to disk!")
+		writer, err := os.OpenFile(c.MasterKeyLog, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
 		if err != nil {
 			errors.LogErrorInner(context.Background(), err, "failed to open ", c.MasterKeyLog, " as master key log")
 		} else {
+			if chmodErr := os.Chmod(c.MasterKeyLog, 0o600); chmodErr != nil {
+				errors.LogWarningInner(context.Background(), chmodErr, "failed to enforce permissions on ", c.MasterKeyLog)
+			}
 			config.KeyLogWriter = writer
 		}
 	}


### PR DESCRIPTION
When `MasterKeyLog` is enabled, the keylog file was created with `0644` permissions, so any local user could read it and decrypt TLS traffic.

Changed to `0600` — owner-only. Also added a warning log when the feature is active.
