### PR TITLE
Fix error while using an outdated ECH record

### DIFF
--- a/transport/internet/ech/wrapper.go
+++ b/transport/internet/ech/wrapper.go
@@ -1,0 +1,145 @@
+/**
+ * Author: Mundo
+ * Date: 12/03/26
+ * Description: ECH wrapper for TLS handshake
+ */
+package ech
+
+import (
+	"context"
+	gotls "crypto/tls"
+	stderrors "errors"
+	"net"
+
+	quic "github.com/apernet/quic-go"
+	utls "github.com/refraction-networking/utls"
+	xtls "github.com/xtls/xray-core/transport/internet/tls"
+)
+
+type DialFacility func(ctx context.Context) (net.Conn, error)
+
+type QUICDialFacility func(ctx context.Context, cfg *gotls.Config) (*quic.Conn, error)
+
+func UHandshake(
+	ctx context.Context,
+	dialFn DialFacility,
+	cfg *gotls.Config,
+	fingerprint *utls.ClientHelloID,
+	websocket bool,
+) (*xtls.UConn, error) {
+	conn, err := uDo(ctx, dialFn, cfg, fingerprint, websocket)
+	if err == nil {
+		return conn, nil
+	}
+
+	var echErr *utls.ECHRejectionError
+	if stderrors.As(err, &echErr) && len(echErr.RetryConfigList) > 0 {
+		retry := cfg.Clone()
+		retry.EncryptedClientHelloConfigList = echErr.RetryConfigList
+
+		conn, retryErr := uDo(ctx, dialFn, retry, fingerprint, websocket)
+		if retryErr != nil {
+			return nil, retryErr
+		}
+
+		xtls.StoreRecentECH(cfg.ServerName, echErr.RetryConfigList)
+		return conn, nil
+	}
+
+	return nil, err
+}
+
+func StdHandshake(
+	ctx context.Context,
+	dialFn DialFacility,
+	cfg *gotls.Config,
+) (*xtls.Conn, error) {
+	conn, err := stdDo(ctx, dialFn, cfg)
+	if err == nil {
+		return conn, nil
+	}
+
+	var echErr *gotls.ECHRejectionError
+	if stderrors.As(err, &echErr) && len(echErr.RetryConfigList) > 0 {
+		retry := cfg.Clone()
+		retry.EncryptedClientHelloConfigList = echErr.RetryConfigList
+
+		conn, retryErr := stdDo(ctx, dialFn, retry)
+		if retryErr != nil {
+			return nil, retryErr
+		}
+
+		xtls.StoreRecentECH(cfg.ServerName, echErr.RetryConfigList)
+		return conn, nil
+	}
+
+	return nil, err
+}
+
+func QUICHandshake(
+	ctx context.Context,
+	quicDialFn QUICDialFacility,
+	cfg *gotls.Config,
+) (*quic.Conn, error) {
+	conn, err := quicDialFn(ctx, cfg)
+	if err == nil {
+		return conn, nil
+	}
+
+	var echErr *gotls.ECHRejectionError
+	if stderrors.As(err, &echErr) && len(echErr.RetryConfigList) > 0 {
+		retry := cfg.Clone()
+		retry.EncryptedClientHelloConfigList = echErr.RetryConfigList
+
+		conn, retryErr := quicDialFn(ctx, retry)
+		if retryErr != nil {
+			return nil, retryErr
+		}
+
+		xtls.StoreRecentECH(cfg.ServerName, echErr.RetryConfigList)
+		return conn, nil
+	}
+
+	return nil, err
+}
+
+func uDo(
+	ctx context.Context,
+	dialFn DialFacility,
+	cfg *gotls.Config,
+	fingerprint *utls.ClientHelloID,
+	websocket bool,
+) (*xtls.UConn, error) {
+	raw, err := dialFn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	uconn := xtls.UClient(raw, cfg, fingerprint).(*xtls.UConn)
+	if websocket {
+		err = uconn.WebsocketHandshakeContext(ctx)
+	} else {
+		err = uconn.HandshakeContext(ctx)
+	}
+	if err != nil {
+		raw.Close()
+		return nil, err
+	}
+	return uconn, nil
+}
+
+func stdDo(
+	ctx context.Context,
+	dialFn DialFacility,
+	cfg *gotls.Config,
+) (*xtls.Conn, error) {
+	raw, err := dialFn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	conn := xtls.Client(raw, cfg).(*xtls.Conn)
+	if err := conn.HandshakeContext(ctx); err != nil {
+		raw.Close()
+		return nil, err
+	}
+	return conn, nil
+}

