### PR TITLE
feat: add mTLS client certificate support

### DIFF
--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -587,6 +587,13 @@ type TLSCertConfig struct {
 	BuildChain     bool     `json:"buildChain"`
 }
 
+type TLSClientCertConfig struct {
+	CertFile string   `json:"certificateFile"`
+	CertStr  []string `json:"certificate"`
+	KeyFile  string   `json:"keyFile"`
+	KeyStr   []string `json:"key"`
+}
+
 // Build implements Buildable.
 func (c *TLSCertConfig) Build() (*tls.Certificate, error) {
 	certificate := new(tls.Certificate)
@@ -646,26 +653,27 @@ type QuicParamsConfig struct {
 }
 
 type TLSConfig struct {
-	AllowInsecure           bool             `json:"allowInsecure"`
-	Certs                   []*TLSCertConfig `json:"certificates"`
-	ServerName              string           `json:"serverName"`
-	ALPN                    *StringList      `json:"alpn"`
-	EnableSessionResumption bool             `json:"enableSessionResumption"`
-	DisableSystemRoot       bool             `json:"disableSystemRoot"`
-	MinVersion              string           `json:"minVersion"`
-	MaxVersion              string           `json:"maxVersion"`
-	CipherSuites            string           `json:"cipherSuites"`
-	Fingerprint             string           `json:"fingerprint"`
-	RejectUnknownSNI        bool             `json:"rejectUnknownSni"`
-	CurvePreferences        *StringList      `json:"curvePreferences"`
-	MasterKeyLog            string           `json:"masterKeyLog"`
-	PinnedPeerCertSha256    string           `json:"pinnedPeerCertSha256"`
-	VerifyPeerCertByName    string           `json:"verifyPeerCertByName"`
-	VerifyPeerCertInNames   []string         `json:"verifyPeerCertInNames"`
-	ECHServerKeys           string           `json:"echServerKeys"`
-	ECHConfigList           string           `json:"echConfigList"`
-	ECHForceQuery           string           `json:"echForceQuery"`
-	ECHSocketSettings       *SocketConfig    `json:"echSockopt"`
+	AllowInsecure           bool                   `json:"allowInsecure"`
+	Certs                   []*TLSCertConfig       `json:"certificates"`
+	ServerName              string                 `json:"serverName"`
+	ALPN                    *StringList            `json:"alpn"`
+	EnableSessionResumption bool                   `json:"enableSessionResumption"`
+	DisableSystemRoot       bool                   `json:"disableSystemRoot"`
+	MinVersion              string                 `json:"minVersion"`
+	MaxVersion              string                 `json:"maxVersion"`
+	CipherSuites            string                 `json:"cipherSuites"`
+	Fingerprint             string                 `json:"fingerprint"`
+	RejectUnknownSNI        bool                   `json:"rejectUnknownSni"`
+	CurvePreferences        *StringList            `json:"curvePreferences"`
+	MasterKeyLog            string                 `json:"masterKeyLog"`
+	PinnedPeerCertSha256    string                 `json:"pinnedPeerCertSha256"`
+	VerifyPeerCertByName    string                 `json:"verifyPeerCertByName"`
+	VerifyPeerCertInNames   []string               `json:"verifyPeerCertInNames"`
+	ECHServerKeys           string                 `json:"echServerKeys"`
+	ECHConfigList           string                 `json:"echConfigList"`
+	ECHForceQuery           string                 `json:"echForceQuery"`
+	ECHSocketSettings       *SocketConfig          `json:"echSockopt"`
+	ClientCertificate       []*TLSClientCertConfig `json:"clientCertificate"`
 }
 
 // Build implements Buildable.
@@ -768,6 +776,23 @@ func (c *TLSConfig) Build() (proto.Message, error) {
 			return nil, errors.New("Failed to build ech sockopt.").Base(err)
 		}
 		config.EchSocketSettings = ss
+	}
+
+	if len(c.ClientCertificate) > 0 {
+		for _, cc := range c.ClientCertificate {
+			clientCert := new(tls.ClientCertificate)
+			cert, err := readFileOrString(cc.CertFile, cc.CertStr)
+			if err != nil {
+				return nil, errors.New("failed to parse client certificate").Base(err)
+			}
+			clientCert.Certificate = cert
+			key, err := readFileOrString(cc.KeyFile, cc.KeyStr)
+			if err != nil {
+				return nil, errors.New("failed to parse client key").Base(err)
+			}
+			clientCert.Key = key
+			config.ClientCertificate = append(config.ClientCertificate, clientCert)
+		}
 	}
 
 	return config, nil

