### PR TITLE
fix: integer overflow panic in SniffQUIC

### DIFF
--- a/common/protocol/quic/sniff.go
+++ b/common/protocol/quic/sniff.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/binary"
 	"io"
+	"math"
 
 	"github.com/apernet/quic-go/quicvarint"
 	"github.com/xtls/xray-core/common"
@@ -219,6 +220,9 @@ func SniffQUIC(b []byte) (*SniffHeader, error) {
 				length, err := quicvarint.Read(buffer) // Field: Length
 				if err != nil || length > uint64(buffer.Len()) {
 					return nil, io.ErrUnexpectedEOF
+				}
+				if offset > math.MaxInt32 || length > math.MaxInt32 || offset > uint64(math.MaxInt32)-length {
+					return nil, io.ErrShortBuffer
 				}
 				currentCryptoLen := int32(offset + length)
 				if cryptoLen < currentCryptoLen {


### PR DESCRIPTION
Fix integer overflow panic in SniffQUIC.

<details>

```
goroutine 14860334692 [running]:
github.com/xtls/xray-core/common/buf.(*Buffer).BytesRange(...)
        github.com/xtls/xray-core/common/buf/buffer.go:167
github.com/xtls/xray-core/common/protocol/quic.SniffQUIC({0xc0a4ef2000, 0x63, 0x8000})
        github.com/xtls/xray-core/common/protocol/quic/sniff.go:231 +0x2005
github.com/xtls/xray-core/app/dispatcher.NewSniffer.func4({0xc19ac0a998?, 0x8?}, {0xc0a4ef2000?, 0x0?, 0x0?})
        github.com/xtls/xray-core/app/dispatcher/sniffer.go:42 +0x25
github.com/xtls/xray-core/app/dispatcher.(*Sniffer).Sniff(0xc0bd9538f0, {0x19a0090, 0xc2235fc300}, {0xc0a4ef2000, 0x63, 0x8000}, 0x3)
        github.com/xtls/xray-core/app/dispatcher/sniffer.go:66 +0xc6
github.com/xtls/xray-core/app/dispatcher.sniffer.func1(...)
        github.com/xtls/xray-core/app/dispatcher/default.go:426
github.com/xtls/xray-core/app/dispatcher.sniffer({0x19a0090, 0xc2235fc300}, 0xc2235fc480, 0x0, 0x3)
        github.com/xtls/xray-core/app/dispatcher/default.go:443 +0x64c
github.com/xtls/xray-core/app/dispatcher.(*DefaultDispatcher).Dispatch.func1()
        github.com/xtls/xray-core/app/dispatcher/default.go:314 +0x130
created by github.com/xtls/xray-core/app/dispatcher.(*DefaultDispatcher).Dispatch in goroutine 14860334690
        github.com/xtls/xray-core/app/dispatcher/default.go:309 +0x59b
panic: runtime error: slice bounds out of range [:-2147483648]
```
</details>