### PR TITLE
OpenBSD: Disable readV

### DIFF
--- a/common/buf/readv_posix.go
+++ b/common/buf/readv_posix.go
@@ -1,5 +1,5 @@
-//go:build !windows && !wasm && !illumos
-// +build !windows,!wasm,!illumos
+//go:build !windows && !wasm && !illumos && !openbsd
+// +build !windows,!wasm,!illumos,!openbsd
 
 package buf
 

--- a/common/buf/readv_reader.go
+++ b/common/buf/readv_reader.go
@@ -1,5 +1,5 @@
-//go:build !wasm
-// +build !wasm
+//go:build !wasm && !openbsd
+// +build !wasm,!openbsd
 
 package buf
 

--- a/common/buf/readv_reader_stub.go
+++ b/common/buf/readv_reader_stub.go
@@ -6,10 +6,12 @@ package buf
 import (
 	"io"
 	"syscall"
+
+	"github.com/xtls/xray-core/features/stats"
 )
 
 const useReadv = false
 
-func NewReadVReader(reader io.Reader, rawConn syscall.RawConn) Reader {
+func NewReadVReader(reader io.Reader, rawConn syscall.RawConn, counter stats.Counter) Reader {
 	panic("not implemented")
 }

--- a/common/buf/readv_reader_stub.go
+++ b/common/buf/readv_reader_stub.go
@@ -1,5 +1,5 @@
-//go:build wasm
-// +build wasm
+//go:build wasm || openbsd
+// +build wasm openbsd
 
 package buf
 

--- a/common/buf/readv_test.go
+++ b/common/buf/readv_test.go
@@ -1,5 +1,5 @@
-//go:build !wasm
-// +build !wasm
+//go:build !wasm && !openbsd
+// +build !wasm,!openbsd
 
 package buf_test
 


### PR DESCRIPTION
OpenBSD 7.5+ 已经禁用 syscall(2) 了 核心里很多东西估计都是坏的 都开单章有点难绷（这个系统用户太少了 这么久来没多少反馈） 就把最影响的这个先切掉吧 反正有一个已经存在的 wasm 禁用
顺带发现 wasm 就build不出来（函数签名不一致）