### PR TITLE
Merge hosts and servers of the built-in DNS server from config files,…

### DIFF
--- a/infra/conf/fakedns.go
+++ b/infra/conf/fakedns.go
@@ -81,11 +81,13 @@ func (FakeDNSPostProcessingStage) Process(config *Config) error {
 			}
 		}
 
-		switch strings.ToLower(config.DNSConfig.QueryStrategy) {
-		case "useip4", "useipv4", "use_ip4", "use_ipv4", "use_ip_v4", "use-ip4", "use-ipv4", "use-ip-v4":
-			isIPv4Enable, isIPv6Enable = true, false
-		case "useip6", "useipv6", "use_ip6", "use_ipv6", "use_ip_v6", "use-ip6", "use-ipv6", "use-ip-v6":
-			isIPv4Enable, isIPv6Enable = false, true
+		if config.DNSConfig.QueryStrategy != nil {
+			switch strings.ToLower(*config.DNSConfig.QueryStrategy) {
+			case "useip4", "useipv4", "use_ip4", "use_ipv4", "use_ip_v4", "use-ip4", "use-ipv4", "use-ip-v4":
+				isIPv4Enable, isIPv6Enable = true, false
+			case "useip6", "useipv6", "use_ip6", "use_ipv6", "use_ip_v6", "use-ip6", "use-ipv6", "use-ip-v6":
+				isIPv4Enable, isIPv6Enable = false, true
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR merges hosts and servers of the built-in DNS from two configuration files and overrides other DNS fields from the latest configuration file.

I have one configuration file per every outbound and one common configuration file with inbound, routing and dns. When using tun inbound I need to route a DNS request for the outbound's address to the domestic DNS via freedom protocol with a special sockopt/mark. Since outbound's address is different in every configuration file I want to write one DNS server with the address of one outbound in "domains" in the per outbound configuration file. Without this PR I have to enumerate addresses from all outbounds in the "domains" of the DNS server in the common configuration file.