### PR TITLE
REALITY config: Fix client's `shortId` length check

### DIFF
--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -1022,7 +1022,7 @@ func (c *REALITYConfig) Build() (proto.Message, error) {
 		if len(c.ShortIds) != 0 {
 			return nil, errors.New(`non-empty "shortIds", please use "shortId" instead`)
 		}
-		if len(c.ShortIds) > 16 {
+		if len(c.ShortId) > 16 {
 			return nil, errors.New(`too long "shortId": `, c.ShortId)
 		}
 		config.ShortId = make([]byte, 8)


### PR DESCRIPTION
This detection will not be enforced when the ShortId's length is more than 16