### PR TITLE
Log: Enhance error handling by directing error messages to stderr

### DIFF
--- a/app/log/log.go
+++ b/app/log/log.go
@@ -53,7 +53,8 @@ func New(ctx context.Context, config *Config) (*Instance, error) {
 
 func (g *Instance) initAccessLogger() error {
 	handler, err := createHandler(g.config.AccessLogType, HandlerCreatorOptions{
-		Path: g.config.AccessLogPath,
+		Path:    g.config.AccessLogPath,
+		IsError: false,
 	})
 	if err != nil {
 		return err
@@ -64,7 +65,8 @@ func (g *Instance) initAccessLogger() error {
 
 func (g *Instance) initErrorLogger() error {
 	handler, err := createHandler(g.config.ErrorLogType, HandlerCreatorOptions{
-		Path: g.config.ErrorLogPath,
+		Path:    g.config.ErrorLogPath,
+		IsError: true,
 	})
 	if err != nil {
 		return err

--- a/app/log/log_creator.go
+++ b/app/log/log_creator.go
@@ -9,7 +9,8 @@ import (
 )
 
 type HandlerCreatorOptions struct {
-	Path string
+	Path    string
+	IsError bool
 }
 
 type HandlerCreator func(LogType, HandlerCreatorOptions) (log.Handler, error)
@@ -43,6 +44,9 @@ func createHandler(logType LogType, options HandlerCreatorOptions) (log.Handler,
 
 func init() {
 	common.Must(RegisterHandlerCreator(LogType_Console, func(lt LogType, options HandlerCreatorOptions) (log.Handler, error) {
+		if options.IsError {
+			return log.NewLogger(log.CreateStderrLogWriter()), nil
+		}
 		return log.NewLogger(log.CreateStdoutLogWriter()), nil
 	}))
 

--- a/main/run.go
+++ b/main/run.go
@@ -77,7 +77,7 @@ func executeRun(cmd *base.Command, args []string) {
 	printVersion()
 	server, err := startXray()
 	if err != nil {
-		fmt.Println("Failed to start:", err)
+		fmt.Fprintln(os.Stderr, "Failed to start:", err)
 		// Configuration error. Exit with a special value to prevent systemd from restarting.
 		os.Exit(23)
 	}
@@ -88,7 +88,7 @@ func executeRun(cmd *base.Command, args []string) {
 	}
 
 	if err := server.Start(); err != nil {
-		fmt.Println("Failed to start:", err)
+		fmt.Fprintln(os.Stderr, "Failed to start:", err)
 		os.Exit(-1)
 	}
 	defer server.Close()
@@ -113,7 +113,7 @@ func executeRun(cmd *base.Command, args []string) {
 func dumpConfig() int {
 	files := getConfigFilePath(false)
 	if config, err := core.GetMergedConfig(files); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		time.Sleep(1 * time.Second)
 		return 23
 	} else {


### PR DESCRIPTION
## Summary
This PR fixes console log stream routing so error logs go to `stderr` instead of `stdout`.

## Changes
- Added `IsError` to `HandlerCreatorOptions` to distinguish error vs non-error logger creation.
- Updated logger initialization:
  - Access logger uses `IsError: false`
  - Error logger uses `IsError: true`
- Updated console handler creator to:
  - use `CreateStderrLogWriter()` when `IsError` is true
  - keep `CreateStdoutLogWriter()` otherwise
- Updated CLI startup/config failure prints in `main/run.go` to `stderr` via `fmt.Fprintln(os.Stderr, ...)`.

## Why
Previously, both access and error logs were written to `stdout`, which is incorrect for standard stream semantics and makes operational log handling (systemd, Docker, shell redirection, log collectors) harder.