### PR TITLE
buffer writing optimized

### DIFF
--- a/transport/pipe/writer.go
+++ b/transport/pipe/writer.go
@@ -9,6 +9,33 @@ type Writer struct {
 	pipe *pipe
 }
 
+// Write implements io.Writer.
+func (w *Writer) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	total := len(p)
+	mb := make(buf.MultiBuffer, 0, (len(p)+buf.Size-1)/buf.Size)
+	for len(p) > 0 {
+		chunkSize := len(p)
+		if chunkSize > buf.Size {
+			chunkSize = buf.Size
+		}
+
+		chunk := buf.NewWithSize(int32(chunkSize))
+		_, _ = chunk.Write(p[:chunkSize])
+		mb = append(mb, chunk)
+		p = p[chunkSize:]
+	}
+
+	if err := w.pipe.WriteMultiBuffer(mb); err != nil {
+		return 0, err
+	}
+
+	return total, nil
+}
+
 // WriteMultiBuffer implements buf.Writer.
 func (w *Writer) WriteMultiBuffer(mb buf.MultiBuffer) error {
 	return w.pipe.WriteMultiBuffer(mb)


### PR DESCRIPTION
in `common/buf/writer.go` there a was block code like this:
```go
if !w.buffered {
    if writer, ok := w.writer.(io.Writer); ok {
       return writer.Write(b)
    }
}
```
Since the class in `transport/pipe/writer.go` didn't implement the `Write` method, this branch was being skipped resulting in a minimum buffer allication of 8 KB. i have added implementation for this method and now the allocation is reduced to 2 KB (if a payload size allows). this parameter is regulated by the `common/bytespool` package

i would also to broadly consider reducing buffer size wherever possible. after a quick review of the project's codebase, i noticed that 8 KB is allocated in most places on `buf.Size`. does such a larger allocation make sense in all of the cases?