### PR TITLE
Hysteria inbound: Use transport's authentication when there are no `clients`

### DIFF
--- a/proxy/hysteria/server.go
+++ b/proxy/hysteria/server.go
@@ -28,11 +28,7 @@ type Server struct {
 }
 
 func NewServer(ctx context.Context, config *ServerConfig) (*Server, error) {
-	var validator *account.Validator
-	if len(config.Users) > 0 {
-		validator = account.NewValidator()
-	}
-
+	validator := account.NewValidator()
 	for _, user := range config.Users {
 		u, err := user.ToMemoryUser()
 		if err != nil {

--- a/proxy/hysteria/server.go
+++ b/proxy/hysteria/server.go
@@ -28,7 +28,11 @@ type Server struct {
 }
 
 func NewServer(ctx context.Context, config *ServerConfig) (*Server, error) {
-	validator := account.NewValidator()
+	var validator *account.Validator
+	if len(config.Users) > 0 {
+		validator = account.NewValidator()
+	}
+
 	for _, user := range config.Users {
 		u, err := user.ToMemoryUser()
 		if err != nil {
@@ -82,24 +86,13 @@ func (s *Server) Process(ctx context.Context, network net.Network, conn stat.Con
 	inbound := session.InboundFromContext(ctx)
 	inbound.Name = "hysteria"
 	inbound.CanSpliceCopy = 3
+	inbound.User = &protocol.MemoryUser{}
 
 	iConn := stat.TryUnwrapStatsConn(conn)
 
-	var useremail string
-	var userlevel uint32
 	type User interface{ User() *protocol.MemoryUser }
-	if v, ok := iConn.(User); ok {
+	if v, ok := iConn.(User); ok && v.User() != nil {
 		inbound.User = v.User()
-		if inbound.User != nil {
-			useremail = inbound.User.Email
-			userlevel = inbound.User.Level
-		}
-	} else {
-		// get a dummy user
-		inbound.User = &protocol.MemoryUser{
-			Email: "",
-			Level: 0,
-		}
 	}
 
 	if _, ok := iConn.(*hysteria.InterUdpConn); ok {
@@ -154,7 +147,7 @@ func (s *Server) Process(ctx context.Context, network net.Network, conn stat.Con
 			Writer: writer,
 		})
 	} else {
-		sessionPolicy := s.policyManager.ForLevel(userlevel)
+		sessionPolicy := s.policyManager.ForLevel(inbound.User.Level)
 
 		common.Must(conn.SetReadDeadline(time.Now().Add(sessionPolicy.Timeouts.Handshake)))
 		addr, err := ReadTCPRequest(conn)
@@ -178,7 +171,7 @@ func (s *Server) Process(ctx context.Context, network net.Network, conn stat.Con
 			To:     dest,
 			Status: log.AccessAccepted,
 			Reason: "",
-			Email:  useremail,
+			Email:  inbound.User.Email,
 		})
 		errors.LogInfo(ctx, "tunnelling request to ", dest)
 

--- a/transport/internet/hysteria/dialer.go
+++ b/transport/internet/hysteria/dialer.go
@@ -450,6 +450,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 	}
 
 	requireDatagram := hyCtx.RequireDatagramFromContext(ctx)
+	dest.Network = net.Network_UDP
 	config := streamSettings.ProtocolSettings.(*Config)
 
 	initmanager.Do(func() {
@@ -464,8 +465,8 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 			},
 		}).Start()
 	})
+
 	manager.mutex.Lock()
-	dest.Network = net.Network_UDP
 	c, ok := manager.m[dialerConf{Destination: dest, MemoryStreamConfig: streamSettings}]
 	if !ok {
 		c = &client{

--- a/transport/internet/hysteria/hub.go
+++ b/transport/internet/hysteria/hub.go
@@ -177,8 +177,8 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var ok bool
 		if h.validator != nil {
 			user = h.validator.Get(auth)
-		} else if auth == h.config.Auth {
-			ok = true
+		} else {
+			ok = auth == h.config.Auth
 		}
 
 		if user != nil || ok {

--- a/transport/internet/hysteria/hub.go
+++ b/transport/internet/hysteria/hub.go
@@ -175,9 +175,9 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		var user *protocol.MemoryUser
 		var ok bool
-		if h.validator != nil {
+		if h.validator != nil && h.validator.GetCount() > 0 {
 			user = h.validator.Get(auth)
-		} else {
+		} else if h.config.Auth != "" {
 			ok = auth == h.config.Auth
 		}
 


### PR DESCRIPTION
在无 clients 时使用传输层的 auth