### PR TITLE
API: Fix Online Map

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -183,12 +183,9 @@ func (d *DefaultDispatcher) getLink(ctx context.Context) (*transport.Link, *tran
 		if p.Stats.UserOnline {
 			name := "user>>>" + user.Email + ">>>online"
 			if om, _ := stats.GetOrRegisterOnlineMap(d.stats, name); om != nil {
-				sessionInbounds := session.InboundFromContext(ctx)
-				userIP := sessionInbounds.Source.Address.String()
+				userIP := sessionInbound.Source.Address.String()
 				om.AddIP(userIP)
-				// log Online user with ips
-				// errors.LogDebug(ctx, "user>>>" + user.Email + ">>>online", om.Count(), om.List())
-
+				context.AfterFunc(ctx, func() { om.RemoveIP(userIP) })
 			}
 		}
 	}
@@ -225,11 +222,9 @@ func WrapLink(ctx context.Context, policyManager policy.Manager, statsManager st
 		if p.Stats.UserOnline {
 			name := "user>>>" + user.Email + ">>>online"
 			if om, _ := stats.GetOrRegisterOnlineMap(statsManager, name); om != nil {
-				sessionInbounds := session.InboundFromContext(ctx)
-				userIP := sessionInbounds.Source.Address.String()
+				userIP := sessionInbound.Source.Address.String()
 				om.AddIP(userIP)
-				// log Online user with ips
-				// errors.LogDebug(ctx, "user>>>" + user.Email + ">>>online", om.Count(), om.List())
+				context.AfterFunc(ctx, func() { om.RemoveIP(userIP) })
 			}
 		}
 	}

--- a/app/stats/command/command.go
+++ b/app/stats/command/command.go
@@ -70,7 +70,7 @@ func (s *statsServer) GetStatsOnlineIpList(ctx context.Context, request *GetStat
 	}
 
 	ips := make(map[string]int64)
-	for ip, t := range c.IpTimeMap() {
+	for ip, t := range c.IPTimeMap() {
 		ips[ip] = t.Unix()
 	}
 

--- a/app/stats/online_map.go
+++ b/app/stats/online_map.go
@@ -2,6 +2,7 @@ package stats
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -21,6 +22,7 @@ type ipEntry struct {
 type OnlineMap struct {
 	entries map[string]*ipEntry
 	access  sync.Mutex
+	count   atomic.Int64
 }
 
 // NewOnlineMap creates a new OnlineMap instance.
@@ -47,6 +49,7 @@ func (om *OnlineMap) AddIP(ip string) {
 			refCount: 1,
 			lastSeen: time.Now(),
 		}
+		om.count.Add(1)
 	}
 }
 
@@ -62,15 +65,13 @@ func (om *OnlineMap) RemoveIP(ip string) {
 	e.refCount--
 	if e.refCount <= 0 {
 		delete(om.entries, ip)
+		om.count.Add(-1)
 	}
 }
 
 // Count implements stats.OnlineMap.
 func (om *OnlineMap) Count() int {
-	om.access.Lock()
-	defer om.access.Unlock()
-
-	return len(om.entries)
+	return int(om.count.Load())
 }
 
 // List implements stats.OnlineMap.

--- a/app/stats/stats.go
+++ b/app/stats/stats.go
@@ -163,12 +163,12 @@ func (m *Manager) GetChannel(name string) stats.Channel {
 
 // GetAllOnlineUsers implements stats.Manager.
 func (m *Manager) GetAllOnlineUsers() []string {
-	m.access.Lock()
-	defer m.access.Unlock()
+	m.access.RLock()
+	defer m.access.RUnlock()
 
 	usersOnline := make([]string, 0, len(m.onlineMap))
 	for user, onlineMap := range m.onlineMap {
-		if len(onlineMap.IpTimeMap()) > 0 {
+		if onlineMap.Count() > 0 {
 			usersOnline = append(usersOnline, user)
 		}
 	}

--- a/features/stats/stats.go
+++ b/features/stats/stats.go
@@ -25,14 +25,16 @@ type Counter interface {
 //
 // xray:api:stable
 type OnlineMap interface {
-	// Count is the current value of the OnlineMap.
+	// Count returns the number of unique online IPs.
 	Count() int
-	// AddIP adds a ip to the current OnlineMap.
+	// AddIP increments the reference count for the given IP.
 	AddIP(string)
-	// List is the current OnlineMap ip list.
+	// RemoveIP decrements the reference count for the given IP. Deletes at zero.
+	RemoveIP(string)
+	// List returns all currently online IPs.
 	List() []string
-	// IpTimeMap return client ips and their last access time.
-	IpTimeMap() map[string]time.Time
+	// IPTimeMap returns a snapshot copy of IPs to their last-seen times.
+	IPTimeMap() map[string]time.Time
 }
 
 // Channel is the interface for stats channel.


### PR DESCRIPTION
After this functionality was introduced last year, there were some doubts about its usefulness. Unfortunately, after it began to be actively used, those concerns were confirmed. In its current state (without these fixes), Online Map is practically unusable and largely pointless.

The logic based on the last 20 seconds simply does not work. Due to the specific nature of how Xray operates, many connections live much longer than 20 seconds, and even if this time could be adjusted, it would not fix the underlying problem.

A fairly common situation was the following: no IP addresses are shown, yet traffic is actively flowing (being recorded in statistics), which indicates that a connection is active. However, it is impossible to determine which IP address it originates from — even though that is precisely what the Online Map feature is supposed to provide.

This PR fixes the incorrect Online Map logic: an IP address is now retained for as long as the connection remains active. Once the connection is closed, the IP address is removed. This is the correct behavior.