### PR TITLE
fix (burstObservatory): immediate BurstObservatory health checks for dynamically registered reverse proxy outbounds

### DIFF
--- a/app/observatory/burst/burstobserver.go
+++ b/app/observatory/burst/burstobserver.go
@@ -65,16 +65,24 @@ func (o *Observer) Type() interface{} {
 func (o *Observer) Start() error {
 	if o.config != nil && len(o.config.SubjectSelector) != 0 {
 		o.finished = done.New()
-		o.hp.StartScheduler(func() ([]string, error) {
+		selector := func() ([]string, error) {
 			hs, ok := o.ohm.(outbound.HandlerSelector)
 			if !ok {
-
 				return nil, errors.New("outbound.Manager is not a HandlerSelector")
 			}
-
 			outbounds := hs.Select(o.config.SubjectSelector)
 			return outbounds, nil
-		})
+		}
+		o.hp.StartScheduler(selector)
+		if notifier, ok := o.ohm.(outbound.HandlerChangeNotifier); ok {
+			notifier.OnHandlerChanged(func() {
+				tags, err := selector()
+				if err != nil || len(tags) == 0 {
+					return
+				}
+				o.hp.Check(tags)
+			})
+		}
 	}
 	return nil
 }

--- a/app/proxyman/outbound/outbound.go
+++ b/app/proxyman/outbound/outbound.go
@@ -21,6 +21,14 @@ type Manager struct {
 	untaggedHandlers []outbound.Handler
 	running          bool
 	tagsCache        *sync.Map
+	onChangeFn       func()
+}
+
+// OnHandlerChanged implements outbound.HandlerChangeNotifier.
+func (m *Manager) OnHandlerChanged(fn func()) {
+	m.access.Lock()
+	defer m.access.Unlock()
+	m.onChangeFn = fn
 }
 
 // New creates a new Manager.
@@ -121,7 +129,16 @@ func (m *Manager) AddHandler(ctx context.Context, handler outbound.Handler) erro
 	}
 
 	if m.running {
-		return handler.Start()
+		if err := handler.Start(); err != nil {
+			return err
+		}
+	}
+
+	if fn := m.onChangeFn; fn != nil {
+		go func() {
+			defer func() { recover() }()
+			fn()
+		}()
 	}
 
 	return nil

--- a/features/outbound/outbound.go
+++ b/features/outbound/outbound.go
@@ -24,6 +24,10 @@ type HandlerSelector interface {
 	Select([]string) []string
 }
 
+type HandlerChangeNotifier interface {
+	OnHandlerChanged(callback func())
+}
+
 // Manager is a feature that manages outbound.Handlers.
 //
 // xray:api:stable


### PR DESCRIPTION
fix for #5750 