### PR TITLE
Commands: `x25519` outputs "Password" -> "Password (PublicKey)"

### DIFF
--- a/main/commands/all/curve25519.go
+++ b/main/commands/all/curve25519.go
@@ -30,11 +30,10 @@ func Curve25519Genkey(StdEncoding bool, input_base64 string) {
 		fmt.Println(err)
 		return
 	}
-	fmt.Printf("PrivateKey: %v\nPassword (Public key/pbk): %v\nHash32: %v\n",
+	fmt.Printf("PrivateKey: %v\nPassword (PublicKey): %v\nHash32: %v\n",
 		encoding.EncodeToString(privateKey),
 		encoding.EncodeToString(password),
 		encoding.EncodeToString(hash32[:]))
-	fmt.Println("\nNote: Use 'Password' as the 'Public Key (pbk)' for connection links; share it only with trusted users to maintain stealth.")
 }
 
 func genCurve25519(inputPrivateKey []byte) (privateKey []byte, password []byte, hash32 [32]byte, returnErr error) {


### PR DESCRIPTION
**The Problem**
As a developer, when you see a _PrivateKey_, the mental model immediately looks for a corresponding _PublicKey_. In the current x25519 command output, the _PublicKey_ is labeled as _Password_. While this was intentionally done to discourage users from sharing it publicly (as seen in this #5084 ), it creates significant friction and confusion for new users.

I personally experienced this confusion, spending considerable time cross-referencing documentation and discussions to realize that Password is indeed the pbk parameter required for Reality/VLESS configurations.

**The Solution**
This PR updates the output labels to provide immediate clarity without compromising the original security intent. By explicitly labeling it as Password (Public key/pbk), we:

1- Reduce Cognitive Load: Users no longer need to guess which field maps to the pbk in their client config.
2- Maintain Security Awareness: A supplementary note is added to explain why this key should be treated with care, addressing the maintainers' original concern about public exposure.

**Changes**
Updated fmt.Printf labels in main/commands/all/curve25519.go.
Added a one-liner instructional note to explain the usage and security of the key.