--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -5,7 +5,7 @@ import (
 	gotls "crypto/tls"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"net/http/httptrace"
 	"net/url"
@@ -25,6 +25,7 @@ import (
 	"github.com/xtls/xray-core/common/uuid"
 	"github.com/xtls/xray-core/transport/internet"
 	"github.com/xtls/xray-core/transport/internet/browser_dialer"
+	"github.com/xtls/xray-core/transport/internet/ech"
 	"github.com/xtls/xray-core/transport/internet/hysteria/congestion"
 	"github.com/xtls/xray-core/transport/internet/hysteria/udphop"
 	"github.com/xtls/xray-core/transport/internet/reality"
@@ -115,37 +116,40 @@ func createHTTPClient(dest net.Destination, streamSettings *internet.MemoryStrea
 
 	transportConfig := streamSettings.ProtocolSettings.(*Config)
 
-	dialContext := func(ctxInner context.Context) (net.Conn, error) {
-		conn, err := internet.DialSystem(ctxInner, dest, streamSettings.SocketSettings)
+	preTLSDialFn := func(c context.Context) (net.Conn, error) {
+		rawConn, err := internet.DialSystem(c, dest, streamSettings.SocketSettings)
 		if err != nil {
 			return nil, err
 		}
 
 		if streamSettings.TcpmaskManager != nil {
-			newConn, err := streamSettings.TcpmaskManager.WrapConnClient(conn)
+			newConn, err := streamSettings.TcpmaskManager.WrapConnClient(rawConn)
 			if err != nil {
-				conn.Close()
+				rawConn.Close()
 				return nil, errors.New("mask err").Base(err)
 			}
-			conn = newConn
+			rawConn = newConn
 		}
+		return rawConn, nil
+	}
 
+	dialContext := func(ctxInner context.Context) (net.Conn, error) {
 		if realityConfig != nil {
-			return reality.UClient(conn, realityConfig, ctxInner, dest)
-		}
-
-		if gotlsConfig != nil {
-			if fingerprint := tls.GetFingerprint(tlsConfig.Fingerprint); fingerprint != nil {
-				conn = tls.UClient(conn, gotlsConfig, fingerprint)
-				if err := conn.(*tls.UConn).HandshakeContext(ctxInner); err != nil {
-					return nil, err
-				}
-			} else {
-				conn = tls.Client(conn, gotlsConfig)
+			raw, err := preTLSDialFn(ctxInner)
+			if err != nil {
+				return nil, err
 			}
+			return reality.UClient(raw, realityConfig, ctxInner, dest)
 		}
 
-		return conn, nil
+		if gotlsConfig == nil {
+			return preTLSDialFn(ctxInner)
+		}
+
+		if fingerprint := tls.GetFingerprint(tlsConfig.Fingerprint); fingerprint != nil {
+			return ech.UHandshake(ctxInner, preTLSDialFn, gotlsConfig, fingerprint, false)
+		}
+		return ech.StdHandshake(ctxInner, preTLSDialFn, gotlsConfig)
 	}
 
 	var keepAlivePeriod time.Duration
@@ -193,110 +197,108 @@ func createHTTPClient(dest net.Destination, streamSettings *internet.MemoryStrea
 			QUICConfig:      quicConfig,
 			TLSClientConfig: gotlsConfig,
 			Dial: func(ctx context.Context, addr string, tlsCfg *gotls.Config, cfg *quic.Config) (*quic.Conn, error) {
-				udphopDialer := func(addr *net.UDPAddr) (net.PacketConn, error) {
-					conn, err := internet.DialSystem(ctx, net.UDPDestination(net.IPAddress(addr.IP), net.Port(addr.Port)), streamSettings.SocketSettings)
+				quicSetupFn := func(c context.Context, echCfg *gotls.Config) (*quic.Conn, error) {
+					udphopDialer := func(addr *net.UDPAddr) (net.PacketConn, error) {
+						conn, err := internet.DialSystem(c, net.UDPDestination(net.IPAddress(addr.IP), net.Port(addr.Port)), streamSettings.SocketSettings)
+						if err != nil {
+							errors.LogDebug(context.Background(), "skip hop: failed to dial to dest")
+							conn.Close()
+							return nil, errors.New()
+						}
+						switch c := conn.(type) {
+						case *internet.PacketConnWrapper:
+							return c.PacketConn, nil
+						case *net.UDPConn:
+							return c, nil
+						default:
+							errors.LogDebug(context.Background(), "skip hop: udphop requires being at the outermost level ", reflect.TypeOf(c))
+							conn.Close()
+							return nil, errors.New()
+						}
+					}
+
+					var index int
+					if len(quicParams.UdpHop.Ports) > 0 {
+						index = rand.IntN(len(quicParams.UdpHop.Ports))
+						dest.Port = net.Port(quicParams.UdpHop.Ports[index])
+					}
+
+					conn, err := internet.DialSystem(c, dest, streamSettings.SocketSettings)
 					if err != nil {
-						errors.LogDebug(context.Background(), "skip hop: failed to dial to dest")
-						conn.Close()
-						return nil, errors.New()
+						return nil, err
 					}
 
 					var udpConn net.PacketConn
+					var udpAddr *net.UDPAddr
 
-					switch c := conn.(type) {
+					switch tc := conn.(type) {
 					case *internet.PacketConnWrapper:
-						udpConn = c.PacketConn
+						udpConn = tc.PacketConn
+						udpAddr, err = net.ResolveUDPAddr("udp", tc.Dest.String())
+						if err != nil {
+							conn.Close()
+							return nil, err
+						}
 					case *net.UDPConn:
-						udpConn = c
+						udpConn = tc
+						udpAddr, err = net.ResolveUDPAddr("udp", tc.RemoteAddr().String())
+						if err != nil {
+							conn.Close()
+							return nil, err
+						}
 					default:
-						errors.LogDebug(context.Background(), "skip hop: udphop requires being at the outermost level ", reflect.TypeOf(c))
-						conn.Close()
-						return nil, errors.New()
-					}
-
-					return udpConn, nil
-				}
-
-				var index int
-				if len(quicParams.UdpHop.Ports) > 0 {
-					index = rand.Intn(len(quicParams.UdpHop.Ports))
-					dest.Port = net.Port(quicParams.UdpHop.Ports[index])
-				}
-
-				conn, err := internet.DialSystem(ctx, dest, streamSettings.SocketSettings)
-				if err != nil {
-					return nil, err
-				}
-
-				var udpConn net.PacketConn
-				var udpAddr *net.UDPAddr
-
-				switch c := conn.(type) {
-				case *internet.PacketConnWrapper:
-					udpConn = c.PacketConn
-					udpAddr, err = net.ResolveUDPAddr("udp", c.Dest.String())
-					if err != nil {
-						conn.Close()
-						return nil, err
-					}
-				case *net.UDPConn:
-					udpConn = c
-					udpAddr, err = net.ResolveUDPAddr("udp", c.RemoteAddr().String())
-					if err != nil {
-						conn.Close()
-						return nil, err
-					}
-				default:
-					udpConn = &internet.FakePacketConn{Conn: c}
-					udpAddr, err = net.ResolveUDPAddr("udp", c.RemoteAddr().String())
-					if err != nil {
-						conn.Close()
-						return nil, err
+						udpConn = &internet.FakePacketConn{Conn: conn}
+						udpAddr, err = net.ResolveUDPAddr("udp", conn.RemoteAddr().String())
+						if err != nil {
+							conn.Close()
+							return nil, err
+						}
+						if len(quicParams.UdpHop.Ports) > 0 {
+							conn.Close()
+							return nil, errors.New("udphop requires being at the outermost level ", reflect.TypeOf(tc))
+						}
 					}
 
 					if len(quicParams.UdpHop.Ports) > 0 {
-						conn.Close()
-						return nil, errors.New("udphop requires being at the outermost level ", reflect.TypeOf(c))
+						addr := &udphop.UDPHopAddr{
+							IP:    udpAddr.IP,
+							Ports: quicParams.UdpHop.Ports,
+						}
+						udpConn, err = udphop.NewUDPHopPacketConn(addr, index, quicParams.UdpHop.IntervalMin, quicParams.UdpHop.IntervalMax, udphopDialer, udpConn)
+						if err != nil {
+							conn.Close()
+							return nil, errors.New("udphop err").Base(err)
+						}
 					}
-				}
 
-				if len(quicParams.UdpHop.Ports) > 0 {
-					addr := &udphop.UDPHopAddr{
-						IP:    udpAddr.IP,
-						Ports: quicParams.UdpHop.Ports,
+					if streamSettings.UdpmaskManager != nil {
+						udpConn, err = streamSettings.UdpmaskManager.WrapPacketConnClient(udpConn)
+						if err != nil {
+							conn.Close()
+							return nil, errors.New("mask err").Base(err)
+						}
 					}
-					udpConn, err = udphop.NewUDPHopPacketConn(addr, index, quicParams.UdpHop.IntervalMin, quicParams.UdpHop.IntervalMax, udphopDialer, udpConn)
+
+					quicConn, err := quic.DialEarly(c, udpConn, udpAddr, echCfg, cfg)
 					if err != nil {
-						conn.Close()
-						return nil, errors.New("udphop err").Base(err)
+						return nil, err
 					}
-				}
 
-				if streamSettings.UdpmaskManager != nil {
-					udpConn, err = streamSettings.UdpmaskManager.WrapPacketConnClient(udpConn)
-					if err != nil {
-						conn.Close()
-						return nil, errors.New("mask err").Base(err)
+					switch quicParams.Congestion {
+					case "force-brutal":
+						errors.LogDebug(context.Background(), quicConn.RemoteAddr(), " ", "congestion brutal bytes per second ", quicParams.BrutalUp)
+						congestion.UseBrutal(quicConn, quicParams.BrutalUp)
+					case "reno":
+						errors.LogDebug(context.Background(), quicConn.RemoteAddr(), " ", "congestion reno")
+					default:
+						errors.LogDebug(context.Background(), quicConn.RemoteAddr(), " ", "congestion bbr")
+						congestion.UseBBR(quicConn)
 					}
+
+					return quicConn, nil
 				}
 
-				quicConn, err := quic.DialEarly(ctx, udpConn, udpAddr, tlsCfg, cfg)
-				if err != nil {
-					return nil, err
-				}
-
-				switch quicParams.Congestion {
-				case "force-brutal":
-					errors.LogDebug(context.Background(), quicConn.RemoteAddr(), " ", "congestion brutal bytes per second ", quicParams.BrutalUp)
-					congestion.UseBrutal(quicConn, quicParams.BrutalUp)
-				case "reno":
-					errors.LogDebug(context.Background(), quicConn.RemoteAddr(), " ", "congestion reno")
-				default:
-					errors.LogDebug(context.Background(), quicConn.RemoteAddr(), " ", "congestion bbr")
-					congestion.UseBBR(quicConn)
-				}
-
-				return quicConn, nil
+				return ech.QUICHandshake(ctx, quicSetupFn, tlsCfg)
 			},
 		}
 	} else if httpVersion == "2" {

--- a/transport/internet/tls/ech.go
+++ b/transport/internet/tls/ech.go
@@ -53,7 +53,7 @@ func ApplyECH(c *Config, config *tls.Config) error {
 		switch ECHForceQuery {
 		case "none", "half", "full":
 		case "":
-			ECHForceQuery = "full" // default to full
+			ECHForceQuery = "none" // default to none
 		default:
 			panic("Invalid ECHForceQuery: " + c.EchForceQuery)
 		}
@@ -105,9 +105,10 @@ type ECHConfigCache struct {
 }
 
 type echConfigRecord struct {
-	config []byte
-	expire time.Time
-	err    error
+	config    []byte
+	expire    time.Time
+	err       error
+	updatedAt time.Time
 }
 
 var (
@@ -146,10 +147,12 @@ func (c *ECHConfigCache) Update(domain string, server string, isLockedUpdate boo
 	if ttl == 0 {
 		ttl = dns2.DefaultTTL
 	}
+	now := time.Now()
 	configRecord = &echConfigRecord{
-		config: echConfig,
-		expire: time.Now().Add(time.Duration(ttl) * time.Second),
-		err:    err,
+		config:    echConfig,
+		expire:    now.Add(time.Duration(ttl) * time.Second),
+		err:       err,
+		updatedAt: now,
 	}
 	c.configRecord.Store(configRecord)
 	return configRecord.config, configRecord.err
@@ -158,6 +161,12 @@ func (c *ECHConfigCache) Update(domain string, server string, isLockedUpdate boo
 // QueryRecord returns the ECH config for given domain.
 // If the record is not in cache or expired, it will query the DNS server and update the cache.
 func QueryRecord(domain string, server string, forceQuery string, sockopt *internet.SocketConfig) ([]byte, error) {
+	if recent, ok := lookupRecentECH(domain); ok {
+		errors.LogDebug(context.Background(), "RecentECH cache hit for domain: ", domain)
+		refreshDNSCacheFromRecent(domain, server, sockopt, recent)
+		return recent, nil
+	}
+
 	GlobalECHConfigCacheKey := ECHCacheKey(server, domain, sockopt)
 	echConfigCache, ok := GlobalECHConfigCache.Load(GlobalECHConfigCacheKey)
 	if !ok {
@@ -171,21 +180,64 @@ func QueryRecord(domain string, server string, forceQuery string, sockopt *inter
 		return configRecord.config, configRecord.err
 	}
 
-	// If expire is zero value, it means we are in initial state, wait for the query to finish
-	// otherwise return old value immediately and update in a goroutine
-	// but if the cache is too old, wait for update
-	if configRecord.expire == (time.Time{}) || configRecord.expire.Add(time.Hour*4).Before(time.Now()) {
+	if configRecord.expire.Equal(time.Time{}) || configRecord.expire.Add(time.Hour*4).Before(time.Now()) {
 		return echConfigCache.Update(domain, server, false, forceQuery, sockopt)
-	} else {
-		// If someone already acquired the lock, it means it is updating, do not start another update goroutine
-		if echConfigCache.UpdateLock.TryLock() {
-			go func() {
-				defer echConfigCache.UpdateLock.Unlock()
-				echConfigCache.Update(domain, server, true, forceQuery, sockopt)
-			}()
-		}
-		return configRecord.config, configRecord.err
 	}
+	if echConfigCache.UpdateLock.TryLock() {
+		go func() {
+			defer echConfigCache.UpdateLock.Unlock()
+			echConfigCache.Update(domain, server, true, forceQuery, sockopt)
+		}()
+	}
+	return configRecord.config, configRecord.err
+}
+
+func refreshDNSCacheFromRecent(domain, server string, sockopt *internet.SocketConfig, config []byte) {
+	key := ECHCacheKey(server, domain, sockopt)
+	cache, ok := GlobalECHConfigCache.Load(key)
+	if !ok {
+		return
+	}
+	now := time.Now()
+	cache.configRecord.Store(&echConfigRecord{
+		config:    config,
+		expire:    now.Add(time.Hour),
+		err:       nil,
+		updatedAt: now,
+	})
+}
+
+const recentECHMaxAge = time.Hour
+
+type recentECHEntry struct {
+	config   []byte
+	storedAt time.Time
+}
+
+var recentECHCache sync.Map
+
+func StoreRecentECH(serverName string, config []byte) {
+	if len(config) == 0 || serverName == "" {
+		return
+	}
+	recentECHCache.Store(serverName, &recentECHEntry{
+		config:   config,
+		storedAt: time.Now(),
+	})
+	errors.LogDebug(context.Background(), "RecentECH stored for: ", serverName, " (", len(config), " bytes)")
+}
+
+func lookupRecentECH(serverName string) ([]byte, bool) {
+	v, ok := recentECHCache.Load(serverName)
+	if !ok {
+		return nil, false
+	}
+	e := v.(*recentECHEntry)
+	if time.Since(e.storedAt) > recentECHMaxAge {
+		recentECHCache.Delete(serverName)
+		return nil, false
+	}
+	return e.config, true
 }
 
 // dnsQuery is the real func for sending type65 query for given domain to given DNS server.
@@ -233,7 +285,7 @@ func dnsQuery(server string, domain string, sockopt *internet.SocketConfig) ([]b
 						if err != nil {
 							return nil, err
 						}
-						conn = utls.UClient(conn, &utls.Config{ServerName: u.Hostname()}, utls.HelloChrome_Auto)
+						conn = utls.UClient(conn, &utls.Config{ServerName: u.Hostname(), InsecureSkipVerify: true}, utls.HelloChrome_Auto)
 						if err := conn.(*utls.UConn).HandshakeContext(ctx); err != nil {
 							return nil, err
 						}
@@ -254,7 +306,7 @@ func dnsQuery(server string, domain string, sockopt *internet.SocketConfig) ([]b
 		req.Header.Set("Accept", "application/dns-message")
 		req.Header.Set("Content-Type", "application/dns-message")
 		req.Header.Set("User-Agent", utils.ChromeUA)
-		req.Header.Set("X-Padding", utils.H2Base62Pad(crypto.RandBetween(100, 1000)))
+		// req.Header.Set("X-Padding", utils.H2Base62Pad(crypto.RandBetween(100, 1000)))
 
 		resp, err := client.Do(req)
 		if err != nil {

--- a/transport/internet/websocket/dialer.go
+++ b/transport/internet/websocket/dialer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/transport/internet"
 	"github.com/xtls/xray-core/transport/internet/browser_dialer"
+	"github.com/xtls/xray-core/transport/internet/ech"
 	"github.com/xtls/xray-core/transport/internet/stat"
 	"github.com/xtls/xray-core/transport/internet/tls"
 )
@@ -46,23 +47,26 @@ func init() {
 func dialWebSocket(ctx context.Context, dest net.Destination, streamSettings *internet.MemoryStreamConfig, ed []byte) (net.Conn, error) {
 	wsSettings := streamSettings.ProtocolSettings.(*Config)
 
+	preTLSDialFn := func(c context.Context) (net.Conn, error) {
+		conn, err := internet.DialSystem(c, dest, streamSettings.SocketSettings)
+		if err != nil {
+			return nil, err
+		}
+		if streamSettings.TcpmaskManager != nil {
+			newConn, err := streamSettings.TcpmaskManager.WrapConnClient(conn)
+			if err != nil {
+				conn.Close()
+				return nil, errors.New("mask err").Base(err)
+			}
+			conn = newConn
+		}
+
+		return conn, nil
+	}
+
 	dialer := &websocket.Dialer{
 		NetDial: func(network, addr string) (net.Conn, error) {
-			conn, err := internet.DialSystem(ctx, dest, streamSettings.SocketSettings)
-			if err != nil {
-				return nil, err
-			}
-
-			if streamSettings.TcpmaskManager != nil {
-				newConn, err := streamSettings.TcpmaskManager.WrapConnClient(conn)
-				if err != nil {
-					conn.Close()
-					return nil, errors.New("mask err").Base(err)
-				}
-				conn = newConn
-			}
-
-			return conn, err
+			return preTLSDialFn(ctx)
 		},
 		ReadBufferSize:   4 * 1024,
 		WriteBufferSize:  4 * 1024,
@@ -77,29 +81,14 @@ func dialWebSocket(ctx context.Context, dest net.Destination, streamSettings *in
 		tlsConfig := tConfig.GetTLSConfig(tls.WithDestination(dest), tls.WithNextProto("http/1.1"))
 		dialer.TLSClientConfig = tlsConfig
 		if fingerprint := tls.GetFingerprint(tConfig.Fingerprint); fingerprint != nil {
-			dialer.NetDialTLSContext = func(_ context.Context, _, addr string) (net.Conn, error) {
+			dialer.NetDialTLSContext = func(c context.Context, _, addr string) (net.Conn, error) {
 				// Like the NetDial in the dialer
-				pconn, err := internet.DialSystem(ctx, dest, streamSettings.SocketSettings)
+				cn, err := ech.UHandshake(c, preTLSDialFn, tlsConfig, fingerprint, true)
 				if err != nil {
 					errors.LogErrorInner(ctx, err, "failed to dial to "+addr)
 					return nil, err
 				}
 
-				if streamSettings.TcpmaskManager != nil {
-					newConn, err := streamSettings.TcpmaskManager.WrapConnClient(pconn)
-					if err != nil {
-						pconn.Close()
-						return nil, errors.New("mask err").Base(err)
-					}
-					pconn = newConn
-				}
-
-				// TLS and apply the handshake
-				cn := tls.UClient(pconn, tlsConfig, fingerprint).(*tls.UConn)
-				if err := cn.WebsocketHandshakeContext(ctx); err != nil {
-					errors.LogErrorInner(ctx, err, "failed to dial to "+addr)
-					return nil, err
-				}
 				if !tlsConfig.InsecureSkipVerify {
 					if err := cn.VerifyHostname(tlsConfig.ServerName); err != nil {
 						errors.LogErrorInner(ctx, err, "failed to dial to "+addr)


### PR DESCRIPTION
An outdated ECH record will break the TLS connection, using the latest ECH config from the server response is safe.