### PR TITLE
TUN inbound: Add `gateway`, `dns`, `autoSystemRoutingTable`, `autoOutboundsInterface` for Windows

### DIFF
--- a/features/dns/localdns/client.go
+++ b/features/dns/localdns/client.go
@@ -1,12 +1,21 @@
 package localdns
 
 import (
+	"context"
+	"syscall"
+	"time"
+
+	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/features/dns"
+	"github.com/xtls/xray-core/transport/internet"
 )
 
 // Client is an implementation of dns.Client, which queries localhost for DNS.
-type Client struct{}
+type Client struct {
+	d *net.Dialer
+	r *net.Resolver
+}
 
 // Type implements common.HasType.
 func (*Client) Type() interface{} {
@@ -20,8 +29,8 @@ func (*Client) Start() error { return nil }
 func (*Client) Close() error { return nil }
 
 // LookupIP implements Client.
-func (*Client) LookupIP(host string, option dns.IPOption) ([]net.IP, uint32, error) {
-	ips, err := net.LookupIP(host)
+func (c *Client) LookupIP(host string, option dns.IPOption) ([]net.IP, uint32, error) {
+	ips, err := c.r.LookupIP(context.Background(), "ip", host)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -62,5 +71,24 @@ func (*Client) LookupIP(host string, option dns.IPOption) ([]net.IP, uint32, err
 
 // New create a new dns.Client that queries localhost for DNS.
 func New() *Client {
-	return &Client{}
+	d := &net.Dialer{}
+	d.Timeout = time.Second * 16
+	d.Control = func(network, address string, c syscall.RawConn) error {
+		for _, ctl := range internet.Controllers {
+			if err := ctl(network, address, c); err != nil {
+				errors.LogInfoInner(context.Background(), err, "failed to apply external controller")
+				return err
+			}
+		}
+		return nil
+	}
+
+	r := &net.Resolver{}
+	r.PreferGo = true
+	r.Dial = d.DialContext
+
+	return &Client{
+		d: d,
+		r: r,
+	}
 }

--- a/features/dns/localdns/client.go
+++ b/features/dns/localdns/client.go
@@ -84,7 +84,6 @@ func New() *Client {
 	}
 
 	r := &net.Resolver{}
-	r.PreferGo = true
 	r.Dial = d.DialContext
 
 	return &Client{

--- a/features/dns/localdns/client.go
+++ b/features/dns/localdns/client.go
@@ -30,7 +30,13 @@ func (*Client) Close() error { return nil }
 
 // LookupIP implements Client.
 func (c *Client) LookupIP(host string, option dns.IPOption) ([]net.IP, uint32, error) {
-	ips, err := c.r.LookupIP(context.Background(), "ip", host)
+	var ips []net.IP
+	var err error
+	if len(internet.Controllers) > 0 {
+		ips, err = c.r.LookupIP(context.Background(), "ip", host)
+	} else {
+		ips, err = net.LookupIP(host)
+	}
 	if err != nil {
 		return nil, 0, err
 	}
@@ -71,20 +77,25 @@ func (c *Client) LookupIP(host string, option dns.IPOption) ([]net.IP, uint32, e
 
 // New create a new dns.Client that queries localhost for DNS.
 func New() *Client {
-	d := &net.Dialer{}
-	d.Timeout = time.Second * 16
-	d.Control = func(network, address string, c syscall.RawConn) error {
-		for _, ctl := range internet.Controllers {
-			if err := ctl(network, address, c); err != nil {
-				errors.LogInfoInner(context.Background(), err, "failed to apply external controller")
-				return err
+	d := &net.Dialer{
+		Timeout: time.Second * 16,
+		Control: func(network, address string, c syscall.RawConn) error {
+			for _, ctl := range internet.Controllers {
+				if err := ctl(network, address, c); err != nil {
+					errors.LogInfoInner(context.Background(), err, "failed to apply external controller")
+					return err
+				}
 			}
-		}
-		return nil
+			return nil
+		},
 	}
 
-	r := &net.Resolver{}
-	r.Dial = d.DialContext
+	r := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			return d.DialContext(ctx, network, address)
+		},
+	}
 
 	return &Client{
 		d: d,

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	golang.org/x/sys v0.42.0
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2
 	golang.zx2c4.com/wireguard v0.0.0-20250521234502-f333402bd9cb
+	golang.zx2c4.com/wireguard/windows v0.5.3
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
 	gvisor.dev/gvisor v0.0.0-20260122175437-89a5d21be8f0

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 h1:B82qJJgjvYKsXS9jeu
 golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2/go.mod h1:deeaetjYA+DHMHg+sMSMI58GrEteJUUzzw7en6TJQcI=
 golang.zx2c4.com/wireguard v0.0.0-20250521234502-f333402bd9cb h1:whnFRlWMcXI9d+ZbWg+4sHnLp52d5yiIPUxMBSt4X9A=
 golang.zx2c4.com/wireguard v0.0.0-20250521234502-f333402bd9cb/go.mod h1:rpwXGsirqLqN2L0JDJQlwOboGHmptD5ZD6T2VmcqhTw=
+golang.zx2c4.com/wireguard/windows v0.5.3 h1:On6j2Rpn3OEMXqBq00QEDC7bWSZrPIHKIus8eIuExIE=
+golang.zx2c4.com/wireguard/windows v0.5.3/go.mod h1:9TEe8TJmtwyQebdFwAkEWOPr3prrtqm+REGFifP60hI=
 gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
 gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260120221211-b8f7ae30c516 h1:sNrWoksmOyF5bvJUcnmbeAmQi8baNhqg5IWaI3llQqU=

--- a/infra/conf/tun.go
+++ b/infra/conf/tun.go
@@ -24,25 +24,21 @@ func (v *TunConfig) Build() (proto.Message, error) {
 		UserLevel:        v.UserLevel,
 		AutoRoutingTable: v.AutoRoutingTable,
 	}
-
 	if v.AutoOutboundsInterface != nil {
 		config.AutoOutboundsInterface = *v.AutoOutboundsInterface
 	}
-
-	if v.Name == "" {
-		config.Name = "xray0"
-	}
-
-	if len(v.MTU) == 1 {
-		v.MTU = append(v.MTU, v.MTU[0])
-	}
-	if len(v.MTU) == 0 {
-		v.MTU = []uint32{1500, 1280}
-	}
-
-	if len(config.AutoRoutingTable) > 0 && v.AutoOutboundsInterface == nil {
+	if len(v.AutoRoutingTable) > 0 && v.AutoOutboundsInterface == nil {
 		config.AutoOutboundsInterface = "auto"
 	}
 
+	if config.Name == "" {
+		config.Name = "xray0"
+	}
+	if len(config.MTU) == 0 {
+		config.MTU = []uint32{1500, 1280}
+	}
+	if len(config.MTU) == 1 {
+		config.MTU = append(config.MTU, config.MTU[0])
+	}
 	return config, nil
 }

--- a/infra/conf/tun.go
+++ b/infra/conf/tun.go
@@ -6,13 +6,13 @@ import (
 )
 
 type TunConfig struct {
-	Name      string   `json:"name"`
-	MTU       uint32   `json:"MTU"`
-	UserLevel uint32   `json:"userLevel"`
-	Interface string   `json:"interface"`
-	Address   []string `json:"address"`
-	Route     []string `json:"route"`
-	Dns       []string `json:"dns"`
+	Name         string   `json:"name"`
+	MTU          uint32   `json:"MTU"`
+	UserLevel    uint32   `json:"userLevel"`
+	Interface    string   `json:"interface"`
+	MyGatewayIPs []string `json:"myGatewayIPs"`
+	AutoRouteIPs []string `json:"autoRouteIPs"`
+	Dns          []string `json:"dns"`
 }
 
 func (v *TunConfig) Build() (proto.Message, error) {
@@ -21,8 +21,8 @@ func (v *TunConfig) Build() (proto.Message, error) {
 		MTU:       v.MTU,
 		UserLevel: v.UserLevel,
 		Interface: v.Interface,
-		Address:   v.Address,
-		Route:     v.Route,
+		Address:   v.MyGatewayIPs,
+		Route:     v.AutoRouteIPs,
 		Dns:       v.Dns,
 	}
 

--- a/infra/conf/tun.go
+++ b/infra/conf/tun.go
@@ -7,11 +7,11 @@ import (
 
 type TunConfig struct {
 	Name                   string   `json:"name"`
-	MTU                    uint32   `json:"mtu"`
-	MyGatewayIPs           []string `json:"myGatewayIPs"`
+	MTU                    []uint32 `json:"mtu"`
+	Gateway                []string `json:"gateway"`
 	DNS                    []string `json:"dns"`
 	UserLevel              uint32   `json:"userLevel"`
-	AutoRouteIPs           []string `json:"autoRouteIPs"`
+	AutoRoutingTable       []string `json:"autoRoutingTable"`
 	AutoOutboundsInterface *string  `json:"autoOutboundsInterface"`
 }
 
@@ -19,10 +19,10 @@ func (v *TunConfig) Build() (proto.Message, error) {
 	config := &tun.Config{
 		Name:             v.Name,
 		MTU:              v.MTU,
-		Gateway:          v.MyGatewayIPs,
+		Gateway:          v.Gateway,
 		DNS:              v.DNS,
 		UserLevel:        v.UserLevel,
-		AutoRoutingTable: v.AutoRouteIPs,
+		AutoRoutingTable: v.AutoRoutingTable,
 	}
 
 	if v.AutoOutboundsInterface != nil {
@@ -33,8 +33,11 @@ func (v *TunConfig) Build() (proto.Message, error) {
 		config.Name = "xray0"
 	}
 
-	if v.MTU == 0 {
-		config.MTU = 1500
+	if len(v.MTU) == 1 {
+		v.MTU = append(v.MTU, v.MTU[0])
+	}
+	if len(v.MTU) == 0 {
+		v.MTU = []uint32{1500, 1280}
 	}
 
 	if len(config.AutoRoutingTable) > 0 && v.AutoOutboundsInterface == nil {

--- a/infra/conf/tun.go
+++ b/infra/conf/tun.go
@@ -11,6 +11,7 @@ type TunConfig struct {
 	UserLevel uint32   `json:"userLevel"`
 	Address   []string `json:"address"`
 	Route     []string `json:"route"`
+	Dns       []string `json:"dns"`
 }
 
 func (v *TunConfig) Build() (proto.Message, error) {
@@ -20,6 +21,7 @@ func (v *TunConfig) Build() (proto.Message, error) {
 		UserLevel: v.UserLevel,
 		Address:   v.Address,
 		Route:     v.Route,
+		Dns:       v.Dns,
 	}
 
 	if v.Name == "" {

--- a/infra/conf/tun.go
+++ b/infra/conf/tun.go
@@ -6,13 +6,13 @@ import (
 )
 
 type TunConfig struct {
-	Name         string   `json:"name"`
-	MTU          uint32   `json:"MTU"`
-	UserLevel    uint32   `json:"userLevel"`
-	Interface    string   `json:"interface"`
-	MyGatewayIPs []string `json:"myGatewayIPs"`
-	AutoRouteIPs []string `json:"autoRouteIPs"`
-	Dns          []string `json:"dns"`
+	Name                   string   `json:"name"`
+	MTU                    uint32   `json:"MTU"`
+	UserLevel              uint32   `json:"userLevel"`
+	AutoOutboundsInterface string   `json:"autoOutboundsInterface"`
+	MyGatewayIPs           []string `json:"myGatewayIPs"`
+	AutoRouteIPs           []string `json:"autoRouteIPs"`
+	Dns                    []string `json:"dns"`
 }
 
 func (v *TunConfig) Build() (proto.Message, error) {
@@ -20,7 +20,7 @@ func (v *TunConfig) Build() (proto.Message, error) {
 		Name:      v.Name,
 		MTU:       v.MTU,
 		UserLevel: v.UserLevel,
-		Interface: v.Interface,
+		Interface: v.AutoOutboundsInterface,
 		Address:   v.MyGatewayIPs,
 		Route:     v.AutoRouteIPs,
 		Dns:       v.Dns,
@@ -32,6 +32,10 @@ func (v *TunConfig) Build() (proto.Message, error) {
 
 	if v.MTU == 0 {
 		config.MTU = 1500
+	}
+
+	if len(config.Route) > 0 && config.Interface == "" {
+		config.Interface = "auto"
 	}
 
 	return config, nil

--- a/infra/conf/tun.go
+++ b/infra/conf/tun.go
@@ -6,9 +6,10 @@ import (
 )
 
 type TunConfig struct {
-	Name      string `json:"name"`
-	MTU       uint32 `json:"MTU"`
-	UserLevel uint32 `json:"userLevel"`
+	Name      string   `json:"name"`
+	MTU       uint32   `json:"MTU"`
+	UserLevel uint32   `json:"userLevel"`
+	WinRoute  []string `json:"winRoute"`
 }
 
 func (v *TunConfig) Build() (proto.Message, error) {
@@ -16,6 +17,7 @@ func (v *TunConfig) Build() (proto.Message, error) {
 		Name:      v.Name,
 		MTU:       v.MTU,
 		UserLevel: v.UserLevel,
+		WinRoute:  v.WinRoute,
 	}
 
 	if v.Name == "" {

--- a/infra/conf/tun.go
+++ b/infra/conf/tun.go
@@ -6,22 +6,24 @@ import (
 )
 
 type TunConfig struct {
-	Name      string   `json:"name"`
-	MTU       uint32   `json:"MTU"`
-	UserLevel uint32   `json:"userLevel"`
-	Address   []string `json:"address"`
-	Route     []string `json:"route"`
-	Dns       []string `json:"dns"`
+	Name          string   `json:"name"`
+	MTU           uint32   `json:"MTU"`
+	UserLevel     uint32   `json:"userLevel"`
+	AutoInterface bool     `json:"autoInterface"`
+	Address       []string `json:"address"`
+	Route         []string `json:"route"`
+	Dns           []string `json:"dns"`
 }
 
 func (v *TunConfig) Build() (proto.Message, error) {
 	config := &tun.Config{
-		Name:      v.Name,
-		MTU:       v.MTU,
-		UserLevel: v.UserLevel,
-		Address:   v.Address,
-		Route:     v.Route,
-		Dns:       v.Dns,
+		Name:          v.Name,
+		MTU:           v.MTU,
+		UserLevel:     v.UserLevel,
+		AutoInterface: v.AutoInterface,
+		Address:       v.Address,
+		Route:         v.Route,
+		Dns:           v.Dns,
 	}
 
 	if v.Name == "" {

--- a/infra/conf/tun.go
+++ b/infra/conf/tun.go
@@ -11,23 +11,23 @@ type TunConfig struct {
 	Gateway                []string `json:"gateway"`
 	DNS                    []string `json:"dns"`
 	UserLevel              uint32   `json:"userLevel"`
-	AutoRoutingTable       []string `json:"autoRoutingTable"`
+	AutoSystemRoutingTable []string `json:"autoSystemRoutingTable"`
 	AutoOutboundsInterface *string  `json:"autoOutboundsInterface"`
 }
 
 func (v *TunConfig) Build() (proto.Message, error) {
 	config := &tun.Config{
-		Name:             v.Name,
-		MTU:              v.MTU,
-		Gateway:          v.Gateway,
-		DNS:              v.DNS,
-		UserLevel:        v.UserLevel,
-		AutoRoutingTable: v.AutoRoutingTable,
+		Name:                   v.Name,
+		MTU:                    v.MTU,
+		Gateway:                v.Gateway,
+		DNS:                    v.DNS,
+		UserLevel:              v.UserLevel,
+		AutoSystemRoutingTable: v.AutoSystemRoutingTable,
 	}
 	if v.AutoOutboundsInterface != nil {
 		config.AutoOutboundsInterface = *v.AutoOutboundsInterface
 	}
-	if len(v.AutoRoutingTable) > 0 && v.AutoOutboundsInterface == nil {
+	if len(v.AutoSystemRoutingTable) > 0 && v.AutoOutboundsInterface == nil {
 		config.AutoOutboundsInterface = "auto"
 	}
 

--- a/infra/conf/tun.go
+++ b/infra/conf/tun.go
@@ -9,7 +9,8 @@ type TunConfig struct {
 	Name      string   `json:"name"`
 	MTU       uint32   `json:"MTU"`
 	UserLevel uint32   `json:"userLevel"`
-	WinRoute  []string `json:"winRoute"`
+	Address   []string `json:"address"`
+	Route     []string `json:"route"`
 }
 
 func (v *TunConfig) Build() (proto.Message, error) {
@@ -17,7 +18,8 @@ func (v *TunConfig) Build() (proto.Message, error) {
 		Name:      v.Name,
 		MTU:       v.MTU,
 		UserLevel: v.UserLevel,
-		WinRoute:  v.WinRoute,
+		Address:   v.Address,
+		Route:     v.Route,
 	}
 
 	if v.Name == "" {

--- a/infra/conf/tun.go
+++ b/infra/conf/tun.go
@@ -7,23 +7,26 @@ import (
 
 type TunConfig struct {
 	Name                   string   `json:"name"`
-	MTU                    uint32   `json:"MTU"`
-	UserLevel              uint32   `json:"userLevel"`
-	AutoOutboundsInterface string   `json:"autoOutboundsInterface"`
+	MTU                    uint32   `json:"mtu"`
 	MyGatewayIPs           []string `json:"myGatewayIPs"`
+	DNS                    []string `json:"dns"`
+	UserLevel              uint32   `json:"userLevel"`
 	AutoRouteIPs           []string `json:"autoRouteIPs"`
-	Dns                    []string `json:"dns"`
+	AutoOutboundsInterface *string  `json:"autoOutboundsInterface"`
 }
 
 func (v *TunConfig) Build() (proto.Message, error) {
 	config := &tun.Config{
-		Name:      v.Name,
-		MTU:       v.MTU,
-		UserLevel: v.UserLevel,
-		Interface: v.AutoOutboundsInterface,
-		Address:   v.MyGatewayIPs,
-		Route:     v.AutoRouteIPs,
-		Dns:       v.Dns,
+		Name:             v.Name,
+		MTU:              v.MTU,
+		Gateway:          v.MyGatewayIPs,
+		DNS:              v.DNS,
+		UserLevel:        v.UserLevel,
+		AutoRoutingTable: v.AutoRouteIPs,
+	}
+
+	if v.AutoOutboundsInterface != nil {
+		config.AutoOutboundsInterface = *v.AutoOutboundsInterface
 	}
 
 	if v.Name == "" {
@@ -34,8 +37,8 @@ func (v *TunConfig) Build() (proto.Message, error) {
 		config.MTU = 1500
 	}
 
-	if len(config.Route) > 0 && config.Interface == "" {
-		config.Interface = "auto"
+	if len(config.AutoRoutingTable) > 0 && v.AutoOutboundsInterface == nil {
+		config.AutoOutboundsInterface = "auto"
 	}
 
 	return config, nil

--- a/infra/conf/tun.go
+++ b/infra/conf/tun.go
@@ -6,24 +6,24 @@ import (
 )
 
 type TunConfig struct {
-	Name          string   `json:"name"`
-	MTU           uint32   `json:"MTU"`
-	UserLevel     uint32   `json:"userLevel"`
-	AutoInterface bool     `json:"autoInterface"`
-	Address       []string `json:"address"`
-	Route         []string `json:"route"`
-	Dns           []string `json:"dns"`
+	Name      string   `json:"name"`
+	MTU       uint32   `json:"MTU"`
+	UserLevel uint32   `json:"userLevel"`
+	Interface string   `json:"interface"`
+	Address   []string `json:"address"`
+	Route     []string `json:"route"`
+	Dns       []string `json:"dns"`
 }
 
 func (v *TunConfig) Build() (proto.Message, error) {
 	config := &tun.Config{
-		Name:          v.Name,
-		MTU:           v.MTU,
-		UserLevel:     v.UserLevel,
-		AutoInterface: v.AutoInterface,
-		Address:       v.Address,
-		Route:         v.Route,
-		Dns:           v.Dns,
+		Name:      v.Name,
+		MTU:       v.MTU,
+		UserLevel: v.UserLevel,
+		Interface: v.Interface,
+		Address:   v.Address,
+		Route:     v.Route,
+		Dns:       v.Dns,
 	}
 
 	if v.Name == "" {

--- a/proxy/tun/config.go
+++ b/proxy/tun/config.go
@@ -17,16 +17,11 @@ type InterfaceUpdater struct {
 
 var updater *InterfaceUpdater
 
-func (updater *InterfaceUpdater) Get() *int {
+func (updater *InterfaceUpdater) Get() *net.Interface {
 	updater.Lock()
 	defer updater.Unlock()
 
-	if updater.iface == nil {
-		return nil
-	}
-
-	index := updater.iface.Index
-	return &index
+	return updater.iface
 }
 
 func (updater *InterfaceUpdater) Update() {
@@ -34,8 +29,8 @@ func (updater *InterfaceUpdater) Update() {
 	defer updater.Unlock()
 
 	if updater.iface != nil {
-		_, err := net.InterfaceByIndex(updater.iface.Index)
-		if err == nil {
+		iface, err := net.InterfaceByIndex(updater.iface.Index)
+		if err == nil && iface.Name == updater.iface.Name {
 			return
 		}
 	}
@@ -44,7 +39,7 @@ func (updater *InterfaceUpdater) Update() {
 
 	interfaces, err := net.Interfaces()
 	if err != nil {
-		errors.LogInfoInner(context.Background(), err, "failed to update default interface")
+		errors.LogInfoInner(context.Background(), err, "[tun] failed to update interface")
 		return
 	}
 
@@ -60,10 +55,10 @@ func (updater *InterfaceUpdater) Update() {
 	}
 
 	if got == nil {
-		errors.LogInfo(context.Background(), "failed to update default interface > got == nil")
+		errors.LogInfo(context.Background(), "[tun] failed to update interface > got == nil")
 		return
 	}
 
 	updater.iface = got
-	errors.LogInfo(context.Background(), "update default interface ", got.Name, " ", got.Index)
+	errors.LogInfo(context.Background(), "[tun] update interface ", got.Name, " ", got.Index)
 }

--- a/proxy/tun/config.go
+++ b/proxy/tun/config.go
@@ -11,8 +11,9 @@ import (
 type InterfaceUpdater struct {
 	sync.Mutex
 
-	tunIndex int
-	iface    *net.Interface
+	tunIndex  int
+	fixedName string
+	iface     *net.Interface
 }
 
 var updater *InterfaceUpdater
@@ -48,9 +49,16 @@ func (updater *InterfaceUpdater) Update() {
 		if iface.Index == updater.tunIndex {
 			continue
 		}
-		if iface.Flags&net.FlagLoopback == 0 {
-			got = &iface
-			break
+		if updater.fixedName != "" {
+			if iface.Name == updater.fixedName {
+				got = &iface
+				break
+			}
+		} else {
+			if iface.Flags&net.FlagLoopback == 0 {
+				got = &iface
+				break
+			}
 		}
 	}
 

--- a/proxy/tun/config.go
+++ b/proxy/tun/config.go
@@ -55,7 +55,13 @@ func (updater *InterfaceUpdater) Update() {
 				break
 			}
 		} else {
-			if iface.Flags&net.FlagLoopback == 0 {
+			addrs, err := iface.Addrs()
+			if err != nil {
+				continue
+			}
+			if (iface.Flags&net.FlagUp != 0) &&
+				(iface.Flags&net.FlagLoopback == 0) &&
+				len(addrs) > 0 {
 				got = &iface
 				break
 			}

--- a/proxy/tun/config.go
+++ b/proxy/tun/config.go
@@ -1,1 +1,69 @@
 package tun
+
+import (
+	"context"
+	"net"
+	"sync"
+
+	"github.com/xtls/xray-core/common/errors"
+)
+
+type InterfaceUpdater struct {
+	sync.Mutex
+
+	tunIndex int
+	iface    *net.Interface
+}
+
+var updater *InterfaceUpdater
+
+func (updater *InterfaceUpdater) Get() *int {
+	updater.Lock()
+	defer updater.Unlock()
+
+	if updater.iface == nil {
+		return nil
+	}
+
+	index := updater.iface.Index
+	return &index
+}
+
+func (updater *InterfaceUpdater) Update() {
+	updater.Lock()
+	defer updater.Unlock()
+
+	if updater.iface != nil {
+		_, err := net.InterfaceByIndex(updater.iface.Index)
+		if err == nil {
+			return
+		}
+	}
+
+	updater.iface = nil
+
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		errors.LogInfoInner(context.Background(), err, "failed to update default interface")
+		return
+	}
+
+	var got *net.Interface
+	for _, iface := range interfaces {
+		if iface.Index == updater.tunIndex {
+			continue
+		}
+		if iface.Flags&net.FlagLoopback == 0 {
+			got = &iface
+			break
+		}
+	}
+
+	if got == nil {
+		errors.LogInfo(context.Background(), "failed to update default interface > got == nil")
+		return
+	}
+
+	updater.iface = got
+	errors.LogInfo(context.Background(), "update default interface ", got.Name, " ", got.Index)
+}

--- a/proxy/tun/config.pb.go
+++ b/proxy/tun/config.pb.go
@@ -26,7 +26,8 @@ type Config struct {
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	MTU           uint32                 `protobuf:"varint,2,opt,name=MTU,proto3" json:"MTU,omitempty"`
 	UserLevel     uint32                 `protobuf:"varint,3,opt,name=user_level,json=userLevel,proto3" json:"user_level,omitempty"`
-	WinRoute      []string               `protobuf:"bytes,4,rep,name=win_route,json=winRoute,proto3" json:"win_route,omitempty"`
+	Address       []string               `protobuf:"bytes,4,rep,name=address,proto3" json:"address,omitempty"`
+	Route         []string               `protobuf:"bytes,5,rep,name=route,proto3" json:"route,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -82,9 +83,16 @@ func (x *Config) GetUserLevel() uint32 {
 	return 0
 }
 
-func (x *Config) GetWinRoute() []string {
+func (x *Config) GetAddress() []string {
 	if x != nil {
-		return x.WinRoute
+		return x.Address
+	}
+	return nil
+}
+
+func (x *Config) GetRoute() []string {
+	if x != nil {
+		return x.Route
 	}
 	return nil
 }
@@ -93,13 +101,14 @@ var File_proxy_tun_config_proto protoreflect.FileDescriptor
 
 const file_proxy_tun_config_proto_rawDesc = "" +
 	"\n" +
-	"\x16proxy/tun/config.proto\x12\x0exray.proxy.tun\"j\n" +
+	"\x16proxy/tun/config.proto\x12\x0exray.proxy.tun\"}\n" +
 	"\x06Config\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n" +
 	"\x03MTU\x18\x02 \x01(\rR\x03MTU\x12\x1d\n" +
 	"\n" +
-	"user_level\x18\x03 \x01(\rR\tuserLevel\x12\x1b\n" +
-	"\twin_route\x18\x04 \x03(\tR\bwinRouteBL\n" +
+	"user_level\x18\x03 \x01(\rR\tuserLevel\x12\x18\n" +
+	"\aaddress\x18\x04 \x03(\tR\aaddress\x12\x14\n" +
+	"\x05route\x18\x05 \x03(\tR\x05routeBL\n" +
 	"\x12com.xray.proxy.tunP\x01Z#github.com/xtls/xray-core/proxy/tun\xaa\x02\x0eXray.Proxy.Tunb\x06proto3"
 
 var (

--- a/proxy/tun/config.pb.go
+++ b/proxy/tun/config.pb.go
@@ -26,6 +26,7 @@ type Config struct {
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	MTU           uint32                 `protobuf:"varint,2,opt,name=MTU,proto3" json:"MTU,omitempty"`
 	UserLevel     uint32                 `protobuf:"varint,3,opt,name=user_level,json=userLevel,proto3" json:"user_level,omitempty"`
+	WinRoute      []string               `protobuf:"bytes,4,rep,name=win_route,json=winRoute,proto3" json:"win_route,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -81,16 +82,24 @@ func (x *Config) GetUserLevel() uint32 {
 	return 0
 }
 
+func (x *Config) GetWinRoute() []string {
+	if x != nil {
+		return x.WinRoute
+	}
+	return nil
+}
+
 var File_proxy_tun_config_proto protoreflect.FileDescriptor
 
 const file_proxy_tun_config_proto_rawDesc = "" +
 	"\n" +
-	"\x16proxy/tun/config.proto\x12\x0exray.proxy.tun\"M\n" +
+	"\x16proxy/tun/config.proto\x12\x0exray.proxy.tun\"j\n" +
 	"\x06Config\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n" +
 	"\x03MTU\x18\x02 \x01(\rR\x03MTU\x12\x1d\n" +
 	"\n" +
-	"user_level\x18\x03 \x01(\rR\tuserLevelBL\n" +
+	"user_level\x18\x03 \x01(\rR\tuserLevel\x12\x1b\n" +
+	"\twin_route\x18\x04 \x03(\tR\bwinRouteBL\n" +
 	"\x12com.xray.proxy.tunP\x01Z#github.com/xtls/xray-core/proxy/tun\xaa\x02\x0eXray.Proxy.Tunb\x06proto3"
 
 var (

--- a/proxy/tun/config.pb.go
+++ b/proxy/tun/config.pb.go
@@ -26,9 +26,10 @@ type Config struct {
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	MTU           uint32                 `protobuf:"varint,2,opt,name=MTU,proto3" json:"MTU,omitempty"`
 	UserLevel     uint32                 `protobuf:"varint,3,opt,name=user_level,json=userLevel,proto3" json:"user_level,omitempty"`
-	Address       []string               `protobuf:"bytes,4,rep,name=address,proto3" json:"address,omitempty"`
-	Route         []string               `protobuf:"bytes,5,rep,name=route,proto3" json:"route,omitempty"`
-	Dns           []string               `protobuf:"bytes,6,rep,name=dns,proto3" json:"dns,omitempty"`
+	AutoInterface bool                   `protobuf:"varint,4,opt,name=auto_interface,json=autoInterface,proto3" json:"auto_interface,omitempty"`
+	Address       []string               `protobuf:"bytes,5,rep,name=address,proto3" json:"address,omitempty"`
+	Route         []string               `protobuf:"bytes,6,rep,name=route,proto3" json:"route,omitempty"`
+	Dns           []string               `protobuf:"bytes,7,rep,name=dns,proto3" json:"dns,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -84,6 +85,13 @@ func (x *Config) GetUserLevel() uint32 {
 	return 0
 }
 
+func (x *Config) GetAutoInterface() bool {
+	if x != nil {
+		return x.AutoInterface
+	}
+	return false
+}
+
 func (x *Config) GetAddress() []string {
 	if x != nil {
 		return x.Address
@@ -109,15 +117,16 @@ var File_proxy_tun_config_proto protoreflect.FileDescriptor
 
 const file_proxy_tun_config_proto_rawDesc = "" +
 	"\n" +
-	"\x16proxy/tun/config.proto\x12\x0exray.proxy.tun\"\x8f\x01\n" +
+	"\x16proxy/tun/config.proto\x12\x0exray.proxy.tun\"\xb6\x01\n" +
 	"\x06Config\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n" +
 	"\x03MTU\x18\x02 \x01(\rR\x03MTU\x12\x1d\n" +
 	"\n" +
-	"user_level\x18\x03 \x01(\rR\tuserLevel\x12\x18\n" +
-	"\aaddress\x18\x04 \x03(\tR\aaddress\x12\x14\n" +
-	"\x05route\x18\x05 \x03(\tR\x05route\x12\x10\n" +
-	"\x03dns\x18\x06 \x03(\tR\x03dnsBL\n" +
+	"user_level\x18\x03 \x01(\rR\tuserLevel\x12%\n" +
+	"\x0eauto_interface\x18\x04 \x01(\bR\rautoInterface\x12\x18\n" +
+	"\aaddress\x18\x05 \x03(\tR\aaddress\x12\x14\n" +
+	"\x05route\x18\x06 \x03(\tR\x05route\x12\x10\n" +
+	"\x03dns\x18\a \x03(\tR\x03dnsBL\n" +
 	"\x12com.xray.proxy.tunP\x01Z#github.com/xtls/xray-core/proxy/tun\xaa\x02\x0eXray.Proxy.Tunb\x06proto3"
 
 var (

--- a/proxy/tun/config.pb.go
+++ b/proxy/tun/config.pb.go
@@ -28,7 +28,7 @@ type Config struct {
 	Gateway                []string               `protobuf:"bytes,3,rep,name=gateway,proto3" json:"gateway,omitempty"`
 	DNS                    []string               `protobuf:"bytes,4,rep,name=DNS,proto3" json:"DNS,omitempty"`
 	UserLevel              uint32                 `protobuf:"varint,5,opt,name=user_level,json=userLevel,proto3" json:"user_level,omitempty"`
-	AutoRoutingTable       []string               `protobuf:"bytes,6,rep,name=auto_routing_table,json=autoRoutingTable,proto3" json:"auto_routing_table,omitempty"`
+	AutoSystemRoutingTable []string               `protobuf:"bytes,6,rep,name=auto_system_routing_table,json=autoSystemRoutingTable,proto3" json:"auto_system_routing_table,omitempty"`
 	AutoOutboundsInterface string                 `protobuf:"bytes,7,opt,name=auto_outbounds_interface,json=autoOutboundsInterface,proto3" json:"auto_outbounds_interface,omitempty"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
@@ -99,9 +99,9 @@ func (x *Config) GetUserLevel() uint32 {
 	return 0
 }
 
-func (x *Config) GetAutoRoutingTable() []string {
+func (x *Config) GetAutoSystemRoutingTable() []string {
 	if x != nil {
-		return x.AutoRoutingTable
+		return x.AutoSystemRoutingTable
 	}
 	return nil
 }
@@ -117,15 +117,15 @@ var File_proxy_tun_config_proto protoreflect.FileDescriptor
 
 const file_proxy_tun_config_proto_rawDesc = "" +
 	"\n" +
-	"\x16proxy/tun/config.proto\x12\x0exray.proxy.tun\"\xe1\x01\n" +
+	"\x16proxy/tun/config.proto\x12\x0exray.proxy.tun\"\xee\x01\n" +
 	"\x06Config\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n" +
 	"\x03MTU\x18\x02 \x03(\rR\x03MTU\x12\x18\n" +
 	"\agateway\x18\x03 \x03(\tR\agateway\x12\x10\n" +
 	"\x03DNS\x18\x04 \x03(\tR\x03DNS\x12\x1d\n" +
 	"\n" +
-	"user_level\x18\x05 \x01(\rR\tuserLevel\x12,\n" +
-	"\x12auto_routing_table\x18\x06 \x03(\tR\x10autoRoutingTable\x128\n" +
+	"user_level\x18\x05 \x01(\rR\tuserLevel\x129\n" +
+	"\x19auto_system_routing_table\x18\x06 \x03(\tR\x16autoSystemRoutingTable\x128\n" +
 	"\x18auto_outbounds_interface\x18\a \x01(\tR\x16autoOutboundsInterfaceBL\n" +
 	"\x12com.xray.proxy.tunP\x01Z#github.com/xtls/xray-core/proxy/tun\xaa\x02\x0eXray.Proxy.Tunb\x06proto3"
 

--- a/proxy/tun/config.pb.go
+++ b/proxy/tun/config.pb.go
@@ -24,7 +24,7 @@ const (
 type Config struct {
 	state                  protoimpl.MessageState `protogen:"open.v1"`
 	Name                   string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	MTU                    uint32                 `protobuf:"varint,2,opt,name=MTU,proto3" json:"MTU,omitempty"`
+	MTU                    []uint32               `protobuf:"varint,2,rep,packed,name=MTU,proto3" json:"MTU,omitempty"`
 	Gateway                []string               `protobuf:"bytes,3,rep,name=gateway,proto3" json:"gateway,omitempty"`
 	DNS                    []string               `protobuf:"bytes,4,rep,name=DNS,proto3" json:"DNS,omitempty"`
 	UserLevel              uint32                 `protobuf:"varint,5,opt,name=user_level,json=userLevel,proto3" json:"user_level,omitempty"`
@@ -71,11 +71,11 @@ func (x *Config) GetName() string {
 	return ""
 }
 
-func (x *Config) GetMTU() uint32 {
+func (x *Config) GetMTU() []uint32 {
 	if x != nil {
 		return x.MTU
 	}
-	return 0
+	return nil
 }
 
 func (x *Config) GetGateway() []string {
@@ -120,7 +120,7 @@ const file_proxy_tun_config_proto_rawDesc = "" +
 	"\x16proxy/tun/config.proto\x12\x0exray.proxy.tun\"\xe1\x01\n" +
 	"\x06Config\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n" +
-	"\x03MTU\x18\x02 \x01(\rR\x03MTU\x12\x18\n" +
+	"\x03MTU\x18\x02 \x03(\rR\x03MTU\x12\x18\n" +
 	"\agateway\x18\x03 \x03(\tR\agateway\x12\x10\n" +
 	"\x03DNS\x18\x04 \x03(\tR\x03DNS\x12\x1d\n" +
 	"\n" +

--- a/proxy/tun/config.pb.go
+++ b/proxy/tun/config.pb.go
@@ -22,16 +22,16 @@ const (
 )
 
 type Config struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	MTU           uint32                 `protobuf:"varint,2,opt,name=MTU,proto3" json:"MTU,omitempty"`
-	UserLevel     uint32                 `protobuf:"varint,3,opt,name=user_level,json=userLevel,proto3" json:"user_level,omitempty"`
-	Interface     string                 `protobuf:"bytes,4,opt,name=interface,proto3" json:"interface,omitempty"`
-	Address       []string               `protobuf:"bytes,5,rep,name=address,proto3" json:"address,omitempty"`
-	Route         []string               `protobuf:"bytes,6,rep,name=route,proto3" json:"route,omitempty"`
-	Dns           []string               `protobuf:"bytes,7,rep,name=dns,proto3" json:"dns,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state                  protoimpl.MessageState `protogen:"open.v1"`
+	Name                   string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	MTU                    uint32                 `protobuf:"varint,2,opt,name=MTU,proto3" json:"MTU,omitempty"`
+	Gateway                []string               `protobuf:"bytes,3,rep,name=gateway,proto3" json:"gateway,omitempty"`
+	DNS                    []string               `protobuf:"bytes,4,rep,name=DNS,proto3" json:"DNS,omitempty"`
+	UserLevel              uint32                 `protobuf:"varint,5,opt,name=user_level,json=userLevel,proto3" json:"user_level,omitempty"`
+	AutoRoutingTable       []string               `protobuf:"bytes,6,rep,name=auto_routing_table,json=autoRoutingTable,proto3" json:"auto_routing_table,omitempty"`
+	AutoOutboundsInterface string                 `protobuf:"bytes,7,opt,name=auto_outbounds_interface,json=autoOutboundsInterface,proto3" json:"auto_outbounds_interface,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *Config) Reset() {
@@ -78,6 +78,20 @@ func (x *Config) GetMTU() uint32 {
 	return 0
 }
 
+func (x *Config) GetGateway() []string {
+	if x != nil {
+		return x.Gateway
+	}
+	return nil
+}
+
+func (x *Config) GetDNS() []string {
+	if x != nil {
+		return x.DNS
+	}
+	return nil
+}
+
 func (x *Config) GetUserLevel() uint32 {
 	if x != nil {
 		return x.UserLevel
@@ -85,48 +99,34 @@ func (x *Config) GetUserLevel() uint32 {
 	return 0
 }
 
-func (x *Config) GetInterface() string {
+func (x *Config) GetAutoRoutingTable() []string {
 	if x != nil {
-		return x.Interface
+		return x.AutoRoutingTable
+	}
+	return nil
+}
+
+func (x *Config) GetAutoOutboundsInterface() string {
+	if x != nil {
+		return x.AutoOutboundsInterface
 	}
 	return ""
-}
-
-func (x *Config) GetAddress() []string {
-	if x != nil {
-		return x.Address
-	}
-	return nil
-}
-
-func (x *Config) GetRoute() []string {
-	if x != nil {
-		return x.Route
-	}
-	return nil
-}
-
-func (x *Config) GetDns() []string {
-	if x != nil {
-		return x.Dns
-	}
-	return nil
 }
 
 var File_proxy_tun_config_proto protoreflect.FileDescriptor
 
 const file_proxy_tun_config_proto_rawDesc = "" +
 	"\n" +
-	"\x16proxy/tun/config.proto\x12\x0exray.proxy.tun\"\xad\x01\n" +
+	"\x16proxy/tun/config.proto\x12\x0exray.proxy.tun\"\xe1\x01\n" +
 	"\x06Config\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n" +
-	"\x03MTU\x18\x02 \x01(\rR\x03MTU\x12\x1d\n" +
+	"\x03MTU\x18\x02 \x01(\rR\x03MTU\x12\x18\n" +
+	"\agateway\x18\x03 \x03(\tR\agateway\x12\x10\n" +
+	"\x03DNS\x18\x04 \x03(\tR\x03DNS\x12\x1d\n" +
 	"\n" +
-	"user_level\x18\x03 \x01(\rR\tuserLevel\x12\x1c\n" +
-	"\tinterface\x18\x04 \x01(\tR\tinterface\x12\x18\n" +
-	"\aaddress\x18\x05 \x03(\tR\aaddress\x12\x14\n" +
-	"\x05route\x18\x06 \x03(\tR\x05route\x12\x10\n" +
-	"\x03dns\x18\a \x03(\tR\x03dnsBL\n" +
+	"user_level\x18\x05 \x01(\rR\tuserLevel\x12,\n" +
+	"\x12auto_routing_table\x18\x06 \x03(\tR\x10autoRoutingTable\x128\n" +
+	"\x18auto_outbounds_interface\x18\a \x01(\tR\x16autoOutboundsInterfaceBL\n" +
 	"\x12com.xray.proxy.tunP\x01Z#github.com/xtls/xray-core/proxy/tun\xaa\x02\x0eXray.Proxy.Tunb\x06proto3"
 
 var (

--- a/proxy/tun/config.pb.go
+++ b/proxy/tun/config.pb.go
@@ -26,7 +26,7 @@ type Config struct {
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	MTU           uint32                 `protobuf:"varint,2,opt,name=MTU,proto3" json:"MTU,omitempty"`
 	UserLevel     uint32                 `protobuf:"varint,3,opt,name=user_level,json=userLevel,proto3" json:"user_level,omitempty"`
-	AutoInterface bool                   `protobuf:"varint,4,opt,name=auto_interface,json=autoInterface,proto3" json:"auto_interface,omitempty"`
+	Interface     string                 `protobuf:"bytes,4,opt,name=interface,proto3" json:"interface,omitempty"`
 	Address       []string               `protobuf:"bytes,5,rep,name=address,proto3" json:"address,omitempty"`
 	Route         []string               `protobuf:"bytes,6,rep,name=route,proto3" json:"route,omitempty"`
 	Dns           []string               `protobuf:"bytes,7,rep,name=dns,proto3" json:"dns,omitempty"`
@@ -85,11 +85,11 @@ func (x *Config) GetUserLevel() uint32 {
 	return 0
 }
 
-func (x *Config) GetAutoInterface() bool {
+func (x *Config) GetInterface() string {
 	if x != nil {
-		return x.AutoInterface
+		return x.Interface
 	}
-	return false
+	return ""
 }
 
 func (x *Config) GetAddress() []string {
@@ -117,13 +117,13 @@ var File_proxy_tun_config_proto protoreflect.FileDescriptor
 
 const file_proxy_tun_config_proto_rawDesc = "" +
 	"\n" +
-	"\x16proxy/tun/config.proto\x12\x0exray.proxy.tun\"\xb6\x01\n" +
+	"\x16proxy/tun/config.proto\x12\x0exray.proxy.tun\"\xad\x01\n" +
 	"\x06Config\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n" +
 	"\x03MTU\x18\x02 \x01(\rR\x03MTU\x12\x1d\n" +
 	"\n" +
-	"user_level\x18\x03 \x01(\rR\tuserLevel\x12%\n" +
-	"\x0eauto_interface\x18\x04 \x01(\bR\rautoInterface\x12\x18\n" +
+	"user_level\x18\x03 \x01(\rR\tuserLevel\x12\x1c\n" +
+	"\tinterface\x18\x04 \x01(\tR\tinterface\x12\x18\n" +
 	"\aaddress\x18\x05 \x03(\tR\aaddress\x12\x14\n" +
 	"\x05route\x18\x06 \x03(\tR\x05route\x12\x10\n" +
 	"\x03dns\x18\a \x03(\tR\x03dnsBL\n" +

--- a/proxy/tun/config.pb.go
+++ b/proxy/tun/config.pb.go
@@ -28,6 +28,7 @@ type Config struct {
 	UserLevel     uint32                 `protobuf:"varint,3,opt,name=user_level,json=userLevel,proto3" json:"user_level,omitempty"`
 	Address       []string               `protobuf:"bytes,4,rep,name=address,proto3" json:"address,omitempty"`
 	Route         []string               `protobuf:"bytes,5,rep,name=route,proto3" json:"route,omitempty"`
+	Dns           []string               `protobuf:"bytes,6,rep,name=dns,proto3" json:"dns,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -97,18 +98,26 @@ func (x *Config) GetRoute() []string {
 	return nil
 }
 
+func (x *Config) GetDns() []string {
+	if x != nil {
+		return x.Dns
+	}
+	return nil
+}
+
 var File_proxy_tun_config_proto protoreflect.FileDescriptor
 
 const file_proxy_tun_config_proto_rawDesc = "" +
 	"\n" +
-	"\x16proxy/tun/config.proto\x12\x0exray.proxy.tun\"}\n" +
+	"\x16proxy/tun/config.proto\x12\x0exray.proxy.tun\"\x8f\x01\n" +
 	"\x06Config\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n" +
 	"\x03MTU\x18\x02 \x01(\rR\x03MTU\x12\x1d\n" +
 	"\n" +
 	"user_level\x18\x03 \x01(\rR\tuserLevel\x12\x18\n" +
 	"\aaddress\x18\x04 \x03(\tR\aaddress\x12\x14\n" +
-	"\x05route\x18\x05 \x03(\tR\x05routeBL\n" +
+	"\x05route\x18\x05 \x03(\tR\x05route\x12\x10\n" +
+	"\x03dns\x18\x06 \x03(\tR\x03dnsBL\n" +
 	"\x12com.xray.proxy.tunP\x01Z#github.com/xtls/xray-core/proxy/tun\xaa\x02\x0eXray.Proxy.Tunb\x06proto3"
 
 var (

--- a/proxy/tun/config.proto
+++ b/proxy/tun/config.proto
@@ -12,6 +12,6 @@ message Config {
   repeated string gateway = 3;
   repeated string DNS = 4;
   uint32 user_level = 5;
-  repeated string auto_routing_table = 6;
+  repeated string auto_system_routing_table = 6;
   string auto_outbounds_interface = 7;
 }

--- a/proxy/tun/config.proto
+++ b/proxy/tun/config.proto
@@ -9,9 +9,9 @@ option java_multiple_files = true;
 message Config {
   string name = 1;
   uint32 MTU = 2;
-  uint32 user_level = 3;
-  string interface = 4;
-  repeated string address = 5;
-  repeated string route = 6;
-  repeated string dns = 7;
+  repeated string gateway = 3;
+  repeated string DNS = 4;
+  uint32 user_level = 5;
+  repeated string auto_routing_table = 6;
+  string auto_outbounds_interface = 7;
 }

--- a/proxy/tun/config.proto
+++ b/proxy/tun/config.proto
@@ -12,4 +12,5 @@ message Config {
   uint32 user_level = 3;
   repeated string address = 4;
   repeated string route = 5;
+  repeated string dns = 6;
 }

--- a/proxy/tun/config.proto
+++ b/proxy/tun/config.proto
@@ -10,7 +10,8 @@ message Config {
   string name = 1;
   uint32 MTU = 2;
   uint32 user_level = 3;
-  repeated string address = 4;
-  repeated string route = 5;
-  repeated string dns = 6;
+  bool auto_interface = 4;
+  repeated string address = 5;
+  repeated string route = 6;
+  repeated string dns = 7;
 }

--- a/proxy/tun/config.proto
+++ b/proxy/tun/config.proto
@@ -10,7 +10,7 @@ message Config {
   string name = 1;
   uint32 MTU = 2;
   uint32 user_level = 3;
-  bool auto_interface = 4;
+  string interface = 4;
   repeated string address = 5;
   repeated string route = 6;
   repeated string dns = 7;

--- a/proxy/tun/config.proto
+++ b/proxy/tun/config.proto
@@ -8,7 +8,7 @@ option java_multiple_files = true;
 
 message Config {
   string name = 1;
-  uint32 MTU = 2;
+  repeated uint32 MTU = 2;
   repeated string gateway = 3;
   repeated string DNS = 4;
   uint32 user_level = 5;

--- a/proxy/tun/config.proto
+++ b/proxy/tun/config.proto
@@ -10,4 +10,5 @@ message Config {
   string name = 1;
   uint32 MTU = 2;
   uint32 user_level = 3;
+  repeated string win_route = 4;
 }

--- a/proxy/tun/config.proto
+++ b/proxy/tun/config.proto
@@ -10,5 +10,6 @@ message Config {
   string name = 1;
   uint32 MTU = 2;
   uint32 user_level = 3;
-  repeated string win_route = 4;
+  repeated string address = 4;
+  repeated string route = 5;
 }

--- a/proxy/tun/handler.go
+++ b/proxy/tun/handler.go
@@ -2,6 +2,7 @@ package tun
 
 import (
 	"context"
+	"syscall"
 
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/buf"
@@ -15,6 +16,7 @@ import (
 	"github.com/xtls/xray-core/features/policy"
 	"github.com/xtls/xray-core/features/routing"
 	"github.com/xtls/xray-core/transport"
+	"github.com/xtls/xray-core/transport/internet"
 	"github.com/xtls/xray-core/transport/internet/stat"
 )
 
@@ -67,6 +69,23 @@ func (t *Handler) Init(ctx context.Context, pm policy.Manager, dispatcher routin
 	}
 	updater = &InterfaceUpdater{tunIndex: tunIndex}
 	updater.Update()
+	err = internet.RegisterDialerController(func(network, address string, c syscall.RawConn) error {
+		iface := updater.Get()
+		if iface == nil {
+			errors.LogInfo(context.Background(), "[tun] falied to set interface > iface == nil")
+			return nil
+		}
+		return c.Control(func(fd uintptr) {
+			err := setinterface(network, address, fd, iface)
+			if err != nil {
+				errors.LogInfoInner(context.Background(), err, "[tun] falied to set interface")
+			}
+		})
+	})
+	if err != nil {
+		_ = tunInterface.Close()
+		return err
+	}
 
 	errors.LogInfo(t.ctx, tunName, " created")
 

--- a/proxy/tun/handler.go
+++ b/proxy/tun/handler.go
@@ -55,13 +55,7 @@ func (t *Handler) Init(ctx context.Context, pm policy.Manager, dispatcher routin
 	t.dispatcher = dispatcher
 
 	tunName := t.config.Name
-	tunOptions := TunOptions{
-		Name:    tunName,
-		MTU:     t.config.MTU,
-		Address: t.config.Address,
-		Route:   t.config.Route,
-	}
-	tunInterface, err := NewTun(tunOptions)
+	tunInterface, err := NewTun(t.config)
 	if err != nil {
 		return err
 	}

--- a/proxy/tun/handler.go
+++ b/proxy/tun/handler.go
@@ -69,7 +69,7 @@ func (t *Handler) Init(ctx context.Context, pm policy.Manager, dispatcher routin
 	}
 	updater = &InterfaceUpdater{tunIndex: tunIndex}
 	updater.Update()
-	err = internet.RegisterDialerController(func(network, address string, c syscall.RawConn) error {
+	internet.RegisterDialerController(func(network, address string, c syscall.RawConn) error {
 		iface := updater.Get()
 		if iface == nil {
 			errors.LogInfo(context.Background(), "[tun] falied to set interface > iface == nil")
@@ -82,10 +82,6 @@ func (t *Handler) Init(ctx context.Context, pm policy.Manager, dispatcher routin
 			}
 		})
 	})
-	if err != nil {
-		_ = tunInterface.Close()
-		return err
-	}
 
 	errors.LogInfo(t.ctx, tunName, " created")
 

--- a/proxy/tun/handler.go
+++ b/proxy/tun/handler.go
@@ -56,9 +56,10 @@ func (t *Handler) Init(ctx context.Context, pm policy.Manager, dispatcher routin
 
 	tunName := t.config.Name
 	tunOptions := TunOptions{
-		Name:     tunName,
-		MTU:      t.config.MTU,
-		WinRoute: t.config.WinRoute,
+		Name:    tunName,
+		MTU:     t.config.MTU,
+		Address: t.config.Address,
+		Route:   t.config.Route,
 	}
 	tunInterface, err := NewTun(tunOptions)
 	if err != nil {

--- a/proxy/tun/handler.go
+++ b/proxy/tun/handler.go
@@ -62,13 +62,16 @@ func (t *Handler) Init(ctx context.Context, pm policy.Manager, dispatcher routin
 		return err
 	}
 
-	if t.config.AutoInterface {
+	if t.config.Interface != "" {
 		tunIndex, err := tunInterface.Index()
 		if err != nil {
 			_ = tunInterface.Close()
 			return err
 		}
-		updater = &InterfaceUpdater{tunIndex: tunIndex}
+		if t.config.Interface == "auto" {
+			t.config.Interface = ""
+		}
+		updater = &InterfaceUpdater{tunIndex: tunIndex, fixedName: t.config.Interface}
 		updater.Update()
 		internet.RegisterDialerController(func(network, address string, c syscall.RawConn) error {
 			iface := updater.Get()

--- a/proxy/tun/handler.go
+++ b/proxy/tun/handler.go
@@ -60,6 +60,14 @@ func (t *Handler) Init(ctx context.Context, pm policy.Manager, dispatcher routin
 		return err
 	}
 
+	tunIndex, err := tunInterface.Index()
+	if err != nil {
+		_ = tunInterface.Close()
+		return err
+	}
+	updater = &InterfaceUpdater{tunIndex: tunIndex}
+	updater.Update()
+
 	errors.LogInfo(t.ctx, tunName, " created")
 
 	tunStackOptions := StackOptions{

--- a/proxy/tun/handler.go
+++ b/proxy/tun/handler.go
@@ -62,26 +62,28 @@ func (t *Handler) Init(ctx context.Context, pm policy.Manager, dispatcher routin
 		return err
 	}
 
-	tunIndex, err := tunInterface.Index()
-	if err != nil {
-		_ = tunInterface.Close()
-		return err
-	}
-	updater = &InterfaceUpdater{tunIndex: tunIndex}
-	updater.Update()
-	internet.RegisterDialerController(func(network, address string, c syscall.RawConn) error {
-		iface := updater.Get()
-		if iface == nil {
-			errors.LogInfo(context.Background(), "[tun] falied to set interface > iface == nil")
-			return nil
+	if t.config.AutoInterface {
+		tunIndex, err := tunInterface.Index()
+		if err != nil {
+			_ = tunInterface.Close()
+			return err
 		}
-		return c.Control(func(fd uintptr) {
-			err := setinterface(network, address, fd, iface)
-			if err != nil {
-				errors.LogInfoInner(context.Background(), err, "[tun] falied to set interface")
+		updater = &InterfaceUpdater{tunIndex: tunIndex}
+		updater.Update()
+		internet.RegisterDialerController(func(network, address string, c syscall.RawConn) error {
+			iface := updater.Get()
+			if iface == nil {
+				errors.LogInfo(context.Background(), "[tun] falied to set interface > iface == nil")
+				return nil
 			}
+			return c.Control(func(fd uintptr) {
+				err := setinterface(network, address, fd, iface)
+				if err != nil {
+					errors.LogInfoInner(context.Background(), err, "[tun] falied to set interface")
+				}
+			})
 		})
-	})
+	}
 
 	errors.LogInfo(t.ctx, tunName, " created")
 

--- a/proxy/tun/handler.go
+++ b/proxy/tun/handler.go
@@ -62,16 +62,16 @@ func (t *Handler) Init(ctx context.Context, pm policy.Manager, dispatcher routin
 		return err
 	}
 
-	if t.config.Interface != "" {
+	if t.config.AutoOutboundsInterface != "" {
 		tunIndex, err := tunInterface.Index()
 		if err != nil {
 			_ = tunInterface.Close()
 			return err
 		}
-		if t.config.Interface == "auto" {
-			t.config.Interface = ""
+		if t.config.AutoOutboundsInterface == "auto" {
+			t.config.AutoOutboundsInterface = ""
 		}
-		updater = &InterfaceUpdater{tunIndex: tunIndex, fixedName: t.config.Interface}
+		updater = &InterfaceUpdater{tunIndex: tunIndex, fixedName: t.config.AutoOutboundsInterface}
 		updater.Update()
 		internet.RegisterDialerController(func(network, address string, c syscall.RawConn) error {
 			iface := updater.Get()

--- a/proxy/tun/handler.go
+++ b/proxy/tun/handler.go
@@ -38,11 +38,6 @@ type ConnectionHandler interface {
 // Handler implements ConnectionHandler
 var _ ConnectionHandler = (*Handler)(nil)
 
-func (t *Handler) policy() policy.Session {
-	p := t.policyManager.ForLevel(t.config.UserLevel)
-	return p
-}
-
 // Init the Handler instance with necessary parameters
 func (t *Handler) Init(ctx context.Context, pm policy.Manager, dispatcher routing.Dispatcher) error {
 	var err error

--- a/proxy/tun/handler.go
+++ b/proxy/tun/handler.go
@@ -61,8 +61,9 @@ func (t *Handler) Init(ctx context.Context, pm policy.Manager, dispatcher routin
 
 	tunName := t.config.Name
 	tunOptions := TunOptions{
-		Name: tunName,
-		MTU:  t.config.MTU,
+		Name:     tunName,
+		MTU:      t.config.MTU,
+		WinRoute: t.config.WinRoute,
 	}
 	tunInterface, err := NewTun(tunOptions)
 	if err != nil {

--- a/proxy/tun/stack_gvisor.go
+++ b/proxy/tun/stack_gvisor.go
@@ -34,23 +34,18 @@ const (
 // stackGVisor is ip stack implemented by gVisor package
 type stackGVisor struct {
 	ctx         context.Context
-	tun         GVisorTun
+	tun         Tun
 	idleTimeout time.Duration
 	handler     *Handler
 	stack       *stack.Stack
 	endpoint    stack.LinkEndpoint
 }
 
-// GVisorTun implements a bridge to connect gVisor ip stack to tun interface
-type GVisorTun interface {
-	newEndpoint() (stack.LinkEndpoint, error)
-}
-
 // NewStack builds new ip stack (using gVisor)
 func NewStack(ctx context.Context, options StackOptions, handler *Handler) (Stack, error) {
 	gStack := &stackGVisor{
 		ctx:         ctx,
-		tun:         options.Tun.(GVisorTun),
+		tun:         options.Tun,
 		idleTimeout: options.IdleTimeout,
 		handler:     handler,
 	}

--- a/proxy/tun/tun.go
+++ b/proxy/tun/tun.go
@@ -5,11 +5,3 @@ type Tun interface {
 	Start() error
 	Close() error
 }
-
-// TunOptions for tun interface implementation
-type TunOptions struct {
-	Name    string
-	MTU     uint32
-	Address []string
-	Route   []string
-}

--- a/proxy/tun/tun.go
+++ b/proxy/tun/tun.go
@@ -8,6 +8,7 @@ type Tun interface {
 
 // TunOptions for tun interface implementation
 type TunOptions struct {
-	Name string
-	MTU  uint32
+	Name     string
+	MTU      uint32
+	WinRoute []string
 }

--- a/proxy/tun/tun.go
+++ b/proxy/tun/tun.go
@@ -1,7 +1,12 @@
 package tun
 
+import "gvisor.dev/gvisor/pkg/tcpip/stack"
+
 // Tun interface implements tun interface interaction
 type Tun interface {
 	Start() error
 	Close() error
+	Name() (string, error)
+	Index() (int, error)
+	newEndpoint() (stack.LinkEndpoint, error)
 }

--- a/proxy/tun/tun.go
+++ b/proxy/tun/tun.go
@@ -8,7 +8,8 @@ type Tun interface {
 
 // TunOptions for tun interface implementation
 type TunOptions struct {
-	Name     string
-	MTU      uint32
-	WinRoute []string
+	Name    string
+	MTU     uint32
+	Address []string
+	Route   []string
 }

--- a/proxy/tun/tun_android.go
+++ b/proxy/tun/tun_android.go
@@ -77,3 +77,7 @@ func (t *AndroidTun) newEndpoint() (stack.LinkEndpoint, error) {
 		RXChecksumOffload: true,
 	})
 }
+
+func setinterface(network, address string, fd uintptr, iface *net.Interface) error {
+	return unix.BindToDevice(int(fd), iface.Name)
+}

--- a/proxy/tun/tun_android.go
+++ b/proxy/tun/tun_android.go
@@ -4,6 +4,7 @@ package tun
 
 import (
 	"context"
+	"net"
 	"strconv"
 
 	"github.com/xtls/xray-core/common/errors"
@@ -20,9 +21,6 @@ type AndroidTun struct {
 
 // DefaultTun implements Tun
 var _ Tun = (*AndroidTun)(nil)
-
-// DefaultTun implements GVisorTun
-var _ GVisorTun = (*AndroidTun)(nil)
 
 // NewTun builds new tun interface handler
 func NewTun(options *Config) (Tun, error) {
@@ -47,6 +45,29 @@ func (t *AndroidTun) Start() error {
 
 func (t *AndroidTun) Close() error {
 	return nil
+}
+
+func (t *AndroidTun) Name() (string, error) {
+	ifr, err := unix.NewIfreq("")
+	if err != nil {
+		return "", err
+	}
+	if err = unix.IoctlIfreq(t.tunFd, unix.TUNGETIFF, ifr); err != nil {
+		return "", err
+	}
+	return ifr.Name(), nil
+}
+
+func (t *AndroidTun) Index() (int, error) {
+	name, err := t.Name()
+	if err != nil {
+		return 0, err
+	}
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return 0, err
+	}
+	return iface.Index, nil
 }
 
 func (t *AndroidTun) newEndpoint() (stack.LinkEndpoint, error) {

--- a/proxy/tun/tun_android.go
+++ b/proxy/tun/tun_android.go
@@ -73,7 +73,7 @@ func (t *AndroidTun) Index() (int, error) {
 func (t *AndroidTun) newEndpoint() (stack.LinkEndpoint, error) {
 	return fdbased.New(&fdbased.Options{
 		FDs:               []int{t.tunFd},
-		MTU:               t.options.MTU,
+		MTU:               t.options.MTU[0],
 		RXChecksumOffload: true,
 	})
 }

--- a/proxy/tun/tun_android.go
+++ b/proxy/tun/tun_android.go
@@ -15,7 +15,7 @@ import (
 
 type AndroidTun struct {
 	tunFd   int
-	options TunOptions
+	options *Config
 }
 
 // DefaultTun implements Tun
@@ -25,7 +25,7 @@ var _ Tun = (*AndroidTun)(nil)
 var _ GVisorTun = (*AndroidTun)(nil)
 
 // NewTun builds new tun interface handler
-func NewTun(options TunOptions) (Tun, error) {
+func NewTun(options *Config) (Tun, error) {
 	fd, err := strconv.Atoi(platform.NewEnvFlag(platform.TunFdKey).GetValue(func() string { return "0" }))
 	errors.LogInfo(context.Background(), "read Android Tun Fd ", fd, err)
 

--- a/proxy/tun/tun_darwin.go
+++ b/proxy/tun/tun_darwin.go
@@ -39,7 +39,7 @@ func procyield(cycles uint32)
 
 type DarwinTun struct {
 	tunFile *os.File
-	options TunOptions
+	options *Config
 	ownsFd  bool // true for macOS (we created the fd), false for iOS (fd from system)
 }
 
@@ -47,7 +47,7 @@ var _ Tun = (*DarwinTun)(nil)
 var _ GVisorTun = (*DarwinTun)(nil)
 var _ GVisorDevice = (*DarwinTun)(nil)
 
-func NewTun(options TunOptions) (Tun, error) {
+func NewTun(options *Config) (Tun, error) {
 	// Check if fd is provided via environment (iOS mode)
 	fdStr := platform.NewEnvFlag(platform.TunFdKey).GetValue(func() string { return "" })
 	if fdStr != "" {

--- a/proxy/tun/tun_darwin.go
+++ b/proxy/tun/tun_darwin.go
@@ -9,7 +9,6 @@ import (
 	"net/netip"
 	"os"
 	"strconv"
-	"syscall"
 	"unsafe"
 
 	"github.com/xtls/xray-core/common/buf"
@@ -365,9 +364,20 @@ func setIPAddress(name string, gateway netip.Prefix) error {
 }
 
 func ioctlPtr(fd int, req uint, arg unsafe.Pointer) error {
-	_, _, errno := unix.Syscall(syscall.SYS_IOCTL, uintptr(fd), uintptr(req), uintptr(arg))
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(req), uintptr(arg))
 	if errno != 0 {
 		return errno
 	}
 	return nil
+}
+
+func setinterface(network, address string, fd uintptr, iface *net.Interface) error {
+	switch network {
+	case "tcp4", "udp4", "ip4":
+		return unix.SetsockoptInt(int(fd), unix.IPPROTO_IP, unix.IP_BOUND_IF, iface.Index)
+	case "tcp6", "udp6", "ip6":
+		return unix.SetsockoptInt(int(fd), unix.IPPROTO_IPV6, unix.IPV6_BOUND_IF, iface.Index)
+	default:
+		return errors.New("unknown network")
+	}
 }

--- a/proxy/tun/tun_darwin.go
+++ b/proxy/tun/tun_darwin.go
@@ -25,6 +25,7 @@ const (
 	sysprotoControl = 2
 	gateway         = "169.254.10.1/30"
 	utunHeaderSize  = 4
+	UTUN_OPT_IFNAME = 2
 )
 
 const (
@@ -40,11 +41,11 @@ func procyield(cycles uint32)
 type DarwinTun struct {
 	tunFile *os.File
 	options *Config
+	tunFd   int
 	ownsFd  bool // true for macOS (we created the fd), false for iOS (fd from system)
 }
 
 var _ Tun = (*DarwinTun)(nil)
-var _ GVisorTun = (*DarwinTun)(nil)
 var _ GVisorDevice = (*DarwinTun)(nil)
 
 func NewTun(options *Config) (Tun, error) {
@@ -64,6 +65,7 @@ func NewTun(options *Config) (Tun, error) {
 		return &DarwinTun{
 			tunFile: os.NewFile(uintptr(fd), "utun"),
 			options: options,
+			tunFd:   fd,
 			ownsFd:  false,
 		}, nil
 	}
@@ -83,6 +85,7 @@ func NewTun(options *Config) (Tun, error) {
 	return &DarwinTun{
 		tunFile: tunFile,
 		options: options,
+		tunFd:   int(tunFile.Fd()),
 		ownsFd:  true,
 	}, nil
 }
@@ -97,6 +100,22 @@ func (t *DarwinTun) Close() error {
 	}
 	// iOS: don't close the fd, it's owned by NetworkExtension
 	return nil
+}
+
+func (t *DarwinTun) Name() (string, error) {
+	return unix.GetsockoptString(t.tunFd, sysprotoControl, UTUN_OPT_IFNAME)
+}
+
+func (t *DarwinTun) Index() (int, error) {
+	name, err := t.Name()
+	if err != nil {
+		return 0, err
+	}
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return 0, err
+	}
+	return iface.Index, nil
 }
 
 // WritePacket implements GVisorDevice method to write one packet to the tun device

--- a/proxy/tun/tun_darwin.go
+++ b/proxy/tun/tun_darwin.go
@@ -3,7 +3,7 @@
 package tun
 
 import (
-	"errors"
+	go_errors "errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -12,6 +12,7 @@ import (
 	"unsafe"
 
 	"github.com/xtls/xray-core/common/buf"
+	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/platform"
 	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/buffer"
@@ -142,7 +143,7 @@ func (t *DarwinTun) WritePacket(packet *stack.PacketBuffer) tcpip.Error {
 	b.SetByte(3, family)
 
 	if _, err := t.tunFile.Write(b.Bytes()); err != nil {
-		if errors.Is(err, unix.EAGAIN) {
+		if go_errors.Is(err, unix.EAGAIN) {
 			return &tcpip.ErrWouldBlock{}
 		}
 		return &tcpip.ErrAborted{}
@@ -159,7 +160,7 @@ func (t *DarwinTun) ReadPacket() (byte, *stack.PacketBuffer, error) {
 
 	// read the bytes to the interface file
 	n, err := b.ReadFrom(t.tunFile)
-	if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EINTR) {
+	if go_errors.Is(err, unix.EAGAIN) || go_errors.Is(err, unix.EINTR) {
 		b.Release()
 		return 0, nil, ErrQueueEmpty
 	}
@@ -378,6 +379,6 @@ func setinterface(network, address string, fd uintptr, iface *net.Interface) err
 	case "tcp6", "udp6", "ip6":
 		return unix.SetsockoptInt(int(fd), unix.IPPROTO_IPV6, unix.IPV6_BOUND_IF, iface.Index)
 	default:
-		return errors.New("unknown network")
+		return errors.New("unknown network ", network)
 	}
 }

--- a/proxy/tun/tun_darwin.go
+++ b/proxy/tun/tun_darwin.go
@@ -76,7 +76,7 @@ func NewTun(options *Config) (Tun, error) {
 		return nil, err
 	}
 
-	err = setup(options.Name, options.MTU)
+	err = setup(options.Name, options.MTU[0])
 	if err != nil {
 		_ = tunFile.Close()
 		return nil, err
@@ -121,7 +121,7 @@ func (t *DarwinTun) Index() (int, error) {
 // WritePacket implements GVisorDevice method to write one packet to the tun device
 func (t *DarwinTun) WritePacket(packet *stack.PacketBuffer) tcpip.Error {
 	// request memory to write from reusable buffer pool
-	b := buf.NewWithSize(int32(t.options.MTU) + utunHeaderSize)
+	b := buf.NewWithSize(int32(t.options.MTU[0]) + utunHeaderSize)
 	defer b.Release()
 
 	// prepare Darwin specific packet header
@@ -156,7 +156,7 @@ func (t *DarwinTun) WritePacket(packet *stack.PacketBuffer) tcpip.Error {
 // which will make the stack call Wait which should implement desired push-back
 func (t *DarwinTun) ReadPacket() (byte, *stack.PacketBuffer, error) {
 	// request memory to write from reusable buffer pool
-	b := buf.NewWithSize(int32(t.options.MTU) + utunHeaderSize)
+	b := buf.NewWithSize(int32(t.options.MTU[0]) + utunHeaderSize)
 
 	// read the bytes to the interface file
 	n, err := b.ReadFrom(t.tunFile)
@@ -193,7 +193,7 @@ func (t *DarwinTun) Wait() {
 }
 
 func (t *DarwinTun) newEndpoint() (stack.LinkEndpoint, error) {
-	return &LinkEndpoint{deviceMTU: t.options.MTU, device: t}, nil
+	return &LinkEndpoint{deviceMTU: t.options.MTU[0], device: t}, nil
 }
 
 // open the interface, by creating new utunN if in the system and returning its file descriptor

--- a/proxy/tun/tun_default.go
+++ b/proxy/tun/tun_default.go
@@ -17,7 +17,7 @@ var _ Tun = (*DefaultTun)(nil)
 var _ GVisorTun = (*DefaultTun)(nil)
 
 // NewTun builds new tun interface handler
-func NewTun(options TunOptions) (Tun, error) {
+func NewTun(options *Config) (Tun, error) {
 	return nil, errors.New("Tun is not supported on your platform")
 }
 

--- a/proxy/tun/tun_default.go
+++ b/proxy/tun/tun_default.go
@@ -13,9 +13,6 @@ type DefaultTun struct {
 // DefaultTun implements Tun
 var _ Tun = (*DefaultTun)(nil)
 
-// DefaultTun implements GVisorTun
-var _ GVisorTun = (*DefaultTun)(nil)
-
 // NewTun builds new tun interface handler
 func NewTun(options *Config) (Tun, error) {
 	return nil, errors.New("Tun is not supported on your platform")
@@ -27,6 +24,14 @@ func (t *DefaultTun) Start() error {
 
 func (t *DefaultTun) Close() error {
 	return errors.New("Tun is not supported on your platform")
+}
+
+func (t *DefaultTun) Name() (string, error) {
+	return "", errors.New("Tun is not supported on your platform")
+}
+
+func (t *DefaultTun) Index() (int, error) {
+	return 0, errors.New("Tun is not supported on your platform")
 }
 
 func (t *DefaultTun) newEndpoint() (stack.LinkEndpoint, error) {

--- a/proxy/tun/tun_default.go
+++ b/proxy/tun/tun_default.go
@@ -3,6 +3,8 @@
 package tun
 
 import (
+	"net"
+
 	"github.com/xtls/xray-core/common/errors"
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
 )
@@ -36,4 +38,8 @@ func (t *DefaultTun) Index() (int, error) {
 
 func (t *DefaultTun) newEndpoint() (stack.LinkEndpoint, error) {
 	return nil, errors.New("Tun is not supported on your platform")
+}
+
+func setinterface(string, string, uintptr, *net.Interface) error {
+	return errors.New("Tun is not supported on your platform")
 }

--- a/proxy/tun/tun_linux.go
+++ b/proxy/tun/tun_linux.go
@@ -3,6 +3,8 @@
 package tun
 
 import (
+	"net"
+
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/tcpip/link/fdbased"
@@ -122,4 +124,8 @@ func (t *LinuxTun) newEndpoint() (stack.LinkEndpoint, error) {
 		MTU:               t.options.MTU,
 		RXChecksumOffload: true,
 	})
+}
+
+func setinterface(network, address string, fd uintptr, iface *net.Interface) error {
+	return unix.BindToDevice(int(fd), iface.Name)
 }

--- a/proxy/tun/tun_linux.go
+++ b/proxy/tun/tun_linux.go
@@ -30,7 +30,7 @@ func NewTun(options *Config) (Tun, error) {
 		return nil, err
 	}
 
-	tunLink, err := setup(options.Name, int(options.MTU))
+	tunLink, err := setup(options.Name, int(options.MTU[0]))
 	if err != nil {
 		_ = unix.Close(tunFd)
 		return nil, err
@@ -121,7 +121,7 @@ func (t *LinuxTun) Index() (int, error) {
 func (t *LinuxTun) newEndpoint() (stack.LinkEndpoint, error) {
 	return fdbased.New(&fdbased.Options{
 		FDs:               []int{t.tunFd},
-		MTU:               t.options.MTU,
+		MTU:               t.options.MTU[0],
 		RXChecksumOffload: true,
 	})
 }

--- a/proxy/tun/tun_linux.go
+++ b/proxy/tun/tun_linux.go
@@ -21,9 +21,6 @@ type LinuxTun struct {
 // LinuxTun implements Tun
 var _ Tun = (*LinuxTun)(nil)
 
-// LinuxTun implements GVisorTun
-var _ GVisorTun = (*LinuxTun)(nil)
-
 // NewTun builds new tun interface handler (linux specific)
 func NewTun(options *Config) (Tun, error) {
 	tunFd, err := open(options.Name)
@@ -108,6 +105,14 @@ func (t *LinuxTun) Close() error {
 	_ = unix.Close(t.tunFd)
 
 	return nil
+}
+
+func (t *LinuxTun) Name() (string, error) {
+	return t.tunLink.Attrs().Name, nil
+}
+
+func (t *LinuxTun) Index() (int, error) {
+	return t.tunLink.Attrs().Index, nil
 }
 
 // newEndpoint builds new gVisor stack.LinkEndpoint from the tun interface file descriptor

--- a/proxy/tun/tun_linux.go
+++ b/proxy/tun/tun_linux.go
@@ -15,7 +15,7 @@ import (
 type LinuxTun struct {
 	tunFd   int
 	tunLink netlink.Link
-	options TunOptions
+	options *Config
 }
 
 // LinuxTun implements Tun
@@ -25,7 +25,7 @@ var _ Tun = (*LinuxTun)(nil)
 var _ GVisorTun = (*LinuxTun)(nil)
 
 // NewTun builds new tun interface handler (linux specific)
-func NewTun(options TunOptions) (Tun, error) {
+func NewTun(options *Config) (Tun, error) {
 	tunFd, err := open(options.Name)
 	if err != nil {
 		return nil, err

--- a/proxy/tun/tun_windows.go
+++ b/proxy/tun/tun_windows.go
@@ -175,7 +175,7 @@ func (t *WindowsTun) Start() error {
 		}
 	}
 
-	if t.options.AutoInterface {
+	if updater != nil {
 		t.changeCallback, err = winipcfg.RegisterInterfaceChangeCallback(func(notificationType winipcfg.MibNotificationType, iface *winipcfg.MibIPInterfaceRow) {
 			if notificationType != winipcfg.MibDeleteInstance {
 				return

--- a/proxy/tun/tun_windows.go
+++ b/proxy/tun/tun_windows.go
@@ -24,7 +24,7 @@ func procyield(cycles uint32)
 // current version is heavily stripped to do nothing more,
 // then create a network interface, to be provided as endpoint to gVisor ip stack
 type WindowsTun struct {
-	options  TunOptions
+	options  *Config
 	adapter  *wintun.Adapter
 	session  wintun.Session
 	readWait windows.Handle
@@ -42,7 +42,7 @@ var _ GVisorDevice = (*WindowsTun)(nil)
 
 // NewTun creates a Wintun interface with the given name. Should a Wintun
 // interface with the same name exist, it tried to be reused.
-func NewTun(options TunOptions) (Tun, error) {
+func NewTun(options *Config) (Tun, error) {
 	// instantiate wintun adapter
 	adapter, err := open(options.Name)
 	if err != nil {
@@ -154,6 +154,21 @@ func (t *WindowsTun) Start() error {
 		ipif.UseAutomaticMetric = false
 		ipif.Metric = 0
 		err = ipif.Set()
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(t.options.Dns) > 0 {
+		dns := make([]netip.Addr, 0, len(t.options.Dns))
+		for _, ip := range t.options.Dns {
+			dns = append(dns, netip.MustParseAddr(ip))
+		}
+		err := luid.SetDNS(windows.AF_INET, dns, nil)
+		if err != nil {
+			return err
+		}
+		err = luid.SetDNS(windows.AF_INET6, dns, nil)
 		if err != nil {
 			return err
 		}

--- a/proxy/tun/tun_windows.go
+++ b/proxy/tun/tun_windows.go
@@ -134,7 +134,7 @@ func (t *WindowsTun) Start() error {
 		ipif.DadTransmits = 0
 		ipif.ManagedAddressConfigurationSupported = false
 		ipif.OtherStatefulConfigurationSupported = false
-		ipif.NLMTU = t.options.MTU
+		ipif.NLMTU = t.options.MTU[0]
 		ipif.UseAutomaticMetric = false
 		ipif.Metric = 0
 		err = ipif.Set()
@@ -151,7 +151,7 @@ func (t *WindowsTun) Start() error {
 		ipif.DadTransmits = 0
 		ipif.ManagedAddressConfigurationSupported = false
 		ipif.OtherStatefulConfigurationSupported = false
-		ipif.NLMTU = t.options.MTU
+		ipif.NLMTU = t.options.MTU[1]
 		ipif.UseAutomaticMetric = false
 		ipif.Metric = 0
 		err = ipif.Set()
@@ -278,7 +278,7 @@ func (t *WindowsTun) Wait() {
 }
 
 func (t *WindowsTun) newEndpoint() (stack.LinkEndpoint, error) {
-	return &LinkEndpoint{deviceMTU: t.options.MTU, device: t}, nil
+	return &LinkEndpoint{deviceMTU: t.options.MTU[0], device: t}, nil
 }
 
 const (

--- a/proxy/tun/tun_windows.go
+++ b/proxy/tun/tun_windows.go
@@ -4,7 +4,9 @@ package tun
 
 import (
 	"crypto/md5"
+	"encoding/binary"
 	go_errors "errors"
+	"net"
 	"net/netip"
 	"unsafe"
 
@@ -24,11 +26,12 @@ func procyield(cycles uint32)
 // current version is heavily stripped to do nothing more,
 // then create a network interface, to be provided as endpoint to gVisor ip stack
 type WindowsTun struct {
-	options  *Config
-	adapter  *wintun.Adapter
-	session  wintun.Session
-	readWait windows.Handle
-	luid     winipcfg.LUID
+	options        *Config
+	adapter        *wintun.Adapter
+	session        wintun.Session
+	readWait       windows.Handle
+	luid           winipcfg.LUID
+	changeCallback winipcfg.ChangeCallback
 }
 
 // WindowsTun implements Tun
@@ -168,10 +171,21 @@ func (t *WindowsTun) Start() error {
 		}
 	}
 
+	t.changeCallback, err = winipcfg.RegisterInterfaceChangeCallback(func(notificationType winipcfg.MibNotificationType, iface *winipcfg.MibIPInterfaceRow) {
+		if notificationType != winipcfg.MibDeleteInstance {
+			return
+		}
+		updater.Update()
+	})
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
 func (t *WindowsTun) Close() error {
+	t.changeCallback.Unregister()
 	t.session.End()
 	_ = t.adapter.Close()
 
@@ -244,4 +258,37 @@ func (t *WindowsTun) Wait() {
 
 func (t *WindowsTun) newEndpoint() (stack.LinkEndpoint, error) {
 	return &LinkEndpoint{deviceMTU: t.options.MTU, device: t}, nil
+}
+
+const (
+	IP_UNICAST_IF   = 31
+	IPV6_UNICAST_IF = 31
+)
+
+func setinterface(network, address string, fd uintptr, iface *net.Interface) error {
+	var index [4]byte
+	binary.BigEndian.PutUint32(index[:], uint32(iface.Index))
+
+	switch network {
+	case "tcp4", "udp4", "ip4":
+		err := windows.SetsockoptInt(windows.Handle(fd), windows.IPPROTO_IP, IP_UNICAST_IF, *(*int)(unsafe.Pointer(&index[0])))
+		if err != nil {
+			return err
+		}
+		if network == "udp4" {
+			return windows.SetsockoptInt(windows.Handle(fd), windows.IPPROTO_IP, windows.IP_MULTICAST_IF, *(*int)(unsafe.Pointer(&index[0])))
+		}
+	case "tcp6", "udp6", "ip6":
+		err := windows.SetsockoptInt(windows.Handle(fd), windows.IPPROTO_IPV6, IPV6_UNICAST_IF, iface.Index)
+		if err != nil {
+			return err
+		}
+		if network == "udp6" {
+			return windows.SetsockoptInt(windows.Handle(fd), windows.IPPROTO_IPV6, windows.IPV6_MULTICAST_IF, iface.Index)
+		}
+	default:
+		return errors.New("unknown network")
+	}
+
+	return nil
 }

--- a/proxy/tun/tun_windows.go
+++ b/proxy/tun/tun_windows.go
@@ -85,8 +85,8 @@ func open(name string) (*wintun.Adapter, error) {
 
 func (t *WindowsTun) Start() error {
 	var has4, has6 bool
-	allowedIPs := make([]netip.Prefix, 0, len(t.options.Route))
-	for _, route := range t.options.Route {
+	allowedIPs := make([]netip.Prefix, 0, len(t.options.AutoRoutingTable))
+	for _, route := range t.options.AutoRoutingTable {
 		allowedIPs = append(allowedIPs, netip.MustParsePrefix(route))
 	}
 	routesMap := make(map[winipcfg.RouteData]struct{})
@@ -114,9 +114,9 @@ func (t *WindowsTun) Start() error {
 		return errors.New("unable to set routes").Base(err)
 	}
 
-	if len(t.options.Address) > 0 {
-		addresses := make([]netip.Prefix, 0, len(t.options.Address))
-		for _, address := range t.options.Address {
+	if len(t.options.Gateway) > 0 {
+		addresses := make([]netip.Prefix, 0, len(t.options.Gateway))
+		for _, address := range t.options.Gateway {
 			addresses = append(addresses, netip.MustParsePrefix(address))
 		}
 		err := t.luid.SetIPAddresses(addresses)
@@ -160,9 +160,9 @@ func (t *WindowsTun) Start() error {
 		}
 	}
 
-	if len(t.options.Dns) > 0 {
-		dns := make([]netip.Addr, 0, len(t.options.Dns))
-		for _, ip := range t.options.Dns {
+	if len(t.options.DNS) > 0 {
+		dns := make([]netip.Addr, 0, len(t.options.DNS))
+		for _, ip := range t.options.DNS {
 			dns = append(dns, netip.MustParseAddr(ip))
 		}
 		err := t.luid.SetDNS(windows.AF_INET, dns, nil)

--- a/proxy/tun/tun_windows.go
+++ b/proxy/tun/tun_windows.go
@@ -8,6 +8,7 @@ import (
 	go_errors "errors"
 	"net"
 	"net/netip"
+	"sync"
 	"unsafe"
 
 	"github.com/xtls/xray-core/common/errors"
@@ -26,12 +27,15 @@ func procyield(cycles uint32)
 // current version is heavily stripped to do nothing more,
 // then create a network interface, to be provided as endpoint to gVisor ip stack
 type WindowsTun struct {
+	sync.Mutex
+
 	options        *Config
 	adapter        *wintun.Adapter
 	session        wintun.Session
 	readWait       windows.Handle
 	luid           winipcfg.LUID
 	changeCallback winipcfg.ChangeCallback
+	closed         bool
 }
 
 // WindowsTun implements Tun
@@ -187,6 +191,13 @@ func (t *WindowsTun) Start() error {
 }
 
 func (t *WindowsTun) Close() error {
+	t.Lock()
+	defer t.Unlock()
+	if t.closed {
+		return nil
+	}
+	t.closed = true
+
 	if t.changeCallback != nil {
 		t.changeCallback.Unregister()
 	}
@@ -214,6 +225,12 @@ func (t *WindowsTun) Index() (int, error) {
 
 // WritePacket implements GVisorDevice method to write one packet to the tun device
 func (t *WindowsTun) WritePacket(packetBuffer *stack.PacketBuffer) tcpip.Error {
+	t.Lock()
+	defer t.Unlock()
+	if t.closed {
+		return nil
+	}
+
 	// request buffer from Wintun
 	packet, err := t.session.AllocateSendPacket(packetBuffer.Size())
 	if err != nil {

--- a/proxy/tun/tun_windows.go
+++ b/proxy/tun/tun_windows.go
@@ -28,7 +28,7 @@ type WindowsTun struct {
 	adapter  *wintun.Adapter
 	session  wintun.Session
 	readWait windows.Handle
-	MTU      uint32
+	luid     winipcfg.LUID
 }
 
 // WindowsTun implements Tun
@@ -61,9 +61,7 @@ func NewTun(options *Config) (Tun, error) {
 		adapter:  adapter,
 		session:  session,
 		readWait: session.ReadWaitEvent(),
-		// there is currently no iphndl.dll support, which is the netlink library for windows
-		// so there is nowhere to change MTU for the Wintun interface, and we take its default value
-		MTU: wintun.PacketSizeMax,
+		luid:     winipcfg.LUID(adapter.LUID()),
 	}
 
 	return tun, nil
@@ -107,8 +105,7 @@ func (t *WindowsTun) Start() error {
 		r := route
 		routesData = append(routesData, &r)
 	}
-	luid := winipcfg.LUID(t.adapter.LUID())
-	err := luid.SetRoutes(routesData)
+	err := t.luid.SetRoutes(routesData)
 	if err != nil {
 		return errors.New("unable to set routes").Base(err)
 	}
@@ -118,14 +115,14 @@ func (t *WindowsTun) Start() error {
 		for _, address := range t.options.Address {
 			addresses = append(addresses, netip.MustParsePrefix(address))
 		}
-		err := luid.SetIPAddresses(addresses)
+		err := t.luid.SetIPAddresses(addresses)
 		if err != nil {
 			return errors.New("unable to set ips").Base(err)
 		}
 	}
 
 	if has4 {
-		ipif, err := luid.IPInterface(windows.AF_INET)
+		ipif, err := t.luid.IPInterface(windows.AF_INET)
 		if err != nil {
 			return err
 		}
@@ -142,7 +139,7 @@ func (t *WindowsTun) Start() error {
 		}
 	}
 	if has6 {
-		ipif, err := luid.IPInterface(windows.AF_INET6)
+		ipif, err := t.luid.IPInterface(windows.AF_INET6)
 		if err != nil {
 			return err
 		}
@@ -164,11 +161,11 @@ func (t *WindowsTun) Start() error {
 		for _, ip := range t.options.Dns {
 			dns = append(dns, netip.MustParseAddr(ip))
 		}
-		err := luid.SetDNS(windows.AF_INET, dns, nil)
+		err := t.luid.SetDNS(windows.AF_INET, dns, nil)
 		if err != nil {
 			return err
 		}
-		err = luid.SetDNS(windows.AF_INET6, dns, nil)
+		err = t.luid.SetDNS(windows.AF_INET6, dns, nil)
 		if err != nil {
 			return err
 		}

--- a/proxy/tun/tun_windows.go
+++ b/proxy/tun/tun_windows.go
@@ -171,14 +171,16 @@ func (t *WindowsTun) Start() error {
 		}
 	}
 
-	t.changeCallback, err = winipcfg.RegisterInterfaceChangeCallback(func(notificationType winipcfg.MibNotificationType, iface *winipcfg.MibIPInterfaceRow) {
-		if notificationType != winipcfg.MibDeleteInstance {
-			return
+	if t.options.AutoInterface {
+		t.changeCallback, err = winipcfg.RegisterInterfaceChangeCallback(func(notificationType winipcfg.MibNotificationType, iface *winipcfg.MibIPInterfaceRow) {
+			if notificationType != winipcfg.MibDeleteInstance {
+				return
+			}
+			updater.Update()
+		})
+		if err != nil {
+			return err
 		}
-		updater.Update()
-	})
-	if err != nil {
-		return err
 	}
 
 	return nil
@@ -289,7 +291,7 @@ func setinterface(network, address string, fd uintptr, iface *net.Interface) err
 			return windows.SetsockoptInt(windows.Handle(fd), windows.IPPROTO_IPV6, windows.IPV6_MULTICAST_IF, iface.Index)
 		}
 	default:
-		return errors.New("unknown network")
+		return errors.New("unknown network ", network)
 	}
 
 	return nil

--- a/proxy/tun/tun_windows.go
+++ b/proxy/tun/tun_windows.go
@@ -27,7 +27,7 @@ func procyield(cycles uint32)
 // current version is heavily stripped to do nothing more,
 // then create a network interface, to be provided as endpoint to gVisor ip stack
 type WindowsTun struct {
-	sync.Mutex
+	sync.RWMutex
 
 	options        *Config
 	adapter        *wintun.Adapter
@@ -225,8 +225,8 @@ func (t *WindowsTun) Index() (int, error) {
 
 // WritePacket implements GVisorDevice method to write one packet to the tun device
 func (t *WindowsTun) WritePacket(packetBuffer *stack.PacketBuffer) tcpip.Error {
-	t.Lock()
-	defer t.Unlock()
+	t.RLock()
+	defer t.RUnlock()
 	if t.closed {
 		return &tcpip.ErrClosedForSend{}
 	}

--- a/proxy/tun/tun_windows.go
+++ b/proxy/tun/tun_windows.go
@@ -4,10 +4,11 @@ package tun
 
 import (
 	"crypto/md5"
-	"errors"
+	go_errors "errors"
 	"net/netip"
 	"unsafe"
 
+	"github.com/xtls/xray-core/common/errors"
 	"golang.org/x/sys/windows"
 	"golang.zx2c4.com/wintun"
 	"golang.zx2c4.com/wireguard/windows/tunnel/winipcfg"
@@ -82,8 +83,8 @@ func open(name string) (*wintun.Adapter, error) {
 
 func (t *WindowsTun) Start() error {
 	var has4, has6 bool
-	allowedIPs := make([]netip.Prefix, 0, len(t.options.WinRoute))
-	for _, route := range t.options.WinRoute {
+	allowedIPs := make([]netip.Prefix, 0, len(t.options.Route))
+	for _, route := range t.options.Route {
 		allowedIPs = append(allowedIPs, netip.MustParsePrefix(route))
 	}
 	routesMap := make(map[winipcfg.RouteData]struct{})
@@ -109,8 +110,20 @@ func (t *WindowsTun) Start() error {
 	luid := winipcfg.LUID(t.adapter.LUID())
 	err := luid.SetRoutes(routesData)
 	if err != nil {
-		return err
+		return errors.New("unable to set routes").Base(err)
 	}
+
+	if len(t.options.Address) > 0 {
+		addresses := make([]netip.Prefix, 0, len(t.options.Address))
+		for _, address := range t.options.Address {
+			addresses = append(addresses, netip.MustParsePrefix(address))
+		}
+		err := luid.SetIPAddresses(addresses)
+		if err != nil {
+			return errors.New("unable to set ips").Base(err)
+		}
+	}
+
 	if has4 {
 		ipif, err := luid.IPInterface(windows.AF_INET)
 		if err != nil {
@@ -145,6 +158,7 @@ func (t *WindowsTun) Start() error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -180,7 +194,7 @@ func (t *WindowsTun) WritePacket(packetBuffer *stack.PacketBuffer) tcpip.Error {
 // which will make the stack call Wait which should implement desired push-back
 func (t *WindowsTun) ReadPacket() (byte, *stack.PacketBuffer, error) {
 	packet, err := t.session.ReceivePacket()
-	if errors.Is(err, windows.ERROR_NO_MORE_ITEMS) {
+	if go_errors.Is(err, windows.ERROR_NO_MORE_ITEMS) {
 		return 0, nil, ErrQueueEmpty
 	}
 	if err != nil {

--- a/proxy/tun/tun_windows.go
+++ b/proxy/tun/tun_windows.go
@@ -228,7 +228,7 @@ func (t *WindowsTun) WritePacket(packetBuffer *stack.PacketBuffer) tcpip.Error {
 	t.Lock()
 	defer t.Unlock()
 	if t.closed {
-		return nil
+		return &tcpip.ErrClosedForSend{}
 	}
 
 	// request buffer from Wintun

--- a/proxy/tun/tun_windows.go
+++ b/proxy/tun/tun_windows.go
@@ -85,8 +85,8 @@ func open(name string) (*wintun.Adapter, error) {
 
 func (t *WindowsTun) Start() error {
 	var has4, has6 bool
-	allowedIPs := make([]netip.Prefix, 0, len(t.options.AutoRoutingTable))
-	for _, route := range t.options.AutoRoutingTable {
+	allowedIPs := make([]netip.Prefix, 0, len(t.options.AutoSystemRoutingTable))
+	for _, route := range t.options.AutoSystemRoutingTable {
 		allowedIPs = append(allowedIPs, netip.MustParsePrefix(route))
 	}
 	routesMap := make(map[winipcfg.RouteData]struct{})

--- a/proxy/tun/tun_windows.go
+++ b/proxy/tun/tun_windows.go
@@ -34,9 +34,6 @@ type WindowsTun struct {
 // WindowsTun implements Tun
 var _ Tun = (*WindowsTun)(nil)
 
-// WindowsTun implements GVisorTun
-var _ GVisorTun = (*WindowsTun)(nil)
-
 // WindowsTun implements GVisorDevice
 var _ GVisorDevice = (*WindowsTun)(nil)
 
@@ -179,6 +176,22 @@ func (t *WindowsTun) Close() error {
 	_ = t.adapter.Close()
 
 	return nil
+}
+
+func (t *WindowsTun) Name() (string, error) {
+	row, err := t.luid.Interface()
+	if err != nil {
+		return "", err
+	}
+	return row.Alias(), nil
+}
+
+func (t *WindowsTun) Index() (int, error) {
+	row, err := t.luid.Interface()
+	if err != nil {
+		return 0, err
+	}
+	return int(row.InterfaceIndex), nil
 }
 
 // WritePacket implements GVisorDevice method to write one packet to the tun device

--- a/proxy/tun/tun_windows.go
+++ b/proxy/tun/tun_windows.go
@@ -5,10 +5,12 @@ package tun
 import (
 	"crypto/md5"
 	"errors"
+	"net/netip"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
 	"golang.zx2c4.com/wintun"
+	"golang.zx2c4.com/wireguard/windows/tunnel/winipcfg"
 	"gvisor.dev/gvisor/pkg/buffer"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
@@ -70,13 +72,8 @@ func open(name string) (*wintun.Adapter, error) {
 	// generate a deterministic GUID from the adapter name
 	id := md5.Sum([]byte(name))
 	guid := (*windows.GUID)(unsafe.Pointer(&id[0]))
-	// try to open existing adapter by name
-	adapter, err := wintun.OpenAdapter(name)
-	if err == nil {
-		return adapter, nil
-	}
 	// try to create adapter anew
-	adapter, err = wintun.CreateAdapter(name, "Xray", guid)
+	adapter, err := wintun.CreateAdapter(name, "Xray", guid)
 	if err == nil {
 		return adapter, nil
 	}
@@ -84,6 +81,70 @@ func open(name string) (*wintun.Adapter, error) {
 }
 
 func (t *WindowsTun) Start() error {
+	var has4, has6 bool
+	allowedIPs := make([]netip.Prefix, 0, len(t.options.WinRoute))
+	for _, route := range t.options.WinRoute {
+		allowedIPs = append(allowedIPs, netip.MustParsePrefix(route))
+	}
+	routesMap := make(map[winipcfg.RouteData]struct{})
+	for _, ip := range allowedIPs {
+		route := winipcfg.RouteData{
+			Destination: ip.Masked(),
+			Metric:      0,
+		}
+		if ip.Addr().Is4() {
+			has4 = true
+			route.NextHop = netip.IPv4Unspecified()
+		} else {
+			has6 = true
+			route.NextHop = netip.IPv6Unspecified()
+		}
+		routesMap[route] = struct{}{}
+	}
+	routesData := make([]*winipcfg.RouteData, 0, len(routesMap))
+	for route := range routesMap {
+		r := route
+		routesData = append(routesData, &r)
+	}
+	luid := winipcfg.LUID(t.adapter.LUID())
+	err := luid.SetRoutes(routesData)
+	if err != nil {
+		return err
+	}
+	if has4 {
+		ipif, err := luid.IPInterface(windows.AF_INET)
+		if err != nil {
+			return err
+		}
+		ipif.RouterDiscoveryBehavior = winipcfg.RouterDiscoveryDisabled
+		ipif.DadTransmits = 0
+		ipif.ManagedAddressConfigurationSupported = false
+		ipif.OtherStatefulConfigurationSupported = false
+		ipif.NLMTU = t.options.MTU
+		ipif.UseAutomaticMetric = false
+		ipif.Metric = 0
+		err = ipif.Set()
+		if err != nil {
+			return err
+		}
+	}
+	if has6 {
+		ipif, err := luid.IPInterface(windows.AF_INET6)
+		if err != nil {
+			return err
+		}
+		ipif.RouterDiscoveryBehavior = winipcfg.RouterDiscoveryDisabled
+		ipif.DadTransmits = 0
+		ipif.ManagedAddressConfigurationSupported = false
+		ipif.OtherStatefulConfigurationSupported = false
+		ipif.NLMTU = t.options.MTU
+		ipif.UseAutomaticMetric = false
+		ipif.Metric = 0
+		err = ipif.Set()
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/proxy/tun/tun_windows.go
+++ b/proxy/tun/tun_windows.go
@@ -185,7 +185,9 @@ func (t *WindowsTun) Start() error {
 }
 
 func (t *WindowsTun) Close() error {
-	t.changeCallback.Unregister()
+	if t.changeCallback != nil {
+		t.changeCallback.Unregister()
+	}
 	t.session.End()
 	_ = t.adapter.Close()
 

--- a/transport/internet/system_dialer.go
+++ b/transport/internet/system_dialer.go
@@ -2,6 +2,7 @@ package internet
 
 import (
 	"context"
+	"sync"
 	"syscall"
 	"time"
 
@@ -11,6 +12,8 @@ import (
 	"github.com/xtls/xray-core/features/outbound"
 )
 
+var Controllers []func(network, address string, c syscall.RawConn) error
+var ControllersLock sync.Mutex
 var effectiveSystemDialer SystemDialer = &DefaultSystemDialer{}
 
 type SystemDialer interface {
@@ -19,9 +22,8 @@ type SystemDialer interface {
 }
 
 type DefaultSystemDialer struct {
-	controllers []func(network, address string, c syscall.RawConn) error
-	dns         dns.Client
-	obm         outbound.Manager
+	dns dns.Client
+	obm outbound.Manager
 }
 
 func resolveSrcAddr(network net.Network, src net.Address) net.Addr {
@@ -63,7 +65,7 @@ func (d *DefaultSystemDialer) Dial(ctx context.Context, src net.Address, dest ne
 			return nil, err
 		}
 		lc.Control = func(network, address string, c syscall.RawConn) error {
-			for _, ctl := range d.controllers {
+			for _, ctl := range Controllers {
 				if err := ctl(network, address, c); err != nil {
 					errors.LogInfoInner(ctx, err, "failed to apply external controller")
 				}
@@ -115,12 +117,12 @@ func (d *DefaultSystemDialer) Dial(ctx context.Context, src net.Address, dest ne
 		KeepAliveConfig: keepAliveConfig,
 	}
 
-	if sockopt != nil || len(d.controllers) > 0 {
+	if sockopt != nil || len(Controllers) > 0 {
 		if sockopt != nil && sockopt.TcpMptcp {
 			dialer.SetMultipathTCP(true)
 		}
 		dialer.Control = func(network, address string, c syscall.RawConn) error {
-			for _, ctl := range d.controllers {
+			for _, ctl := range Controllers {
 				if err := ctl(network, address, c); err != nil {
 					errors.LogInfoInner(ctx, err, "failed to apply external controller")
 				}
@@ -187,34 +189,13 @@ func (d *SimpleSystemDialer) DestIpAddress() net.IP {
 	return nil
 }
 
-// UseAlternativeSystemDialer replaces the current system dialer with a given one.
-// Caller must ensure there is no race condition.
-//
-// xray:api:stable
-func UseAlternativeSystemDialer(dialer SystemDialer) {
-	if dialer == nil {
-		dialer = &DefaultSystemDialer{}
-	}
-	effectiveSystemDialer = dialer
-}
-
-// RegisterDialerController adds a controller to the effective system dialer.
-// The controller can be used to operate on file descriptors before they are put into use.
-// It only works when effective dialer is the default dialer.
-//
-// xray:api:beta
-func RegisterDialerController(ctl func(network, address string, c syscall.RawConn) error) error {
+func RegisterDialerController(ctl func(network, address string, c syscall.RawConn) error) {
 	if ctl == nil {
-		return errors.New("nil listener controller")
+		return
 	}
-
-	dialer, ok := effectiveSystemDialer.(*DefaultSystemDialer)
-	if !ok {
-		return errors.New("RegisterListenerController not supported in custom dialer")
-	}
-
-	dialer.controllers = append(dialer.controllers, ctl)
-	return nil
+	ControllersLock.Lock()
+	Controllers = append(Controllers, ctl)
+	ControllersLock.Unlock()
 }
 
 type FakePacketConn struct {

--- a/transport/internet/system_dialer.go
+++ b/transport/internet/system_dialer.go
@@ -189,13 +189,37 @@ func (d *SimpleSystemDialer) DestIpAddress() net.IP {
 	return nil
 }
 
-func RegisterDialerController(ctl func(network, address string, c syscall.RawConn) error) {
-	if ctl == nil {
-		return
+// UseAlternativeSystemDialer replaces the current system dialer with a given one.
+// Caller must ensure there is no race condition.
+//
+// xray:api:stable
+func UseAlternativeSystemDialer(dialer SystemDialer) {
+	if dialer == nil {
+		dialer = &DefaultSystemDialer{}
 	}
+	effectiveSystemDialer = dialer
+}
+
+// RegisterDialerController adds a controller to the effective system dialer.
+// The controller can be used to operate on file descriptors before they are put into use.
+// It only works when effective dialer is the default dialer.
+//
+// xray:api:beta
+func RegisterDialerController(ctl func(network, address string, c syscall.RawConn) error) error {
+	if ctl == nil {
+		return errors.New("nil listener controller")
+	}
+
 	ControllersLock.Lock()
 	Controllers = append(Controllers, ctl)
 	ControllersLock.Unlock()
+
+	_, ok := effectiveSystemDialer.(*DefaultSystemDialer)
+	if !ok {
+		return errors.New("RegisterListenerController not supported in custom dialer")
+	}
+
+	return nil
 }
 
 type FakePacketConn struct {


### PR DESCRIPTION
```jsonc
{
  "log": { "loglevel": "debug" },
  "inbounds": [
    {
      "protocol": "tun",
      "settings": {
        "name": "xray0",
        "mtu": [
          1500,
          1280
        ],
        "gateway": [
          "10.0.0.1/16",
          "fc00::1/64"
        ],
        "dns": [
          "1.1.1.1",
          "8.8.8.8"
          // "2606:4700:4700::1111",
          // "2001:4860:4860::8888"
        ],
        "userLevel": 0,
        "autoSystemRoutingTable": [
          "0.0.0.0/0",
          "::/0"
        ]
        // ,"autoOutboundsInterface": "auto"
      }
    }
  ],
  "outbounds": [
    {
      "protocol": "freedom"
    }
  ]
}
```