--- a/transport/internet/tls/config.go
+++ b/transport/internet/tls/config.go
@@ -477,6 +477,12 @@ func (c *Config) GetTLSConfig(opts ...Option) *tls.Config {
 		}
 	}
 
+	if clientCerts := c.BuildClientCertificates(); len(clientCerts) > 0 {
+		config.GetClientCertificate = func(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return clientCerts[0], nil
+		}
+	}
+
 	return config
 }
 
@@ -546,6 +552,63 @@ func ParseCurveName(curveNames []string) []tls.CurveID {
 
 func IsFromMitm(str string) bool {
 	return strings.ToLower(str) == "frommitm"
+}
+
+func (c *Config) BuildClientCertificates() []*tls.Certificate {
+	if len(c.ClientCertificate) == 0 {
+		return nil
+	}
+
+	certs := make([]*tls.Certificate, 0, len(c.ClientCertificate))
+
+	for _, clientCert := range c.ClientCertificate {
+		certData := clientCert.Certificate
+		keyData := clientCert.Key
+
+		if clientCert.CertificatePath != "" {
+			content, err := filesystem.ReadCert(clientCert.CertificatePath)
+			if err != nil {
+				errors.LogError(context.Background(), "failed to read client certificate file: ", err)
+				continue
+			}
+			certData = content
+		}
+
+		if clientCert.KeyPath != "" {
+			content, err := filesystem.ReadCert(clientCert.KeyPath)
+			if err != nil {
+				errors.LogError(context.Background(), "failed to read client key file: ", err)
+				continue
+			}
+			keyData = content
+		}
+
+		if len(certData) == 0 {
+			certData = clientCert.Certificate
+		}
+		if len(keyData) == 0 {
+			keyData = clientCert.Key
+		}
+
+		if len(certData) == 0 || len(keyData) == 0 {
+			errors.LogWarning(context.Background(), "client certificate and key must be provided together, skipping")
+			continue
+		}
+
+		keyPair, err := tls.X509KeyPair(certData, keyData)
+		if err != nil {
+			errors.LogWarningInner(context.Background(), err, "failed to parse client X509 key pair")
+			continue
+		}
+
+		certs = append(certs, &keyPair)
+	}
+
+	if len(certs) == 0 {
+		return nil
+	}
+
+	return certs
 }
 
 type verifyResult int

--- a/transport/internet/tls/config.pb.go
+++ b/transport/internet/tls/config.pb.go
@@ -176,6 +176,74 @@ func (x *Certificate) GetBuildChain() bool {
 	return false
 }
 
+type ClientCertificate struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Certificate     []byte                 `protobuf:"bytes,1,opt,name=certificate,proto3" json:"certificate,omitempty"`
+	Key             []byte                 `protobuf:"bytes,2,opt,name=key,proto3" json:"key,omitempty"`
+	CertificatePath string                 `protobuf:"bytes,3,opt,name=certificate_path,json=certificatePath,proto3" json:"certificate_path,omitempty"`
+	KeyPath         string                 `protobuf:"bytes,4,opt,name=key_path,json=keyPath,proto3" json:"key_path,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *ClientCertificate) Reset() {
+	*x = ClientCertificate{}
+	mi := &file_transport_internet_tls_config_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClientCertificate) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClientCertificate) ProtoMessage() {}
+
+func (x *ClientCertificate) ProtoReflect() protoreflect.Message {
+	mi := &file_transport_internet_tls_config_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClientCertificate.ProtoReflect.Descriptor instead.
+func (*ClientCertificate) Descriptor() ([]byte, []int) {
+	return file_transport_internet_tls_config_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *ClientCertificate) GetCertificate() []byte {
+	if x != nil {
+		return x.Certificate
+	}
+	return nil
+}
+
+func (x *ClientCertificate) GetKey() []byte {
+	if x != nil {
+		return x.Key
+	}
+	return nil
+}
+
+func (x *ClientCertificate) GetCertificatePath() string {
+	if x != nil {
+		return x.CertificatePath
+	}
+	return ""
+}
+
+func (x *ClientCertificate) GetKeyPath() string {
+	if x != nil {
+		return x.KeyPath
+	}
+	return ""
+}
+
 type Config struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	AllowInsecure bool                   `protobuf:"varint,1,opt,name=allow_insecure,json=allowInsecure,proto3" json:"allow_insecure,omitempty"`
@@ -208,13 +276,14 @@ type Config struct {
 	EchForceQuery        string                 `protobuf:"bytes,20,opt,name=ech_force_query,json=echForceQuery,proto3" json:"ech_force_query,omitempty"`
 	EchSocketSettings    *internet.SocketConfig `protobuf:"bytes,21,opt,name=ech_socket_settings,json=echSocketSettings,proto3" json:"ech_socket_settings,omitempty"`
 	PinnedPeerCertSha256 [][]byte               `protobuf:"bytes,22,rep,name=pinned_peer_cert_sha256,json=pinnedPeerCertSha256,proto3" json:"pinned_peer_cert_sha256,omitempty"`
+	ClientCertificate    []*ClientCertificate   `protobuf:"bytes,23,rep,name=client_certificate,json=clientCertificate,proto3" json:"client_certificate,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
 
 func (x *Config) Reset() {
 	*x = Config{}
-	mi := &file_transport_internet_tls_config_proto_msgTypes[1]
+	mi := &file_transport_internet_tls_config_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -226,7 +295,7 @@ func (x *Config) String() string {
 func (*Config) ProtoMessage() {}
 
 func (x *Config) ProtoReflect() protoreflect.Message {
-	mi := &file_transport_internet_tls_config_proto_msgTypes[1]
+	mi := &file_transport_internet_tls_config_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -239,7 +308,7 @@ func (x *Config) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Config.ProtoReflect.Descriptor instead.
 func (*Config) Descriptor() ([]byte, []int) {
-	return file_transport_internet_tls_config_proto_rawDescGZIP(), []int{1}
+	return file_transport_internet_tls_config_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *Config) GetAllowInsecure() bool {
@@ -375,6 +444,13 @@ func (x *Config) GetPinnedPeerCertSha256() [][]byte {
 	return nil
 }
 
+func (x *Config) GetClientCertificate() []*ClientCertificate {
+	if x != nil {
+		return x.ClientCertificate
+	}
+	return nil
+}
+
 var File_transport_internet_tls_config_proto protoreflect.FileDescriptor
 
 const file_transport_internet_tls_config_proto_rawDesc = "" +
@@ -393,7 +469,12 @@ const file_transport_internet_tls_config_proto_rawDesc = "" +
 	"\x05Usage\x12\x10\n" +
 	"\fENCIPHERMENT\x10\x00\x12\x14\n" +
 	"\x10AUTHORITY_VERIFY\x10\x01\x12\x13\n" +
-	"\x0fAUTHORITY_ISSUE\x10\x02\"\xf5\x06\n" +
+	"\x0fAUTHORITY_ISSUE\x10\x02\"\x8d\x01\n" +
+	"\x11ClientCertificate\x12 \n" +
+	"\vcertificate\x18\x01 \x01(\fR\vcertificate\x12\x10\n" +
+	"\x03key\x18\x02 \x01(\fR\x03key\x12)\n" +
+	"\x10certificate_path\x18\x03 \x01(\tR\x0fcertificatePath\x12\x19\n" +
+	"\bkey_path\x18\x04 \x01(\tR\akeyPath\"\xd4\a\n" +
 	"\x06Config\x12%\n" +
 	"\x0eallow_insecure\x18\x01 \x01(\bR\rallowInsecure\x12J\n" +
 	"\vcertificate\x18\x02 \x03(\v2(.xray.transport.internet.tls.CertificateR\vcertificate\x12\x1f\n" +
@@ -416,7 +497,8 @@ const file_transport_internet_tls_config_proto_rawDesc = "" +
 	"\x0fech_config_list\x18\x13 \x01(\tR\rechConfigList\x12&\n" +
 	"\x0fech_force_query\x18\x14 \x01(\tR\rechForceQuery\x12U\n" +
 	"\x13ech_socket_settings\x18\x15 \x01(\v2%.xray.transport.internet.SocketConfigR\x11echSocketSettings\x125\n" +
-	"\x17pinned_peer_cert_sha256\x18\x16 \x03(\fR\x14pinnedPeerCertSha256Bs\n" +
+	"\x17pinned_peer_cert_sha256\x18\x16 \x03(\fR\x14pinnedPeerCertSha256\x12]\n" +
+	"\x12client_certificate\x18\x17 \x03(\v2..xray.transport.internet.tls.ClientCertificateR\x11clientCertificateBs\n" +
 	"\x1fcom.xray.transport.internet.tlsP\x01Z0github.com/xtls/xray-core/transport/internet/tls\xaa\x02\x1bXray.Transport.Internet.Tlsb\x06proto3"
 
 var (
@@ -432,22 +514,24 @@ func file_transport_internet_tls_config_proto_rawDescGZIP() []byte {
 }
 
 var file_transport_internet_tls_config_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_transport_internet_tls_config_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_transport_internet_tls_config_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_transport_internet_tls_config_proto_goTypes = []any{
 	(Certificate_Usage)(0),        // 0: xray.transport.internet.tls.Certificate.Usage
 	(*Certificate)(nil),           // 1: xray.transport.internet.tls.Certificate
-	(*Config)(nil),                // 2: xray.transport.internet.tls.Config
-	(*internet.SocketConfig)(nil), // 3: xray.transport.internet.SocketConfig
+	(*ClientCertificate)(nil),     // 2: xray.transport.internet.tls.ClientCertificate
+	(*Config)(nil),                // 3: xray.transport.internet.tls.Config
+	(*internet.SocketConfig)(nil), // 4: xray.transport.internet.SocketConfig
 }
 var file_transport_internet_tls_config_proto_depIdxs = []int32{
 	0, // 0: xray.transport.internet.tls.Certificate.usage:type_name -> xray.transport.internet.tls.Certificate.Usage
 	1, // 1: xray.transport.internet.tls.Config.certificate:type_name -> xray.transport.internet.tls.Certificate
-	3, // 2: xray.transport.internet.tls.Config.ech_socket_settings:type_name -> xray.transport.internet.SocketConfig
-	3, // [3:3] is the sub-list for method output_type
-	3, // [3:3] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	4, // 2: xray.transport.internet.tls.Config.ech_socket_settings:type_name -> xray.transport.internet.SocketConfig
+	2, // 3: xray.transport.internet.tls.Config.client_certificate:type_name -> xray.transport.internet.tls.ClientCertificate
+	4, // [4:4] is the sub-list for method output_type
+	4, // [4:4] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_transport_internet_tls_config_proto_init() }
@@ -461,7 +545,7 @@ func file_transport_internet_tls_config_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_transport_internet_tls_config_proto_rawDesc), len(file_transport_internet_tls_config_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   2,
+			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/transport/internet/tls/config.proto
+++ b/transport/internet/tls/config.proto
@@ -37,6 +37,13 @@ message Certificate {
   bool build_chain = 8;
 }
 
+message ClientCertificate {
+  bytes certificate = 1;
+  bytes key = 2;
+  string certificate_path = 3;
+  string key_path = 4;
+}
+
 message Config {
   bool allow_insecure = 1;
 
@@ -86,4 +93,6 @@ message Config {
   SocketConfig ech_socket_settings = 21;
 
   repeated bytes pinned_peer_cert_sha256 = 22;
+
+  repeated ClientCertificate client_certificate = 23;
 }

--- a/transport/internet/tls/tls.go
+++ b/transport/internet/tls/tls.go
@@ -147,6 +147,23 @@ func copyConfig(c *tls.Config) *utls.Config {
 		KeyLogWriter:                   c.KeyLogWriter,
 		EncryptedClientHelloConfigList: c.EncryptedClientHelloConfigList,
 	}
+	if c.GetClientCertificate != nil {
+		origFunc := c.GetClientCertificate
+		config.GetClientCertificate = func(cri *utls.CertificateRequestInfo) (*utls.Certificate, error) {
+			tlsCert, err := origFunc(&tls.CertificateRequestInfo{
+				AcceptableCAs: cri.AcceptableCAs,
+			})
+			if err != nil || tlsCert == nil {
+				return nil, err
+			}
+			return &utls.Certificate{
+				Certificate:                 tlsCert.Certificate,
+				PrivateKey:                  tlsCert.PrivateKey,
+				OCSPStaple:                  tlsCert.OCSPStaple,
+				SignedCertificateTimestamps: tlsCert.SignedCertificateTimestamps,
+			}, nil
+		}
+	}
 	if config.EncryptedClientHelloConfigList != nil {
 		config.NextProtos = c.NextProtos
 	}


### PR DESCRIPTION
- Add ClientCertificate message to TLS config proto
- Add BuildClientCertificates() method to load client certs
- Add uTLS adapter for client cert support
- Add JSON config parsing for clientCertificate field

Supports file path and inline PEM formats.

```json
{
  "outbounds": [
    {
      "tag": "vless-mtls",
      "protocol": "vless",
      "settings": {
        "vnext": [
          {
            "address": "mtls.example.com",
            "port": 443,
            "users": [
              {
                "id": "bcrn6-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
                "flow": "",
                "encryption": "none"
              }
            ]
          }
        ]
      },
      "streamSettings": {
        "network": "ws",
        "security": "tls",
        "tlsSettings": {
          "serverName": "mtls.example.com",
          "clientCertificate": [
            {
              "certificateFile": "/path/to/client.crt",
              "keyFile": "/path/to/client.key"
            }
          ]
        },
        "wsSettings": {
          "path": "/vless"
        }
      }
    },
  ]
}
```

Related issue:
https://github.com/XTLS/Xray-core/issues/1508
https://github.com/XTLS/Xray-core/issues/2273