### PR TITLE
Add --json flag to x25519 command for machine-readable output

### DIFF
--- a/main/commands/all/curve25519.go
+++ b/main/commands/all/curve25519.go
@@ -4,12 +4,13 @@ import (
 	"crypto/ecdh"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 
 	"lukechampine.com/blake3"
 )
 
-func Curve25519Genkey(StdEncoding bool, input_base64 string) {
+func Curve25519Genkey(StdEncoding bool, input_base64 string, jsonOutput bool) {
 	var encoding *base64.Encoding
 	if *input_stdEncoding || StdEncoding {
 		encoding = base64.StdEncoding
@@ -30,10 +31,19 @@ func Curve25519Genkey(StdEncoding bool, input_base64 string) {
 		fmt.Println(err)
 		return
 	}
-	fmt.Printf("PrivateKey: %v\nPassword (PublicKey): %v\nHash32: %v\n",
-		encoding.EncodeToString(privateKey),
-		encoding.EncodeToString(password),
-		encoding.EncodeToString(hash32[:]))
+	if jsonOutput {
+		output, _ := json.Marshal(map[string]string{
+			"privateKey": encoding.EncodeToString(privateKey),
+			"publicKey":  encoding.EncodeToString(password),
+			"hash32":     encoding.EncodeToString(hash32[:]),
+		})
+		fmt.Println(string(output))
+	} else {
+		fmt.Printf("PrivateKey: %v\nPassword (PublicKey): %v\nHash32: %v\n",
+			encoding.EncodeToString(privateKey),
+			encoding.EncodeToString(password),
+			encoding.EncodeToString(hash32[:]))
+	}
 }
 
 func genCurve25519(inputPrivateKey []byte) (privateKey []byte, password []byte, hash32 [32]byte, returnErr error) {

--- a/main/commands/all/wg.go
+++ b/main/commands/all/wg.go
@@ -23,5 +23,5 @@ func init() {
 var input_wireguard = cmdWG.Flag.String("i", "", "")
 
 func executeWG(cmd *base.Command, args []string) {
-	Curve25519Genkey(true, *input_wireguard)
+	Curve25519Genkey(true, *input_wireguard, false)
 }

--- a/main/commands/all/x25519.go
+++ b/main/commands/all/x25519.go
@@ -5,7 +5,7 @@ import (
 )
 
 var cmdX25519 = &base.Command{
-	UsageLine: `{{.Exec}} x25519 [-i "private key (base64.RawURLEncoding)"] [--std-encoding]`,
+	UsageLine: `{{.Exec}} x25519 [-i "private key (base64.RawURLEncoding)"] [--std-encoding] [--json]`,
 	Short:     `Generate key pair for X25519 key exchange (REALITY, VLESS Encryption)`,
 	Long: `
 Generate key pair for X25519 key exchange (REALITY, VLESS Encryption).
@@ -23,7 +23,8 @@ func init() {
 
 var input_stdEncoding = cmdX25519.Flag.Bool("std-encoding", false, "")
 var input_x25519 = cmdX25519.Flag.String("i", "", "")
+var input_jsonOutput = cmdX25519.Flag.Bool("json", false, "")
 
 func executeX25519(cmd *base.Command, args []string) {
-	Curve25519Genkey(false, *input_x25519)
+	Curve25519Genkey(false, *input_x25519, *input_jsonOutput)
 }


### PR DESCRIPTION
### Problem

The `xray x25519` output labels have changed multiple times across versions:

- v1.8: `Private key` / `Public key`
- v24+: `PrivateKey` / `PublicKey`  
- v25+: `PrivateKey` / `Password`
- v26.2+: `PrivateKey` / `Password (PublicKey)` (#5759)

Every change breaks install scripts and automation tools that parse the output with grep/awk. This has been a recurring source of confusion (#5159, #5219, #5412).

### Solution

Add a `--json` flag that outputs a stable, machine-parseable JSON object:
```
$ xray x25519 --json
{"privateKey":"...","publicKey":"...","hash32":"..."}

$ xray x25519 -i "existing_private_key" --json
{"privateKey":"...","publicKey":"...","hash32":"..."}
```

Without `--json`, output remains unchanged (no breaking change).

### Notes

- Works with existing `-i` and `--std-encoding` flags
- Uses stdlib `encoding/json` only
- Minimal change, no refactoring of unrelated code