### PR TITLE
bugfix: avoid DNS leakage with gRPC transports

### DIFF
--- a/transport/internet/grpc/dial.go
+++ b/transport/internet/grpc/dial.go
@@ -176,6 +176,8 @@ func getGrpcClient(ctx context.Context, dest net.Destination, streamSettings *in
 		grpcDestHost = dest.Address.IP().String()
 	}
 
+	dialOptions = append(dialOptions, grpc.WithDisableServiceConfig())
+
 	conn, err := grpc.NewClient(
 		"passthrough:///"+net.JoinHostPort(grpcDestHost, dest.Port.String()),
 		dialOptions...,


### PR DESCRIPTION
ported from v2fly/v2ray-core#3587, fixing exactly the same issue