### PR TITLE
Commands: Fix potential nil pointer dereference in executeAddRules()

### DIFF
--- a/main/commands/all/api/rules_add.go
+++ b/main/commands/all/api/rules_add.go
@@ -33,23 +33,6 @@ Arguments:
 Example:
 
 	{{.Exec}} {{.LongName}} --server=127.0.0.1:8080 c1.json c2.json
-
-	c1.json:
-
-	{
-		"routing": {
-			"domainStrategy": "AsIs",
-			"domainMatcher": "hybrid",
-			"rules": [
-				{
-					"inboundTag": [
-						"api"
-					],
-					"outboundTag": "api"
-				},
-			]
-		}
-	}
 `,
 	Run: executeAddRules,
 }


### PR DESCRIPTION
See issue  #5748. Closes issue #5748. 
Previous behavior:
```bash
$ ./xray api adrules -s=127.0.0.1:8080 empty_routing.json
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x11330dc]

goroutine 1 [running]:
github.com/xtls/xray-core/main/commands/all/api.executeAddRules(0x2271c80, {0x2557ff0ca030, 0x2, 0x2})
	github.com/xtls/xray-core/main/commands/all/api/rules_add.go:66 +0x3dc
github.com/xtls/xray-core/main/commands/base.Execute()
	github.com/xtls/xray-core/main/commands/base/execute.go:64 +0x59f
main.main()
	github.com/xtls/xray-core/main/main.go:22 +0x1a5
```
New behavior:
```bash
$ ./xray api adrules -s=127.0.0.1:8080 ../empty_routing.json
failed to add routing rule: config did not have "routing" field
```
