### PR TITLE
mKCP config: Check TTI 10~100 -> Check TTI 10~5000

### DIFF
--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -72,9 +72,9 @@ func (c *KCPConfig) Build() (proto.Message, error) {
 	}
 	if c.Tti != nil {
 		tti := *c.Tti
-		//if tti < 10 || tti > 100 {
-		//	return nil, errors.New("invalid mKCP TTI: ", tti).AtError()
-		//}
+		if tti < 10 || tti > 5000 {
+			return nil, errors.New("invalid mKCP TTI: ", tti).AtError()
+		}
 		config.Tti = &kcp.TTI{Value: tti}
 	}
 	if c.UpCap != nil {

--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -72,9 +72,9 @@ func (c *KCPConfig) Build() (proto.Message, error) {
 	}
 	if c.Tti != nil {
 		tti := *c.Tti
-		//if tti < 10 || tti > 100 {
-		//	return nil, errors.New("invalid mKCP TTI: ", tti).AtError()
-		//}
+		if tti < 10 || tti > 100 {
+			return nil, errors.New("invalid mKCP TTI: ", tti).AtError()
+		}
 		config.Tti = &kcp.TTI{Value: tti}
 	}
 	if c.UpCap != nil {

--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -72,9 +72,9 @@ func (c *KCPConfig) Build() (proto.Message, error) {
 	}
 	if c.Tti != nil {
 		tti := *c.Tti
-		if tti < 10 || tti > 100 {
-			return nil, errors.New("invalid mKCP TTI: ", tti).AtError()
-		}
+		//if tti < 10 || tti > 100 {
+		//	return nil, errors.New("invalid mKCP TTI: ", tti).AtError()
+		//}
 		config.Tti = &kcp.TTI{Value: tti}
 	}
 	if c.UpCap != nil {


### PR DESCRIPTION
Now, kcp is used for XDNS, so like mtu, the restriction on tti should also be removed.

This is because when we use recursive-resolver, the tti may increase.

i test for some random recursive resolver and it takes 400-600 ms to receive answer from my server, so tti should be set to 200-300.