### PR TITLE
mux: Fix OOM crash on UDP keep frames

### DIFF
--- a/common/mux/frame.go
+++ b/common/mux/frame.go
@@ -100,9 +100,22 @@ func (f FrameMetadata) WriteTo(b *buf.Buffer) error {
 		} else if b.UDP != nil { // make sure it's user's proxy request
 			b.Write(f.GlobalID[:]) // no need to check whether it's empty
 		}
-	} else if b.UDP != nil {
-		b.WriteByte(byte(TargetNetworkUDP))
-		addrParser.WriteAddressPort(b, b.UDP.Address, b.UDP.Port)
+	} else if udp := b.UDP; udp != nil {
+		// Snapshot the destination by value before serializing it. b.UDP is
+		// a *net.Destination borrowed from the upstream UDP reader (set by
+		// writeMetaWithFrame as `frame.UDP = data[0].UDP`), and reading
+		// udp.Address — a non-atomic two-word interface — races with the
+		// producer mutating the same Destination for its next packet. The
+		// race produces a torn DomainAddress that crashes
+		// addressParser.writeAddress with a multi-exabyte allocation.
+		// Copying the struct is still racy at the field level, but it
+		// closes the window between the type-byte write and the address
+		// write, and it lets us actually return the error below.
+		snap := *udp
+		common.Must(b.WriteByte(byte(TargetNetworkUDP)))
+		if err := addrParser.WriteAddressPort(b, snap.Address, snap.Port); err != nil {
+			return err
+		}
 	}
 
 	len1 := b.Len()

--- a/common/protocol/headers.go
+++ b/common/protocol/headers.go
@@ -91,5 +91,12 @@ func (sc *SecurityConfig) GetSecurityType() SecurityType {
 }
 
 func isDomainTooLong(domain string) bool {
-	return len(domain) > 256
+	// Use unsigned comparison: len() returns a signed int, and a torn read
+	// of a string header (e.g. via a racy 16-byte interface read of a
+	// *DomainAddress) can leave the high bit set. With the previous signed
+	// `> 256` check that case slipped through and reached
+	// runtime.stringtoslicebyte with a uint length of ~9 EB, crashing the
+	// process with "fatal error: out of memory". The wire format also only
+	// has one byte for the length, so 255 is the real upper bound.
+	return uint(len(domain)) > 255
 }


### PR DESCRIPTION
Fixes #5901.

`FrameMetadata.WriteTo` on the UDP keep-frame path dereferences `b.UDP.Address` (a non-atomic two-word interface) while the upstream UDP reader is free to mutate the same `*net.Destination` for its next packet. The resulting torn read can produce a `DomainAddress` whose backing string header has a garbage `(ptr, len)` pair.

`isDomainTooLong` then fails to catch it because it uses a signed `len(domain) > 256` comparison: a negative torn length is `< 256`, slips through, and reaches `runtime.stringtoslicebyte` with a `uint` length of ~9 EB, aborting the process with `fatal error: out of memory`.

The error from `WriteAddressPort` on this branch was also discarded, so even the existing guard would have produced a malformed frame instead of a clean failure.

This PR fixes both halves:

- **`common/protocol/headers.go`** — switch to `uint(len(domain)) > 255` so any negative or absurd length is rejected, and tighten the bound to the actual one-byte wire-format limit.
- **`common/mux/frame.go`** — snapshot `*b.UDP` into a local before writing the address bytes (closes the window between the network-type byte and the address bytes), and actually return `WriteAddressPort`'s error instead of dropping it.

Full root-cause writeup, production stack trace, and a deterministic standalone reproducer are in #5901. With this PR applied the reproducer cleanly returns `Super long domain is not supported: ...` instead of crashing.

## Note on the underlying race

This patch stops the crash and stops the malformed frame, but it does not fix the *root* of the data race — a producer that keeps mutating a `*net.Destination` after handing the pointer to a buffer is fundamentally unsafe, and the proper long-term fix is to make UDP producers either allocate a fresh `Destination` per packet or store it by value on `buf.Buffer`. I haven't tracked down the specific producer that triggers it; happy to follow up in a separate PR if you'd like.
