### PR TITLE
Routing: `process` supports UID on Android

### DIFF
--- a/app/router/condition.go
+++ b/app/router/condition.go
@@ -390,6 +390,7 @@ func (m *ProcessNameMatcher) Apply(ctx routing.Context) bool {
 	if len(ctx.GetSourceIPs()) == 0 {
 		return false
 	}
+
 	srcPort := ctx.GetSourcePort().String()
 	srcIP := ctx.GetSourceIPs()[0].String()
 	var network string
@@ -401,11 +402,25 @@ func (m *ProcessNameMatcher) Apply(ctx routing.Context) bool {
 	default:
 		return false
 	}
+
 	src, err := net.ParseDestination(strings.Join([]string{network, srcIP, srcPort}, ":"))
 	if err != nil {
 		return false
 	}
-	pid, name, absPath, err := net.FindProcess(src)
+
+	if ctx.GetTargetIPs() == nil || len(ctx.GetTargetIPs()) == 0 {
+		errors.LogDebug(context.Background(), "No target IP. src = "+srcIP+":"+srcPort)
+		return false
+	}
+
+	dstPort := ctx.GetTargetPort().String()
+	dstIP := ctx.GetTargetIPs()[0].String()
+	dst, err := net.ParseDestination(strings.Join([]string{network, dstIP, dstPort}, ":"))
+	if err != nil {
+		return false
+	}
+
+	pid, name, absPath, err := net.FindProcess(src, dst)
 	if err != nil {
 		if err != net.ErrNotLocal {
 			errors.LogError(context.Background(), "Unables to find local process name: ", err)

--- a/app/router/condition.go
+++ b/app/router/condition.go
@@ -2,7 +2,6 @@ package router
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -385,14 +384,6 @@ func NewProcessNameMatcher(names []string) *ProcessNameMatcher {
 		Folders:       folders,
 		MatchXraySelf: matchXraySelf,
 	}
-}
-
-// parseDestination is a wrapper of net.ParseDestination, with ipv6 support.
-func parseDestination(network, ip, port string) (net.Destination, error) {
-	if strings.Contains(ip, ":") {
-		ip = fmt.Sprintf("[%s]", ip)
-	}
-	return net.ParseDestination(fmt.Sprintf("%s:%s:%s", network, ip, port))
 }
 
 func (m *ProcessNameMatcher) Apply(ctx routing.Context) bool {

--- a/app/router/condition.go
+++ b/app/router/condition.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -386,6 +387,14 @@ func NewProcessNameMatcher(names []string) *ProcessNameMatcher {
 	}
 }
 
+// parseDestination is a wrapper of net.ParseDestination, with ipv6 support.
+func parseDestination(network, ip, port string) (net.Destination, error) {
+	if strings.Contains(ip, ":") {
+		ip = fmt.Sprintf("[%s]", ip)
+	}
+	return net.ParseDestination(fmt.Sprintf("%s:%s:%s", network, ip, port))
+}
+
 func (m *ProcessNameMatcher) Apply(ctx routing.Context) bool {
 	if len(ctx.GetSourceIPs()) == 0 {
 		return false
@@ -403,20 +412,22 @@ func (m *ProcessNameMatcher) Apply(ctx routing.Context) bool {
 		return false
 	}
 
-	src, err := net.ParseDestination(strings.Join([]string{network, srcIP, srcPort}, ":"))
+	src, err := parseDestination(network, srcIP, srcPort)
 	if err != nil {
+		errors.LogDebug(context.Background(), fmt.Sprintf("parse destination failed. src = %s %s %s, err = %s", network, srcIP, srcPort, err))
 		return false
 	}
 
 	if ctx.GetTargetIPs() == nil || len(ctx.GetTargetIPs()) == 0 {
-		errors.LogDebug(context.Background(), "No target IP. src = "+srcIP+":"+srcPort)
+		errors.LogDebug(context.Background(), fmt.Sprintf("No target IP. src = %s %s %s", network, srcIP, srcPort))
 		return false
 	}
 
 	dstPort := ctx.GetTargetPort().String()
 	dstIP := ctx.GetTargetIPs()[0].String()
-	dst, err := net.ParseDestination(strings.Join([]string{network, dstIP, dstPort}, ":"))
+	dst, err := parseDestination(network, dstIP, dstPort)
 	if err != nil {
+		errors.LogDebug(context.Background(), fmt.Sprintf("parse destination failed. dst = %s %s %s, err = %s", network, dstIP, dstPort, err))
 		return false
 	}
 

--- a/app/router/condition.go
+++ b/app/router/condition.go
@@ -400,8 +400,9 @@ func (m *ProcessNameMatcher) Apply(ctx routing.Context) bool {
 		return false
 	}
 
-	srcPort := ctx.GetSourcePort().String()
+	srcPort := uint16(ctx.GetSourcePort())
 	srcIP := ctx.GetSourceIPs()[0].String()
+
 	var network string
 	switch ctx.GetNetwork() {
 	case net.Network_TCP:
@@ -412,26 +413,14 @@ func (m *ProcessNameMatcher) Apply(ctx routing.Context) bool {
 		return false
 	}
 
-	src, err := parseDestination(network, srcIP, srcPort)
-	if err != nil {
-		errors.LogDebug(context.Background(), fmt.Sprintf("parse destination failed. src = %s %s %s, err = %s", network, srcIP, srcPort, err))
-		return false
+	var dstIP string
+	var dstPort uint16 = 0
+	if len(ctx.GetTargetIPs()) > 0 {
+		dstIP = ctx.GetTargetIPs()[0].String()
+		dstPort = uint16(ctx.GetTargetPort())
 	}
 
-	if ctx.GetTargetIPs() == nil || len(ctx.GetTargetIPs()) == 0 {
-		errors.LogDebug(context.Background(), fmt.Sprintf("No target IP. src = %s %s %s", network, srcIP, srcPort))
-		return false
-	}
-
-	dstPort := ctx.GetTargetPort().String()
-	dstIP := ctx.GetTargetIPs()[0].String()
-	dst, err := parseDestination(network, dstIP, dstPort)
-	if err != nil {
-		errors.LogDebug(context.Background(), fmt.Sprintf("parse destination failed. dst = %s %s %s, err = %s", network, dstIP, dstPort, err))
-		return false
-	}
-
-	pid, name, absPath, err := net.FindProcess(src, dst)
+	pid, name, absPath, err := net.FindProcess(network, srcIP, uint16(srcPort), dstIP, uint16(dstPort))
 	if err != nil {
 		if err != net.ErrNotLocal {
 			errors.LogError(context.Background(), "Unables to find local process name: ", err)

--- a/common/net/find_process_android.go
+++ b/common/net/find_process_android.go
@@ -6,10 +6,15 @@ import (
 	"github.com/xtls/xray-core/common/errors"
 )
 
-var AndroidFindProcessImpl func(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (int, string, string, error) = func(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (int, string, string, error) {
-	return 0, "", "", errors.New("stub: process lookup is not implemented")
+var AndroidFindProcessFinder func(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (int, string, string, error)
+
+func RegisterAndroidFindProcessFinder(f func(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (int, string, string, error)) {
+	AndroidFindProcessFinder = f
 }
 
 func FindProcess(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (int, string, string, error) {
-	return AndroidFindProcessImpl(network, srcIP, srcPort, destIP, destPort)
+	if AndroidFindProcessFinder != nil {
+		return AndroidFindProcessFinder(network, srcIP, srcPort, destIP, destPort)
+	}
+	return 0, "", "", errors.New("android process lookup must be registered before use")
 }

--- a/common/net/find_process_android.go
+++ b/common/net/find_process_android.go
@@ -6,15 +6,15 @@ import (
 	"github.com/xtls/xray-core/common/errors"
 )
 
-var androidFindProcessFinder func(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (int, string, string, error)
+var androidProcessFinder func(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (int, string, string, error)
 
-func RegisterAndroidFindProcessFinder(f func(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (int, string, string, error)) {
-	androidFindProcessFinder = f
+func RegisterAndroidProcessFinder(f func(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (int, string, string, error)) {
+	androidProcessFinder = f
 }
 
 func FindProcess(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (int, string, string, error) {
-	if androidFindProcessFinder != nil {
-		return androidFindProcessFinder(network, srcIP, srcPort, destIP, destPort)
+	if androidProcessFinder != nil {
+		return androidProcessFinder(network, srcIP, srcPort, destIP, destPort)
 	}
 	return 0, "", "", errors.New("android process lookup must be registered before use")
 }

--- a/common/net/find_process_android.go
+++ b/common/net/find_process_android.go
@@ -1,0 +1,15 @@
+//go:build android
+
+package net
+
+import (
+	"github.com/xtls/xray-core/common/errors"
+)
+
+var AndroidFindProcessImpl func(src Destination, dest Destination) (int, string, string, error) = func(src Destination, dest Destination) (int, string, string, error) {
+	return 0, "", "", errors.New("stub: process lookup is not implemented")
+}
+
+func FindProcess(src Destination, dest Destination) (int, string, string, error) {
+	return AndroidFindProcessImpl(src, dest)
+}

--- a/common/net/find_process_android.go
+++ b/common/net/find_process_android.go
@@ -6,10 +6,10 @@ import (
 	"github.com/xtls/xray-core/common/errors"
 )
 
-var AndroidFindProcessImpl func(src Destination, dest Destination) (int, string, string, error) = func(src Destination, dest Destination) (int, string, string, error) {
+var AndroidFindProcessImpl func(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (int, string, string, error) = func(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (int, string, string, error) {
 	return 0, "", "", errors.New("stub: process lookup is not implemented")
 }
 
-func FindProcess(src Destination, dest Destination) (int, string, string, error) {
-	return AndroidFindProcessImpl(src, dest)
+func FindProcess(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (int, string, string, error) {
+	return AndroidFindProcessImpl(network, srcIP, srcPort, destIP, destPort)
 }

--- a/common/net/find_process_android.go
+++ b/common/net/find_process_android.go
@@ -6,15 +6,15 @@ import (
 	"github.com/xtls/xray-core/common/errors"
 )
 
-var AndroidFindProcessFinder func(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (int, string, string, error)
+var androidFindProcessFinder func(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (int, string, string, error)
 
 func RegisterAndroidFindProcessFinder(f func(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (int, string, string, error)) {
-	AndroidFindProcessFinder = f
+	androidFindProcessFinder = f
 }
 
 func FindProcess(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (int, string, string, error) {
-	if AndroidFindProcessFinder != nil {
-		return AndroidFindProcessFinder(network, srcIP, srcPort, destIP, destPort)
+	if androidFindProcessFinder != nil {
+		return androidFindProcessFinder(network, srcIP, srcPort, destIP, destPort)
 	}
 	return 0, "", "", errors.New("android process lookup must be registered before use")
 }

--- a/common/net/find_process_linux.go
+++ b/common/net/find_process_linux.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"encoding/hex"
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -13,43 +14,38 @@ import (
 	"github.com/xtls/xray-core/common/errors"
 )
 
-func FindProcess(src Destination, dest Destination) (PID int, Name string, AbsolutePath string, err error) {
-	isLocal, err := IsLocal(src.Address.IP())
+func FindProcess(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (PID int, Name string, AbsolutePath string, err error) {
+	isLocal, err := IsLocal(net.ParseIP(srcIP))
 	if err != nil {
 		return 0, "", "", errors.New("failed to determine if address is local: ", err)
 	}
 	if !isLocal {
 		return 0, "", "", ErrNotLocal
 	}
-	if src.Network != Network_TCP && src.Network != Network_UDP {
+	if network != "tcp" && network != "udp" {
 		panic("Unsupported network type for process lookup.")
 	}
-	// the core should never has a domain as source(?
-	if src.Address.Family() == AddressFamilyDomain {
-		panic("Domain addresses are not supported for process lookup.")
-	}
+
 	var procFile string
 
-	switch src.Network {
-	case Network_TCP:
-		if src.Address.Family() == AddressFamilyIPv4 {
+	switch network {
+	case "tcp":
+		if net.ParseIP(srcIP).To4() != nil {
 			procFile = "/proc/net/tcp"
-		}
-		if src.Address.Family() == AddressFamilyIPv6 {
+		} else {
 			procFile = "/proc/net/tcp6"
 		}
-	case Network_UDP:
-		if src.Address.Family() == AddressFamilyIPv4 {
+	case "udp":
+		if net.ParseIP(srcIP).To4() != nil {
 			procFile = "/proc/net/udp"
-		}
-		if src.Address.Family() == AddressFamilyIPv6 {
+		} else {
 			procFile = "/proc/net/udp6"
 		}
 	default:
 		panic("Unsupported network type for process lookup.")
 	}
 
-	targetHexAddr, err := formatLittleEndianString(src.Address, src.Port)
+	targetHexAddr, err := formatLittleEndianString(net.ParseIP(srcIP), Port(srcPort))
 	if err != nil {
 		return 0, "", "", errors.New("failed to format address: ", err)
 	}
@@ -59,7 +55,7 @@ func FindProcess(src Destination, dest Destination) (PID int, Name string, Absol
 		return 0, "", "", errors.New("could not search in ", procFile).Base(err)
 	}
 	if inode == "" {
-		return 0, "", "", errors.New("connection for ", src.Address, ":", src.Port, " not found in ", procFile)
+		return 0, "", "", errors.New("connection for ", srcIP, ":", srcPort, " not found in ", procFile)
 	}
 
 	pidStr, err := findPidByInode(inode)
@@ -86,16 +82,16 @@ func FindProcess(src Destination, dest Destination) (PID int, Name string, Absol
 	return pid, procName, absPath, nil
 }
 
-func formatLittleEndianString(addr Address, port Port) (string, error) {
-	ip := addr.IP()
+func formatLittleEndianString(addr net.IP, port Port) (string, error) {
+	ip := addr
 	var ipBytes []byte
-	if addr.Family() == AddressFamilyIPv4 {
+	if ip.To4() != nil {
 		ipBytes = ip.To4()
 	} else {
 		ipBytes = ip.To16()
 	}
 	if ipBytes == nil {
-		return "", errors.New("invalid IP format for ", addr.Family(), ": ", ip)
+		return "", errors.New("invalid IP format for ", addr, ": ", ip)
 	}
 
 	for i, j := 0, len(ipBytes)-1; i < j; i, j = i+1, j-1 {

--- a/common/net/find_process_linux.go
+++ b/common/net/find_process_linux.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && !android
 
 package net
 
@@ -13,43 +13,43 @@ import (
 	"github.com/xtls/xray-core/common/errors"
 )
 
-func FindProcess(dest Destination) (PID int, Name string, AbsolutePath string, err error) {
-	isLocal, err := IsLocal(dest.Address.IP())
+func FindProcess(src Destination, dest Destination) (PID int, Name string, AbsolutePath string, err error) {
+	isLocal, err := IsLocal(src.Address.IP())
 	if err != nil {
 		return 0, "", "", errors.New("failed to determine if address is local: ", err)
 	}
 	if !isLocal {
 		return 0, "", "", ErrNotLocal
 	}
-	if dest.Network != Network_TCP && dest.Network != Network_UDP {
+	if src.Network != Network_TCP && src.Network != Network_UDP {
 		panic("Unsupported network type for process lookup.")
 	}
 	// the core should never has a domain as source(?
-	if dest.Address.Family() == AddressFamilyDomain {
+	if src.Address.Family() == AddressFamilyDomain {
 		panic("Domain addresses are not supported for process lookup.")
 	}
 	var procFile string
 
-	switch dest.Network {
+	switch src.Network {
 	case Network_TCP:
-		if dest.Address.Family() == AddressFamilyIPv4 {
+		if src.Address.Family() == AddressFamilyIPv4 {
 			procFile = "/proc/net/tcp"
 		}
-		if dest.Address.Family() == AddressFamilyIPv6 {
+		if src.Address.Family() == AddressFamilyIPv6 {
 			procFile = "/proc/net/tcp6"
 		}
 	case Network_UDP:
-		if dest.Address.Family() == AddressFamilyIPv4 {
+		if src.Address.Family() == AddressFamilyIPv4 {
 			procFile = "/proc/net/udp"
 		}
-		if dest.Address.Family() == AddressFamilyIPv6 {
+		if src.Address.Family() == AddressFamilyIPv6 {
 			procFile = "/proc/net/udp6"
 		}
 	default:
 		panic("Unsupported network type for process lookup.")
 	}
 
-	targetHexAddr, err := formatLittleEndianString(dest.Address, dest.Port)
+	targetHexAddr, err := formatLittleEndianString(src.Address, src.Port)
 	if err != nil {
 		return 0, "", "", errors.New("failed to format address: ", err)
 	}
@@ -59,7 +59,7 @@ func FindProcess(dest Destination) (PID int, Name string, AbsolutePath string, e
 		return 0, "", "", errors.New("could not search in ", procFile).Base(err)
 	}
 	if inode == "" {
-		return 0, "", "", errors.New("connection for ", dest.Address, ":", dest.Port, " not found in ", procFile)
+		return 0, "", "", errors.New("connection for ", src.Address, ":", src.Port, " not found in ", procFile)
 	}
 
 	pidStr, err := findPidByInode(inode)

--- a/common/net/find_process_others.go
+++ b/common/net/find_process_others.go
@@ -6,6 +6,6 @@ import (
 	"github.com/xtls/xray-core/common/errors"
 )
 
-func FindProcess(src Destination, dest Destination) (int, string, string, error) {
+func FindProcess(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (int, string, string, error) {
 	return 0, "", "", errors.New("process lookup is not supported on this platform")
 }

--- a/common/net/find_process_others.go
+++ b/common/net/find_process_others.go
@@ -1,4 +1,4 @@
-//go:build !windows && !linux
+//go:build !windows && !linux && !android
 
 package net
 
@@ -6,6 +6,6 @@ import (
 	"github.com/xtls/xray-core/common/errors"
 )
 
-func FindProcess(dest Destination) (int, string, string, error) {
+func FindProcess(src Destination, dest Destination) (int, string, string, error) {
 	return 0, "", "", errors.New("process lookup is not supported on this platform")
 }

--- a/common/net/find_process_windows.go
+++ b/common/net/find_process_windows.go
@@ -3,6 +3,7 @@
 package net
 
 import (
+	"net"
 	"net/netip"
 	"path/filepath"
 	"strings"
@@ -49,41 +50,37 @@ func initWin32API() error {
 	return nil
 }
 
-func FindProcess(src Destination, dest Destination) (PID int, Name string, AbsolutePath string, err error) {
+func FindProcess(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (PID int, Name string, AbsolutePath string, err error) {
 	once.Do(func() {
 		initErr = initWin32API()
 	})
 	if initErr != nil {
 		return 0, "", "", initErr
 	}
-	isLocal, err := IsLocal(src.Address.IP())
+	isLocal, err := IsLocal(net.ParseIP(srcIP))
 	if err != nil {
 		return 0, "", "", errors.New("failed to determine if address is local: ", err)
 	}
 	if !isLocal {
 		return 0, "", "", ErrNotLocal
 	}
-	if src.Network != Network_TCP && src.Network != Network_UDP {
+	if network != "tcp" && network != "udp" {
 		panic("Unsupported network type for process lookup.")
-	}
-	// the core should never has a domain as source(?
-	if src.Address.Family() == AddressFamilyDomain {
-		panic("Domain addresses are not supported for process lookup.")
 	}
 	var class int
 	var fn uintptr
-	switch src.Network {
-	case Network_TCP:
+	switch network {
+	case "tcp":
 		fn = getExTCPTable
 		class = tcpTablePidConn
-	case Network_UDP:
+	case "udp":
 		fn = getExUDPTable
 		class = udpTablePid
 	default:
 		panic("Unsupported network type for process lookup.")
 	}
-	ip := src.Address.IP()
-	port := int(src.Port)
+	ip := net.ParseIP(srcIP)
+	port := int(srcPort)
 
 	addr, ok := netip.AddrFromSlice(ip)
 	if !ok {
@@ -101,7 +98,15 @@ func FindProcess(src Destination, dest Destination) (PID int, Name string, Absol
 		return 0, "", "", err
 	}
 
-	s := newSearcher(src.Network, src.Address.Family())
+	networkType := Network_TCP
+	if network == "udp" {
+		networkType = Network_UDP
+	}
+	familyType := AddressFamilyIPv4
+	if addr.Is6() {
+		familyType = AddressFamilyIPv6
+	}
+	s := newSearcher(networkType, familyType)
 
 	pid, err := s.Search(buf, addr, uint16(port))
 	if err != nil {

--- a/common/net/find_process_windows.go
+++ b/common/net/find_process_windows.go
@@ -49,30 +49,30 @@ func initWin32API() error {
 	return nil
 }
 
-func FindProcess(dest Destination) (PID int, Name string, AbsolutePath string, err error) {
+func FindProcess(src Destination, dest Destination) (PID int, Name string, AbsolutePath string, err error) {
 	once.Do(func() {
 		initErr = initWin32API()
 	})
 	if initErr != nil {
 		return 0, "", "", initErr
 	}
-	isLocal, err := IsLocal(dest.Address.IP())
+	isLocal, err := IsLocal(src.Address.IP())
 	if err != nil {
 		return 0, "", "", errors.New("failed to determine if address is local: ", err)
 	}
 	if !isLocal {
 		return 0, "", "", ErrNotLocal
 	}
-	if dest.Network != Network_TCP && dest.Network != Network_UDP {
+	if src.Network != Network_TCP && src.Network != Network_UDP {
 		panic("Unsupported network type for process lookup.")
 	}
 	// the core should never has a domain as source(?
-	if dest.Address.Family() == AddressFamilyDomain {
+	if src.Address.Family() == AddressFamilyDomain {
 		panic("Domain addresses are not supported for process lookup.")
 	}
 	var class int
 	var fn uintptr
-	switch dest.Network {
+	switch src.Network {
 	case Network_TCP:
 		fn = getExTCPTable
 		class = tcpTablePidConn
@@ -82,8 +82,8 @@ func FindProcess(dest Destination) (PID int, Name string, AbsolutePath string, e
 	default:
 		panic("Unsupported network type for process lookup.")
 	}
-	ip := dest.Address.IP()
-	port := int(dest.Port)
+	ip := src.Address.IP()
+	port := int(src.Port)
 
 	addr, ok := netip.AddrFromSlice(ip)
 	if !ok {
@@ -101,7 +101,7 @@ func FindProcess(dest Destination) (PID int, Name string, AbsolutePath string, e
 		return 0, "", "", err
 	}
 
-	s := newSearcher(dest.Network, dest.Address.Family())
+	s := newSearcher(src.Network, src.Address.Family())
 
 	pid, err := s.Search(buf, addr, uint16(port))
 	if err != nil {


### PR DESCRIPTION



[ConnectivityManager#getConnectionOwnerUid](https://developer.android.com/reference/android/net/ConnectivityManager#getConnectionOwnerUid(int,%20java.net.InetSocketAddress,%20java.net.InetSocketAddress))

Android 根据连接获取进程 UID 的 API 需要同时提供本地和远程的IP+端口，所以我把 `func FindProcess(dest Destination)` 改成 `func FindProcess(src Destination, dest Destination)` 了。

同时还增加了 `AndroidFindProcessImpl` 变量，Xray 客户端可以自行实现 FindProcess 的逻辑。