### PR TITLE
SOCKS inbound: Add Unix domain socket support

### DIFF
--- a/proxy/socks/server.go
+++ b/proxy/socks/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	goerrors "errors"
 	"io"
+	gonet "net"
 	"time"
 
 	"github.com/xtls/xray-core/common"
@@ -64,6 +65,7 @@ func (s *Server) Network() []net.Network {
 	if s.config.UdpEnabled {
 		list = append(list, net.Network_UDP)
 	}
+	list = append(list, net.Network_UNIX)
 	return list
 }
 
@@ -80,7 +82,7 @@ func (s *Server) Process(ctx context.Context, network net.Network, conn stat.Con
 	}
 
 	switch network {
-	case net.Network_TCP:
+	case net.Network_TCP, net.Network_UNIX:
 		firstbyte := make([]byte, 1)
 		if n, err := conn.Read(firstbyte); n == 0 {
 			if goerrors.Is(err, io.EOF) {
@@ -112,11 +114,18 @@ func (s *Server) processTCP(ctx context.Context, conn stat.Connection, dispatche
 		return errors.New("inbound gateway not specified")
 	}
 
+	var localAddr net.Address
+	if tcpAddr, ok := conn.LocalAddr().(*gonet.TCPAddr); ok {
+		localAddr = net.IPAddress(tcpAddr.IP)
+	} else {
+		localAddr = net.LocalHostIP
+	}
+
 	svrSession := &ServerSession{
 		config:       s.config,
 		address:      inbound.Gateway.Address,
 		port:         inbound.Gateway.Port,
-		localAddress: net.IPAddress(conn.LocalAddr().(*net.TCPAddr).IP),
+		localAddress: localAddr,
 	}
 
 	// Firstbyte is for forwarded conn from SOCKS inbound


### PR DESCRIPTION
## Summary

Enables the SOCKS5 inbound proxy to listen on Unix domain sockets, matching the existing support in VLESS, VMess, Trojan, and HTTP inbounds.

### Changes

- Add `net.Network_UNIX` to the SOCKS server's `Network()` method
- Handle `net.Network_UNIX` in the `Process()` switch alongside `net.Network_TCP` (both are stream-based)
- Fix `LocalAddr()` type assertion in `processTCP()` to safely handle non-TCP connections (previously hard-cast to `*net.TCPAddr`, which would panic on Unix socket connections)

### Motivation

In some regions, authorities instruct local IT companies to detect and block VPN users. One common detection method is scanning `/proc/net/tcp` for open SOCKS5 proxy ports on localhost (e.g., port 10808) — a clear fingerprint of a running VPN client.

Unix domain sockets do not appear in `/proc/net/tcp`, making them invisible to local port scanners. This is particularly useful for Android VPN clients (like v2rayNG) where the SOCKS5 inbound serves only as an internal bridge between tun2socks and Xray-core — there is no reason to expose it as a TCP port.

The Xray-core infrastructure (`dsWorker`, config parser) already fully supports Unix domain sockets. The SOCKS5 server was the only built-in inbound protocol that didn't opt in.

### Configuration

```json
{
  "inbounds": [{
    "listen": "/path/to/socks.sock",
    "protocol": "socks",
    "settings": {
      "udp": false
    }
  }]
}
```

Abstract sockets (Linux) also work: `"listen": "@xray_socks"`

### Related

- Original issue: https://github.com/2dust/v2rayNG/issues/5457
- Discussion: https://github.com/XTLS/Xray-core/discussions/1607
- Issue: https://github.com/XTLS/Xray-core/issues/1649