### PR TITLE
Fix observatory reliability and leastload tolerance handling

### DIFF
--- a/app/observatory/burst/healthping.go
+++ b/app/observatory/burst/healthping.go
@@ -63,7 +63,7 @@ func NewHealthPing(ctx context.Context, dispatcher routing.Dispatcher, config *H
 	}
 	if settings.Interval == 0 {
 		settings.Interval = time.Duration(1) * time.Minute
-	} else if settings.Interval < 10 {
+	} else if settings.Interval < 10*time.Second {
 		errors.LogWarning(ctx, "health check interval is too small, 10s is applied")
 		settings.Interval = time.Duration(10) * time.Second
 	}

--- a/app/observatory/burst/healthping_test.go
+++ b/app/observatory/burst/healthping_test.go
@@ -1,0 +1,53 @@
+package burst
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestNewHealthPingIntervalBounds(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		inputInterval time.Duration
+		wantInterval  time.Duration
+	}{
+		{
+			name:          "default interval",
+			inputInterval: 0,
+			wantInterval:  time.Minute,
+		},
+		{
+			name:          "below min interval",
+			inputInterval: 9 * time.Second,
+			wantInterval:  10 * time.Second,
+		},
+		{
+			name:          "at min interval",
+			inputInterval: 10 * time.Second,
+			wantInterval:  10 * time.Second,
+		},
+		{
+			name:          "above min interval",
+			inputInterval: 11 * time.Second,
+			wantInterval:  11 * time.Second,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			hp := NewHealthPing(context.Background(), nil, &HealthPingConfig{
+				Interval: int64(tc.inputInterval),
+			})
+
+			if got := hp.Settings.Interval; got != tc.wantInterval {
+				t.Fatalf("unexpected interval: got %s, want %s", got, tc.wantInterval)
+			}
+		})
+	}
+}

