### PR TITLE
mux nil user

### DIFF
--- a/common/mux/server.go
+++ b/common/mux/server.go
@@ -181,7 +181,9 @@ func (w *ServerWorker) handleStatusNew(ctx context.Context, meta *FrameMetadata,
 		}
 		if inbound := session.InboundFromContext(ctx); inbound != nil && inbound.Source.IsValid() {
 			msg.From = inbound.Source
-			msg.Email = inbound.User.Email
+			if inbound.User != nil {
+				msg.Email = inbound.User.Email
+			}
 		}
 		ctx = log.ContextWithAccessMessage(ctx, msg)
 	}


### PR DESCRIPTION
https://github.com/XTLS/Xray-core/pull/5679#issuecomment-4229655047

看起来 mux 假设所有入站 user 都不为 nil，~不是很想动 hy protocol，mux 受累动一下吧~

可复现配置

```jsonc
{
  "log": { "loglevel": "debug" },
  "inbounds": [
    {
      "listen": "127.0.0.1",
      "port": 1080,
      "protocol": "socks",
      "settings": {
        "auth": "noauth",
        "udp": true
      }
    }
  ],
  "outbounds": [
    {
      "protocol": "hysteria",
      "settings": {
        "version": 2,
        "address": "127.0.0.1",
        "port": 1081
      },
      "streamSettings": {
        "network": "tcp"
      },
      "mux": {
        "enabled": true,
        "concurrency": 8
      }
    }
  ]
}
```

```jsonc
{
  "log": { "loglevel": "debug" },
  "inbounds": [
    {
      "listen": "127.0.0.1",
      "port": 1081,
      "protocol": "hysteria",
      "settings": {
        "version": 2
      },
      "streamSettings": {
        "network": "tcp"
      }
    }
  ],
  "outbounds": [
    {
      "protocol": "freedom"
    }
  ]
}
```