### PR TITLE
Add ECH-aware routing and MASQUE UDP telemetry

### DIFF
--- a/app/observatory/burst/burstobserver.go
+++ b/app/observatory/burst/burstobserver.go
@@ -2,6 +2,7 @@ package burst
 
 import (
 	"context"
+	"sort"
 
 	"sync"
 
@@ -59,6 +60,9 @@ func (o *Observer) createResult() []*observatory.OutboundStatus {
 		}
 		result = append(result, &status)
 	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].OutboundTag < result[j].OutboundTag
+	})
 	return result
 }
 

--- a/app/observatory/ech.go
+++ b/app/observatory/ech.go
@@ -1,0 +1,30 @@
+package observatory
+
+import (
+	"github.com/xtls/xray-core/common/session"
+	"github.com/xtls/xray-core/features/extension"
+)
+
+type echCollector struct {
+	status extension.ECHStatus
+}
+
+func newECHCollector() *echCollector {
+	return &echCollector{}
+}
+
+func (e *echCollector) SubmitECHStatus(status session.OutboundECHStatus) {
+	if status.Enabled {
+		e.status.Enabled = true
+	}
+	if status.Accepted {
+		e.status.Accepted = true
+	}
+	if status.ServerName != "" {
+		e.status.ServerName = status.ServerName
+	}
+}
+
+func (e *echCollector) Status() extension.ECHStatus {
+	return e.status
+}

