### PR TITLE
Hysteria inbound: Unwrap stats conn before extracting user

### DIFF
--- a/proxy/hysteria/server.go
+++ b/proxy/hysteria/server.go
@@ -83,10 +83,12 @@ func (s *Server) Process(ctx context.Context, network net.Network, conn stat.Con
 	inbound.Name = "hysteria"
 	inbound.CanSpliceCopy = 3
 
+	iConn := stat.TryUnwrapStatsConn(conn)
+
 	var useremail string
 	var userlevel uint32
 	type User interface{ User() *protocol.MemoryUser }
-	if v, ok := conn.(User); ok {
+	if v, ok := iConn.(User); ok {
 		inbound.User = v.User()
 		if inbound.User != nil {
 			useremail = inbound.User.Email
@@ -94,7 +96,6 @@ func (s *Server) Process(ctx context.Context, network net.Network, conn stat.Con
 		}
 	}
 
-	iConn := stat.TryUnwrapStatsConn(conn)
 	if _, ok := iConn.(*hysteria.InterUdpConn); ok {
 		r := io.Reader(conn)
 		b := make([]byte, MaxUDPSize)


### PR DESCRIPTION
proxy/hysteria/server.go extracts the user from conn before unwrapping stats wrappers.

If the connection is wrapped, conn.(User) may fail even though the underlying Hysteria connection implements User() *protocol.MemoryUser.

As a result, inbound.User may remain nil and AccessMessage.Email stays empty.

Fix

Unwrap the stats connection first and then extract the user from the underlying connection.

Related to #5868