### PR TITLE
TUN inbound: Closable by AlwaysOnInboundHandler

### DIFF
--- a/app/proxyman/inbound/always.go
+++ b/app/proxyman/inbound/always.go
@@ -186,6 +186,7 @@ func (h *AlwaysOnInboundHandler) Close() error {
 		errs = append(errs, worker.Close())
 	}
 	errs = append(errs, h.mux.Close())
+	errs = append(errs, common.Close(h.proxy))
 	if err := errors.Combine(errs...); err != nil {
 		return errors.New("failed to close all resources").Base(err)
 	}

--- a/proxy/tun/handler.go
+++ b/proxy/tun/handler.go
@@ -23,6 +23,7 @@ type Handler struct {
 	ctx             context.Context
 	config          *Config
 	stack           Stack
+	tun             Tun
 	policyManager   policy.Manager
 	dispatcher      routing.Dispatcher
 	tag             string
@@ -95,6 +96,7 @@ func (t *Handler) Init(ctx context.Context, pm policy.Manager, dispatcher routin
 	}
 
 	t.stack = tunStack
+	t.tun = tunInterface
 
 	errors.LogInfo(t.ctx, tunName, " up")
 	return nil
@@ -142,6 +144,11 @@ func (t *Handler) HandleConnection(conn net.Conn, destination net.Destination) {
 	if err := t.dispatcher.DispatchLink(ctx, destination, link); err != nil {
 		errors.LogError(ctx, errors.New("connection closed").Base(err))
 	}
+}
+
+// Close implements common.Closable.
+func (t *Handler) Close() error {
+	return errors.Combine(t.stack.Close(), t.tun.Close())
 }
 
 // Network implements proxy.Inbound


### PR DESCRIPTION
Fixes broken chain of `Close()` calls on TUN inbound.
On Windows this fixes dangling adapter after calling `Close()` on `Instance`, and, strangely, fixes timeout on first attempt to create adapter again after application reboot.
On Linux nothing technically changes (I'm not really sure if `Tun.Start()` is called by `AlwaysOnInboundHandler`)
On Darwin, Android and iOS nothing changes because they have empty `Close()` implementations.