--- a/app/observatory/observer.go
+++ b/app/observatory/observer.go
@@ -30,6 +30,7 @@ type Observer struct {
 
 	statusLock sync.Mutex
 	status     []*OutboundStatus
+	echStatus  map[string]extension.ECHStatus
 
 	finished *done.Instance
 
@@ -38,7 +39,25 @@ type Observer struct {
 }
 
 func (o *Observer) GetObservation(ctx context.Context) (proto.Message, error) {
-	return &ObservationResult{Status: o.status}, nil
+	o.statusLock.Lock()
+	defer o.statusLock.Unlock()
+
+	return &ObservationResult{Status: cloneAndSortOutboundStatuses(o.status)}, nil
+}
+
+func (o *Observer) GetOutboundECHStatus(ctx context.Context) (map[string]extension.ECHStatus, error) {
+	o.statusLock.Lock()
+	defer o.statusLock.Unlock()
+
+	if len(o.echStatus) == 0 {
+		return nil, nil
+	}
+
+	snapshot := make(map[string]extension.ECHStatus, len(o.echStatus))
+	for tag, status := range o.echStatus {
+		snapshot[tag] = status
+	}
+	return snapshot, nil
 }
 
 func (o *Observer) Type() interface{} {
@@ -80,8 +99,8 @@ func (o *Observer) background() {
 		if !o.config.EnableConcurrency {
 			sort.Strings(outbounds)
 			for _, v := range outbounds {
-				result := o.probe(v)
-				o.updateStatusForResult(v, &result)
+				result, echStatus := o.probe(v)
+				o.updateStatusForResult(v, &result, echStatus)
 				if o.finished.Done() {
 					return
 				}
@@ -94,8 +113,8 @@ func (o *Observer) background() {
 
 		for _, v := range outbounds {
 			go func(v string) {
-				result := o.probe(v)
-				o.updateStatusForResult(v, &result)
+				result, echStatus := o.probe(v)
+				o.updateStatusForResult(v, &result, echStatus)
 				ch <- struct{}{}
 			}(v)
 		}
@@ -114,12 +133,41 @@ func (o *Observer) background() {
 func (o *Observer) updateStatus(outbounds []string) {
 	o.statusLock.Lock()
 	defer o.statusLock.Unlock()
-	// TODO should remove old inbound that is removed
-	_ = outbounds
+
+	allowed := make(map[string]struct{}, len(outbounds))
+	for _, outbound := range outbounds {
+		allowed[outbound] = struct{}{}
+	}
+
+	for tag := range o.echStatus {
+		if _, ok := allowed[tag]; !ok {
+			delete(o.echStatus, tag)
+		}
+	}
+
+	if len(o.status) == 0 {
+		return
+	}
+
+	filtered := o.status[:0]
+	for _, status := range o.status {
+		if status == nil {
+			continue
+		}
+		if _, ok := allowed[status.OutboundTag]; ok {
+			filtered = append(filtered, status)
+		}
+	}
+
+	for i := len(filtered); i < len(o.status); i++ {
+		o.status[i] = nil
+	}
+	o.status = filtered
 }
 
-func (o *Observer) probe(outbound string) ProbeResult {
+func (o *Observer) probe(outbound string) (ProbeResult, extension.ECHStatus) {
 	errorCollectorForRequest := newErrorCollector()
+	echCollectorForRequest := newECHCollector()
 
 	httpTransport := http.Transport{
 		Proxy: func(*http.Request) (*url.URL, error) {
@@ -134,6 +182,7 @@ func (o *Observer) probe(outbound string) ProbeResult {
 					return errors.New("cannot understand address").Base(err)
 				}
 				trackedCtx := session.TrackedConnectionError(o.ctx, errorCollectorForRequest)
+				trackedCtx = session.TrackedOutboundECHStatus(trackedCtx, echCollectorForRequest)
 				conn, err := tagged.Dialer(trackedCtx, o.dispatcher, dest, outbound)
 				if err != nil {
 					return errors.New("cannot dial remote address ", dest).Base(err)
@@ -179,13 +228,13 @@ func (o *Observer) probe(outbound string) ProbeResult {
 	if err != nil {
 		var errorMessage = "the outbound " + outbound + " is dead: GET request failed:" + err.Error() + "with outbound handler report underlying connection failed"
 		errors.LogInfoInner(o.ctx, errorCollectorForRequest.UnderlyingError(), errorMessage)
-		return ProbeResult{Alive: false, LastErrorReason: errorMessage}
+		return ProbeResult{Alive: false, LastErrorReason: errorMessage}, echCollectorForRequest.Status()
 	}
 	errors.LogInfo(o.ctx, "the outbound ", outbound, " is alive:", GETTime.Seconds())
-	return ProbeResult{Alive: true, Delay: GETTime.Milliseconds()}
+	return ProbeResult{Alive: true, Delay: GETTime.Milliseconds()}, echCollectorForRequest.Status()
 }
 
-func (o *Observer) updateStatusForResult(outbound string, result *ProbeResult) {
+func (o *Observer) updateStatusForResult(outbound string, result *ProbeResult, echStatus extension.ECHStatus) {
 	o.statusLock.Lock()
 	defer o.statusLock.Unlock()
 	var status *OutboundStatus
@@ -207,6 +256,18 @@ func (o *Observer) updateStatusForResult(outbound string, result *ProbeResult) {
 		status.LastErrorReason = result.LastErrorReason
 		status.Delay = 99999999
 	}
+
+	if o.echStatus == nil {
+		o.echStatus = make(map[string]extension.ECHStatus)
+	}
+	echStatus.LastTryTime = status.LastTryTime
+	echStatus.Accepted = echStatus.Accepted && result.Alive
+	if echStatus.Accepted {
+		echStatus.LastSeenTime = status.LastTryTime
+	} else {
+		echStatus.LastSeenTime = 0
+	}
+	o.echStatus[outbound] = echStatus
 }
 
 func (o *Observer) findStatusLocationLockHolderOnly(outbound string) int {
@@ -216,6 +277,40 @@ func (o *Observer) findStatusLocationLockHolderOnly(outbound string) int {
 		}
 	}
 	return -1
+}
+
+func cloneAndSortOutboundStatuses(statuses []*OutboundStatus) []*OutboundStatus {
+	if len(statuses) == 0 {
+		return nil
+	}
+
+	snapshot := make([]*OutboundStatus, 0, len(statuses))
+	for _, status := range statuses {
+		if status == nil {
+			continue
+		}
+		snapshot = append(snapshot, cloneOutboundStatus(status))
+	}
+
+	sort.Slice(snapshot, func(i, j int) bool {
+		return snapshot[i].OutboundTag < snapshot[j].OutboundTag
+	})
+
+	return snapshot
+}
+
+func cloneOutboundStatus(status *OutboundStatus) *OutboundStatus {
+	if status == nil {
+		return nil
+	}
+
+	cloned := *status
+	if status.HealthPing != nil {
+		healthPing := *status.HealthPing
+		cloned.HealthPing = &healthPing
+	}
+
+	return &cloned
 }
 
 func New(ctx context.Context, config *Config) (*Observer, error) {

--- a/app/observatory/observer_test.go
+++ b/app/observatory/observer_test.go
@@ -1,0 +1,165 @@
+package observatory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/xtls/xray-core/features/extension"
+)
+
+func TestGetObservationReturnsSortedSnapshot(t *testing.T) {
+	observer := &Observer{
+		status: []*OutboundStatus{
+			{
+				OutboundTag: "z-out",
+				Delay:       50,
+				HealthPing: &HealthPingMeasurementResult{
+					Average: 50,
+				},
+			},
+			{
+				OutboundTag: "a-out",
+				Delay:       10,
+				HealthPing: &HealthPingMeasurementResult{
+					Average: 10,
+				},
+			},
+		},
+	}
+
+	msg, err := observer.GetObservation(context.Background())
+	if err != nil {
+		t.Fatalf("GetObservation returned error: %v", err)
+	}
+
+	result, ok := msg.(*ObservationResult)
+	if !ok {
+		t.Fatalf("GetObservation returned %T, want *ObservationResult", msg)
+	}
+
+	if len(result.Status) != 2 {
+		t.Fatalf("unexpected snapshot size: got %d, want 2", len(result.Status))
+	}
+	if got := result.Status[0].OutboundTag; got != "a-out" {
+		t.Fatalf("unexpected first tag: got %q, want %q", got, "a-out")
+	}
+	if got := result.Status[1].OutboundTag; got != "z-out" {
+		t.Fatalf("unexpected second tag: got %q, want %q", got, "z-out")
+	}
+
+	result.Status[0].Delay = 999
+	result.Status[0].HealthPing.Average = 999
+
+	if observer.status[1].Delay != 10 {
+		t.Fatalf("internal delay was modified through snapshot: got %d, want 10", observer.status[1].Delay)
+	}
+	if observer.status[1].HealthPing.Average != 10 {
+		t.Fatalf("internal health ping was modified through snapshot: got %d, want 10", observer.status[1].HealthPing.Average)
+	}
+}
+
+func TestUpdateStatusRemovesStaleOutbounds(t *testing.T) {
+	observer := &Observer{
+		status: []*OutboundStatus{
+			{OutboundTag: "keep-b"},
+			{OutboundTag: "remove-me"},
+			{OutboundTag: "keep-a"},
+		},
+	}
+
+	observer.updateStatus([]string{"keep-a", "keep-b"})
+
+	if len(observer.status) != 2 {
+		t.Fatalf("unexpected status size after cleanup: got %d, want 2", len(observer.status))
+	}
+
+	msg, err := observer.GetObservation(context.Background())
+	if err != nil {
+		t.Fatalf("GetObservation returned error: %v", err)
+	}
+
+	result := msg.(*ObservationResult)
+	if len(result.Status) != 2 {
+		t.Fatalf("unexpected snapshot size after cleanup: got %d, want 2", len(result.Status))
+	}
+	if result.Status[0].OutboundTag != "keep-a" || result.Status[1].OutboundTag != "keep-b" {
+		t.Fatalf("unexpected tags after cleanup: got %q, %q", result.Status[0].OutboundTag, result.Status[1].OutboundTag)
+	}
+
+	observer.updateStatus(nil)
+	if len(observer.status) != 0 {
+		t.Fatalf("expected all statuses to be removed, got %d", len(observer.status))
+	}
+}
+
+func TestGetOutboundECHStatusReturnsSnapshotAndCleanup(t *testing.T) {
+	observer := &Observer{
+		echStatus: map[string]extension.ECHStatus{
+			"keep": {
+				Enabled:      true,
+				Accepted:     true,
+				ServerName:   "keep.example",
+				LastTryTime:  100,
+				LastSeenTime: 100,
+			},
+			"drop": {
+				Enabled:     true,
+				Accepted:    false,
+				LastTryTime: 90,
+			},
+		},
+	}
+
+	snapshot, err := observer.GetOutboundECHStatus(context.Background())
+	if err != nil {
+		t.Fatalf("GetOutboundECHStatus returned error: %v", err)
+	}
+	if len(snapshot) != 2 {
+		t.Fatalf("unexpected ech snapshot size: got %d, want 2", len(snapshot))
+	}
+
+	snapshot["keep"] = extension.ECHStatus{}
+	if !observer.echStatus["keep"].Accepted {
+		t.Fatal("internal ech status was modified through snapshot")
+	}
+
+	observer.updateStatus([]string{"keep"})
+	if _, ok := observer.echStatus["drop"]; ok {
+		t.Fatal("stale ech status was not removed during cleanup")
+	}
+}
+
+func TestUpdateStatusForResultTracksECHAcceptance(t *testing.T) {
+	observer := &Observer{}
+	result := &ProbeResult{Alive: true, Delay: 15}
+	observer.updateStatusForResult("ech-out", result, extension.ECHStatus{
+		Enabled:    true,
+		Accepted:   true,
+		ServerName: "cdn.example",
+	})
+
+	status, err := observer.GetOutboundECHStatus(context.Background())
+	if err != nil {
+		t.Fatalf("GetOutboundECHStatus returned error: %v", err)
+	}
+	got := status["ech-out"]
+	if !got.Enabled || !got.Accepted {
+		t.Fatalf("unexpected ech status after success: %+v", got)
+	}
+	if got.ServerName != "cdn.example" {
+		t.Fatalf("unexpected ech server name: got %q, want %q", got.ServerName, "cdn.example")
+	}
+	if got.LastSeenTime == 0 || got.LastTryTime == 0 {
+		t.Fatalf("expected ech timestamps to be populated, got %+v", got)
+	}
+
+	observer.updateStatusForResult("ech-out", &ProbeResult{Alive: false, LastErrorReason: "failed"}, extension.ECHStatus{
+		Enabled:    true,
+		Accepted:   true,
+		ServerName: "cdn.example",
+	})
+	status, _ = observer.GetOutboundECHStatus(context.Background())
+	if status["ech-out"].Accepted {
+		t.Fatalf("expected ech acceptance to reset after failed probe, got %+v", status["ech-out"])
+	}
+}

--- a/app/router/balancing.go
+++ b/app/router/balancing.go
@@ -67,6 +67,7 @@ func (s *RoundRobinStrategy) PickOutbound(tags []string) string {
 				tags = aliveTags
 			}
 		}
+		tags = preferECHAcceptedCandidates(s.ctx, s.observatory, tags)
 	}
 
 	n := len(tags)

--- a/app/router/ech_preference.go
+++ b/app/router/ech_preference.go
@@ -1,0 +1,30 @@
+package router
+
+import (
+	"context"
+
+	"github.com/xtls/xray-core/features/extension"
+)
+
+func preferECHAcceptedCandidates(ctx context.Context, observer extension.Observatory, candidates []string) []string {
+	provider, ok := observer.(extension.ECHStatusProvider)
+	if !ok {
+		return candidates
+	}
+
+	statuses, err := provider.GetOutboundECHStatus(ctx)
+	if err != nil || len(statuses) == 0 {
+		return candidates
+	}
+
+	preferred := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		if status, ok := statuses[candidate]; ok && status.Accepted {
+			preferred = append(preferred, candidate)
+		}
+	}
+	if len(preferred) == 0 {
+		return candidates
+	}
+	return preferred
+}

--- a/app/router/ech_preference_test.go
+++ b/app/router/ech_preference_test.go
@@ -1,0 +1,56 @@
+package router
+
+import (
+	"context"
+	"testing"
+
+	"github.com/xtls/xray-core/features/extension"
+	"google.golang.org/protobuf/proto"
+)
+
+type fakeECHObservatory struct {
+	status map[string]extension.ECHStatus
+}
+
+func (f *fakeECHObservatory) Start() error { return nil }
+
+func (f *fakeECHObservatory) Close() error { return nil }
+
+func (f *fakeECHObservatory) Type() interface{} { return extension.ObservatoryType() }
+
+func (f *fakeECHObservatory) GetObservation(ctx context.Context) (proto.Message, error) {
+	return nil, nil
+}
+
+func (f *fakeECHObservatory) GetOutboundECHStatus(ctx context.Context) (map[string]extension.ECHStatus, error) {
+	return f.status, nil
+}
+
+func TestPreferECHAcceptedCandidatesReturnsAcceptedSubset(t *testing.T) {
+	observer := &fakeECHObservatory{
+		status: map[string]extension.ECHStatus{
+			"a": {Accepted: true},
+			"b": {Accepted: false},
+			"c": {Accepted: true},
+		},
+	}
+
+	got := preferECHAcceptedCandidates(context.Background(), observer, []string{"a", "b", "c"})
+	if len(got) != 2 || got[0] != "a" || got[1] != "c" {
+		t.Fatalf("unexpected preferred candidates: got %v, want [a c]", got)
+	}
+}
+
+func TestPreferECHAcceptedCandidatesFallsBackToOriginalCandidates(t *testing.T) {
+	observer := &fakeECHObservatory{
+		status: map[string]extension.ECHStatus{
+			"a": {Accepted: false},
+			"b": {Accepted: false},
+		},
+	}
+
+	got := preferECHAcceptedCandidates(context.Background(), observer, []string{"a", "b"})
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("unexpected fallback candidates: got %v, want [a b]", got)
+	}
+}

--- a/app/router/strategy_leastload.go
+++ b/app/router/strategy_leastload.go
@@ -151,6 +151,7 @@ func (s *LeastLoadStrategy) getNodes(candidates []string, maxRTT time.Duration) 
 
 	results := observeResult.(*observatory.ObservationResult)
 
+	candidates = preferECHAcceptedCandidates(s.ctx, s.observer, candidates)
 	outboundlist := outboundList(candidates)
 
 	var ret []*node

--- a/app/router/strategy_leastping.go
+++ b/app/router/strategy_leastping.go
@@ -38,11 +38,15 @@ func (l *LeastPingStrategy) PickOutbound(strings []string) string {
 		return ""
 	}
 	outboundsList := outboundList(strings)
+	preferred := outboundList(preferECHAcceptedCandidates(l.ctx, l.observatory, strings))
 	if result, ok := observeReport.(*observatory.ObservationResult); ok {
 		status := result.Status
 		leastPing := int64(99999999)
 		selectedOutboundName := ""
 		for _, v := range status {
+			if len(preferred) > 0 && !preferred.contains(v.OutboundTag) {
+				continue
+			}
 			if outboundsList.contains(v.OutboundTag) && v.Alive && v.Delay < leastPing {
 				selectedOutboundName = v.OutboundTag
 				leastPing = v.Delay

--- a/common/session/context.go
+++ b/common/session/context.go
@@ -26,6 +26,7 @@ const (
 	fullHandlerKey            ctx.SessionKey = 10 // outbound gets full handler
 	mitmAlpn11Key             ctx.SessionKey = 11 // used by TLS dialer
 	mitmServerNameKey         ctx.SessionKey = 12 // used by TLS dialer
+	trackedECHStatusKey       ctx.SessionKey = 13 // used by observatory to detect ECH usage
 )
 
 func ContextWithInbound(ctx context.Context, inbound *Inbound) context.Context {
@@ -116,6 +117,16 @@ type TrackedRequestErrorFeedback interface {
 	SubmitError(err error)
 }
 
+type OutboundECHStatus struct {
+	Enabled    bool
+	Accepted   bool
+	ServerName string
+}
+
+type TrackedECHFeedback interface {
+	SubmitECHStatus(status OutboundECHStatus)
+}
+
 func SubmitOutboundErrorToOriginator(ctx context.Context, err error) {
 	if errorTracker := ctx.Value(trackedConnectionErrorKey); errorTracker != nil {
 		errorTracker := errorTracker.(TrackedRequestErrorFeedback)
@@ -123,8 +134,19 @@ func SubmitOutboundErrorToOriginator(ctx context.Context, err error) {
 	}
 }
 
+func SubmitOutboundECHStatusToOriginator(ctx context.Context, status OutboundECHStatus) {
+	if echTracker := ctx.Value(trackedECHStatusKey); echTracker != nil {
+		echTracker := echTracker.(TrackedECHFeedback)
+		echTracker.SubmitECHStatus(status)
+	}
+}
+
 func TrackedConnectionError(ctx context.Context, tracker TrackedRequestErrorFeedback) context.Context {
 	return context.WithValue(ctx, trackedConnectionErrorKey, tracker)
+}
+
+func TrackedOutboundECHStatus(ctx context.Context, tracker TrackedECHFeedback) context.Context {
+	return context.WithValue(ctx, trackedECHStatusKey, tracker)
 }
 
 func ContextWithDispatcher(ctx context.Context, dispatcher routing.Dispatcher) context.Context {

--- a/features/extension/observatory.go
+++ b/features/extension/observatory.go
@@ -13,6 +13,18 @@ type Observatory interface {
 	GetObservation(ctx context.Context) (proto.Message, error)
 }
 
+type ECHStatus struct {
+	Enabled      bool
+	Accepted     bool
+	ServerName   string
+	LastTryTime  int64
+	LastSeenTime int64
+}
+
+type ECHStatusProvider interface {
+	GetOutboundECHStatus(ctx context.Context) (map[string]ECHStatus, error)
+}
+
 type BurstObservatory interface {
 	Observatory
 	Check(tag []string)

--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -279,8 +279,8 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 
 	switch c.Mode {
 	case "":
-		c.Mode = "auto"
-	case "auto", "packet-up", "stream-up", "stream-one":
+		c.Mode = splithttp.ModeAuto
+	case splithttp.ModeAuto, splithttp.ModePacketUp, splithttp.ModeStreamUp, splithttp.ModeStreamOne, splithttp.ModeMasque:
 	default:
 		return nil, errors.New("unsupported mode: " + c.Mode)
 	}
@@ -325,7 +325,7 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 		c.UplinkDataPlacement = splithttp.PlacementAuto
 	case splithttp.PlacementAuto, splithttp.PlacementBody:
 	case splithttp.PlacementCookie, splithttp.PlacementHeader:
-		if c.Mode != "packet-up" {
+		if c.Mode != splithttp.ModePacketUp {
 			return nil, errors.New("UplinkDataPlacement can be " + c.UplinkDataPlacement + " only in packet-up mode")
 		}
 	default:
@@ -337,7 +337,7 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 	}
 	c.UplinkHTTPMethod = strings.ToUpper(c.UplinkHTTPMethod)
 
-	if c.UplinkHTTPMethod == "GET" && c.Mode != "packet-up" {
+	if c.UplinkHTTPMethod == "GET" && c.Mode != splithttp.ModePacketUp {
 		return nil, errors.New("uplinkHTTPMethod can be GET only in packet-up mode")
 	}
 
@@ -437,8 +437,8 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 	}
 
 	if c.DownloadSettings != nil {
-		if c.Mode == "stream-one" {
-			return nil, errors.New(`Can not use "downloadSettings" in "stream-one" mode.`)
+		if c.Mode == splithttp.ModeStreamOne || c.Mode == splithttp.ModeMasque {
+			return nil, errors.New(`Can not use "downloadSettings" in "stream-one" or "masque" mode.`)
 		}
 		var err error
 		if config.DownloadSettings, err = c.DownloadSettings.Build(); err != nil {

--- a/infra/conf/transport_test.go
+++ b/infra/conf/transport_test.go
@@ -2,10 +2,12 @@ package conf_test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	. "github.com/xtls/xray-core/infra/conf"
 	"github.com/xtls/xray-core/transport/internet"
+	"github.com/xtls/xray-core/transport/internet/splithttp"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -154,5 +156,43 @@ func TestSocketConfig(t *testing.T) {
 	})
 	if expectedOutput.ParseTFOValue() != -1 {
 		t.Fatalf("unexpected parsed TFO value, which should be -1")
+	}
+}
+
+func TestSplitHTTPMasqueModeBuild(t *testing.T) {
+	config := &SplitHTTPConfig{
+		Path: "/sh",
+		Mode: splithttp.ModeMasque,
+	}
+
+	msg, err := config.Build()
+	if err != nil {
+		t.Fatalf("unexpected build error: %v", err)
+	}
+
+	built, ok := msg.(*splithttp.Config)
+	if !ok {
+		t.Fatalf("unexpected config type %T", msg)
+	}
+	if built.Mode != splithttp.ModeMasque {
+		t.Fatalf("expected mode %q, got %q", splithttp.ModeMasque, built.Mode)
+	}
+}
+
+func TestSplitHTTPMasqueModeRejectsDownloadSettings(t *testing.T) {
+	config := &SplitHTTPConfig{
+		Path: "/sh",
+		Mode: splithttp.ModeMasque,
+		DownloadSettings: &StreamConfig{
+			Network: func() *TransportProtocol {
+				protocol := TransportProtocol("tcp")
+				return &protocol
+			}(),
+		},
+	}
+
+	_, err := config.Build()
+	if err == nil || !strings.Contains(err.Error(), `"downloadSettings"`) {
+		t.Fatalf("expected downloadSettings validation error, got %v", err)
 	}
 }

--- a/main/commands/all/api/api.go
+++ b/main/commands/all/api/api.go
@@ -15,6 +15,7 @@ var CmdAPI = &base.Command{
 		cmdGetStats,
 		cmdQueryStats,
 		cmdSysStats,
+		cmdMasqueTelemetry,
 		cmdBalancerInfo,
 		cmdBalancerOverride,
 		cmdAddInbounds,

--- a/main/commands/all/api/balancer_info.go
+++ b/main/commands/all/api/balancer_info.go
@@ -1,22 +1,23 @@
 package api
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
 	routerService "github.com/xtls/xray-core/app/router/command"
+	creflect "github.com/xtls/xray-core/common/reflect"
 	"github.com/xtls/xray-core/main/commands/base"
 )
 
-// TODO: support "-json" flag for json output
 var cmdBalancerInfo = &base.Command{
 	CustomFlags: true,
-	UsageLine:   "{{.Exec}} api bi [--server=127.0.0.1:8080] [balancer]...",
+	UsageLine:   "{{.Exec}} api bi [--server=127.0.0.1:8080] <balancer>...",
 	Short:       "Retrieve balancer information",
 	Long: `
-Retrieve information of specified balancers, including health, strategy and selecting.
-If no balancer tag specified, information for all balancers is returned.
+Retrieve information for one or more balancers, including override target and selectable outbounds.
 
 > Ensure that "RoutingService" is enabled under "config.api.services" in the server configuration.
 
@@ -28,6 +29,9 @@ Arguments:
 	-t, -timeout <seconds>
 		Timeout in seconds for calling API. Default 3
 
+	-json
+		Output JSON. When multiple balancer tags are provided, the result is a JSON array keyed by tag.
+
 Example:
 
     {{.Exec}} {{.LongName}} --server=127.0.0.1:8080 balancer1 balancer2
@@ -35,35 +39,109 @@ Example:
 	Run: executeBalancerInfo,
 }
 
+type balancerInfoResult struct {
+	Tag      string                     `json:"tag,omitempty"`
+	Balancer *routerService.BalancerMsg `json:"balancer,omitempty"`
+}
+
 func executeBalancerInfo(cmd *base.Command, args []string) {
 	setSharedFlags(cmd)
 	cmd.Flag.Parse(args)
-	unnamedArgs := cmd.Flag.Args()
-	if len(unnamedArgs) == 0 {
-		fmt.Println("set balancer tag")
-		unnamedArgs = []string{""}
+	tags, err := resolveBalancerInfoTags(cmd.Flag.Args())
+	if err != nil {
+		base.Fatalf("%s", err)
 	}
 
 	conn, ctx, close := dialAPIServer()
 	defer close()
+
 	client := routerService.NewRoutingServiceClient(conn)
-	r := &routerService.GetBalancerInfoRequest{Tag: unnamedArgs[0]}
-	resp, err := client.GetBalancerInfo(ctx, r)
+	results, err := fetchBalancerInfoResults(ctx, client, tags)
 	if err != nil {
-		base.Fatalf("failed to get health information: %s", err)
+		base.Fatalf("%s", err)
 	}
 
 	if apiJSON {
-		showJSONResponse(resp)
+		output, err := renderBalancerInfoJSON(results)
+		if err != nil {
+			base.Fatalf("%s", err)
+		}
+		os.Stdout.WriteString(output)
 		return
 	}
 
-	showBalancerInfo(resp.Balancer)
-
+	os.Stdout.WriteString(renderBalancerInfoResults(results))
 }
 
-func showBalancerInfo(b *routerService.BalancerMsg) {
+func resolveBalancerInfoTags(args []string) ([]string, error) {
+	if len(args) == 0 {
+		return nil, errors.New("balancer tag not specified")
+	}
+	return args, nil
+}
+
+func fetchBalancerInfoResults(ctx context.Context, client routerService.RoutingServiceClient, tags []string) ([]balancerInfoResult, error) {
+	results := make([]balancerInfoResult, 0, len(tags))
+	for _, tag := range tags {
+		resp, err := client.GetBalancerInfo(ctx, &routerService.GetBalancerInfoRequest{Tag: tag})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get balancer information for %q: %w", tag, err)
+		}
+		results = append(results, balancerInfoResult{
+			Tag:      tag,
+			Balancer: resp.GetBalancer(),
+		})
+	}
+	return results, nil
+}
+
+func renderBalancerInfoResults(results []balancerInfoResult) string {
+	if len(results) == 0 {
+		return ""
+	}
+
+	if len(results) == 1 {
+		return formatBalancerInfo(results[0].Balancer)
+	}
+
+	sb := new(strings.Builder)
+	for i, result := range results {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(result.Tag)
+		sb.WriteString(":\n")
+		sb.WriteString(formatBalancerInfo(result.Balancer))
+	}
+	return sb.String()
+}
+
+func renderBalancerInfoJSON(results []balancerInfoResult) (string, error) {
+	if len(results) == 0 {
+		return "", nil
+	}
+
+	if len(results) == 1 {
+		if j, ok := creflect.MarshalToJson(&routerService.GetBalancerInfoResponse{
+			Balancer: results[0].Balancer,
+		}, true); ok {
+			return j, nil
+		}
+		return "", errors.New("error encode json")
+	}
+
+	if j, ok := creflect.MarshalToJson(results, true); ok {
+		return j, nil
+	}
+
+	return "", errors.New("error encode json")
+}
+
+func formatBalancerInfo(b *routerService.BalancerMsg) string {
 	const tableIndent = 4
+	if b == nil {
+		return ""
+	}
 	sb := new(strings.Builder)
 	// Override
 	if b.Override != nil {
@@ -79,7 +157,7 @@ func showBalancerInfo(b *routerService.BalancerMsg) {
 			writeRow(sb, tableIndent, i+1, []string{o}, nil)
 		}
 	}
-	os.Stdout.WriteString(sb.String())
+	return sb.String()
 }
 
 func getColumnFormats(titles []string) []string {

--- a/main/commands/all/api/balancer_override.go
+++ b/main/commands/all/api/balancer_override.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"errors"
+
 	routerService "github.com/xtls/xray-core/app/router/command"
 	"github.com/xtls/xray-core/main/commands/base"
 )
@@ -25,6 +27,9 @@ Arguments:
 
 	-t, -timeout <seconds>
 		Timeout in seconds for calling API. Default 3
+
+	-b, -balancer <tag>
+		The balancer tag to override.
 
 	-r, -remove
 		Remove the existing override.
@@ -53,21 +58,40 @@ func executeBalancerOverride(cmd *base.Command, args []string) {
 		base.Fatalf("balancer tag not specified")
 	}
 
+	target, err := resolveBalancerOverrideTarget(cmd.Flag.Args(), remove)
+	if err != nil {
+		base.Fatalf("%s", err)
+	}
+
 	conn, ctx, close := dialAPIServer()
 	defer close()
 
 	client := routerService.NewRoutingServiceClient(conn)
-	target := ""
-	if !remove {
-		target = cmd.Flag.Args()[0]
-	}
 	r := &routerService.OverrideBalancerTargetRequest{
 		BalancerTag: balancer,
 		Target:      target,
 	}
 
-	_, err := client.OverrideBalancerTarget(ctx, r)
+	_, err = client.OverrideBalancerTarget(ctx, r)
 	if err != nil {
-		base.Fatalf("failed to perform balancer health checks: %s", err)
+		base.Fatalf("failed to override balancer target: %s", err)
 	}
+}
+
+func resolveBalancerOverrideTarget(args []string, remove bool) (string, error) {
+	if remove {
+		if len(args) > 0 {
+			return "", errors.New("outbound tag is not allowed with -remove")
+		}
+		return "", nil
+	}
+
+	if len(args) == 0 {
+		return "", errors.New("outbound tag not specified")
+	}
+	if len(args) > 1 {
+		return "", errors.New("too many outbound tags specified")
+	}
+
+	return args[0], nil
 }

--- a/main/commands/all/api/balancer_test.go
+++ b/main/commands/all/api/balancer_test.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	routerService "github.com/xtls/xray-core/app/router/command"
+)
+
+func TestResolveBalancerInfoTags(t *testing.T) {
+	tags, err := resolveBalancerInfoTags([]string{"balancer-a", "balancer-b"})
+	if err != nil {
+		t.Fatalf("resolveBalancerInfoTags returned error: %v", err)
+	}
+
+	if len(tags) != 2 || tags[0] != "balancer-a" || tags[1] != "balancer-b" {
+		t.Fatalf("unexpected tags: %#v", tags)
+	}
+}
+
+func TestResolveBalancerInfoTagsRequiresArgument(t *testing.T) {
+	if _, err := resolveBalancerInfoTags(nil); err == nil {
+		t.Fatal("expected an error for empty balancer tag list")
+	}
+}
+
+func TestResolveBalancerOverrideTarget(t *testing.T) {
+	target, err := resolveBalancerOverrideTarget([]string{"direct"}, false)
+	if err != nil {
+		t.Fatalf("resolveBalancerOverrideTarget returned error: %v", err)
+	}
+	if target != "direct" {
+		t.Fatalf("unexpected target: %q", target)
+	}
+}
+
+func TestResolveBalancerOverrideTargetRemoveMode(t *testing.T) {
+	target, err := resolveBalancerOverrideTarget(nil, true)
+	if err != nil {
+		t.Fatalf("resolveBalancerOverrideTarget returned error: %v", err)
+	}
+	if target != "" {
+		t.Fatalf("unexpected target in remove mode: %q", target)
+	}
+}
+
+func TestResolveBalancerOverrideTargetRejectsInvalidArgs(t *testing.T) {
+	testCases := []struct {
+		name   string
+		args   []string
+		remove bool
+	}{
+		{name: "missing target", args: nil},
+		{name: "extra targets", args: []string{"direct", "backup"}},
+		{name: "remove with target", args: []string{"direct"}, remove: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if _, err := resolveBalancerOverrideTarget(testCase.args, testCase.remove); err == nil {
+				t.Fatal("expected an error")
+			}
+		})
+	}
+}
+
+func TestRenderBalancerInfoResultsWithMultipleTags(t *testing.T) {
+	output := renderBalancerInfoResults([]balancerInfoResult{
+		{
+			Tag: "balancer-a",
+			Balancer: &routerService.BalancerMsg{
+				Override:        &routerService.OverrideInfo{Target: "direct"},
+				PrincipleTarget: &routerService.PrincipleTargetInfo{Tag: []string{"direct", "proxy"}},
+			},
+		},
+		{
+			Tag: "balancer-b",
+			Balancer: &routerService.BalancerMsg{
+				PrincipleTarget: &routerService.PrincipleTargetInfo{Tag: []string{"backup"}},
+			},
+		},
+	})
+
+	for _, expected := range []string{
+		"balancer-a:",
+		"balancer-b:",
+		"Selecting Override:",
+		"direct",
+		"proxy",
+		"backup",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("output %q does not contain %q", output, expected)
+		}
+	}
+}
+
+func TestRenderBalancerInfoJSONWithMultipleTags(t *testing.T) {
+	output, err := renderBalancerInfoJSON([]balancerInfoResult{
+		{
+			Tag: "balancer-a",
+			Balancer: &routerService.BalancerMsg{
+				Override: &routerService.OverrideInfo{Target: "direct"},
+			},
+		},
+		{
+			Tag: "balancer-b",
+			Balancer: &routerService.BalancerMsg{
+				PrincipleTarget: &routerService.PrincipleTargetInfo{Tag: []string{"proxy"}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("renderBalancerInfoJSON returned error: %v", err)
+	}
+
+	for _, expected := range []string{
+		"\"tag\": \"balancer-a\"",
+		"\"tag\": \"balancer-b\"",
+		"\"balancer\":",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("output %q does not contain %q", output, expected)
+		}
+	}
+}

--- a/main/commands/all/api/masque_telemetry.go
+++ b/main/commands/all/api/masque_telemetry.go
@@ -1,0 +1,473 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/xtls/xray-core/main/commands/base"
+)
+
+var cmdMasqueTelemetry = &base.Command{
+	CustomFlags: true,
+	UsageLine:   "{{.Exec}} api masque [--server=127.0.0.1:8080] [-tag outboundTag]",
+	Short:       "Retrieve MASQUE telemetry",
+	Long: `
+Retrieve MASQUE transport telemetry from the metrics endpoint.
+
+> Ensure that the metrics server is enabled and reachable. The command reads "/debug/vars" and extracts the "masque" section.
+
+Arguments:
+
+	-s, -server <server:port|url>
+		The metrics HTTP server address. Default 127.0.0.1:8080
+		You may also pass a full URL such as http://127.0.0.1:8080/debug/vars
+
+	-t, -timeout <seconds>
+		Timeout in seconds for fetching telemetry. Default 3
+
+	-json
+		Output JSON.
+
+	-tag <outboundTag>
+		Show only one outbound telemetry bucket.
+
+	-only <healthy|degraded|fallback-heavy|idle>
+		Show only outbound buckets with the selected verdict.
+
+	-sort <name|score|fallback|read-fallback|write-fallback|requested|datagram-read|datagram-write>
+		Sort outbound buckets in text output. Default name.
+
+	-limit <n>
+		Show only the first n outbound buckets after sorting. Default 0 means all.
+
+Example:
+
+	{{.Exec}} {{.LongName}} --server=127.0.0.1:8080
+	{{.Exec}} {{.LongName}} --server=http://127.0.0.1:8080/debug/vars -tag proxy-a
+	{{.Exec}} {{.LongName}} --server=127.0.0.1:8080 -only fallback-heavy -sort score
+	{{.Exec}} {{.LongName}} --server=127.0.0.1:8080 -sort fallback -limit 5
+`,
+	Run: executeMasqueTelemetry,
+}
+
+type masqueTelemetrySnapshot struct {
+	Global   map[string]int64            `json:"global"`
+	Outbound map[string]map[string]int64 `json:"outbound"`
+}
+
+type masqueTelemetryRenderOptions struct {
+	sortMode    string
+	limit       int
+	onlyVerdict string
+}
+
+type masqueOutboundTelemetryEntry struct {
+	Key     string
+	Metrics map[string]int64
+}
+
+const (
+	masqueSortName          = "name"
+	masqueSortScore         = "score"
+	masqueSortFallback      = "fallback"
+	masqueSortReadFallback  = "read-fallback"
+	masqueSortWriteFallback = "write-fallback"
+	masqueSortRequested     = "requested"
+	masqueSortDatagramRead  = "datagram-read"
+	masqueSortDatagramWrite = "datagram-write"
+)
+
+func executeMasqueTelemetry(cmd *base.Command, args []string) {
+	setSharedFlags(cmd)
+	tag := cmd.Flag.String("tag", "", "")
+	onlyVerdict := cmd.Flag.String("only", "", "")
+	sortMode := cmd.Flag.String("sort", masqueSortName, "")
+	limit := cmd.Flag.Int("limit", 0, "")
+	cmd.Flag.Parse(args)
+
+	normalizedOnlyVerdict, err := normalizeMasqueTelemetryOnlyVerdict(*onlyVerdict)
+	if err != nil {
+		base.Fatalf("%s", err)
+	}
+	normalizedSortMode, err := normalizeMasqueTelemetrySortMode(*sortMode)
+	if err != nil {
+		base.Fatalf("%s", err)
+	}
+	if *limit < 0 {
+		base.Fatalf("limit must be >= 0")
+	}
+
+	snapshot, err := fetchMasqueTelemetry(apiServerAddrPtr, time.Duration(apiTimeout)*time.Second)
+	if err != nil {
+		base.Fatalf("%s", err)
+	}
+
+	snapshot, err = filterMasqueTelemetry(snapshot, *tag)
+	if err != nil {
+		base.Fatalf("%s", err)
+	}
+	snapshot = filterMasqueTelemetryByVerdict(snapshot, normalizedOnlyVerdict)
+
+	options := masqueTelemetryRenderOptions{
+		sortMode:    normalizedSortMode,
+		limit:       *limit,
+		onlyVerdict: normalizedOnlyVerdict,
+	}
+	snapshot = limitMasqueTelemetrySnapshot(snapshot, options)
+
+	if apiJSON {
+		output, err := renderMasqueTelemetryJSON(snapshot)
+		if err != nil {
+			base.Fatalf("%s", err)
+		}
+		os.Stdout.WriteString(output)
+		return
+	}
+
+	os.Stdout.WriteString(renderMasqueTelemetryText(snapshot, options))
+}
+
+func fetchMasqueTelemetry(server string, timeout time.Duration) (*masqueTelemetrySnapshot, error) {
+	target, err := resolveMetricsDebugVarsURL(server)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Get(target)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch metrics from %s: %w", target, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected HTTP status code from %s: %d", target, resp.StatusCode)
+	}
+
+	var debugVars map[string]json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&debugVars); err != nil {
+		return nil, fmt.Errorf("failed to decode debug vars from %s: %w", target, err)
+	}
+
+	raw, ok := debugVars["masque"]
+	if !ok {
+		return nil, errors.New(`"masque" telemetry not found in /debug/vars`)
+	}
+
+	var snapshot masqueTelemetrySnapshot
+	if err := json.Unmarshal(raw, &snapshot); err != nil {
+		return nil, fmt.Errorf("failed to decode masque telemetry: %w", err)
+	}
+	if snapshot.Global == nil {
+		snapshot.Global = map[string]int64{}
+	}
+	if snapshot.Outbound == nil {
+		snapshot.Outbound = map[string]map[string]int64{}
+	}
+	return &snapshot, nil
+}
+
+func resolveMetricsDebugVarsURL(server string) (string, error) {
+	target := strings.TrimSpace(server)
+	if target == "" {
+		return "", errors.New("metrics server address not specified")
+	}
+	if !strings.Contains(target, "://") {
+		target = "http://" + target
+	}
+
+	parsed, err := url.Parse(target)
+	if err != nil {
+		return "", fmt.Errorf("invalid metrics server address %q: %w", server, err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("unsupported metrics URL scheme %q", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return "", fmt.Errorf("invalid metrics server address %q", server)
+	}
+	if parsed.Path == "" || parsed.Path == "/" {
+		parsed.Path = "/debug/vars"
+	}
+	return parsed.String(), nil
+}
+
+func filterMasqueTelemetry(snapshot *masqueTelemetrySnapshot, tag string) (*masqueTelemetrySnapshot, error) {
+	if snapshot == nil {
+		return nil, errors.New("nil masque telemetry snapshot")
+	}
+	if tag == "" {
+		return snapshot, nil
+	}
+
+	metrics, ok := snapshot.Outbound[tag]
+	if !ok {
+		return nil, fmt.Errorf("masque telemetry for outbound %q not found", tag)
+	}
+
+	filtered := &masqueTelemetrySnapshot{
+		Global:   snapshot.Global,
+		Outbound: map[string]map[string]int64{tag: metrics},
+	}
+	return filtered, nil
+}
+
+func renderMasqueTelemetryJSON(snapshot *masqueTelemetrySnapshot) (string, error) {
+	if snapshot == nil {
+		return "", nil
+	}
+	output, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to encode masque telemetry as JSON: %w", err)
+	}
+	return string(output) + "\n", nil
+}
+
+func renderMasqueTelemetryText(snapshot *masqueTelemetrySnapshot, options masqueTelemetryRenderOptions) string {
+	if snapshot == nil {
+		return ""
+	}
+
+	sb := new(strings.Builder)
+	writeMasqueTelemetrySection(sb, "Global", snapshot.Global)
+
+	for _, entry := range selectMasqueTelemetryOutbounds(snapshot.Outbound, options) {
+		sb.WriteByte('\n')
+		writeMasqueTelemetrySection(sb, formatMasqueOutboundTitle(entry, options.sortMode), masqueTelemetryDisplayMetrics(entry.Metrics))
+	}
+
+	return sb.String()
+}
+
+func writeMasqueTelemetrySection(sb *strings.Builder, title string, metrics map[string]int64) {
+	sb.WriteString(title)
+	sb.WriteString(":\n")
+	for _, key := range sortedMetricKeys(metrics) {
+		sb.WriteString("  ")
+		sb.WriteString(key)
+		sb.WriteString(": ")
+		sb.WriteString(fmt.Sprintf("%d", metrics[key]))
+		sb.WriteByte('\n')
+	}
+}
+
+func sortedTelemetryKeys(values map[string]map[string]int64) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedMetricKeys(values map[string]int64) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func normalizeMasqueTelemetrySortMode(mode string) (string, error) {
+	normalized := strings.TrimSpace(strings.ToLower(mode))
+	if normalized == "" {
+		return masqueSortName, nil
+	}
+	switch normalized {
+	case masqueSortName,
+		masqueSortScore,
+		masqueSortFallback,
+		masqueSortReadFallback,
+		masqueSortWriteFallback,
+		masqueSortRequested,
+		masqueSortDatagramRead,
+		masqueSortDatagramWrite:
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("unsupported sort mode %q", mode)
+	}
+}
+
+func normalizeMasqueTelemetryOnlyVerdict(verdict string) (string, error) {
+	normalized := strings.TrimSpace(strings.ToLower(verdict))
+	if normalized == "" {
+		return "", nil
+	}
+	switch normalized {
+	case "healthy", "degraded", "fallback-heavy", "idle":
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("unsupported verdict filter %q", verdict)
+	}
+}
+
+func filterMasqueTelemetryByVerdict(snapshot *masqueTelemetrySnapshot, verdict string) *masqueTelemetrySnapshot {
+	if snapshot == nil || verdict == "" {
+		return snapshot
+	}
+
+	filtered := &masqueTelemetrySnapshot{
+		Global:   snapshot.Global,
+		Outbound: map[string]map[string]int64{},
+	}
+	for key, metrics := range snapshot.Outbound {
+		if masqueTelemetryVerdict(metrics) == verdict {
+			filtered.Outbound[key] = metrics
+		}
+	}
+	return filtered
+}
+
+func limitMasqueTelemetrySnapshot(snapshot *masqueTelemetrySnapshot, options masqueTelemetryRenderOptions) *masqueTelemetrySnapshot {
+	if snapshot == nil {
+		return nil
+	}
+	selected := selectMasqueTelemetryOutbounds(snapshot.Outbound, options)
+	outbound := make(map[string]map[string]int64, len(selected))
+	for _, entry := range selected {
+		outbound[entry.Key] = entry.Metrics
+	}
+	return &masqueTelemetrySnapshot{
+		Global:   snapshot.Global,
+		Outbound: outbound,
+	}
+}
+
+func selectMasqueTelemetryOutbounds(values map[string]map[string]int64, options masqueTelemetryRenderOptions) []masqueOutboundTelemetryEntry {
+	entries := make([]masqueOutboundTelemetryEntry, 0, len(values))
+	for key, metrics := range values {
+		entries = append(entries, masqueOutboundTelemetryEntry{
+			Key:     key,
+			Metrics: metrics,
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if options.sortMode == masqueSortName {
+			return entries[i].Key < entries[j].Key
+		}
+		left := masqueTelemetrySortValue(entries[i].Metrics, options.sortMode)
+		right := masqueTelemetrySortValue(entries[j].Metrics, options.sortMode)
+		if left != right {
+			if options.sortMode == masqueSortScore {
+				return left < right
+			}
+			return left > right
+		}
+		return entries[i].Key < entries[j].Key
+	})
+
+	if options.limit > 0 && len(entries) > options.limit {
+		entries = entries[:options.limit]
+	}
+	return entries
+}
+
+func masqueTelemetrySortValue(metrics map[string]int64, sortMode string) int64 {
+	switch sortMode {
+	case masqueSortScore:
+		return masqueTelemetryHealthScore(metrics)
+	case masqueSortFallback:
+		return masqueTelemetryFallbackTotal(metrics)
+	case masqueSortReadFallback:
+		return metrics["read_fallback_sessions"]
+	case masqueSortWriteFallback:
+		return metrics["write_fallback_sessions"]
+	case masqueSortRequested:
+		return metrics["requested_sessions"]
+	case masqueSortDatagramRead:
+		return metrics["datagram_read_packets"]
+	case masqueSortDatagramWrite:
+		return metrics["datagram_write_packets"]
+	default:
+		return 0
+	}
+}
+
+func formatMasqueOutboundTitle(entry masqueOutboundTelemetryEntry, sortMode string) string {
+	verdict := masqueTelemetryVerdict(entry.Metrics)
+	if sortMode == masqueSortName {
+		return fmt.Sprintf("Outbound %s [%s]", entry.Key, verdict)
+	}
+	return fmt.Sprintf("Outbound %s [%s=%d %s]", entry.Key, sortMode, masqueTelemetrySortValue(entry.Metrics, sortMode), verdict)
+}
+
+func masqueTelemetryDisplayMetrics(metrics map[string]int64) map[string]int64 {
+	display := make(map[string]int64, len(metrics)+2)
+	for key, value := range metrics {
+		display[key] = value
+	}
+	display["fallback_total"] = masqueTelemetryFallbackTotal(metrics)
+	display["health_score"] = masqueTelemetryHealthScore(metrics)
+	return display
+}
+
+func masqueTelemetryFallbackTotal(metrics map[string]int64) int64 {
+	return metrics["read_fallback_sessions"] + metrics["write_fallback_sessions"]
+}
+
+func masqueTelemetryHealthScore(metrics map[string]int64) int64 {
+	requested := metrics["requested_sessions"]
+	if requested <= 0 {
+		return 100
+	}
+
+	directionalCapacity := requested * 2
+	fallbackPercent := minInt64(100, masqueTelemetryFallbackTotal(metrics)*100/directionalCapacity)
+	bidirectionalPercent := minInt64(100, metrics["bidirectional_datagram_sessions"]*100/requested)
+	missingBidirectionalPercent := 100 - bidirectionalPercent
+
+	score := int64(100)
+	score -= (fallbackPercent * 80) / 100
+	score -= (missingBidirectionalPercent * 20) / 100
+	return clampInt64(score, 0, 100)
+}
+
+func masqueTelemetryVerdict(metrics map[string]int64) string {
+	requested := metrics["requested_sessions"]
+	if requested <= 0 {
+		return "idle"
+	}
+
+	fallbackTotal := masqueTelemetryFallbackTotal(metrics)
+	directionalCapacity := requested * 2
+	fallbackPercent := int64(0)
+	if directionalCapacity > 0 {
+		fallbackPercent = minInt64(100, fallbackTotal*100/directionalCapacity)
+	}
+
+	score := masqueTelemetryHealthScore(metrics)
+	switch {
+	case fallbackPercent >= 50 || score < 60:
+		return "fallback-heavy"
+	case fallbackTotal > 0 || score < 95:
+		return "degraded"
+	default:
+		return "healthy"
+	}
+}
+
+func minInt64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func clampInt64(v, minValue, maxValue int64) int64 {
+	if v < minValue {
+		return minValue
+	}
+	if v > maxValue {
+		return maxValue
+	}
+	return v
+}

--- a/main/commands/all/api/masque_telemetry_test.go
+++ b/main/commands/all/api/masque_telemetry_test.go
@@ -1,0 +1,376 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeMasqueTelemetrySortMode(t *testing.T) {
+	got, err := normalizeMasqueTelemetrySortMode("score")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != masqueSortScore {
+		t.Fatalf("unexpected sort mode: %q", got)
+	}
+}
+
+func TestNormalizeMasqueTelemetrySortModeRejectsInvalid(t *testing.T) {
+	if _, err := normalizeMasqueTelemetrySortMode("weird"); err == nil {
+		t.Fatal("expected invalid sort mode error")
+	}
+}
+
+func TestNormalizeMasqueTelemetryOnlyVerdict(t *testing.T) {
+	got, err := normalizeMasqueTelemetryOnlyVerdict("fallback-heavy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "fallback-heavy" {
+		t.Fatalf("unexpected verdict filter: %q", got)
+	}
+}
+
+func TestNormalizeMasqueTelemetryOnlyVerdictRejectsInvalid(t *testing.T) {
+	if _, err := normalizeMasqueTelemetryOnlyVerdict("bad"); err == nil {
+		t.Fatal("expected invalid verdict filter error")
+	}
+}
+
+func TestResolveMetricsDebugVarsURLAddsDefaults(t *testing.T) {
+	got, err := resolveMetricsDebugVarsURL("127.0.0.1:8080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "http://127.0.0.1:8080/debug/vars" {
+		t.Fatalf("unexpected url: %q", got)
+	}
+}
+
+func TestResolveMetricsDebugVarsURLPreservesExplicitPath(t *testing.T) {
+	got, err := resolveMetricsDebugVarsURL("https://example.com/custom/vars")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "https://example.com/custom/vars" {
+		t.Fatalf("unexpected url: %q", got)
+	}
+}
+
+func TestFilterMasqueTelemetryByTag(t *testing.T) {
+	snapshot := &masqueTelemetrySnapshot{
+		Global: map[string]int64{
+			"requested_sessions": 2,
+		},
+		Outbound: map[string]map[string]int64{
+			"proxy-a": {"requested_sessions": 1},
+			"proxy-b": {"requested_sessions": 1},
+		},
+	}
+
+	filtered, err := filterMasqueTelemetry(snapshot, "proxy-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered.Outbound) != 1 {
+		t.Fatalf("expected 1 outbound bucket, got %d", len(filtered.Outbound))
+	}
+	if filtered.Outbound["proxy-b"]["requested_sessions"] != 1 {
+		t.Fatalf("unexpected filtered value: %#v", filtered.Outbound["proxy-b"])
+	}
+}
+
+func TestFilterMasqueTelemetryByMissingTagReturnsError(t *testing.T) {
+	snapshot := &masqueTelemetrySnapshot{
+		Global: map[string]int64{},
+		Outbound: map[string]map[string]int64{
+			"proxy-a": {"requested_sessions": 1},
+		},
+	}
+
+	if _, err := filterMasqueTelemetry(snapshot, "missing"); err == nil {
+		t.Fatal("expected missing tag error")
+	}
+}
+
+func TestFilterMasqueTelemetryByVerdict(t *testing.T) {
+	snapshot := &masqueTelemetrySnapshot{
+		Global: map[string]int64{
+			"requested_sessions": 3,
+		},
+		Outbound: map[string]map[string]int64{
+			"healthy-a": {
+				"requested_sessions":              10,
+				"bidirectional_datagram_sessions": 10,
+			},
+			"degraded-a": {
+				"requested_sessions":              10,
+				"bidirectional_datagram_sessions": 9,
+				"read_fallback_sessions":          1,
+			},
+			"fallback-a": {
+				"requested_sessions":              10,
+				"bidirectional_datagram_sessions": 3,
+				"read_fallback_sessions":          4,
+				"write_fallback_sessions":         3,
+			},
+		},
+	}
+
+	degraded := filterMasqueTelemetryByVerdict(snapshot, "degraded")
+	if len(degraded.Outbound) != 1 {
+		t.Fatalf("expected 1 degraded outbound, got %d", len(degraded.Outbound))
+	}
+	if _, ok := degraded.Outbound["degraded-a"]; !ok {
+		t.Fatalf("expected degraded-a, got %#v", degraded.Outbound)
+	}
+
+	fallbackHeavy := filterMasqueTelemetryByVerdict(snapshot, "fallback-heavy")
+	if len(fallbackHeavy.Outbound) != 1 {
+		t.Fatalf("expected 1 fallback-heavy outbound, got %d", len(fallbackHeavy.Outbound))
+	}
+	if _, ok := fallbackHeavy.Outbound["fallback-a"]; !ok {
+		t.Fatalf("expected fallback-a, got %#v", fallbackHeavy.Outbound)
+	}
+}
+
+func TestRenderMasqueTelemetryText(t *testing.T) {
+	output := renderMasqueTelemetryText(&masqueTelemetrySnapshot{
+		Global: map[string]int64{
+			"requested_sessions":              3,
+			"bidirectional_datagram_sessions": 2,
+		},
+		Outbound: map[string]map[string]int64{
+			"proxy-a": {
+				"requested_sessions": 2,
+			},
+			"_unscoped": {
+				"requested_sessions": 1,
+			},
+		},
+	}, masqueTelemetryRenderOptions{sortMode: masqueSortName})
+
+	for _, fragment := range []string{
+		"Global:",
+		"bidirectional_datagram_sessions: 2",
+		"health_score: 80",
+		"fallback_total: 0",
+		"requested_sessions: 3",
+		"Outbound _unscoped [degraded]:",
+		"Outbound proxy-a [degraded]:",
+	} {
+		if !strings.Contains(output, fragment) {
+			t.Fatalf("expected output to contain %q, got:\n%s", fragment, output)
+		}
+	}
+}
+
+func TestMasqueTelemetryHealthScore(t *testing.T) {
+	score := masqueTelemetryHealthScore(map[string]int64{
+		"requested_sessions":              10,
+		"bidirectional_datagram_sessions": 9,
+		"read_fallback_sessions":          1,
+		"write_fallback_sessions":         0,
+	})
+	if score != 94 {
+		t.Fatalf("unexpected health score: %d", score)
+	}
+}
+
+func TestMasqueTelemetryVerdict(t *testing.T) {
+	testCases := []struct {
+		name     string
+		metrics  map[string]int64
+		expected string
+	}{
+		{
+			name: "idle",
+			metrics: map[string]int64{
+				"requested_sessions": 0,
+			},
+			expected: "idle",
+		},
+		{
+			name: "healthy",
+			metrics: map[string]int64{
+				"requested_sessions":              10,
+				"bidirectional_datagram_sessions": 10,
+				"read_fallback_sessions":          0,
+				"write_fallback_sessions":         0,
+			},
+			expected: "healthy",
+		},
+		{
+			name: "degraded",
+			metrics: map[string]int64{
+				"requested_sessions":              10,
+				"bidirectional_datagram_sessions": 9,
+				"read_fallback_sessions":          1,
+				"write_fallback_sessions":         0,
+			},
+			expected: "degraded",
+		},
+		{
+			name: "fallback-heavy",
+			metrics: map[string]int64{
+				"requested_sessions":              10,
+				"bidirectional_datagram_sessions": 3,
+				"read_fallback_sessions":          4,
+				"write_fallback_sessions":         3,
+			},
+			expected: "fallback-heavy",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := masqueTelemetryVerdict(tc.metrics)
+			if got != tc.expected {
+				t.Fatalf("unexpected verdict: got %q want %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestRenderMasqueTelemetryTextSortsByFallbackAndLimits(t *testing.T) {
+	output := renderMasqueTelemetryText(&masqueTelemetrySnapshot{
+		Global: map[string]int64{
+			"requested_sessions": 3,
+		},
+		Outbound: map[string]map[string]int64{
+			"proxy-a": {
+				"requested_sessions":      2,
+				"read_fallback_sessions":  1,
+				"write_fallback_sessions": 0,
+			},
+			"proxy-b": {
+				"requested_sessions":      2,
+				"read_fallback_sessions":  2,
+				"write_fallback_sessions": 1,
+			},
+			"proxy-c": {
+				"requested_sessions":      2,
+				"read_fallback_sessions":  0,
+				"write_fallback_sessions": 0,
+			},
+		},
+	}, masqueTelemetryRenderOptions{
+		sortMode: masqueSortFallback,
+		limit:    2,
+	})
+
+	first := strings.Index(output, "Outbound proxy-b [fallback=3 fallback-heavy]:")
+	second := strings.Index(output, "Outbound proxy-a [fallback=1 degraded]:")
+	third := strings.Index(output, "Outbound proxy-c")
+	if first == -1 || second == -1 {
+		t.Fatalf("expected fallback-sorted output, got:\n%s", output)
+	}
+	if !(first < second) {
+		t.Fatalf("expected proxy-b before proxy-a, got:\n%s", output)
+	}
+	if third != -1 {
+		t.Fatalf("expected limit to exclude proxy-c, got:\n%s", output)
+	}
+}
+
+func TestRenderMasqueTelemetryTextSortsByScoreWorstFirst(t *testing.T) {
+	output := renderMasqueTelemetryText(&masqueTelemetrySnapshot{
+		Global: map[string]int64{
+			"requested_sessions": 3,
+		},
+		Outbound: map[string]map[string]int64{
+			"proxy-a": {
+				"requested_sessions":              10,
+				"bidirectional_datagram_sessions": 9,
+				"read_fallback_sessions":          1,
+				"write_fallback_sessions":         0,
+			},
+			"proxy-b": {
+				"requested_sessions":              10,
+				"bidirectional_datagram_sessions": 3,
+				"read_fallback_sessions":          4,
+				"write_fallback_sessions":         3,
+			},
+			"proxy-c": {
+				"requested_sessions":              10,
+				"bidirectional_datagram_sessions": 10,
+				"read_fallback_sessions":          0,
+				"write_fallback_sessions":         0,
+			},
+		},
+	}, masqueTelemetryRenderOptions{
+		sortMode: masqueSortScore,
+	})
+
+	first := strings.Index(output, "Outbound proxy-b [score=58 fallback-heavy]:")
+	second := strings.Index(output, "Outbound proxy-a [score=94 degraded]:")
+	third := strings.Index(output, "Outbound proxy-c [score=100 healthy]:")
+	if first == -1 || second == -1 || third == -1 {
+		t.Fatalf("expected score-sorted output, got:\n%s", output)
+	}
+	if !(first < second && second < third) {
+		t.Fatalf("expected proxy-b before proxy-a before proxy-c, got:\n%s", output)
+	}
+}
+
+func TestRenderMasqueTelemetryJSON(t *testing.T) {
+	output, err := renderMasqueTelemetryJSON(&masqueTelemetrySnapshot{
+		Global: map[string]int64{
+			"requested_sessions": 1,
+		},
+		Outbound: map[string]map[string]int64{
+			"proxy-a": {
+				"requested_sessions": 1,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, fragment := range []string{
+		"\"global\"",
+		"\"outbound\"",
+		"\"proxy-a\"",
+		"\"requested_sessions\": 1",
+	} {
+		if !strings.Contains(output, fragment) {
+			t.Fatalf("expected json output to contain %q, got:\n%s", fragment, output)
+		}
+	}
+}
+
+func TestLimitMasqueTelemetrySnapshotUsesTopSelection(t *testing.T) {
+	snapshot := limitMasqueTelemetrySnapshot(&masqueTelemetrySnapshot{
+		Global: map[string]int64{
+			"requested_sessions": 3,
+		},
+		Outbound: map[string]map[string]int64{
+			"proxy-a": {
+				"requested_sessions": 1,
+			},
+			"proxy-b": {
+				"requested_sessions": 3,
+			},
+			"proxy-c": {
+				"requested_sessions": 2,
+			},
+		},
+	}, masqueTelemetryRenderOptions{
+		sortMode: masqueSortRequested,
+		limit:    2,
+	})
+
+	if len(snapshot.Outbound) != 2 {
+		t.Fatalf("expected 2 outbound buckets, got %d", len(snapshot.Outbound))
+	}
+	if _, ok := snapshot.Outbound["proxy-b"]; !ok {
+		t.Fatalf("expected proxy-b in limited snapshot: %#v", snapshot.Outbound)
+	}
+	if _, ok := snapshot.Outbound["proxy-c"]; !ok {
+		t.Fatalf("expected proxy-c in limited snapshot: %#v", snapshot.Outbound)
+	}
+	if _, ok := snapshot.Outbound["proxy-a"]; ok {
+		t.Fatalf("did not expect proxy-a in limited snapshot: %#v", snapshot.Outbound)
+	}
+}

--- a/proxy/trojan/client.go
+++ b/proxy/trojan/client.go
@@ -60,7 +60,7 @@ func (c *Client) Process(ctx context.Context, link *transport.Link, dialer inter
 	var conn stat.Connection
 
 	err := retry.ExponentialBackoff(5, 100).On(func() error {
-		rawConn, err := dialer.Dial(ctx, server.Destination)
+		rawConn, err := dialer.Dial(internet.ContextWithTransportDatagrams(ctx, destination.Network == net.Network_UDP), server.Destination)
 		if err != nil {
 			return err
 		}
@@ -109,24 +109,32 @@ func (c *Client) Process(ctx context.Context, link *transport.Link, dialer inter
 
 		var bodyWriter buf.Writer
 		if destination.Network == net.Network_UDP {
-			bodyWriter = &PacketWriter{Writer: connWriter, Target: destination}
+			if _, err = connWriter.Write(nil); err != nil {
+				return err.(*errors.Error).AtWarning()
+			}
+			if err = bufferWriter.SetBuffered(false); err != nil {
+				return errors.New("failed to flush trojan udp header").Base(err).AtWarning()
+			}
+			if err = internet.EnableTransportDatagramWrite(conn); err != nil {
+				return errors.New("failed to enable transport datagram write").Base(err).AtWarning()
+			}
+			bodyWriter = &PacketWriter{Writer: conn, Target: destination}
 		} else {
 			bodyWriter = connWriter
-		}
+			// write some request payload to buffer
+			if err = buf.CopyOnceTimeout(link.Reader, bodyWriter, time.Millisecond*100); err != nil && err != buf.ErrNotTimeoutReader && err != buf.ErrReadTimeout {
+				return errors.New("failed to write A request payload").Base(err).AtWarning()
+			}
 
-		// write some request payload to buffer
-		if err = buf.CopyOnceTimeout(link.Reader, bodyWriter, time.Millisecond*100); err != nil && err != buf.ErrNotTimeoutReader && err != buf.ErrReadTimeout {
-			return errors.New("failed to write A request payload").Base(err).AtWarning()
-		}
+			// Flush; bufferWriter.WriteMultiBuffer now is bufferWriter.writer.WriteMultiBuffer
+			if err = bufferWriter.SetBuffered(false); err != nil {
+				return errors.New("failed to flush payload").Base(err).AtWarning()
+			}
 
-		// Flush; bufferWriter.WriteMultiBuffer now is bufferWriter.writer.WriteMultiBuffer
-		if err = bufferWriter.SetBuffered(false); err != nil {
-			return errors.New("failed to flush payload").Base(err).AtWarning()
-		}
-
-		// Send header if not sent yet
-		if _, err = connWriter.Write([]byte{}); err != nil {
-			return err.(*errors.Error).AtWarning()
+			// Send header if not sent yet
+			if _, err = connWriter.Write([]byte{}); err != nil {
+				return err.(*errors.Error).AtWarning()
+			}
 		}
 
 		if err = buf.Copy(link.Reader, bodyWriter, buf.UpdateActivity(timer)); err != nil {
@@ -141,6 +149,9 @@ func (c *Client) Process(ctx context.Context, link *transport.Link, dialer inter
 
 		var reader buf.Reader
 		if network == net.Network_UDP {
+			if err := internet.EnableTransportDatagramRead(conn); err != nil {
+				return errors.New("failed to enable transport datagram read").Base(err).AtWarning()
+			}
 			reader = &PacketReader{
 				Reader: conn,
 			}

--- a/proxy/trojan/server.go
+++ b/proxy/trojan/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/xtls/xray-core/core"
 	"github.com/xtls/xray-core/features/policy"
 	"github.com/xtls/xray-core/features/routing"
+	"github.com/xtls/xray-core/transport/internet"
 	"github.com/xtls/xray-core/transport/internet/reality"
 	"github.com/xtls/xray-core/transport/internet/stat"
 	"github.com/xtls/xray-core/transport/internet/tls"
@@ -229,6 +230,12 @@ func (s *Server) Process(ctx context.Context, network net.Network, conn stat.Con
 	sessionPolicy = s.policyManager.ForLevel(user.Level)
 
 	if destination.Network == net.Network_UDP { // handle udp request
+		if err := internet.EnableTransportDatagramRead(conn); err != nil {
+			return errors.New("failed to enable transport datagram read").Base(err).AtWarning()
+		}
+		if err := internet.EnableTransportDatagramWrite(conn); err != nil {
+			return errors.New("failed to enable transport datagram write").Base(err).AtWarning()
+		}
 		return s.handleUDPPayload(ctx, sessionPolicy, &PacketReader{Reader: clientReader}, &PacketWriter{Writer: conn}, dispatcher)
 	}
 

--- a/proxy/vless/inbound/inbound.go
+++ b/proxy/vless/inbound/inbound.go
@@ -40,6 +40,7 @@ import (
 	"github.com/xtls/xray-core/proxy/vless/encoding"
 	"github.com/xtls/xray-core/proxy/vless/encryption"
 	"github.com/xtls/xray-core/transport"
+	"github.com/xtls/xray-core/transport/internet"
 	"github.com/xtls/xray-core/transport/internet/reality"
 	"github.com/xtls/xray-core/transport/internet/stat"
 	"github.com/xtls/xray-core/transport/internet/tls"
@@ -596,6 +597,8 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection s
 	default:
 		return errors.New("unknown request flow " + requestAddons.Flow).AtWarning()
 	}
+	useTransportDatagrams := requestAddons.Flow != vless.XRV &&
+		(request.Command == protocol.RequestCommandUDP || (request.Command == protocol.RequestCommandMux && !isMuxAndNotXUDP(request, first)))
 
 	if request.Command != protocol.RequestCommandMux {
 		ctx = log.ContextWithAccessMessage(ctx, &log.AccessMessage{
@@ -610,6 +613,11 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection s
 	}
 
 	trafficState := proxy.NewTrafficState(userSentID)
+	if useTransportDatagrams {
+		if err := internet.EnableTransportDatagramRead(connection); err != nil {
+			return errors.New("failed to enable transport datagram read").Base(err).AtWarning()
+		}
+	}
 	clientReader := encoding.DecodeBodyAddons(reader, request, requestAddons)
 	if requestAddons.Flow == vless.XRV {
 		clientReader = proxy.NewVisionReader(clientReader, trafficState, true, ctx, connection, input, rawInput, nil)
@@ -619,8 +627,19 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection s
 	if err := encoding.EncodeResponseHeader(bufferWriter, request, responseAddons); err != nil {
 		return errors.New("failed to encode response header").Base(err).AtWarning()
 	}
-	clientWriter := encoding.EncodeBodyAddons(bufferWriter, request, requestAddons, trafficState, false, ctx, connection, nil)
-	bufferWriter.SetFlushNext()
+	var clientWriter buf.Writer
+	if useTransportDatagrams {
+		if err := bufferWriter.SetBuffered(false); err != nil {
+			return errors.New("failed to flush VLESS UDP response header").Base(err).AtWarning()
+		}
+		if err := internet.EnableTransportDatagramWrite(connection); err != nil {
+			return errors.New("failed to enable transport datagram write").Base(err).AtWarning()
+		}
+		clientWriter = encoding.EncodeBodyAddons(buf.NewWriter(connection), request, requestAddons, trafficState, false, ctx, connection, nil)
+	} else {
+		clientWriter = encoding.EncodeBodyAddons(bufferWriter, request, requestAddons, trafficState, false, ctx, connection, nil)
+		bufferWriter.SetFlushNext()
+	}
 
 	if request.Command == protocol.RequestCommandRvs {
 		r, err := h.GetReverse(account)

--- a/proxy/vless/outbound/outbound.go
+++ b/proxy/vless/outbound/outbound.go
@@ -164,7 +164,7 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 					defer func() { recover() }()
 					ctx := xctx.ContextWithID(context.Background(), session.NewID())
 					for {
-						conn, err := dialer.Dial(ctx, rec.Destination)
+						conn, err := dialer.Dial(internet.ContextWithTransportDatagrams(ctx, ob.Target.Network == net.Network_UDP), rec.Destination)
 						if err != nil {
 							errors.LogWarningInner(ctx, err, "pre-connect failed")
 							continue
@@ -191,7 +191,7 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 	if conn == nil {
 		if err := retry.ExponentialBackoff(5, 200).On(func() error {
 			var err error
-			conn, err = dialer.Dial(ctx, rec.Destination)
+			conn, err = dialer.Dial(internet.ContextWithTransportDatagrams(ctx, ob.Target.Network == net.Network_UDP), rec.Destination)
 			if err != nil {
 				return err
 			}
@@ -293,6 +293,7 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 	default:
 		ob.CanSpliceCopy = 3
 	}
+	useTransportDatagrams := target.Network == net.Network_UDP && requestAddons.Flow != vless.XRV
 
 	var newCtx context.Context
 	var newCancel context.CancelFunc
@@ -326,33 +327,45 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 			return errors.New("failed to encode request header").Base(err).AtWarning()
 		}
 
-		// default: serverWriter := bufferWriter
-		serverWriter := encoding.EncodeBodyAddons(bufferWriter, request, requestAddons, trafficState, true, ctx, conn, ob)
+		var serverWriter buf.Writer
+		if useTransportDatagrams {
+			if err := bufferWriter.SetBuffered(false); err != nil {
+				return errors.New("failed to flush VLESS UDP header").Base(err).AtWarning()
+			}
+			if err := internet.EnableTransportDatagramWrite(conn); err != nil {
+				return errors.New("failed to enable transport datagram write").Base(err).AtWarning()
+			}
+			serverWriter = encoding.EncodeBodyAddons(buf.NewWriter(conn), request, requestAddons, trafficState, true, ctx, conn, ob)
+		} else {
+			serverWriter = encoding.EncodeBodyAddons(bufferWriter, request, requestAddons, trafficState, true, ctx, conn, ob)
+		}
 		if request.Command == protocol.RequestCommandMux && request.Port == 666 {
 			serverWriter = xudp.NewPacketWriter(serverWriter, target, xudp.GetGlobalID(ctx))
 		}
-		timeoutReader, ok := clientReader.(buf.TimeoutReader)
-		if ok {
-			multiBuffer, err1 := timeoutReader.ReadMultiBufferTimeout(time.Millisecond * 500)
-			if err1 == nil {
-				if err := serverWriter.WriteMultiBuffer(multiBuffer); err != nil {
-					return err // ...
+		if !useTransportDatagrams {
+			timeoutReader, ok := clientReader.(buf.TimeoutReader)
+			if ok {
+				multiBuffer, err1 := timeoutReader.ReadMultiBufferTimeout(time.Millisecond * 500)
+				if err1 == nil {
+					if err := serverWriter.WriteMultiBuffer(multiBuffer); err != nil {
+						return err // ...
+					}
+				} else if err1 != buf.ErrReadTimeout {
+					return err1
+				} else if requestAddons.Flow == vless.XRV {
+					mb := make(buf.MultiBuffer, 1)
+					errors.LogInfo(ctx, "Insert padding with empty content to camouflage VLESS header ", mb.Len())
+					if err := serverWriter.WriteMultiBuffer(mb); err != nil {
+						return err // ...
+					}
 				}
-			} else if err1 != buf.ErrReadTimeout {
-				return err1
-			} else if requestAddons.Flow == vless.XRV {
-				mb := make(buf.MultiBuffer, 1)
-				errors.LogInfo(ctx, "Insert padding with empty content to camouflage VLESS header ", mb.Len())
-				if err := serverWriter.WriteMultiBuffer(mb); err != nil {
-					return err // ...
-				}
+			} else {
+				errors.LogDebug(ctx, "Reader is not timeout reader, will send out vless header separately from first payload")
 			}
-		} else {
-			errors.LogDebug(ctx, "Reader is not timeout reader, will send out vless header separately from first payload")
-		}
-		// Flush; bufferWriter.WriteMultiBuffer now is bufferWriter.writer.WriteMultiBuffer
-		if err := bufferWriter.SetBuffered(false); err != nil {
-			return errors.New("failed to write A request payload").Base(err).AtWarning()
+			// Flush; bufferWriter.WriteMultiBuffer now is bufferWriter.writer.WriteMultiBuffer
+			if err := bufferWriter.SetBuffered(false); err != nil {
+				return errors.New("failed to write A request payload").Base(err).AtWarning()
+			}
 		}
 
 		if requestAddons.Flow == vless.XRV {
@@ -385,8 +398,12 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 		if err != nil {
 			return errors.New("failed to decode response header").Base(err).AtInfo()
 		}
+		if useTransportDatagrams {
+			if err := internet.EnableTransportDatagramRead(conn); err != nil {
+				return errors.New("failed to enable transport datagram read").Base(err).AtWarning()
+			}
+		}
 
-		// default: serverReader := buf.NewReader(conn)
 		serverReader := encoding.DecodeBodyAddons(conn, request, responseAddons)
 		if requestAddons.Flow == vless.XRV {
 			serverReader = proxy.NewVisionReader(serverReader, trafficState, false, ctx, conn, input, rawInput, ob)

--- a/proxy/vmess/inbound/inbound.go
+++ b/proxy/vmess/inbound/inbound.go
@@ -23,6 +23,7 @@ import (
 	"github.com/xtls/xray-core/features/routing"
 	"github.com/xtls/xray-core/proxy/vmess"
 	"github.com/xtls/xray-core/proxy/vmess/encoding"
+	"github.com/xtls/xray-core/transport/internet"
 	"github.com/xtls/xray-core/transport/internet/stat"
 )
 
@@ -273,6 +274,7 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection s
 	inbound.User = request.User
 
 	sessionPolicy = h.policyManager.ForLevel(request.User.Level)
+	useTransportDatagrams := request.Command == protocol.RequestCommandUDP
 
 	ctx, cancel := context.WithCancel(ctx)
 	timer := signal.CancelAfterInactivity(ctx, cancel, sessionPolicy.Timeouts.ConnectionIdle)
@@ -286,6 +288,11 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection s
 	requestDone := func() error {
 		defer timer.SetTimeout(sessionPolicy.Timeouts.DownlinkOnly)
 
+		if useTransportDatagrams {
+			if err := internet.EnableTransportDatagramRead(connection); err != nil {
+				return errors.New("failed to enable transport datagram read").Base(err).AtWarning()
+			}
+		}
 		bodyReader, err := svrSession.DecodeRequestBody(request, reader)
 		if err != nil {
 			return errors.New("failed to start decoding").Base(err)
@@ -300,11 +307,28 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection s
 		defer timer.SetTimeout(sessionPolicy.Timeouts.UplinkOnly)
 
 		writer := buf.NewBufferedWriter(buf.NewWriter(connection))
-		defer writer.Flush()
 
 		response := &protocol.ResponseHeader{
 			Command: h.generateCommand(ctx, request),
 		}
+		if useTransportDatagrams {
+			svrSession.EncodeResponseHeader(response, writer)
+			if err := writer.SetBuffered(false); err != nil {
+				return err
+			}
+			if err := internet.EnableTransportDatagramWrite(connection); err != nil {
+				return errors.New("failed to enable transport datagram write").Base(err).AtWarning()
+			}
+			bodyWriter, err := svrSession.EncodeResponseBody(request, connection)
+			if err != nil {
+				return errors.New("failed to start encoding response").Base(err)
+			}
+			if response.Command != nil {
+				return errors.New("transport datagrams do not support VMess response commands").AtWarning()
+			}
+			return buf.Copy(link.Reader, bodyWriter, buf.UpdateActivity(timer))
+		}
+		defer writer.Flush()
 		return transferResponse(timer, svrSession, request, response, link.Reader, writer)
 	}
 

--- a/proxy/vmess/outbound/outbound.go
+++ b/proxy/vmess/outbound/outbound.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"hash/crc64"
+	"io"
 	"time"
 
 	"github.com/xtls/xray-core/common"
@@ -68,7 +69,7 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 	var conn stat.Connection
 
 	err := retry.ExponentialBackoff(5, 200).On(func() error {
-		rawConn, err := dialer.Dial(ctx, rec.Destination)
+		rawConn, err := dialer.Dial(internet.ContextWithTransportDatagrams(ctx, ob.Target.Network == net.Network_UDP), rec.Destination)
 		if err != nil {
 			return err
 		}
@@ -153,6 +154,7 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 		request.Address = net.DomainAddress("v1.mux.cool")
 		request.Port = net.Port(666)
 	}
+	useTransportDatagrams := target.Network == net.Network_UDP
 
 	requestDone := func() error {
 		defer timer.SetTimeout(sessionPolicy.Timeouts.DownlinkOnly)
@@ -162,7 +164,17 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 			return errors.New("failed to encode request").Base(err).AtWarning()
 		}
 
-		bodyWriter, err := session.EncodeRequestBody(request, writer)
+		var bodyWriterTarget io.Writer = writer
+		if useTransportDatagrams {
+			if err := writer.SetBuffered(false); err != nil {
+				return errors.New("failed to flush VMess UDP header").Base(err).AtWarning()
+			}
+			if err := internet.EnableTransportDatagramWrite(conn); err != nil {
+				return errors.New("failed to enable transport datagram write").Base(err).AtWarning()
+			}
+			bodyWriterTarget = conn
+		}
+		bodyWriter, err := session.EncodeRequestBody(request, bodyWriterTarget)
 		if err != nil {
 			return errors.New("failed to start encoding").Base(err)
 		}
@@ -170,12 +182,14 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 		if request.Command == protocol.RequestCommandMux && request.Port == 666 {
 			bodyWriter = xudp.NewPacketWriter(bodyWriter, target, xudp.GetGlobalID(ctx))
 		}
-		if err := buf.CopyOnceTimeout(input, bodyWriter, time.Millisecond*100); err != nil && err != buf.ErrNotTimeoutReader && err != buf.ErrReadTimeout {
-			return errors.New("failed to write first payload").Base(err)
-		}
+		if !useTransportDatagrams {
+			if err := buf.CopyOnceTimeout(input, bodyWriter, time.Millisecond*100); err != nil && err != buf.ErrNotTimeoutReader && err != buf.ErrReadTimeout {
+				return errors.New("failed to write first payload").Base(err)
+			}
 
-		if err := writer.SetBuffered(false); err != nil {
-			return err
+			if err := writer.SetBuffered(false); err != nil {
+				return err
+			}
 		}
 
 		if err := buf.Copy(input, bodyWriter, buf.UpdateActivity(timer)); err != nil {
@@ -200,6 +214,11 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 			return errors.New("failed to read header").Base(err)
 		}
 		h.handleCommand(rec.Destination, header.Command)
+		if useTransportDatagrams {
+			if err := internet.EnableTransportDatagramRead(conn); err != nil {
+				return errors.New("failed to enable transport datagram read").Base(err).AtWarning()
+			}
+		}
 
 		bodyReader, err := session.DecodeResponseBody(request, reader)
 		if err != nil {

--- a/transport/internet/datagram.go
+++ b/transport/internet/datagram.go
@@ -1,0 +1,50 @@
+package internet
+
+import (
+	"context"
+	"net"
+
+	"github.com/xtls/xray-core/transport/internet/stat"
+)
+
+type transportDatagramContextKey struct{}
+
+// TransportDatagramConn is an optional transport capability that allows
+// protocols to switch payload I/O from stream frames to transport datagrams
+// after their own headers were exchanged on the stream.
+type TransportDatagramConn interface {
+	EnableTransportDatagramRead() error
+	EnableTransportDatagramWrite() error
+}
+
+func ContextWithTransportDatagrams(ctx context.Context, enable bool) context.Context {
+	if !enable {
+		return ctx
+	}
+	return context.WithValue(ctx, transportDatagramContextKey{}, struct{}{})
+}
+
+func WantTransportDatagrams(ctx context.Context) bool {
+	_, ok := ctx.Value(transportDatagramContextKey{}).(struct{})
+	return ok
+}
+
+func EnableTransportDatagramRead(conn net.Conn) error {
+	if conn == nil {
+		return nil
+	}
+	if dc, ok := stat.TryUnwrapStatsConn(conn).(TransportDatagramConn); ok {
+		return dc.EnableTransportDatagramRead()
+	}
+	return nil
+}
+
+func EnableTransportDatagramWrite(conn net.Conn) error {
+	if conn == nil {
+		return nil
+	}
+	if dc, ok := stat.TryUnwrapStatsConn(conn).(TransportDatagramConn); ok {
+		return dc.EnableTransportDatagramWrite()
+	}
+	return nil
+}

--- a/transport/internet/splithttp/client.go
+++ b/transport/internet/splithttp/client.go
@@ -56,7 +56,9 @@ func (c *DefaultDialerClient) OpenStream(ctx context.Context, url string, sessio
 	})
 
 	method := "GET" // stream-down
-	if body != nil {
+	if c.transportConfig.IsMASQUEMode() {
+		method = http.MethodConnect
+	} else if body != nil {
 		method = c.transportConfig.GetNormalizedUplinkHTTPMethod() // stream-up/one
 	}
 	req, _ := http.NewRequestWithContext(context.WithoutCancel(ctx), method, url, body)

--- a/transport/internet/splithttp/common.go
+++ b/transport/internet/splithttp/common.go
@@ -1,6 +1,15 @@
 package splithttp
 
 const (
+	ModeAuto      = "auto"
+	ModePacketUp  = "packet-up"
+	ModeStreamUp  = "stream-up"
+	ModeStreamOne = "stream-one"
+	ModeMasque    = "masque"
+
+	MASQUEProtocolConnectUDP = "connect-udp"
+	HeaderCapsuleProtocol    = "Capsule-Protocol"
+
 	PlacementQueryInHeader = "queryInHeader"
 	PlacementCookie        = "cookie"
 	PlacementHeader        = "header"

--- a/transport/internet/splithttp/config.go
+++ b/transport/internet/splithttp/config.go
@@ -29,6 +29,18 @@ func (c *Config) GetNormalizedPath() string {
 	return path
 }
 
+func (c *Config) GetNormalizedMode() string {
+	if c.Mode == "" {
+		return ModeAuto
+	}
+
+	return c.Mode
+}
+
+func (c *Config) IsMASQUEMode() bool {
+	return c.GetNormalizedMode() == ModeMasque
+}
+
 func (c *Config) GetNormalizedQuery() string {
 	pathAndQuery := strings.SplitN(c.Path, "?", 2)
 	query := ""
@@ -51,6 +63,12 @@ func (c *Config) GetRequestHeader() http.Header {
 	header := http.Header{}
 	for k, v := range c.Headers {
 		header.Add(k, v)
+	}
+	if c.IsMASQUEMode() {
+		if header.Get("Accept") == "" {
+			header.Set("Accept", "*/*")
+		}
+		return header
 	}
 	utils.TryDefaultHeadersWith(header, "fetch")
 	return header
@@ -316,6 +334,17 @@ func (c *Config) FillStreamRequest(request *http.Request, sessionId string, seqS
 
 	c.ApplyXPaddingToRequest(request, config)
 	c.ApplyMetaToRequest(request, sessionId, "")
+
+	if c.IsMASQUEMode() {
+		request.Method = http.MethodConnect
+		request.Proto = MASQUEProtocolConnectUDP
+		request.ProtoMajor = 3
+		request.ProtoMinor = 0
+		if request.Header.Get(HeaderCapsuleProtocol) == "" {
+			request.Header.Set(HeaderCapsuleProtocol, "?1")
+		}
+		return
+	}
 
 	if request.Body != nil && !c.NoGRPCHeader { // stream-up/one
 		request.Header.Set("Content-Type", "application/grpc")

--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -5,11 +5,9 @@ import (
 	gotls "crypto/tls"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"net/http/httptrace"
 	"net/url"
-	reflect "reflect"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -25,8 +23,6 @@ import (
 	"github.com/xtls/xray-core/common/uuid"
 	"github.com/xtls/xray-core/transport/internet"
 	"github.com/xtls/xray-core/transport/internet/browser_dialer"
-	"github.com/xtls/xray-core/transport/internet/hysteria/congestion"
-	"github.com/xtls/xray-core/transport/internet/hysteria/udphop"
 	"github.com/xtls/xray-core/transport/internet/reality"
 	"github.com/xtls/xray-core/transport/internet/stat"
 	"github.com/xtls/xray-core/transport/internet/tls"
@@ -46,9 +42,10 @@ var (
 
 func getHTTPClient(ctx context.Context, dest net.Destination, streamSettings *internet.MemoryStreamConfig) (DialerClient, *XmuxClient) {
 	realityConfig := reality.ConfigFromStreamSettings(streamSettings)
+	transportConfig := streamSettings.ProtocolSettings.(*Config)
 
-	if browser_dialer.HasBrowserDialer() && realityConfig == nil {
-		return &BrowserDialerClient{transportConfig: streamSettings.ProtocolSettings.(*Config)}, nil
+	if browser_dialer.HasBrowserDialer() && realityConfig == nil && !transportConfig.IsMASQUEMode() {
+		return &BrowserDialerClient{transportConfig: transportConfig}, nil
 	}
 
 	globalDialerAccess.Lock()
@@ -63,7 +60,6 @@ func getHTTPClient(ctx context.Context, dest net.Destination, streamSettings *in
 	xmuxManager, found := globalDialerMap[key]
 
 	if !found {
-		transportConfig := streamSettings.ProtocolSettings.(*Config)
 		var xmuxConfig XmuxConfig
 		if transportConfig.Xmux != nil {
 			xmuxConfig = *transportConfig.Xmux
@@ -156,147 +152,14 @@ func createHTTPClient(dest net.Destination, streamSettings *internet.MemoryStrea
 	var transport http.RoundTripper
 
 	if httpVersion == "3" {
-		quicParams := streamSettings.QuicParams
-		if quicParams == nil {
-			quicParams = &internet.QuicParams{}
-		}
-		if quicParams.UdpHop == nil {
-			quicParams.UdpHop = &internet.UdpHop{}
-		}
-
-		quicConfig := &quic.Config{
-			InitialStreamReceiveWindow:     quicParams.InitStreamReceiveWindow,
-			MaxStreamReceiveWindow:         quicParams.MaxStreamReceiveWindow,
-			InitialConnectionReceiveWindow: quicParams.InitConnReceiveWindow,
-			MaxConnectionReceiveWindow:     quicParams.MaxConnReceiveWindow,
-			MaxIdleTimeout:                 time.Duration(quicParams.MaxIdleTimeout) * time.Second,
-			KeepAlivePeriod:                time.Duration(quicParams.KeepAlivePeriod) * time.Second,
-			MaxIncomingStreams:             quicParams.MaxIncomingStreams,
-			DisablePathMTUDiscovery:        quicParams.DisablePathMtuDiscovery,
-		}
-		if quicParams.MaxIdleTimeout == 0 {
-			quicConfig.MaxIdleTimeout = net.ConnIdleTimeout
-		}
-		if quicParams.KeepAlivePeriod == 0 {
-			if keepAlivePeriod == 0 {
-				quicConfig.KeepAlivePeriod = net.QuicgoH3KeepAlivePeriod
-			}
-		}
-		if quicParams.MaxIncomingStreams == 0 {
-			// these two are defaults of quic-go/http3. the default of quic-go (no
-			// http3) is different, so it is hardcoded here for clarity.
-			// https://github.com/quic-go/quic-go/blob/b8ea5c798155950fb5bbfdd06cad1939c9355878/http3/client.go#L36-L39
-			quicConfig.MaxIncomingStreams = -1
-		}
+		quicConfig := newH3QUICConfig(streamSettings, keepAlivePeriod, transportConfig.IsMASQUEMode())
 
 		transport = &http3.Transport{
 			QUICConfig:      quicConfig,
 			TLSClientConfig: gotlsConfig,
+			EnableDatagrams: transportConfig.IsMASQUEMode(),
 			Dial: func(ctx context.Context, addr string, tlsCfg *gotls.Config, cfg *quic.Config) (*quic.Conn, error) {
-				udphopDialer := func(addr *net.UDPAddr) (net.PacketConn, error) {
-					conn, err := internet.DialSystem(ctx, net.UDPDestination(net.IPAddress(addr.IP), net.Port(addr.Port)), streamSettings.SocketSettings)
-					if err != nil {
-						errors.LogDebug(context.Background(), "skip hop: failed to dial to dest")
-						conn.Close()
-						return nil, errors.New()
-					}
-
-					var udpConn net.PacketConn
-
-					switch c := conn.(type) {
-					case *internet.PacketConnWrapper:
-						udpConn = c.PacketConn
-					case *net.UDPConn:
-						udpConn = c
-					default:
-						errors.LogDebug(context.Background(), "skip hop: udphop requires being at the outermost level ", reflect.TypeOf(c))
-						conn.Close()
-						return nil, errors.New()
-					}
-
-					return udpConn, nil
-				}
-
-				var index int
-				if len(quicParams.UdpHop.Ports) > 0 {
-					index = rand.Intn(len(quicParams.UdpHop.Ports))
-					dest.Port = net.Port(quicParams.UdpHop.Ports[index])
-				}
-
-				conn, err := internet.DialSystem(ctx, dest, streamSettings.SocketSettings)
-				if err != nil {
-					return nil, err
-				}
-
-				var udpConn net.PacketConn
-				var udpAddr *net.UDPAddr
-
-				switch c := conn.(type) {
-				case *internet.PacketConnWrapper:
-					udpConn = c.PacketConn
-					udpAddr, err = net.ResolveUDPAddr("udp", c.Dest.String())
-					if err != nil {
-						conn.Close()
-						return nil, err
-					}
-				case *net.UDPConn:
-					udpConn = c
-					udpAddr, err = net.ResolveUDPAddr("udp", c.RemoteAddr().String())
-					if err != nil {
-						conn.Close()
-						return nil, err
-					}
-				default:
-					udpConn = &internet.FakePacketConn{Conn: c}
-					udpAddr, err = net.ResolveUDPAddr("udp", c.RemoteAddr().String())
-					if err != nil {
-						conn.Close()
-						return nil, err
-					}
-
-					if len(quicParams.UdpHop.Ports) > 0 {
-						conn.Close()
-						return nil, errors.New("udphop requires being at the outermost level ", reflect.TypeOf(c))
-					}
-				}
-
-				if len(quicParams.UdpHop.Ports) > 0 {
-					addr := &udphop.UDPHopAddr{
-						IP:    udpAddr.IP,
-						Ports: quicParams.UdpHop.Ports,
-					}
-					udpConn, err = udphop.NewUDPHopPacketConn(addr, index, quicParams.UdpHop.IntervalMin, quicParams.UdpHop.IntervalMax, udphopDialer, udpConn)
-					if err != nil {
-						conn.Close()
-						return nil, errors.New("udphop err").Base(err)
-					}
-				}
-
-				if streamSettings.UdpmaskManager != nil {
-					udpConn, err = streamSettings.UdpmaskManager.WrapPacketConnClient(udpConn)
-					if err != nil {
-						conn.Close()
-						return nil, errors.New("mask err").Base(err)
-					}
-				}
-
-				quicConn, err := quic.DialEarly(ctx, udpConn, udpAddr, tlsCfg, cfg)
-				if err != nil {
-					return nil, err
-				}
-
-				switch quicParams.Congestion {
-				case "force-brutal":
-					errors.LogDebug(context.Background(), quicConn.RemoteAddr(), " ", "congestion brutal bytes per second ", quicParams.BrutalUp)
-					congestion.UseBrutal(quicConn, quicParams.BrutalUp)
-				case "reno":
-					errors.LogDebug(context.Background(), quicConn.RemoteAddr(), " ", "congestion reno")
-				default:
-					errors.LogDebug(context.Background(), quicConn.RemoteAddr(), " ", "congestion bbr")
-					congestion.UseBBR(quicConn)
-				}
-
-				return quicConn, nil
+				return dialQUICConn(ctx, dest, streamSettings, tlsCfg, cfg)
 			},
 		}
 	} else if httpVersion == "2" {
@@ -354,6 +217,11 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 		dest.Network = net.Network_UDP
 	}
 
+	var gotlsConfig *gotls.Config
+	if tlsConfig != nil {
+		gotlsConfig = tlsConfig.GetTLSConfig(tls.WithDestination(dest))
+	}
+
 	transportConfiguration := streamSettings.ProtocolSettings.(*Config)
 	var requestURL url.URL
 
@@ -376,21 +244,27 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 	requestURL.Path = transportConfiguration.GetNormalizedPath()
 	requestURL.RawQuery = transportConfiguration.GetNormalizedQuery()
 
-	httpClient, xmuxClient := getHTTPClient(ctx, dest, streamSettings)
-
-	mode := transportConfiguration.Mode
-	if mode == "" || mode == "auto" {
-		mode = "packet-up"
+	mode := transportConfiguration.GetNormalizedMode()
+	if mode == ModeAuto {
+		mode = ModePacketUp
 		if realityConfig != nil {
-			mode = "stream-one"
+			mode = ModeStreamOne
 			if transportConfiguration.DownloadSettings != nil {
-				mode = "stream-up"
+				mode = ModeStreamUp
 			}
 		}
 	}
+	if mode == ModeMasque && httpVersion != "3" {
+		return nil, errors.New("MASQUE mode requires HTTP/3")
+	}
+	if mode == ModeMasque && internet.WantTransportDatagrams(ctx) {
+		return dialMASQUE(ctx, dest, requestURL, streamSettings, gotlsConfig)
+	}
+
+	httpClient, xmuxClient := getHTTPClient(ctx, dest, streamSettings)
 
 	sessionId := ""
-	if mode != "stream-one" {
+	if mode != ModeStreamOne && mode != ModeMasque {
 		sessionIdUuid := uuid.New()
 		sessionId = sessionIdUuid.String()
 	}
@@ -464,7 +338,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 	}
 
 	var err error
-	if mode == "stream-one" {
+	if mode == ModeStreamOne || mode == ModeMasque {
 		requestURL.Path = transportConfiguration.GetNormalizedPath()
 		if xmuxClient != nil {
 			xmuxClient.LeftRequests.Add(-1)
@@ -483,7 +357,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 			return nil, err
 		}
 	}
-	if mode == "stream-up" {
+	if mode == ModeStreamUp {
 		if xmuxClient != nil {
 			xmuxClient.LeftRequests.Add(-1)
 		}

--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -50,6 +50,40 @@ type httpSession struct {
 	isFullyConnected *done.Instance
 }
 
+func (h *requestHandler) isMASQUERequest(request *http.Request) bool {
+	return request.Method == http.MethodConnect && request.Proto == MASQUEProtocolConnectUDP
+}
+
+func (h *requestHandler) handleMASQUERequest(writer http.ResponseWriter, request *http.Request, remoteAddr net.Addr) bool {
+	if !h.isMASQUERequest(request) {
+		return false
+	}
+	if request.ProtoMajor != 3 {
+		errors.LogInfo(context.Background(), "MASQUE mode requires HTTP/3")
+		writer.WriteHeader(http.StatusBadRequest)
+		return true
+	}
+	if mode := h.config.GetNormalizedMode(); mode != ModeAuto && mode != ModeMasque {
+		errors.LogInfo(context.Background(), "masque mode is not allowed")
+		writer.WriteHeader(http.StatusBadRequest)
+		return true
+	}
+
+	streamer, ok := writer.(http3.HTTPStreamer)
+	if !ok {
+		errors.LogInfo(context.Background(), "MASQUE request requires HTTP/3 stream hijacking support")
+		writer.WriteHeader(http.StatusInternalServerError)
+		return true
+	}
+
+	writer.Header().Set("Cache-Control", "no-store")
+	writer.WriteHeader(http.StatusOK)
+
+	stream := streamer.HTTPStream()
+	h.ln.addConn(newServerMASQUEConn(stream, h.localAddr, remoteAddr))
+	return true
+}
+
 func (h *requestHandler) upsertSession(sessionId string) *httpSession {
 	// fast path
 	currentSessionAny, ok := h.sessions.Load(sessionId)
@@ -147,7 +181,7 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 
 	sessionId, seqStr := h.config.ExtractMetaFromRequest(request, h.path)
 
-	if sessionId == "" && h.config.Mode != "" && h.config.Mode != "auto" && h.config.Mode != "stream-one" && h.config.Mode != "stream-up" {
+	if sessionId == "" && !h.isMASQUERequest(request) && h.config.Mode != "" && h.config.Mode != ModeAuto && h.config.Mode != ModeStreamOne && h.config.Mode != ModeStreamUp {
 		errors.LogInfo(context.Background(), "stream-one mode is not allowed")
 		writer.WriteHeader(http.StatusBadRequest)
 		return
@@ -186,6 +220,10 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		}
 	}
 
+	if h.handleMASQUERequest(writer, request, remoteAddr) {
+		return
+	}
+
 	var currentSession *httpSession
 	if sessionId != "" {
 		currentSession = h.upsertSession(sessionId)
@@ -204,7 +242,7 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 
 	if isUplinkRequest && sessionId != "" { // stream-up, packet-up
 		if seqStr == "" {
-			if h.config.Mode != "" && h.config.Mode != "auto" && h.config.Mode != "stream-up" {
+			if h.config.Mode != "" && h.config.Mode != ModeAuto && h.config.Mode != ModeStreamUp {
 				errors.LogInfo(context.Background(), "stream-up mode is not allowed")
 				writer.WriteHeader(http.StatusBadRequest)
 				return
@@ -246,7 +284,7 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 			return
 		}
 
-		if h.config.Mode != "" && h.config.Mode != "auto" && h.config.Mode != "packet-up" {
+		if h.config.Mode != "" && h.config.Mode != ModeAuto && h.config.Mode != ModePacketUp {
 			errors.LogInfo(context.Background(), "packet-up mode is not allowed")
 			writer.WriteHeader(http.StatusBadRequest)
 			return
@@ -466,6 +504,9 @@ func ListenXH(ctx context.Context, address net.Address, port net.Port, streamSet
 	}
 	tlsConfig := getTLSConfig(streamSettings)
 	l.isH3 = len(tlsConfig.NextProtos) == 1 && tlsConfig.NextProtos[0] == "h3"
+	if l.config.IsMASQUEMode() && !l.isH3 {
+		return nil, errors.New("MASQUE mode requires HTTP/3")
+	}
 
 	var err error
 	if port == net.Port(0) { // unix
@@ -518,7 +559,8 @@ func ListenXH(ctx context.Context, address net.Address, port net.Port, streamSet
 		handler.localAddr = l.h3listener.Addr()
 
 		l.h3server = &http3.Server{
-			Handler: handler,
+			Handler:         handler,
+			EnableDatagrams: l.config.IsMASQUEMode(),
 		}
 		go func() {
 			for {

--- a/transport/internet/splithttp/masque.go
+++ b/transport/internet/splithttp/masque.go
@@ -1,0 +1,592 @@
+package splithttp
+
+import (
+	"context"
+	gotls "crypto/tls"
+	"expvar"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/apernet/quic-go"
+	"github.com/apernet/quic-go/http3"
+	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/session"
+	"github.com/xtls/xray-core/transport/internet"
+	"github.com/xtls/xray-core/transport/internet/hysteria/congestion"
+	"github.com/xtls/xray-core/transport/internet/hysteria/udphop"
+	"github.com/xtls/xray-core/transport/internet/stat"
+)
+
+const masqueTelemetryUnscopedKey = "_unscoped"
+
+type masqueTelemetry struct {
+	requestedSessions             atomic.Int64
+	datagramReadEnabledSessions   atomic.Int64
+	datagramWriteEnabledSessions  atomic.Int64
+	bidirectionalDatagramSessions atomic.Int64
+	readFallbackSessions          atomic.Int64
+	writeFallbackSessions         atomic.Int64
+	streamReadOps                 atomic.Int64
+	streamReadBytes               atomic.Int64
+	streamWriteOps                atomic.Int64
+	streamWriteBytes              atomic.Int64
+	datagramReadPackets           atomic.Int64
+	datagramReadBytes             atomic.Int64
+	datagramWritePackets          atomic.Int64
+	datagramWriteBytes            atomic.Int64
+}
+
+func (t *masqueTelemetry) snapshot() map[string]int64 {
+	return map[string]int64{
+		"requested_sessions":              t.requestedSessions.Load(),
+		"datagram_read_enabled_sessions":  t.datagramReadEnabledSessions.Load(),
+		"datagram_write_enabled_sessions": t.datagramWriteEnabledSessions.Load(),
+		"bidirectional_datagram_sessions": t.bidirectionalDatagramSessions.Load(),
+		"read_fallback_sessions":          t.readFallbackSessions.Load(),
+		"write_fallback_sessions":         t.writeFallbackSessions.Load(),
+		"stream_read_ops":                 t.streamReadOps.Load(),
+		"stream_read_bytes":               t.streamReadBytes.Load(),
+		"stream_write_ops":                t.streamWriteOps.Load(),
+		"stream_write_bytes":              t.streamWriteBytes.Load(),
+		"datagram_read_packets":           t.datagramReadPackets.Load(),
+		"datagram_read_bytes":             t.datagramReadBytes.Load(),
+		"datagram_write_packets":          t.datagramWritePackets.Load(),
+		"datagram_write_bytes":            t.datagramWriteBytes.Load(),
+	}
+}
+
+type masqueTelemetryScope struct {
+	global   *masqueTelemetry
+	outbound *masqueTelemetry
+}
+
+func (s masqueTelemetryScope) apply(fn func(*masqueTelemetry)) {
+	if s.global != nil {
+		fn(s.global)
+	}
+	if s.outbound != nil {
+		fn(s.outbound)
+	}
+}
+
+type masqueTelemetryRegistry struct {
+	global   masqueTelemetry
+	outbound sync.Map // map[string]*masqueTelemetry
+}
+
+func (r *masqueTelemetryRegistry) scope(outboundKey string) masqueTelemetryScope {
+	scope := masqueTelemetryScope{global: &r.global}
+	if outboundKey == "" {
+		outboundKey = masqueTelemetryUnscopedKey
+	}
+	scope.outbound = r.outboundTelemetry(outboundKey)
+	return scope
+}
+
+func (r *masqueTelemetryRegistry) outboundTelemetry(outboundKey string) *masqueTelemetry {
+	if outboundKey == "" {
+		outboundKey = masqueTelemetryUnscopedKey
+	}
+	if existing, ok := r.outbound.Load(outboundKey); ok {
+		return existing.(*masqueTelemetry)
+	}
+	created := new(masqueTelemetry)
+	actual, _ := r.outbound.LoadOrStore(outboundKey, created)
+	return actual.(*masqueTelemetry)
+}
+
+func (r *masqueTelemetryRegistry) globalSnapshot() map[string]int64 {
+	return r.global.snapshot()
+}
+
+func (r *masqueTelemetryRegistry) outboundSnapshot() map[string]map[string]int64 {
+	resp := map[string]map[string]int64{}
+	r.outbound.Range(func(key, value any) bool {
+		resp[key.(string)] = value.(*masqueTelemetry).snapshot()
+		return true
+	})
+	return resp
+}
+
+func (r *masqueTelemetryRegistry) outboundSnapshotFor(outboundKey string) map[string]int64 {
+	if outboundKey == "" {
+		outboundKey = masqueTelemetryUnscopedKey
+	}
+	if value, ok := r.outbound.Load(outboundKey); ok {
+		return value.(*masqueTelemetry).snapshot()
+	}
+	return (&masqueTelemetry{}).snapshot()
+}
+
+func (r *masqueTelemetryRegistry) snapshot() map[string]interface{} {
+	return map[string]interface{}{
+		"global":   r.globalSnapshot(),
+		"outbound": r.outboundSnapshot(),
+	}
+}
+
+var globalMASQUETelemetry masqueTelemetryRegistry
+
+func masqueTelemetryOutboundKeyFromContext(ctx context.Context) string {
+	outbounds := session.OutboundsFromContext(ctx)
+	if len(outbounds) == 0 {
+		return masqueTelemetryUnscopedKey
+	}
+	ob := outbounds[len(outbounds)-1]
+	switch {
+	case ob.Tag != "":
+		return ob.Tag
+	case ob.Name != "":
+		return "name:" + ob.Name
+	default:
+		return masqueTelemetryUnscopedKey
+	}
+}
+
+func init() {
+	expvar.Publish("masque", expvar.Func(func() interface{} {
+		return globalMASQUETelemetry.snapshot()
+	}))
+}
+
+type masqueStream interface {
+	io.ReadWriteCloser
+	SendDatagram([]byte) error
+	ReceiveDatagram(context.Context) ([]byte, error)
+	Context() context.Context
+	SetDeadline(time.Time) error
+	SetReadDeadline(time.Time) error
+	SetWriteDeadline(time.Time) error
+}
+
+type masqueConn struct {
+	stream     masqueStream
+	localAddr  net.Addr
+	remoteAddr net.Addr
+	closeFunc  func() error
+
+	readMu         sync.Mutex
+	writeMu        sync.Mutex
+	stateMu        sync.RWMutex
+	readDatagrams  bool
+	writeDatagrams bool
+	readBuf        []byte
+	readPos        int
+	closeOnce      sync.Once
+
+	requestedDatagrams          bool
+	readEnabledCounted          bool
+	writeEnabledCounted         bool
+	bidirectionalEnabledCounted bool
+	telemetry                   masqueTelemetryScope
+}
+
+func (c *masqueConn) EnableTransportDatagramRead() error {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	if !c.readDatagrams {
+		c.readDatagrams = true
+		c.readBuf = nil
+		c.readPos = 0
+		if !c.readEnabledCounted {
+			c.telemetry.apply(func(t *masqueTelemetry) {
+				t.datagramReadEnabledSessions.Add(1)
+			})
+			c.readEnabledCounted = true
+		}
+		c.maybeCountBidirectionalLocked()
+	}
+	return nil
+}
+
+func (c *masqueConn) EnableTransportDatagramWrite() error {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	if !c.writeDatagrams {
+		c.writeDatagrams = true
+		if !c.writeEnabledCounted {
+			c.telemetry.apply(func(t *masqueTelemetry) {
+				t.datagramWriteEnabledSessions.Add(1)
+			})
+			c.writeEnabledCounted = true
+		}
+		c.maybeCountBidirectionalLocked()
+	}
+	return nil
+}
+
+func (c *masqueConn) maybeCountBidirectionalLocked() {
+	if c.readDatagrams && c.writeDatagrams && !c.bidirectionalEnabledCounted {
+		c.telemetry.apply(func(t *masqueTelemetry) {
+			t.bidirectionalDatagramSessions.Add(1)
+		})
+		c.bidirectionalEnabledCounted = true
+	}
+}
+
+func (c *masqueConn) Read(p []byte) (int, error) {
+	c.stateMu.RLock()
+	readDatagrams := c.readDatagrams
+	c.stateMu.RUnlock()
+	if !readDatagrams {
+		n, err := c.stream.Read(p)
+		if n > 0 {
+			c.telemetry.apply(func(t *masqueTelemetry) {
+				t.streamReadOps.Add(1)
+				t.streamReadBytes.Add(int64(n))
+			})
+		}
+		return n, err
+	}
+
+	c.readMu.Lock()
+	defer c.readMu.Unlock()
+
+	for c.readPos >= len(c.readBuf) {
+		ctx := c.stream.Context()
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		data, err := c.stream.ReceiveDatagram(ctx)
+		if err != nil {
+			return 0, err
+		}
+		c.telemetry.apply(func(t *masqueTelemetry) {
+			t.datagramReadPackets.Add(1)
+			t.datagramReadBytes.Add(int64(len(data)))
+		})
+		c.readBuf = data
+		c.readPos = 0
+	}
+
+	n := copy(p, c.readBuf[c.readPos:])
+	c.readPos += n
+	if c.readPos >= len(c.readBuf) {
+		c.readBuf = nil
+		c.readPos = 0
+	}
+	return n, nil
+}
+
+func (c *masqueConn) Write(p []byte) (int, error) {
+	c.stateMu.RLock()
+	writeDatagrams := c.writeDatagrams
+	c.stateMu.RUnlock()
+	if !writeDatagrams {
+		n, err := c.stream.Write(p)
+		if n > 0 {
+			c.telemetry.apply(func(t *masqueTelemetry) {
+				t.streamWriteOps.Add(1)
+				t.streamWriteBytes.Add(int64(n))
+			})
+		}
+		return n, err
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	if err := c.stream.SendDatagram(p); err != nil {
+		return 0, err
+	}
+	c.telemetry.apply(func(t *masqueTelemetry) {
+		t.datagramWritePackets.Add(1)
+		t.datagramWriteBytes.Add(int64(len(p)))
+	})
+	return len(p), nil
+}
+
+func (c *masqueConn) Close() error {
+	var err error
+	c.closeOnce.Do(func() {
+		c.stateMu.RLock()
+		requestedDatagrams := c.requestedDatagrams
+		readDatagrams := c.readDatagrams
+		writeDatagrams := c.writeDatagrams
+		c.stateMu.RUnlock()
+		if requestedDatagrams {
+			if !readDatagrams {
+				c.telemetry.apply(func(t *masqueTelemetry) {
+					t.readFallbackSessions.Add(1)
+				})
+			}
+			if !writeDatagrams {
+				c.telemetry.apply(func(t *masqueTelemetry) {
+					t.writeFallbackSessions.Add(1)
+				})
+			}
+		}
+		if c.closeFunc != nil {
+			err = c.closeFunc()
+			return
+		}
+		err = c.stream.Close()
+	})
+	return err
+}
+
+func (c *masqueConn) LocalAddr() net.Addr {
+	return c.localAddr
+}
+
+func (c *masqueConn) RemoteAddr() net.Addr {
+	return c.remoteAddr
+}
+
+func (c *masqueConn) SetDeadline(t time.Time) error {
+	return c.stream.SetDeadline(t)
+}
+
+func (c *masqueConn) SetReadDeadline(t time.Time) error {
+	return c.stream.SetReadDeadline(t)
+}
+
+func (c *masqueConn) SetWriteDeadline(t time.Time) error {
+	return c.stream.SetWriteDeadline(t)
+}
+
+func newMASQUEConn(stream masqueStream, localAddr, remoteAddr net.Addr, closeFunc func() error, requestedDatagrams bool, telemetry masqueTelemetryScope) *masqueConn {
+	conn := &masqueConn{
+		stream:             stream,
+		localAddr:          localAddr,
+		remoteAddr:         remoteAddr,
+		closeFunc:          closeFunc,
+		requestedDatagrams: requestedDatagrams,
+		telemetry:          telemetry,
+	}
+	if requestedDatagrams {
+		conn.telemetry.apply(func(t *masqueTelemetry) {
+			t.requestedSessions.Add(1)
+		})
+	}
+	return conn
+}
+
+func newH3QUICConfig(streamSettings *internet.MemoryStreamConfig, keepAlivePeriod time.Duration, enableDatagrams bool) *quic.Config {
+	quicParams := streamSettings.QuicParams
+	if quicParams == nil {
+		quicParams = &internet.QuicParams{}
+	}
+
+	quicConfig := &quic.Config{
+		InitialStreamReceiveWindow:     quicParams.InitStreamReceiveWindow,
+		MaxStreamReceiveWindow:         quicParams.MaxStreamReceiveWindow,
+		InitialConnectionReceiveWindow: quicParams.InitConnReceiveWindow,
+		MaxConnectionReceiveWindow:     quicParams.MaxConnReceiveWindow,
+		MaxIdleTimeout:                 time.Duration(quicParams.MaxIdleTimeout) * time.Second,
+		KeepAlivePeriod:                time.Duration(quicParams.KeepAlivePeriod) * time.Second,
+		MaxIncomingStreams:             quicParams.MaxIncomingStreams,
+		DisablePathMTUDiscovery:        quicParams.DisablePathMtuDiscovery,
+		EnableDatagrams:                enableDatagrams,
+	}
+	if quicParams.MaxIdleTimeout == 0 {
+		quicConfig.MaxIdleTimeout = net.ConnIdleTimeout
+	}
+	if quicParams.KeepAlivePeriod == 0 && keepAlivePeriod == 0 {
+		quicConfig.KeepAlivePeriod = net.QuicgoH3KeepAlivePeriod
+	}
+	if quicParams.MaxIncomingStreams == 0 {
+		quicConfig.MaxIncomingStreams = -1
+	}
+	return quicConfig
+}
+
+func dialQUICConn(ctx context.Context, dest net.Destination, streamSettings *internet.MemoryStreamConfig, tlsCfg *gotls.Config, quicConfig *quic.Config) (*quic.Conn, error) {
+	quicParams := streamSettings.QuicParams
+	if quicParams == nil {
+		quicParams = &internet.QuicParams{}
+	}
+	if quicParams.UdpHop == nil {
+		quicParams.UdpHop = &internet.UdpHop{}
+	}
+
+	udphopDialer := func(addr *net.UDPAddr) (net.PacketConn, error) {
+		conn, err := internet.DialSystem(ctx, net.UDPDestination(net.IPAddress(addr.IP), net.Port(addr.Port)), streamSettings.SocketSettings)
+		if err != nil {
+			errors.LogDebug(context.Background(), "skip hop: failed to dial to dest")
+			return nil, errors.New().Base(err)
+		}
+
+		switch c := conn.(type) {
+		case *internet.PacketConnWrapper:
+			return c.PacketConn, nil
+		case *net.UDPConn:
+			return c, nil
+		default:
+			errors.LogDebug(context.Background(), "skip hop: udphop requires being at the outermost level ", reflect.TypeOf(c))
+			conn.Close()
+			return nil, errors.New()
+		}
+	}
+
+	var index int
+	if len(quicParams.UdpHop.Ports) > 0 {
+		index = rand.Intn(len(quicParams.UdpHop.Ports))
+		dest.Port = net.Port(quicParams.UdpHop.Ports[index])
+	}
+
+	conn, err := internet.DialSystem(ctx, dest, streamSettings.SocketSettings)
+	if err != nil {
+		return nil, err
+	}
+
+	var udpConn net.PacketConn
+	var udpAddr *net.UDPAddr
+
+	switch c := conn.(type) {
+	case *internet.PacketConnWrapper:
+		udpConn = c.PacketConn
+		udpAddr, err = net.ResolveUDPAddr("udp", c.Dest.String())
+		if err != nil {
+			conn.Close()
+			return nil, err
+		}
+	case *net.UDPConn:
+		udpConn = c
+		udpAddr, err = net.ResolveUDPAddr("udp", c.RemoteAddr().String())
+		if err != nil {
+			conn.Close()
+			return nil, err
+		}
+	default:
+		udpConn = &internet.FakePacketConn{Conn: c}
+		udpAddr, err = net.ResolveUDPAddr("udp", c.RemoteAddr().String())
+		if err != nil {
+			conn.Close()
+			return nil, err
+		}
+
+		if len(quicParams.UdpHop.Ports) > 0 {
+			conn.Close()
+			return nil, errors.New("udphop requires being at the outermost level ", reflect.TypeOf(c))
+		}
+	}
+
+	if len(quicParams.UdpHop.Ports) > 0 {
+		addr := &udphop.UDPHopAddr{
+			IP:    udpAddr.IP,
+			Ports: quicParams.UdpHop.Ports,
+		}
+		udpConn, err = udphop.NewUDPHopPacketConn(addr, index, quicParams.UdpHop.IntervalMin, quicParams.UdpHop.IntervalMax, udphopDialer, udpConn)
+		if err != nil {
+			conn.Close()
+			return nil, errors.New("udphop err").Base(err)
+		}
+	}
+
+	if streamSettings.UdpmaskManager != nil {
+		udpConn, err = streamSettings.UdpmaskManager.WrapPacketConnClient(udpConn)
+		if err != nil {
+			conn.Close()
+			return nil, errors.New("mask err").Base(err)
+		}
+	}
+
+	quicConn, err := quic.DialEarly(ctx, udpConn, udpAddr, tlsCfg, quicConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	switch quicParams.Congestion {
+	case "force-brutal":
+		errors.LogDebug(context.Background(), quicConn.RemoteAddr(), " ", "congestion brutal bytes per second ", quicParams.BrutalUp)
+		congestion.UseBrutal(quicConn, quicParams.BrutalUp)
+	case "reno":
+		errors.LogDebug(context.Background(), quicConn.RemoteAddr(), " ", "congestion reno")
+	default:
+		errors.LogDebug(context.Background(), quicConn.RemoteAddr(), " ", "congestion bbr")
+		congestion.UseBBR(quicConn)
+	}
+
+	return quicConn, nil
+}
+
+func dialMASQUE(ctx context.Context, dest net.Destination, requestURL url.URL, streamSettings *internet.MemoryStreamConfig, tlsCfg *gotls.Config) (stat.Connection, error) {
+	transportConfig := streamSettings.ProtocolSettings.(*Config)
+	quicConfig := newH3QUICConfig(streamSettings, 0, true)
+	quicConn, err := dialQUICConn(ctx, dest, streamSettings, tlsCfg, quicConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	clientConn := (&http3.Transport{
+		EnableDatagrams: true,
+		QUICConfig:      quicConfig,
+	}).NewClientConn(quicConn)
+
+	select {
+	case <-quicConn.HandshakeComplete():
+	case <-ctx.Done():
+		_ = quicConn.CloseWithError(0, "")
+		return nil, context.Cause(ctx)
+	}
+
+	select {
+	case <-clientConn.ReceivedSettings():
+	case <-ctx.Done():
+		_ = quicConn.CloseWithError(0, "")
+		return nil, context.Cause(ctx)
+	}
+
+	if !clientConn.Settings().EnableExtendedConnect {
+		_ = quicConn.CloseWithError(0, "")
+		return nil, errors.New("http3: server didn't enable Extended CONNECT")
+	}
+
+	reqStream, err := clientConn.OpenRequestStream(ctx)
+	if err != nil {
+		_ = quicConn.CloseWithError(0, "")
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(context.WithoutCancel(ctx), http.MethodConnect, requestURL.String(), nil)
+	if err != nil {
+		_ = quicConn.CloseWithError(0, "")
+		return nil, err
+	}
+	req.Host = requestURL.Host
+	transportConfig.FillStreamRequest(req, "", "")
+
+	if err := reqStream.SendRequestHeader(req); err != nil {
+		_ = quicConn.CloseWithError(0, "")
+		return nil, err
+	}
+	resp, err := reqStream.ReadResponse()
+	if err != nil {
+		_ = quicConn.CloseWithError(0, "")
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		_ = quicConn.CloseWithError(0, "")
+		return nil, errors.New("unexpected MASQUE status ", resp.StatusCode)
+	}
+
+	return newMASQUEConn(reqStream, quicConn.LocalAddr(), quicConn.RemoteAddr(), func() error {
+		reqStream.CancelRead(0)
+		reqStream.CancelWrite(0)
+		_ = reqStream.Close()
+		return quicConn.CloseWithError(0, "")
+	}, true, globalMASQUETelemetry.scope(masqueTelemetryOutboundKeyFromContext(ctx))), nil
+}
+
+func newServerMASQUEConn(stream *http3.Stream, localAddr, remoteAddr net.Addr) stat.Connection {
+	return newMASQUEConn(stream, localAddr, remoteAddr, func() error {
+		stream.CancelRead(0)
+		stream.CancelWrite(0)
+		return stream.Close()
+	}, true, globalMASQUETelemetry.scope(masqueTelemetryUnscopedKey))
+}
+
+func unexpectedMASQUEStatusError(code int) error {
+	return errors.New(fmt.Sprintf("unexpected MASQUE status %d", code))
+}

--- a/transport/internet/splithttp/masque_test.go
+++ b/transport/internet/splithttp/masque_test.go
@@ -1,0 +1,314 @@
+package splithttp
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/xtls/xray-core/common/session"
+)
+
+type fakeMASQUEStream struct {
+	ctx            context.Context
+	streamReadBuf  bytes.Buffer
+	streamWriteBuf bytes.Buffer
+	datagramReads  [][]byte
+	datagramWrites [][]byte
+}
+
+func (f *fakeMASQUEStream) Read(p []byte) (int, error) {
+	return f.streamReadBuf.Read(p)
+}
+
+func (f *fakeMASQUEStream) Write(p []byte) (int, error) {
+	return f.streamWriteBuf.Write(p)
+}
+
+func (f *fakeMASQUEStream) Close() error {
+	return nil
+}
+
+func (f *fakeMASQUEStream) SendDatagram(p []byte) error {
+	f.datagramWrites = append(f.datagramWrites, append([]byte(nil), p...))
+	return nil
+}
+
+func (f *fakeMASQUEStream) ReceiveDatagram(context.Context) ([]byte, error) {
+	if len(f.datagramReads) == 0 {
+		return nil, io.EOF
+	}
+	data := f.datagramReads[0]
+	f.datagramReads = f.datagramReads[1:]
+	return append([]byte(nil), data...), nil
+}
+
+func (f *fakeMASQUEStream) Context() context.Context {
+	if f.ctx != nil {
+		return f.ctx
+	}
+	return context.Background()
+}
+
+func (f *fakeMASQUEStream) SetDeadline(time.Time) error {
+	return nil
+}
+
+func (f *fakeMASQUEStream) SetReadDeadline(time.Time) error {
+	return nil
+}
+
+func (f *fakeMASQUEStream) SetWriteDeadline(time.Time) error {
+	return nil
+}
+
+func masqueTelemetryDelta(before map[string]int64) map[string]int64 {
+	after := globalMASQUETelemetry.globalSnapshot()
+	delta := make(map[string]int64, len(after))
+	for key, value := range after {
+		delta[key] = value - before[key]
+	}
+	return delta
+}
+
+func masqueOutboundTelemetryDelta(outboundKey string, before map[string]int64) map[string]int64 {
+	after := globalMASQUETelemetry.outboundSnapshotFor(outboundKey)
+	delta := make(map[string]int64, len(after))
+	for key, value := range after {
+		delta[key] = value - before[key]
+	}
+	return delta
+}
+
+func TestMASQUEConnTelemetryTracksUsageAndFallback(t *testing.T) {
+	before := globalMASQUETelemetry.globalSnapshot()
+
+	stream := &fakeMASQUEStream{
+		ctx: context.Background(),
+		datagramReads: [][]byte{
+			[]byte("pong"),
+			[]byte("pong-2"),
+		},
+	}
+	conn := newMASQUEConn(stream, nil, nil, nil, true, globalMASQUETelemetry.scope(masqueTelemetryUnscopedKey))
+
+	if _, err := conn.Write([]byte("hdr")); err != nil {
+		t.Fatal(err)
+	}
+	if got := stream.streamWriteBuf.String(); got != "hdr" {
+		t.Fatalf("unexpected stream control write: %q", got)
+	}
+
+	if err := conn.EnableTransportDatagramWrite(); err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.EnableTransportDatagramRead(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		t.Fatal(err)
+	}
+	if len(stream.datagramWrites) != 1 || string(stream.datagramWrites[0]) != "ping" {
+		t.Fatalf("unexpected datagram writes: %#v", stream.datagramWrites)
+	}
+
+	reply1 := make([]byte, len("pong"))
+	if _, err := io.ReadFull(conn, reply1); err != nil {
+		t.Fatal(err)
+	}
+	if string(reply1) != "pong" {
+		t.Fatalf("unexpected reply1: %q", string(reply1))
+	}
+
+	reply2 := make([]byte, len("pong-2"))
+	if _, err := io.ReadFull(conn, reply2); err != nil {
+		t.Fatal(err)
+	}
+	if string(reply2) != "pong-2" {
+		t.Fatalf("unexpected reply2: %q", string(reply2))
+	}
+
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	delta := masqueTelemetryDelta(before)
+	if delta["requested_sessions"] != 1 {
+		t.Fatalf("requested_sessions delta = %d", delta["requested_sessions"])
+	}
+	if delta["datagram_read_enabled_sessions"] != 1 {
+		t.Fatalf("datagram_read_enabled_sessions delta = %d", delta["datagram_read_enabled_sessions"])
+	}
+	if delta["datagram_write_enabled_sessions"] != 1 {
+		t.Fatalf("datagram_write_enabled_sessions delta = %d", delta["datagram_write_enabled_sessions"])
+	}
+	if delta["bidirectional_datagram_sessions"] != 1 {
+		t.Fatalf("bidirectional_datagram_sessions delta = %d", delta["bidirectional_datagram_sessions"])
+	}
+	if delta["read_fallback_sessions"] != 0 || delta["write_fallback_sessions"] != 0 {
+		t.Fatalf("unexpected fallback deltas: read=%d write=%d", delta["read_fallback_sessions"], delta["write_fallback_sessions"])
+	}
+	if delta["stream_write_ops"] != 1 || delta["stream_write_bytes"] != int64(len("hdr")) {
+		t.Fatalf("unexpected stream write telemetry: ops=%d bytes=%d", delta["stream_write_ops"], delta["stream_write_bytes"])
+	}
+	if delta["datagram_write_packets"] != 1 || delta["datagram_write_bytes"] != int64(len("ping")) {
+		t.Fatalf("unexpected datagram write telemetry: packets=%d bytes=%d", delta["datagram_write_packets"], delta["datagram_write_bytes"])
+	}
+	if delta["datagram_read_packets"] != 2 || delta["datagram_read_bytes"] != int64(len("pong")+len("pong-2")) {
+		t.Fatalf("unexpected datagram read telemetry: packets=%d bytes=%d", delta["datagram_read_packets"], delta["datagram_read_bytes"])
+	}
+}
+
+func TestMASQUEConnTelemetryTracksDirectionalFallback(t *testing.T) {
+	before := globalMASQUETelemetry.globalSnapshot()
+
+	stream := &fakeMASQUEStream{ctx: context.Background()}
+	conn := newMASQUEConn(stream, nil, nil, nil, true, globalMASQUETelemetry.scope(masqueTelemetryUnscopedKey))
+
+	if _, err := conn.Write([]byte("header-only")); err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	delta := masqueTelemetryDelta(before)
+	if delta["requested_sessions"] != 1 {
+		t.Fatalf("requested_sessions delta = %d", delta["requested_sessions"])
+	}
+	if delta["read_fallback_sessions"] != 1 || delta["write_fallback_sessions"] != 1 {
+		t.Fatalf("unexpected fallback deltas: read=%d write=%d", delta["read_fallback_sessions"], delta["write_fallback_sessions"])
+	}
+	if delta["datagram_read_enabled_sessions"] != 0 || delta["datagram_write_enabled_sessions"] != 0 {
+		t.Fatalf("unexpected datagram enable deltas: read=%d write=%d", delta["datagram_read_enabled_sessions"], delta["datagram_write_enabled_sessions"])
+	}
+}
+
+func TestMASQUEConnDatagramReadPreservesReceiveOrder(t *testing.T) {
+	stream := &fakeMASQUEStream{
+		ctx: context.Background(),
+		datagramReads: [][]byte{
+			[]byte("pkt-2"),
+			[]byte("pkt-1"),
+		},
+	}
+	conn := newMASQUEConn(stream, nil, nil, nil, false, globalMASQUETelemetry.scope(masqueTelemetryUnscopedKey))
+
+	if err := conn.EnableTransportDatagramRead(); err != nil {
+		t.Fatal(err)
+	}
+
+	first := make([]byte, len("pkt-2"))
+	if _, err := io.ReadFull(conn, first); err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != "pkt-2" {
+		t.Fatalf("unexpected first datagram: %q", string(first))
+	}
+
+	second := make([]byte, len("pkt-1"))
+	if _, err := io.ReadFull(conn, second); err != nil {
+		t.Fatal(err)
+	}
+	if string(second) != "pkt-1" {
+		t.Fatalf("unexpected second datagram: %q", string(second))
+	}
+}
+
+func TestMASQUEConnDatagramReadHandlesLossWithoutCorruption(t *testing.T) {
+	stream := &fakeMASQUEStream{
+		ctx: context.Background(),
+		datagramReads: [][]byte{
+			[]byte("pkt-1"),
+			[]byte("pkt-3"),
+		},
+	}
+	conn := newMASQUEConn(stream, nil, nil, nil, false, globalMASQUETelemetry.scope(masqueTelemetryUnscopedKey))
+
+	if err := conn.EnableTransportDatagramRead(); err != nil {
+		t.Fatal(err)
+	}
+
+	firstChunk := make([]byte, 2)
+	if _, err := io.ReadFull(conn, firstChunk); err != nil {
+		t.Fatal(err)
+	}
+	if string(firstChunk) != "pk" {
+		t.Fatalf("unexpected first chunk: %q", string(firstChunk))
+	}
+
+	firstTail := make([]byte, len("pkt-1")-2)
+	if _, err := io.ReadFull(conn, firstTail); err != nil {
+		t.Fatal(err)
+	}
+	if string(firstTail) != "t-1" {
+		t.Fatalf("unexpected first tail: %q", string(firstTail))
+	}
+
+	second := make([]byte, len("pkt-3"))
+	if _, err := io.ReadFull(conn, second); err != nil {
+		t.Fatal(err)
+	}
+	if string(second) != "pkt-3" {
+		t.Fatalf("unexpected second datagram: %q", string(second))
+	}
+}
+
+func TestMASQUETelemetryTracksPerOutboundBreakdown(t *testing.T) {
+	const outboundKey = "proxy-a"
+
+	beforeGlobal := globalMASQUETelemetry.globalSnapshot()
+	beforeOutbound := globalMASQUETelemetry.outboundSnapshotFor(outboundKey)
+	beforeUnscoped := globalMASQUETelemetry.outboundSnapshotFor(masqueTelemetryUnscopedKey)
+
+	stream := &fakeMASQUEStream{
+		ctx: context.Background(),
+		datagramReads: [][]byte{
+			[]byte("reply"),
+		},
+	}
+	ctx := session.ContextWithOutbounds(context.Background(), []*session.Outbound{{
+		Tag:  outboundKey,
+		Name: "trojan",
+	}})
+	conn := newMASQUEConn(stream, nil, nil, nil, true, globalMASQUETelemetry.scope(masqueTelemetryOutboundKeyFromContext(ctx)))
+
+	if err := conn.EnableTransportDatagramWrite(); err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.EnableTransportDatagramRead(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		t.Fatal(err)
+	}
+	reply := make([]byte, len("reply"))
+	if _, err := io.ReadFull(conn, reply); err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	globalDelta := masqueTelemetryDelta(beforeGlobal)
+	outboundDelta := masqueOutboundTelemetryDelta(outboundKey, beforeOutbound)
+	unscopedDelta := masqueOutboundTelemetryDelta(masqueTelemetryUnscopedKey, beforeUnscoped)
+
+	if globalDelta["requested_sessions"] != 1 {
+		t.Fatalf("unexpected global requested_sessions delta: %d", globalDelta["requested_sessions"])
+	}
+	if outboundDelta["requested_sessions"] != 1 {
+		t.Fatalf("unexpected outbound requested_sessions delta: %d", outboundDelta["requested_sessions"])
+	}
+	if outboundDelta["bidirectional_datagram_sessions"] != 1 {
+		t.Fatalf("unexpected outbound bidirectional_datagram_sessions delta: %d", outboundDelta["bidirectional_datagram_sessions"])
+	}
+	if outboundDelta["datagram_write_packets"] != 1 || outboundDelta["datagram_read_packets"] != 1 {
+		t.Fatalf("unexpected outbound datagram packet deltas: write=%d read=%d", outboundDelta["datagram_write_packets"], outboundDelta["datagram_read_packets"])
+	}
+	if unscopedDelta["requested_sessions"] != 0 || unscopedDelta["bidirectional_datagram_sessions"] != 0 {
+		t.Fatalf("unexpected unscoped telemetry delta: requested=%d bidirectional=%d", unscopedDelta["requested_sessions"], unscopedDelta["bidirectional_datagram_sessions"])
+	}
+}

--- a/transport/internet/splithttp/splithttp_test.go
+++ b/transport/internet/splithttp/splithttp_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -221,6 +222,30 @@ func Test_ListenXHAndDial_H2C(t *testing.T) {
 	}
 }
 
+func TestFillStreamRequestMASQUE(t *testing.T) {
+	config := &Config{Mode: ModeMasque}
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/sh", bytes.NewBufferString("payload"))
+	common.Must(err)
+
+	config.FillStreamRequest(req, "", "")
+
+	if req.Method != http.MethodConnect {
+		t.Fatalf("expected CONNECT, got %q", req.Method)
+	}
+	if req.Proto != MASQUEProtocolConnectUDP {
+		t.Fatalf("expected MASQUE protocol %q, got %q", MASQUEProtocolConnectUDP, req.Proto)
+	}
+	if got := req.Header.Get(HeaderCapsuleProtocol); got != "?1" {
+		t.Fatalf("expected Capsule-Protocol ?1, got %q", got)
+	}
+	if got := req.Header.Get("Content-Type"); got != "" {
+		t.Fatalf("expected no gRPC content type in MASQUE mode, got %q", got)
+	}
+	if got := req.Header.Get("Sec-Fetch-Mode"); got != "" {
+		t.Fatalf("expected no fetch camouflage headers in MASQUE mode, got %q", got)
+	}
+}
+
 func Test_ListenXHAndDial_QUIC(t *testing.T) {
 	if runtime.GOARCH == "arm64" {
 		return
@@ -302,6 +327,163 @@ func Test_ListenXHAndDial_QUIC(t *testing.T) {
 	end := time.Now()
 	if !end.Before(start.Add(time.Second * 5)) {
 		t.Error("end: ", end, " start: ", start)
+	}
+}
+
+func Test_ListenXHAndDial_QUIC_MASQUE(t *testing.T) {
+	if runtime.GOARCH == "arm64" {
+		return
+	}
+
+	listenPort := udp.PickPort()
+	ct, ctHash := cert.MustGenerate(nil, cert.CommonName("localhost"))
+
+	streamSettings := &internet.MemoryStreamConfig{
+		ProtocolName: "splithttp",
+		ProtocolSettings: &Config{
+			Path: "shs",
+			Mode: ModeMasque,
+		},
+		SecurityType: "tls",
+		SecuritySettings: &tls.Config{
+			Certificate:          []*tls.Certificate{tls.ParseCertificate(ct)},
+			PinnedPeerCertSha256: [][]byte{ctHash[:]},
+			NextProtocol:         []string{"h3"},
+		},
+	}
+
+	listen, err := ListenXH(context.Background(), net.LocalHostIP, listenPort, streamSettings, func(conn stat.Connection) {
+		go func() {
+			defer conn.Close()
+
+			b := buf.New()
+			defer b.Release()
+
+			for {
+				b.Clear()
+				if _, err := b.ReadFrom(conn); err != nil {
+					return
+				}
+				common.Must2(conn.Write(b.Bytes()))
+			}
+		}()
+	})
+	common.Must(err)
+	defer listen.Close()
+
+	time.Sleep(time.Second)
+
+	conn, err := Dial(context.Background(), net.UDPDestination(net.DomainAddress("localhost"), listenPort), streamSettings)
+	common.Must(err)
+	defer conn.Close()
+
+	payload := []byte("masque payload")
+	common.Must2(conn.Write(payload))
+
+	reply := make([]byte, len(payload))
+	common.Must2(io.ReadFull(conn, reply))
+	if r := cmp.Diff(reply, payload); r != "" {
+		t.Error(r)
+	}
+}
+
+func Test_ListenXHAndDial_QUIC_MASQUE_Datagrams(t *testing.T) {
+	if runtime.GOARCH == "arm64" {
+		return
+	}
+
+	listenPort := udp.PickPort()
+	ct, ctHash := cert.MustGenerate(nil, cert.CommonName("localhost"))
+
+	streamSettings := &internet.MemoryStreamConfig{
+		ProtocolName: "splithttp",
+		ProtocolSettings: &Config{
+			Path: "shs",
+			Mode: ModeMasque,
+		},
+		SecurityType: "tls",
+		SecuritySettings: &tls.Config{
+			Certificate:          []*tls.Certificate{tls.ParseCertificate(ct)},
+			PinnedPeerCertSha256: [][]byte{ctHash[:]},
+			NextProtocol:         []string{"h3"},
+		},
+	}
+
+	listen, err := ListenXH(context.Background(), net.LocalHostIP, listenPort, streamSettings, func(conn stat.Connection) {
+		go func() {
+			defer conn.Close()
+
+			common.Must(internet.EnableTransportDatagramRead(conn))
+			common.Must(internet.EnableTransportDatagramWrite(conn))
+
+			payloads := [][]byte{
+				[]byte("masque datagram one"),
+				[]byte("masque datagram two with more bytes"),
+			}
+
+			for _, payload := range payloads {
+				reply := make([]byte, len(payload))
+				common.Must2(io.ReadFull(conn, reply))
+				if r := cmp.Diff(reply, payload); r != "" {
+					t.Error(r)
+					return
+				}
+				common.Must2(conn.Write(reply))
+			}
+		}()
+	})
+	common.Must(err)
+	defer listen.Close()
+
+	time.Sleep(time.Second)
+
+	ctx := internet.ContextWithTransportDatagrams(context.Background(), true)
+	conn, err := Dial(ctx, net.UDPDestination(net.DomainAddress("localhost"), listenPort), streamSettings)
+	common.Must(err)
+	defer conn.Close()
+
+	common.Must(internet.EnableTransportDatagramWrite(conn))
+	common.Must(internet.EnableTransportDatagramRead(conn))
+
+	payloads := [][]byte{
+		[]byte("masque datagram one"),
+		[]byte("masque datagram two with more bytes"),
+	}
+
+	for _, payload := range payloads {
+		common.Must2(conn.Write(payload))
+
+		reply := make([]byte, len(payload))
+		common.Must2(io.ReadFull(conn, reply))
+		if r := cmp.Diff(reply, payload); r != "" {
+			t.Error(r)
+		}
+	}
+}
+
+func TestDialMASQUERequiresHTTP3(t *testing.T) {
+	_, err := Dial(context.Background(), net.TCPDestination(net.DomainAddress("localhost"), tcp.PickPort()), &internet.MemoryStreamConfig{
+		ProtocolName: "splithttp",
+		ProtocolSettings: &Config{
+			Path: "/sh",
+			Mode: ModeMasque,
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "MASQUE mode requires HTTP/3") {
+		t.Fatalf("expected HTTP/3 requirement error, got %v", err)
+	}
+}
+
+func TestListenXHRejectsMASQUENonH3(t *testing.T) {
+	_, err := ListenXH(context.Background(), net.LocalHostIP, tcp.PickPort(), &internet.MemoryStreamConfig{
+		ProtocolName: "splithttp",
+		ProtocolSettings: &Config{
+			Path: "/sh",
+			Mode: ModeMasque,
+		},
+	}, func(conn stat.Connection) {})
+	if err == nil || !strings.Contains(err.Error(), "MASQUE mode requires HTTP/3") {
+		t.Fatalf("expected HTTP/3 requirement error, got %v", err)
 	}
 }
 

--- a/transport/internet/tls/ech.go
+++ b/transport/internet/tls/ech.go
@@ -3,13 +3,16 @@ package tls
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/binary"
 	"fmt"
 	"io"
+	stdnet "net"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -26,10 +29,12 @@ import (
 	"github.com/xtls/xray-core/common/utils"
 	"github.com/xtls/xray-core/transport/internet"
 	"golang.org/x/crypto/cryptobyte"
+	"google.golang.org/protobuf/proto"
 )
 
 func ApplyECH(c *Config, config *tls.Config) error {
 	var ECHConfig []byte
+	var requireECH bool
 	var err error
 
 	var nameToQuery string
@@ -49,27 +54,21 @@ func ApplyECH(c *Config, config *tls.Config) error {
 
 	// for client
 	if len(c.EchConfigList) != 0 {
-		ECHForceQuery := c.EchForceQuery
-		switch ECHForceQuery {
-		case "none", "half", "full":
-		case "":
-			ECHForceQuery = "full" // default to full
-		default:
-			panic("Invalid ECHForceQuery: " + c.EchForceQuery)
+		ECHForceQuery, forceQueryErr := normalizeECHForceQuery(c.EchForceQuery)
+		if forceQueryErr != nil {
+			return forceQueryErr
 		}
 		defer func() {
-			// if failed to get ECHConfig, use an invalid one to make connection fail
-			if err != nil || len(ECHConfig) == 0 {
-				if ECHForceQuery == "full" {
-					ECHConfig = []byte{1, 1, 4, 5, 1, 4}
-				}
+			// Only force a hard failure when bootstrap concluded the route must use ECH.
+			if ECHForceQuery == "full" && (err != nil || (requireECH && len(ECHConfig) == 0)) {
+				ECHConfig = []byte{1, 1, 4, 5, 1, 4}
 			}
 			config.EncryptedClientHelloConfigList = ECHConfig
 		}()
 		// direct base64 config
 		if strings.Contains(c.EchConfigList, "://") {
 			// query config from dns
-			parts := strings.Split(c.EchConfigList, "+")
+			parts := strings.SplitN(c.EchConfigList, "+", 2)
 			if len(parts) == 2 {
 				// parse ECH DNS server in format of "example.com+https://1.1.1.1/dns-query"
 				nameToQuery = parts[0]
@@ -83,7 +82,7 @@ func ApplyECH(c *Config, config *tls.Config) error {
 			if nameToQuery == "" {
 				return errors.New("Using DNS for ECH Config needs serverName or use Server format example.com+https://1.1.1.1/dns-query")
 			}
-			ECHConfig, err = QueryRecord(nameToQuery, DNSServer, c.EchForceQuery, c.EchSocketSettings)
+			ECHConfig, requireECH, err = QueryRecord(nameToQuery, DNSServer, ECHForceQuery, c.EchSocketSettings)
 			if err != nil {
 				return errors.New("Failed to query ECH DNS record for domain: ", nameToQuery, " at server: ", DNSServer).Base(err)
 			}
@@ -105,9 +104,10 @@ type ECHConfigCache struct {
 }
 
 type echConfigRecord struct {
-	config []byte
-	expire time.Time
-	err    error
+	config     []byte
+	requireECH bool
+	expire     time.Time
+	err        error
 }
 
 var (
@@ -116,16 +116,41 @@ var (
 	clientForECHDOH      = utils.NewTypedSyncMap[string, *http.Client]()
 )
 
+const maxECHAliasDepth = 8
+
 // sockopt can be nil if not specified.
 // if for clientForECHDOH, domain can be empty.
 func ECHCacheKey(server, domain string, sockopt *internet.SocketConfig) string {
-	return server + "|" + domain + "|" + fmt.Sprintf("%p", sockopt)
+	return server + "|" + domain + "|" + logicalSocketConfigCacheKey(sockopt)
+}
+
+func normalizeECHForceQuery(forceQuery string) (string, error) {
+	switch forceQuery {
+	case "none", "half", "full":
+		return forceQuery, nil
+	case "":
+		return "full", nil
+	default:
+		return "", errors.New("invalid ECHForceQuery: ", forceQuery)
+	}
+}
+
+func logicalSocketConfigCacheKey(sockopt *internet.SocketConfig) string {
+	if sockopt == nil {
+		return ""
+	}
+	payload, err := proto.MarshalOptions{Deterministic: true}.Marshal(sockopt)
+	if err != nil {
+		return sockopt.String()
+	}
+	sum := sha256.Sum256(payload)
+	return fmt.Sprintf("%x", sum)
 }
 
 // Update updates the ECH config for given domain and server.
 // this method is concurrent safe, only one update request will be sent, others get the cache.
 // if isLockedUpdate is true, it will not try to acquire the lock.
-func (c *ECHConfigCache) Update(domain string, server string, isLockedUpdate bool, forceQuery string, sockopt *internet.SocketConfig) ([]byte, error) {
+func (c *ECHConfigCache) Update(domain string, server string, isLockedUpdate bool, forceQuery string, sockopt *internet.SocketConfig) ([]byte, bool, error) {
 	if !isLockedUpdate {
 		c.UpdateLock.Lock()
 		defer c.UpdateLock.Unlock()
@@ -134,30 +159,31 @@ func (c *ECHConfigCache) Update(domain string, server string, isLockedUpdate boo
 	configRecord := c.configRecord.Load()
 	if configRecord.expire.After(time.Now()) && configRecord.err == nil {
 		errors.LogDebug(context.Background(), "Cache hit for domain after double check: ", domain)
-		return configRecord.config, configRecord.err
+		return configRecord.config, configRecord.requireECH, configRecord.err
 	}
 	// Query ECH config from DNS server
 	errors.LogDebug(context.Background(), "Trying to query ECH config for domain: ", domain, " with ECH server: ", server)
-	echConfig, ttl, err := dnsQuery(server, domain, sockopt)
+	echConfig, requireECH, ttl, err := dnsQuery(server, domain, forceQuery, sockopt)
 	// if in "full", directly return
 	if err != nil && forceQuery == "full" {
-		return nil, err
+		return nil, requireECH, err
 	}
 	if ttl == 0 {
 		ttl = dns2.DefaultTTL
 	}
 	configRecord = &echConfigRecord{
-		config: echConfig,
-		expire: time.Now().Add(time.Duration(ttl) * time.Second),
-		err:    err,
+		config:     echConfig,
+		requireECH: requireECH,
+		expire:     time.Now().Add(time.Duration(ttl) * time.Second),
+		err:        err,
 	}
 	c.configRecord.Store(configRecord)
-	return configRecord.config, configRecord.err
+	return configRecord.config, configRecord.requireECH, configRecord.err
 }
 
 // QueryRecord returns the ECH config for given domain.
 // If the record is not in cache or expired, it will query the DNS server and update the cache.
-func QueryRecord(domain string, server string, forceQuery string, sockopt *internet.SocketConfig) ([]byte, error) {
+func QueryRecord(domain string, server string, forceQuery string, sockopt *internet.SocketConfig) ([]byte, bool, error) {
 	GlobalECHConfigCacheKey := ECHCacheKey(server, domain, sockopt)
 	echConfigCache, ok := GlobalECHConfigCache.Load(GlobalECHConfigCacheKey)
 	if !ok {
@@ -168,7 +194,7 @@ func QueryRecord(domain string, server string, forceQuery string, sockopt *inter
 	configRecord := echConfigCache.configRecord.Load()
 	if configRecord.expire.After(time.Now()) && (configRecord.err == nil || forceQuery == "none") {
 		errors.LogDebug(context.Background(), "Cache hit for domain: ", domain)
-		return configRecord.config, configRecord.err
+		return configRecord.config, configRecord.requireECH, configRecord.err
 	}
 
 	// If expire is zero value, it means we are in initial state, wait for the query to finish
@@ -184,13 +210,150 @@ func QueryRecord(domain string, server string, forceQuery string, sockopt *inter
 				echConfigCache.Update(domain, server, true, forceQuery, sockopt)
 			}()
 		}
-		return configRecord.config, configRecord.err
+		return configRecord.config, configRecord.requireECH, configRecord.err
 	}
 }
 
+type echBootstrapServer struct {
+	raw       string
+	encrypted bool
+}
+
+type echBootstrapResult struct {
+	config     []byte
+	requireECH bool
+	ttl        uint32
+	err        error
+	server     echBootstrapServer
+}
+
 // dnsQuery is the real func for sending type65 query for given domain to given DNS server.
-// return ECH config, TTL and error
-func dnsQuery(server string, domain string, sockopt *internet.SocketConfig) ([]byte, uint32, error) {
+// return ECH config, whether bootstrap requires ECH, TTL and error
+func dnsQuery(server string, domain string, forceQuery string, sockopt *internet.SocketConfig) ([]byte, bool, uint32, error) {
+	servers, err := parseECHBootstrapServers(server)
+	if err != nil {
+		return nil, false, 0, err
+	}
+	return queryECHBootstrapServers(domain, forceQuery, servers, func(server echBootstrapServer) ([]byte, bool, uint32, error) {
+		return resolveECHFromHTTPSLookup(domain, maxECHAliasDepth, map[string]struct{}{}, func(name string) (*dns.Msg, error) {
+			return queryHTTPSMsg(server.raw, name, sockopt)
+		})
+	})
+}
+
+func parseECHBootstrapServers(serverList string) ([]echBootstrapServer, error) {
+	parts := strings.Split(serverList, ",")
+	servers := make([]echBootstrapServer, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		encrypted, supported := echBootstrapTransportSecurity(part)
+		if !supported {
+			return nil, errors.New("unsupported ECH bootstrap DNS transport: ", part)
+		}
+		servers = append(servers, echBootstrapServer{
+			raw:       part,
+			encrypted: encrypted,
+		})
+	}
+	if len(servers) == 0 {
+		return nil, errors.New("empty ECH bootstrap DNS server list")
+	}
+	return servers, nil
+}
+
+func echBootstrapTransportSecurity(server string) (bool, bool) {
+	switch {
+	case strings.HasPrefix(server, "https://"), strings.HasPrefix(server, "tls://"):
+		return true, true
+	case strings.HasPrefix(server, "h2c://"), strings.HasPrefix(server, "tcp://"), strings.HasPrefix(server, "udp://"):
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+func queryECHBootstrapServers(domain string, forceQuery string, servers []echBootstrapServer, query func(server echBootstrapServer) ([]byte, bool, uint32, error)) ([]byte, bool, uint32, error) {
+	hasEncrypted := false
+	for _, server := range servers {
+		if server.encrypted {
+			hasEncrypted = true
+			break
+		}
+	}
+
+	results := make(chan echBootstrapResult, len(servers))
+	for _, server := range servers {
+		go func(server echBootstrapServer) {
+			config, requireECH, ttl, err := query(server)
+			results <- echBootstrapResult{
+				config:     config,
+				requireECH: requireECH,
+				ttl:        ttl,
+				err:        err,
+				server:     server,
+			}
+		}(server)
+	}
+
+	var insecureSuccess *echBootstrapResult
+	var encryptedSuccess *echBootstrapResult
+	var firstEncryptedErr error
+	var firstAnyErr error
+	for range servers {
+		result := <-results
+		if result.err == nil {
+			if result.server.encrypted {
+				if len(result.config) != 0 || result.requireECH {
+					return result.config, result.requireECH, result.ttl, nil
+				}
+				if encryptedSuccess == nil {
+					candidate := result
+					encryptedSuccess = &candidate
+				}
+				continue
+			}
+			if !hasEncrypted {
+				return result.config, result.requireECH, result.ttl, nil
+			}
+			if insecureSuccess == nil {
+				candidate := result
+				insecureSuccess = &candidate
+			}
+			continue
+		}
+		if result.server.encrypted && firstEncryptedErr == nil {
+			firstEncryptedErr = result.err
+		}
+		if firstAnyErr == nil {
+			firstAnyErr = result.err
+		}
+	}
+
+	if encryptedSuccess != nil {
+		return encryptedSuccess.config, encryptedSuccess.requireECH, encryptedSuccess.ttl, nil
+	}
+	if insecureSuccess != nil {
+		if hasEncrypted && forceQuery == "full" {
+			if firstEncryptedErr != nil {
+				return nil, false, 0, errors.New("failed to obtain ECH bootstrap over encrypted DNS for domain: ", domain).Base(firstEncryptedErr)
+			}
+			return nil, false, 0, errors.New("configured ECH bootstrap resolvers require encrypted DNS for domain: ", domain)
+		}
+		return insecureSuccess.config, insecureSuccess.requireECH, insecureSuccess.ttl, nil
+	}
+	if firstEncryptedErr != nil {
+		return nil, false, 0, firstEncryptedErr
+	}
+	if firstAnyErr != nil {
+		return nil, false, 0, firstAnyErr
+	}
+	return nil, false, dns2.DefaultTTL, nil
+}
+
+func queryHTTPSMsg(server string, domain string, sockopt *internet.SocketConfig) (*dns.Msg, error) {
 	m := new(dns.Msg)
 	var dnsResolve []byte
 	m.SetQuestion(dns.Fqdn(domain), dns.TypeHTTPS)
@@ -206,7 +369,7 @@ func dnsQuery(server string, domain string, sockopt *internet.SocketConfig) ([]b
 		m.Id = 0
 		msg, err := m.Pack()
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 		var client *http.Client
 		serverKey := ECHCacheKey(server, "", sockopt)
@@ -249,7 +412,7 @@ func dnsQuery(server string, domain string, sockopt *internet.SocketConfig) ([]b
 		}
 		req, err := http.NewRequest("POST", server, bytes.NewReader(msg))
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 		req.Header.Set("Accept", "application/dns-message")
 		req.Header.Set("Content-Type", "application/dns-message")
@@ -258,15 +421,15 @@ func dnsQuery(server string, domain string, sockopt *internet.SocketConfig) ([]b
 
 		resp, err := client.Do(req)
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 		defer resp.Body.Close()
 		respBody, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 		if resp.StatusCode != http.StatusOK {
-			return nil, 0, errors.New("query failed with response code:", resp.StatusCode)
+			return nil, errors.New("query failed with response code:", resp.StatusCode)
 		}
 		dnsResolve = respBody
 	} else if strings.HasPrefix(server, "udp://") { // for classic udp dns server
@@ -277,14 +440,14 @@ func dnsQuery(server string, domain string, sockopt *internet.SocketConfig) ([]b
 		}
 		dest, err := net.ParseDestination("udp" + ":" + udpServerAddr)
 		if err != nil {
-			return nil, 0, errors.New("failed to parse udp dns server ", udpServerAddr, " for ECH: ", err)
+			return nil, errors.New("failed to parse udp dns server ", udpServerAddr, " for ECH: ", err)
 		}
 		dnsTimeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		// use xray's internet.DialSystem as mentioned above
 		conn, err := internet.DialSystem(dnsTimeoutCtx, dest, sockopt)
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 		defer func() {
 			err := conn.Close()
@@ -294,36 +457,252 @@ func dnsQuery(server string, domain string, sockopt *internet.SocketConfig) ([]b
 		}()
 		msg, err := m.Pack()
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 		conn.Write(msg)
 		udpResponse := make([]byte, 512)
 		conn.SetReadDeadline(time.Now().Add(5 * time.Second))
 		_, err = conn.Read(udpResponse)
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 		dnsResolve = udpResponse
+	} else if strings.HasPrefix(server, "tcp://") || strings.HasPrefix(server, "tls://") {
+		useTLS := strings.HasPrefix(server, "tls://")
+		streamURL, err := url.Parse(server)
+		if err != nil {
+			return nil, errors.New("failed to parse stream dns server ", server, " for ECH: ", err)
+		}
+		port := streamURL.Port()
+		if port == "" {
+			if useTLS {
+				port = "853"
+			} else {
+				port = "53"
+			}
+		}
+		addr := stdnet.JoinHostPort(streamURL.Hostname(), port)
+		dest, err := net.ParseDestination("tcp:" + addr)
+		if err != nil {
+			return nil, errors.New("failed to parse stream dns server ", addr, " for ECH: ", err)
+		}
+		dnsTimeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		conn, err := internet.DialSystem(dnsTimeoutCtx, dest, sockopt)
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			err := conn.Close()
+			if err != nil {
+				errors.LogDebug(context.Background(), "Failed to close connection: ", err)
+			}
+		}()
+		if useTLS {
+			tlsConn := utls.UClient(conn, &utls.Config{ServerName: streamURL.Hostname()}, utls.HelloChrome_Auto)
+			if err := tlsConn.HandshakeContext(dnsTimeoutCtx); err != nil {
+				return nil, err
+			}
+			conn = tlsConn
+		}
+		msg, err := m.Pack()
+		if err != nil {
+			return nil, err
+		}
+		frame := make([]byte, 2+len(msg))
+		binary.BigEndian.PutUint16(frame[:2], uint16(len(msg)))
+		copy(frame[2:], msg)
+		conn.SetDeadline(time.Now().Add(5 * time.Second))
+		if _, err := conn.Write(frame); err != nil {
+			return nil, err
+		}
+		lengthBuf := make([]byte, 2)
+		if _, err := io.ReadFull(conn, lengthBuf); err != nil {
+			return nil, err
+		}
+		responseLength := binary.BigEndian.Uint16(lengthBuf)
+		dnsResolve = make([]byte, responseLength)
+		if _, err := io.ReadFull(conn, dnsResolve); err != nil {
+			return nil, err
+		}
+	} else {
+		return nil, errors.New("unsupported ECH bootstrap DNS transport: ", server)
 	}
 	respMsg := new(dns.Msg)
 	err := respMsg.Unpack(dnsResolve)
 	if err != nil {
-		return nil, 0, errors.New("failed to unpack dns response for ECH: ", err)
+		return nil, errors.New("failed to unpack dns response for ECH: ", err)
 	}
-	if len(respMsg.Answer) > 0 {
-		for _, answer := range respMsg.Answer {
-			if https, ok := answer.(*dns.HTTPS); ok && https.Hdr.Name == dns.Fqdn(domain) {
-				for _, v := range https.Value {
-					if echConfig, ok := v.(*dns.SVCBECHConfig); ok {
-						errors.LogDebug(context.Background(), "Get ECH config:", echConfig.String(), " TTL:", respMsg.Answer[0].Header().Ttl)
-						return echConfig.ECH, answer.Header().Ttl, nil
-					}
-				}
+	return respMsg, nil
+}
+
+func resolveECHFromHTTPSLookup(domain string, remainingAliasDepth int, seen map[string]struct{}, lookup func(string) (*dns.Msg, error)) ([]byte, bool, uint32, error) {
+	name := dns.Fqdn(domain)
+	if remainingAliasDepth < 0 {
+		return nil, false, dns2.DefaultTTL, nil
+	}
+	if _, ok := seen[name]; ok {
+		return nil, false, dns2.DefaultTTL, nil
+	}
+	seen[name] = struct{}{}
+
+	respMsg, err := lookup(name)
+	if err != nil {
+		return nil, false, 0, err
+	}
+
+	canonicalName := canonicalHTTPSName(name, respMsg)
+	rrset := httpsAnswerSet(respMsg, canonicalName)
+	if len(rrset) == 0 {
+		return nil, false, dns2.DefaultTTL, nil
+	}
+
+	if alias := firstHTTPSAlias(rrset); alias != nil {
+		if alias.Target == "." {
+			return nil, false, alias.Header().Ttl, nil
+		}
+		return resolveECHFromHTTPSLookup(alias.Target, remainingAliasDepth-1, seen, lookup)
+	}
+
+	return resolveECHFromHTTPSRRSet(rrset)
+}
+
+func canonicalHTTPSName(domain string, respMsg *dns.Msg) string {
+	current := dns.Fqdn(domain)
+	for range maxECHAliasDepth {
+		next, ok := nextCNAME(current, respMsg)
+		if !ok || next == current {
+			return current
+		}
+		current = next
+	}
+	return current
+}
+
+func nextCNAME(domain string, respMsg *dns.Msg) (string, bool) {
+	for _, answer := range respMsg.Answer {
+		cname, ok := answer.(*dns.CNAME)
+		if ok && cname.Hdr.Name == domain {
+			return dns.Fqdn(cname.Target), true
+		}
+	}
+	return "", false
+}
+
+func httpsAnswerSet(respMsg *dns.Msg, domain string) []*dns.HTTPS {
+	var rrset []*dns.HTTPS
+	for _, answer := range respMsg.Answer {
+		if https, ok := answer.(*dns.HTTPS); ok && https.Hdr.Name == domain {
+			rrset = append(rrset, https)
+		}
+	}
+	return rrset
+}
+
+func firstHTTPSAlias(rrset []*dns.HTTPS) *dns.HTTPS {
+	for _, rr := range rrset {
+		if rr.Priority == 0 {
+			return rr
+		}
+	}
+	return nil
+}
+
+func resolveECHFromHTTPSRRSet(rrset []*dns.HTTPS) ([]byte, bool, uint32, error) {
+	serviceMode := make([]*dns.HTTPS, 0, len(rrset))
+	for _, rr := range rrset {
+		if rr.Priority != 0 {
+			serviceMode = append(serviceMode, rr)
+		}
+	}
+	if len(serviceMode) == 0 {
+		return nil, false, dns2.DefaultTTL, nil
+	}
+
+	sort.SliceStable(serviceMode, func(i, j int) bool {
+		return serviceMode[i].Priority < serviceMode[j].Priority
+	})
+
+	var (
+		selectedConfig     []byte
+		compatibleCount    int
+		compatibleECHCount int
+		minTTL             uint32
+	)
+
+	for _, rr := range serviceMode {
+		compatible, echConfig := compatibleHTTPSRecord(rr)
+		if !compatible {
+			continue
+		}
+		compatibleCount++
+		minTTL = minNonZeroTTL(minTTL, rr.Header().Ttl)
+		if len(echConfig) == 0 {
+			continue
+		}
+		compatibleECHCount++
+		if len(selectedConfig) == 0 {
+			selectedConfig = bytes.Clone(echConfig)
+			errors.LogDebug(context.Background(), "Get ECH config: ", base64.StdEncoding.EncodeToString(selectedConfig), " TTL: ", rr.Header().Ttl)
+		}
+	}
+
+	if compatibleCount == 0 {
+		return nil, false, dns2.DefaultTTL, nil
+	}
+	return selectedConfig, compatibleCount == compatibleECHCount, minTTL, nil
+}
+
+func compatibleHTTPSRecord(rr *dns.HTTPS) (bool, []byte) {
+	params := make(map[dns.SVCBKey]dns.SVCBKeyValue, len(rr.Value))
+	var mandatory *dns.SVCBMandatory
+	var echConfig []byte
+	for _, value := range rr.Value {
+		params[value.Key()] = value
+		switch typed := value.(type) {
+		case *dns.SVCBMandatory:
+			mandatory = typed
+		case *dns.SVCBECHConfig:
+			if len(typed.ECH) != 0 {
+				echConfig = typed.ECH
 			}
 		}
 	}
-	// empty is valid, means no ECH config found
-	return nil, dns2.DefaultTTL, nil
+
+	if _, hasPort := params[dns.SVCB_PORT]; hasPort {
+		return false, nil
+	}
+	if _, hasNoDefaultALPN := params[dns.SVCB_NO_DEFAULT_ALPN]; hasNoDefaultALPN {
+		if _, hasALPN := params[dns.SVCB_ALPN]; !hasALPN {
+			return false, nil
+		}
+		return false, nil
+	}
+	if mandatory == nil {
+		return true, echConfig
+	}
+	for _, key := range mandatory.Code {
+		if key == dns.SVCB_MANDATORY || key == dns.SVCB_PORT || key == dns.SVCB_NO_DEFAULT_ALPN {
+			return false, nil
+		}
+		if _, ok := params[key]; !ok {
+			return false, nil
+		}
+		if key != dns.SVCB_ECHCONFIG {
+			return false, nil
+		}
+	}
+	return true, echConfig
+}
+
+func minNonZeroTTL(left uint32, right uint32) uint32 {
+	if left == 0 {
+		return right
+	}
+	if right == 0 || left < right {
+		return left
+	}
+	return right
 }
 
 var ErrInvalidLen = errors.New("goech: invalid length")

--- a/transport/internet/tls/ech_test.go
+++ b/transport/internet/tls/ech_test.go
@@ -1,14 +1,291 @@
 package tls
 
 import (
+	"bytes"
+	gotls "crypto/tls"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/miekg/dns"
 	"github.com/xtls/xray-core/common"
+	"github.com/xtls/xray-core/transport/internet"
 )
+
+func newHTTPSRecord(name string, priority uint16, ttl uint32, target string, values ...dns.SVCBKeyValue) *dns.HTTPS {
+	return &dns.HTTPS{
+		SVCB: dns.SVCB{
+			Hdr: dns.RR_Header{
+				Name:   dns.Fqdn(name),
+				Rrtype: dns.TypeHTTPS,
+				Class:  dns.ClassINET,
+				Ttl:    ttl,
+			},
+			Priority: priority,
+			Target:   dns.Fqdn(target),
+			Value:    values,
+		},
+	}
+}
+
+func newMandatory(keys ...dns.SVCBKey) *dns.SVCBMandatory {
+	return &dns.SVCBMandatory{Code: keys}
+}
+
+func newECHConfig(config []byte) *dns.SVCBECHConfig {
+	return &dns.SVCBECHConfig{ECH: config}
+}
+
+func TestApplyECHInvalidForceQueryReturnsError(t *testing.T) {
+	err := ApplyECH(&Config{
+		EchConfigList: "AQI=",
+		EchForceQuery: "broken",
+	}, &gotls.Config{ServerName: "example.com"})
+	if err == nil {
+		t.Fatal("ApplyECH() expected error for invalid EchForceQuery")
+	}
+}
+
+func TestECHCacheKeyUsesLogicalSocketConfig(t *testing.T) {
+	left := &internet.SocketConfig{
+		Mark:        100,
+		DialerProxy: "proxy-tag",
+		Interface:   "en0",
+	}
+	right := &internet.SocketConfig{
+		Mark:        100,
+		DialerProxy: "proxy-tag",
+		Interface:   "en0",
+	}
+	different := &internet.SocketConfig{
+		Mark:        101,
+		DialerProxy: "proxy-tag",
+		Interface:   "en0",
+	}
+
+	leftKey := ECHCacheKey("https://1.1.1.1/dns-query", "example.com", left)
+	rightKey := ECHCacheKey("https://1.1.1.1/dns-query", "example.com", right)
+	differentKey := ECHCacheKey("https://1.1.1.1/dns-query", "example.com", different)
+
+	if leftKey != rightKey {
+		t.Fatalf("ECHCacheKey() should be stable for logically equal sockopts: %q != %q", leftKey, rightKey)
+	}
+	if leftKey == differentKey {
+		t.Fatalf("ECHCacheKey() should differ for different sockopts: %q == %q", leftKey, differentKey)
+	}
+}
+
+func TestParseECHBootstrapServersRecognizesEncryptedResolvers(t *testing.T) {
+	servers, err := parseECHBootstrapServers(" https://1.1.1.1/dns-query , tls://dns.google , udp://1.1.1.1 ")
+	if err != nil {
+		t.Fatalf("parseECHBootstrapServers() error = %v", err)
+	}
+	if len(servers) != 3 {
+		t.Fatalf("parseECHBootstrapServers() len = %d, want 3", len(servers))
+	}
+	if !servers[0].encrypted {
+		t.Fatal("parseECHBootstrapServers() should mark https resolver as encrypted")
+	}
+	if !servers[1].encrypted {
+		t.Fatal("parseECHBootstrapServers() should mark tls resolver as encrypted")
+	}
+	if servers[2].encrypted {
+		t.Fatal("parseECHBootstrapServers() should not mark udp resolver as encrypted")
+	}
+}
+
+func TestQueryECHBootstrapServersPrefersEncryptedSuccess(t *testing.T) {
+	encryptedConfig := []byte{0xEE}
+	insecureConfig := []byte{0xAA}
+	servers := []echBootstrapServer{
+		{raw: "udp://1.1.1.1", encrypted: false},
+		{raw: "https://1.1.1.1/dns-query", encrypted: true},
+	}
+
+	config, requireECH, ttl, err := queryECHBootstrapServers("example.com", "full", servers, func(server echBootstrapServer) ([]byte, bool, uint32, error) {
+		switch server.raw {
+		case "udp://1.1.1.1":
+			return insecureConfig, false, 120, nil
+		case "https://1.1.1.1/dns-query":
+			time.Sleep(10 * time.Millisecond)
+			return encryptedConfig, true, 30, nil
+		default:
+			return nil, false, 0, fmt.Errorf("unexpected server %s", server.raw)
+		}
+	})
+	if err != nil {
+		t.Fatalf("queryECHBootstrapServers() error = %v", err)
+	}
+	if !bytes.Equal(config, encryptedConfig) {
+		t.Fatalf("queryECHBootstrapServers() config = %v, want %v", config, encryptedConfig)
+	}
+	if !requireECH {
+		t.Fatal("queryECHBootstrapServers() should keep requireECH from the encrypted resolver")
+	}
+	if ttl != 30 {
+		t.Fatalf("queryECHBootstrapServers() ttl = %d, want 30", ttl)
+	}
+}
+
+func TestQueryECHBootstrapServersFullRejectsInsecureFallback(t *testing.T) {
+	servers := []echBootstrapServer{
+		{raw: "udp://1.1.1.1", encrypted: false},
+		{raw: "https://1.1.1.1/dns-query", encrypted: true},
+	}
+
+	_, _, _, err := queryECHBootstrapServers("example.com", "full", servers, func(server echBootstrapServer) ([]byte, bool, uint32, error) {
+		switch server.raw {
+		case "udp://1.1.1.1":
+			return []byte{0xAA}, false, 120, nil
+		case "https://1.1.1.1/dns-query":
+			return nil, false, 0, fmt.Errorf("doh failed")
+		default:
+			return nil, false, 0, fmt.Errorf("unexpected server %s", server.raw)
+		}
+	})
+	if err == nil {
+		t.Fatal("queryECHBootstrapServers() expected error when only insecure fallback succeeded in full mode")
+	}
+}
+
+func TestQueryECHBootstrapServersFullKeepsLegacySingleUDP(t *testing.T) {
+	expectedConfig := []byte{0xAA}
+	servers := []echBootstrapServer{
+		{raw: "udp://1.1.1.1", encrypted: false},
+	}
+
+	config, requireECH, ttl, err := queryECHBootstrapServers("example.com", "full", servers, func(server echBootstrapServer) ([]byte, bool, uint32, error) {
+		return expectedConfig, false, 120, nil
+	})
+	if err != nil {
+		t.Fatalf("queryECHBootstrapServers() error = %v", err)
+	}
+	if !bytes.Equal(config, expectedConfig) {
+		t.Fatalf("queryECHBootstrapServers() config = %v, want %v", config, expectedConfig)
+	}
+	if requireECH {
+		t.Fatal("queryECHBootstrapServers() unexpectedly required ECH for legacy udp-only bootstrap")
+	}
+	if ttl != 120 {
+		t.Fatalf("queryECHBootstrapServers() ttl = %d, want 120", ttl)
+	}
+}
+
+func TestResolveECHFromHTTPSLookupFollowsAliasAndKeepsOptionalFallback(t *testing.T) {
+	expectedConfig := []byte{0x01, 0x02, 0x03}
+	responses := map[string]*dns.Msg{
+		"example.com.": {
+			Answer: []dns.RR{
+				newHTTPSRecord("example.com", 0, 120, "svc.example.com"),
+			},
+		},
+		"svc.example.com.": {
+			Answer: []dns.RR{
+				newHTTPSRecord("svc.example.com", 1, 30, "."),
+				newHTTPSRecord("svc.example.com", 2, 60, ".", newECHConfig(expectedConfig)),
+			},
+		},
+	}
+
+	config, requireECH, ttl, err := resolveECHFromHTTPSLookup("example.com", maxECHAliasDepth, map[string]struct{}{}, func(name string) (*dns.Msg, error) {
+		msg, ok := responses[dns.Fqdn(name)]
+		if !ok {
+			return nil, fmt.Errorf("unexpected lookup for %s", name)
+		}
+		return msg, nil
+	})
+	if err != nil {
+		t.Fatalf("resolveECHFromHTTPSLookup() error = %v", err)
+	}
+	if !bytes.Equal(config, expectedConfig) {
+		t.Fatalf("resolveECHFromHTTPSLookup() config = %v, want %v", config, expectedConfig)
+	}
+	if requireECH {
+		t.Fatal("resolveECHFromHTTPSLookup() unexpectedly required ECH when a compatible fallback endpoint exists")
+	}
+	if ttl != 30 {
+		t.Fatalf("resolveECHFromHTTPSLookup() ttl = %d, want 30", ttl)
+	}
+}
+
+func TestResolveECHFromHTTPSRRSetRejectsUnsupportedMandatoryParams(t *testing.T) {
+	rejectedConfig := []byte{0x0A}
+	selectedConfig := []byte{0x0B, 0x0C}
+	rrset := []*dns.HTTPS{
+		newHTTPSRecord("example.com", 1, 90, ".", newECHConfig(rejectedConfig), &dns.SVCBPort{Port: 8443}),
+		newHTTPSRecord("example.com", 2, 45, ".", newECHConfig(selectedConfig), newMandatory(dns.SVCB_ECHCONFIG)),
+	}
+
+	config, requireECH, ttl, err := resolveECHFromHTTPSRRSet(rrset)
+	if err != nil {
+		t.Fatalf("resolveECHFromHTTPSRRSet() error = %v", err)
+	}
+	if !bytes.Equal(config, selectedConfig) {
+		t.Fatalf("resolveECHFromHTTPSRRSet() config = %v, want %v", config, selectedConfig)
+	}
+	if !requireECH {
+		t.Fatal("resolveECHFromHTTPSRRSet() should require ECH when every compatible record carries ech")
+	}
+	if ttl != 45 {
+		t.Fatalf("resolveECHFromHTTPSRRSet() ttl = %d, want 45", ttl)
+	}
+}
+
+func TestApplyECHFullAllowsFallbackWhenBootstrapIsOptional(t *testing.T) {
+	GlobalECHConfigCache.Clear()
+	t.Cleanup(func() {
+		GlobalECHConfigCache.Clear()
+	})
+
+	cache := &ECHConfigCache{}
+	cache.configRecord.Store(&echConfigRecord{
+		expire: time.Now().Add(time.Minute),
+	})
+	GlobalECHConfigCache.Store(ECHCacheKey("udp://1.1.1.1", "example.com", nil), cache)
+
+	tlsConfig := &gotls.Config{ServerName: "example.com"}
+	err := ApplyECH(&Config{
+		EchConfigList: "udp://1.1.1.1",
+		EchForceQuery: "full",
+	}, tlsConfig)
+	if err != nil {
+		t.Fatalf("ApplyECH() error = %v", err)
+	}
+	if len(tlsConfig.EncryptedClientHelloConfigList) != 0 {
+		t.Fatalf("ApplyECH() forced an invalid config for an optional fallback path: %v", tlsConfig.EncryptedClientHelloConfigList)
+	}
+}
+
+func TestApplyECHFullFailsWhenBootstrapRequiresECH(t *testing.T) {
+	GlobalECHConfigCache.Clear()
+	t.Cleanup(func() {
+		GlobalECHConfigCache.Clear()
+	})
+
+	cache := &ECHConfigCache{}
+	cache.configRecord.Store(&echConfigRecord{
+		requireECH: true,
+		expire:     time.Now().Add(time.Minute),
+	})
+	GlobalECHConfigCache.Store(ECHCacheKey("udp://1.1.1.1", "example.com", nil), cache)
+
+	tlsConfig := &gotls.Config{ServerName: "example.com"}
+	err := ApplyECH(&Config{
+		EchConfigList: "udp://1.1.1.1",
+		EchForceQuery: "full",
+	}, tlsConfig)
+	if err != nil {
+		t.Fatalf("ApplyECH() error = %v", err)
+	}
+	expectedInvalid := []byte{1, 1, 4, 5, 1, 4}
+	if !bytes.Equal(tlsConfig.EncryptedClientHelloConfigList, expectedInvalid) {
+		t.Fatalf("ApplyECH() config = %v, want %v", tlsConfig.EncryptedClientHelloConfigList, expectedInvalid)
+	}
+}
 
 func TestECHDial(t *testing.T) {
 	config := &Config{

--- a/transport/internet/tls/tls.go
+++ b/transport/internet/tls/tls.go
@@ -10,6 +10,7 @@ import (
 	utls "github.com/refraction-networking/utls"
 	"github.com/xtls/xray-core/common/buf"
 	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/session"
 	"github.com/xtls/xray-core/common/utils"
 )
 
@@ -26,6 +27,7 @@ var _ Interface = (*Conn)(nil)
 
 type Conn struct {
 	*tls.Conn
+	echConfigured bool
 }
 
 const tlsCloseTimeout = 250 * time.Millisecond
@@ -36,6 +38,15 @@ func (c *Conn) Close() error {
 	})
 	defer timer.Stop()
 	return c.Conn.Close()
+}
+
+func (c *Conn) HandshakeContext(ctx context.Context) error {
+	if err := c.Conn.HandshakeContext(ctx); err != nil {
+		return err
+	}
+	state := c.ConnectionState()
+	reportECHStatus(ctx, c.echConfigured, state.ECHAccepted, state.ServerName)
+	return nil
 }
 
 func (c *Conn) WriteMultiBuffer(mb buf.MultiBuffer) error {
@@ -60,7 +71,10 @@ func (c *Conn) NegotiatedProtocol() string {
 // Client initiates a TLS client handshake on the given connection.
 func Client(c net.Conn, config *tls.Config) net.Conn {
 	tlsConn := tls.Client(c, config)
-	return &Conn{Conn: tlsConn}
+	return &Conn{
+		Conn:          tlsConn,
+		echConfigured: len(config.EncryptedClientHelloConfigList) != 0,
+	}
 }
 
 // Server initiates a TLS server handshake on the given connection.
@@ -71,6 +85,7 @@ func Server(c net.Conn, config *tls.Config) net.Conn {
 
 type UConn struct {
 	*utls.UConn
+	echConfigured bool
 }
 
 var _ Interface = (*UConn)(nil)
@@ -81,6 +96,15 @@ func (c *UConn) Close() error {
 	})
 	defer timer.Stop()
 	return c.Conn.Close()
+}
+
+func (c *UConn) HandshakeContext(ctx context.Context) error {
+	if err := c.UConn.HandshakeContext(ctx); err != nil {
+		return err
+	}
+	state := c.ConnectionState()
+	reportECHStatus(ctx, c.echConfigured, state.ECHAccepted, state.ServerName)
+	return nil
 }
 
 func (c *UConn) HandshakeContextServerName(ctx context.Context) string {
@@ -130,7 +154,10 @@ func (c *UConn) NegotiatedProtocol() string {
 
 func UClient(c net.Conn, config *tls.Config, fingerprint *utls.ClientHelloID) net.Conn {
 	utlsConn := utls.UClient(c, copyConfig(config), *fingerprint)
-	return &UConn{UConn: utlsConn}
+	return &UConn{
+		UConn:         utlsConn,
+		echConfigured: len(config.EncryptedClientHelloConfigList) != 0,
+	}
 }
 
 func GeneraticUClient(c net.Conn, config *tls.Config) *utls.UConn {
@@ -151,6 +178,17 @@ func copyConfig(c *tls.Config) *utls.Config {
 		config.NextProtos = c.NextProtos
 	}
 	return config
+}
+
+func reportECHStatus(ctx context.Context, echConfigured bool, echAccepted bool, serverName string) {
+	if !echConfigured && !echAccepted {
+		return
+	}
+	session.SubmitOutboundECHStatusToOriginator(ctx, session.OutboundECHStatus{
+		Enabled:    echConfigured,
+		Accepted:   echAccepted,
+		ServerName: serverName,
+	})
 }
 
 func init() {


### PR DESCRIPTION
Improves ECH bootstrap/routing, observatory snapshots, and adds MASQUE-based UDP transport datagrams with telemetry and CLI inspection.