--- a/app/observatory/observer.go
+++ b/app/observatory/observer.go
@@ -38,7 +38,18 @@ type Observer struct {
 }
 
 func (o *Observer) GetObservation(ctx context.Context) (proto.Message, error) {
-	return &ObservationResult{Status: o.status}, nil
+	o.statusLock.Lock()
+	defer o.statusLock.Unlock()
+
+	status := make([]*OutboundStatus, 0, len(o.status))
+	for _, entry := range o.status {
+		if entry == nil {
+			continue
+		}
+		copied := *entry
+		status = append(status, &copied)
+	}
+	return &ObservationResult{Status: status}, nil
 }
 
 func (o *Observer) Type() interface{} {
@@ -114,8 +125,26 @@ func (o *Observer) background() {
 func (o *Observer) updateStatus(outbounds []string) {
 	o.statusLock.Lock()
 	defer o.statusLock.Unlock()
-	// TODO should remove old inbound that is removed
-	_ = outbounds
+
+	if len(o.status) == 0 {
+		return
+	}
+
+	valid := make(map[string]struct{}, len(outbounds))
+	for _, outbound := range outbounds {
+		valid[outbound] = struct{}{}
+	}
+
+	filtered := o.status[:0]
+	for _, status := range o.status {
+		if status == nil {
+			continue
+		}
+		if _, found := valid[status.OutboundTag]; found {
+			filtered = append(filtered, status)
+		}
+	}
+	o.status = filtered
 }
 
 func (o *Observer) probe(outbound string) ProbeResult {

--- a/app/observatory/observer_test.go
+++ b/app/observatory/observer_test.go
@@ -1,0 +1,59 @@
+package observatory
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetObservationReturnsSnapshot(t *testing.T) {
+	t.Parallel()
+
+	observer := &Observer{
+		status: []*OutboundStatus{
+			{
+				OutboundTag: "old",
+				Alive:       true,
+				Delay:       10,
+			},
+		},
+	}
+
+	msg, err := observer.GetObservation(context.Background())
+	if err != nil {
+		t.Fatalf("GetObservation() error = %v", err)
+	}
+
+	result := msg.(*ObservationResult)
+	if len(result.Status) != 1 {
+		t.Fatalf("unexpected status len: got %d, want 1", len(result.Status))
+	}
+	if result.Status[0] == observer.status[0] {
+		t.Fatal("GetObservation() returned internal status pointer")
+	}
+
+	result.Status[0].Alive = false
+	if !observer.status[0].Alive {
+		t.Fatal("mutating observation result must not mutate internal status")
+	}
+}
+
+func TestUpdateStatusRemovesStaleOutbounds(t *testing.T) {
+	t.Parallel()
+
+	observer := &Observer{
+		status: []*OutboundStatus{
+			{OutboundTag: "a"},
+			{OutboundTag: "b"},
+			{OutboundTag: "c"},
+		},
+	}
+
+	observer.updateStatus([]string{"b", "d"})
+
+	if len(observer.status) != 1 {
+		t.Fatalf("unexpected status len after cleanup: got %d, want 1", len(observer.status))
+	}
+	if observer.status[0].OutboundTag != "b" {
+		t.Fatalf("unexpected remaining outbound: got %q, want %q", observer.status[0].OutboundTag, "b")
+	}
+}

--- a/app/router/strategy_leastload.go
+++ b/app/router/strategy_leastload.go
@@ -152,11 +152,25 @@ func (s *LeastLoadStrategy) getNodes(candidates []string, maxRTT time.Duration) 
 	results := observeResult.(*observatory.ObservationResult)
 
 	outboundlist := outboundList(candidates)
+	tolerance := s.settings.Tolerance
+	if tolerance < 0 {
+		tolerance = 0
+	}
+	if tolerance > 1 {
+		tolerance = 1
+	}
 
 	var ret []*node
 
 	for _, v := range results.Status {
 		if v.Alive && (v.Delay < maxRTT.Milliseconds() || maxRTT == 0) && outboundlist.contains(v.OutboundTag) {
+			if v.HealthPing != nil && v.HealthPing.All > 0 {
+				failRate := float64(v.HealthPing.Fail) / float64(v.HealthPing.All)
+				if failRate > float64(tolerance) {
+					continue
+				}
+			}
+
 			record := &node{
 				Tag:              v.OutboundTag,
 				CountAll:         1,

--- a/app/router/strategy_leastload_test.go
+++ b/app/router/strategy_leastload_test.go
@@ -1,7 +1,12 @@
 package router
 
 import (
+	"context"
 	"testing"
+	"time"
+
+	"github.com/xtls/xray-core/app/observatory"
+	"google.golang.org/protobuf/proto"
 )
 
 /*
@@ -175,5 +180,95 @@ func TestSelectLeastLoadBaselinesNoQualified(t *testing.T) {
 	ns := strategy.selectLeastLoad(nodes)
 	if len(ns) != expected {
 		t.Errorf("expected: %v, actual: %v", expected, len(ns))
+	}
+}
+
+type mockLeastLoadObserver struct {
+	result *observatory.ObservationResult
+	err    error
+}
+
+func (m *mockLeastLoadObserver) Type() interface{} {
+	return nil
+}
+
+func (m *mockLeastLoadObserver) Start() error {
+	return nil
+}
+
+func (m *mockLeastLoadObserver) Close() error {
+	return nil
+}
+
+func (m *mockLeastLoadObserver) GetObservation(ctx context.Context) (proto.Message, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.result, nil
+}
+
+func TestLeastLoadToleranceFiltersFailureRate(t *testing.T) {
+	t.Parallel()
+
+	strategy := NewLeastLoadStrategy(&StrategyLeastLoadConfig{
+		Tolerance: 0.5,
+	})
+	strategy.ctx = context.Background()
+	strategy.observer = &mockLeastLoadObserver{
+		result: &observatory.ObservationResult{
+			Status: []*observatory.OutboundStatus{
+				{
+					OutboundTag: "drop",
+					Alive:       true,
+					Delay:       50,
+					HealthPing: &observatory.HealthPingMeasurementResult{
+						All:       10,
+						Fail:      6,
+						Average:   int64(50 * time.Millisecond),
+						Deviation: int64(5 * time.Millisecond),
+					},
+				},
+				{
+					OutboundTag: "keep_edge",
+					Alive:       true,
+					Delay:       40,
+					HealthPing: &observatory.HealthPingMeasurementResult{
+						All:       10,
+						Fail:      5,
+						Average:   int64(40 * time.Millisecond),
+						Deviation: int64(4 * time.Millisecond),
+					},
+				},
+				{
+					OutboundTag: "keep_unknown",
+					Alive:       true,
+					Delay:       60,
+				},
+				{
+					OutboundTag: "keep_all_zero",
+					Alive:       true,
+					Delay:       70,
+					HealthPing: &observatory.HealthPingMeasurementResult{
+						All:  0,
+						Fail: 0,
+					},
+				},
+			},
+		},
+	}
+
+	nodes := strategy.getNodes([]string{"drop", "keep_edge", "keep_unknown", "keep_all_zero"}, 0)
+	got := make(map[string]struct{}, len(nodes))
+	for _, node := range nodes {
+		got[node.Tag] = struct{}{}
+	}
+
+	if _, found := got["drop"]; found {
+		t.Fatal("expected 'drop' to be filtered out by tolerance")
+	}
+	for _, tag := range []string{"keep_edge", "keep_unknown", "keep_all_zero"} {
+		if _, found := got[tag]; !found {
+			t.Fatalf("expected %q to remain eligible", tag)
+		}
 	}
 }

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -554,6 +554,10 @@ func (c *Config) Build() (*core.Config, error) {
 		config.App = append([]*serial.TypedMessage{serial.ToTypedMessage(r)}, config.App...)
 	}
 
+	if c.Observatory != nil && c.BurstObservatory != nil {
+		return nil, errors.New("configure only one of observatory or burstObservatory")
+	}
+
 	if c.Observatory != nil {
 		r, err := c.Observatory.Build()
 		if err != nil {

--- a/infra/conf/xray_observatory_test.go
+++ b/infra/conf/xray_observatory_test.go
@@ -1,0 +1,38 @@
+package conf_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	. "github.com/xtls/xray-core/infra/conf"
+)
+
+func TestXrayConfigRejectsBothObservatories(t *testing.T) {
+	t.Parallel()
+
+	raw := `{
+		"observatory": {
+			"subjectSelector": ["a"]
+		},
+		"burstObservatory": {
+			"subjectSelector": ["a"],
+			"pingConfig": {
+				"destination": "https://connectivitycheck.gstatic.com/generate_204"
+			}
+		}
+	}`
+
+	config := new(Config)
+	if err := json.Unmarshal([]byte(raw), config); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	_, err := config.Build()
+	if err == nil {
+		t.Fatal("Build() error = nil, want conflict error")
+	}
+	if !strings.Contains(err.Error(), "configure only one of observatory or burstObservatory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
This PR fixes 5 reliability issues across observatory and least-load routing.

## What Changed
- Fixed burst health-check interval guard to clamp values below `10s` correctly.
- Made legacy observatory reads thread-safe by returning a lock-protected snapshot in `GetObservation`.
- Implemented stale status cleanup in legacy observatory for removed outbound tags.
- Added strict config validation: startup/build now fails if both `observatory` and `burstObservatory` are set.
- Activated `leastload.tolerance` logic: outbounds with `fail/all > tolerance` are excluded when health data is available.
- Kept unknown/insufficient health data eligible (`health_ping == nil` or `all == 0`).

## Behavior Notes
- No protobuf or public schema changes.
- Config behavior is now explicit for dual observatory configuration (hard error instead of silent shadowing).
- `leastload.tolerance` is now effective at runtime.

## Tests Added
- Burst interval normalization bounds (`0`, `<10s`, `=10s`, `>10s`).
- Legacy observatory snapshot safety test.
- Legacy observatory stale-status removal test.
- Dual observatory conflict build test.
- Least-load tolerance filtering test (`>`, `<=`, unknown, and `all==0` cases).