### PR TITLE
Balancer: add fallbackBalancerTag support

### DIFF
--- a/app/router/balancing.go
+++ b/app/router/balancing.go
@@ -83,23 +83,35 @@ func (s *RoundRobinStrategy) PickOutbound(tags []string) string {
 }
 
 type Balancer struct {
-	selectors   []string
-	strategy    BalancingStrategy
-	ohm         outbound.Manager
-	fallbackTag string
+	tag                 string
+	selectors           []string
+	strategy            BalancingStrategy
+	ohm                 outbound.Manager
+	fallbackTag         string
+	fallbackOutboundTag string
+	fallbackBalancerTag string
+	fallbackBalancer    *Balancer
 
 	override override
 }
 
 // PickOutbound picks the tag of a outbound
 func (b *Balancer) PickOutbound() (string, error) {
+	return b.pickOutbound(make(map[string]bool))
+}
+
+func (b *Balancer) pickOutbound(visited map[string]bool) (string, error) {
+	if b.tag != "" {
+		if visited[b.tag] {
+			return "", errors.New("fallback balancer cycle detected at ", b.tag)
+		}
+		visited[b.tag] = true
+		defer delete(visited, b.tag)
+	}
+
 	candidates, err := b.SelectOutbounds()
 	if err != nil {
-		if b.fallbackTag != "" {
-			errors.LogInfo(context.Background(), "fallback to [", b.fallbackTag, "], due to error: ", err)
-			return b.fallbackTag, nil
-		}
-		return "", err
+		return b.pickFallback(visited, err)
 	}
 	var tag string
 	if o := b.override.Get(); o != "" {
@@ -108,14 +120,40 @@ func (b *Balancer) PickOutbound() (string, error) {
 		tag = b.strategy.PickOutbound(candidates)
 	}
 	if tag == "" {
-		if b.fallbackTag != "" {
-			errors.LogInfo(context.Background(), "fallback to [", b.fallbackTag, "], due to empty tag returned")
-			return b.fallbackTag, nil
-		}
-		// will use default handler
-		return "", errors.New("balancing strategy returns empty tag")
+		return b.pickFallback(visited, errors.New("balancing strategy returns empty tag"))
 	}
 	return tag, nil
+}
+
+func (b *Balancer) pickFallback(visited map[string]bool, cause error) (string, error) {
+	if name := b.fallbackName(); name != "" {
+		errors.LogInfo(context.Background(), "fallback to [", name, "], due to error: ", cause)
+	}
+
+	if b.fallbackOutboundTag != "" {
+		return b.fallbackOutboundTag, nil
+	}
+	if b.fallbackBalancerTag != "" {
+		if b.fallbackBalancer == nil {
+			return "", errors.New("fallback balancer ", b.fallbackBalancerTag, " not found")
+		}
+		return b.fallbackBalancer.pickOutbound(visited)
+	}
+	if b.fallbackTag != "" {
+		return b.fallbackTag, nil
+	}
+	return "", cause
+}
+
+func (b *Balancer) fallbackName() string {
+	switch {
+	case b.fallbackOutboundTag != "":
+		return b.fallbackOutboundTag
+	case b.fallbackBalancerTag != "":
+		return b.fallbackBalancerTag
+	default:
+		return b.fallbackTag
+	}
 }
 
 func (b *Balancer) InjectContext(ctx context.Context) {

--- a/app/router/config.go
+++ b/app/router/config.go
@@ -122,17 +122,23 @@ func (br *BalancingRule) Build(ohm outbound.Manager, dispatcher routing.Dispatch
 	switch strings.ToLower(br.Strategy) {
 	case "leastping":
 		return &Balancer{
-			selectors:   br.OutboundSelector,
-			strategy:    &LeastPingStrategy{},
-			fallbackTag: br.FallbackTag,
-			ohm:         ohm,
+			tag:                 br.Tag,
+			selectors:           br.OutboundSelector,
+			strategy:            &LeastPingStrategy{},
+			fallbackTag:         br.GetFallbackTag(),
+			fallbackOutboundTag: br.GetFallbackOutboundTag(),
+			fallbackBalancerTag: br.GetFallbackBalancerTag(),
+			ohm:                 ohm,
 		}, nil
 	case "roundrobin":
 		return &Balancer{
-			selectors:   br.OutboundSelector,
-			strategy:    &RoundRobinStrategy{FallbackTag: br.FallbackTag},
-			fallbackTag: br.FallbackTag,
-			ohm:         ohm,
+			tag:                 br.Tag,
+			selectors:           br.OutboundSelector,
+			strategy:            &RoundRobinStrategy{FallbackTag: firstNonEmpty(br.GetFallbackOutboundTag(), br.GetFallbackBalancerTag(), br.GetFallbackTag())},
+			fallbackTag:         br.GetFallbackTag(),
+			fallbackOutboundTag: br.GetFallbackOutboundTag(),
+			fallbackBalancerTag: br.GetFallbackBalancerTag(),
+			ohm:                 ohm,
 		}, nil
 	case "leastload":
 		i, err := br.StrategySettings.GetInstance()
@@ -145,21 +151,36 @@ func (br *BalancingRule) Build(ohm outbound.Manager, dispatcher routing.Dispatch
 		}
 		leastLoadStrategy := NewLeastLoadStrategy(s)
 		return &Balancer{
-			selectors:   br.OutboundSelector,
-			ohm:         ohm,
-			fallbackTag: br.FallbackTag,
-			strategy:    leastLoadStrategy,
+			tag:                 br.Tag,
+			selectors:           br.OutboundSelector,
+			ohm:                 ohm,
+			fallbackTag:         br.GetFallbackTag(),
+			fallbackOutboundTag: br.GetFallbackOutboundTag(),
+			fallbackBalancerTag: br.GetFallbackBalancerTag(),
+			strategy:            leastLoadStrategy,
 		}, nil
 	case "random":
 		fallthrough
 	case "":
 		return &Balancer{
-			selectors:   br.OutboundSelector,
-			ohm:         ohm,
-			fallbackTag: br.FallbackTag,
-			strategy:    &RandomStrategy{FallbackTag: br.FallbackTag},
+			tag:                 br.Tag,
+			selectors:           br.OutboundSelector,
+			ohm:                 ohm,
+			fallbackTag:         br.GetFallbackTag(),
+			fallbackOutboundTag: br.GetFallbackOutboundTag(),
+			fallbackBalancerTag: br.GetFallbackBalancerTag(),
+			strategy:            &RandomStrategy{FallbackTag: firstNonEmpty(br.GetFallbackOutboundTag(), br.GetFallbackBalancerTag(), br.GetFallbackTag())},
 		}, nil
 	default:
 		return nil, errors.New("unrecognized balancer type")
 	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/app/router/config.pb.go
+++ b/app/router/config.pb.go
@@ -357,14 +357,16 @@ func (x *WebhookConfig) GetHeaders() map[string]string {
 }
 
 type BalancingRule struct {
-	state            protoimpl.MessageState `protogen:"open.v1"`
-	Tag              string                 `protobuf:"bytes,1,opt,name=tag,proto3" json:"tag,omitempty"`
-	OutboundSelector []string               `protobuf:"bytes,2,rep,name=outbound_selector,json=outboundSelector,proto3" json:"outbound_selector,omitempty"`
-	Strategy         string                 `protobuf:"bytes,3,opt,name=strategy,proto3" json:"strategy,omitempty"`
-	StrategySettings *serial.TypedMessage   `protobuf:"bytes,4,opt,name=strategy_settings,json=strategySettings,proto3" json:"strategy_settings,omitempty"`
-	FallbackTag      string                 `protobuf:"bytes,5,opt,name=fallback_tag,json=fallbackTag,proto3" json:"fallback_tag,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	state               protoimpl.MessageState `protogen:"open.v1"`
+	Tag                 string                 `protobuf:"bytes,1,opt,name=tag,proto3" json:"tag,omitempty"`
+	OutboundSelector    []string               `protobuf:"bytes,2,rep,name=outbound_selector,json=outboundSelector,proto3" json:"outbound_selector,omitempty"`
+	Strategy            string                 `protobuf:"bytes,3,opt,name=strategy,proto3" json:"strategy,omitempty"`
+	StrategySettings    *serial.TypedMessage   `protobuf:"bytes,4,opt,name=strategy_settings,json=strategySettings,proto3" json:"strategy_settings,omitempty"`
+	FallbackTag         string                 `protobuf:"bytes,5,opt,name=fallback_tag,json=fallbackTag,proto3" json:"fallback_tag,omitempty"`
+	FallbackOutboundTag string                 `protobuf:"bytes,7,opt,name=fallback_outbound_tag,json=fallbackOutboundTag,proto3" json:"fallback_outbound_tag,omitempty"`
+	FallbackBalancerTag string                 `protobuf:"bytes,8,opt,name=fallback_balancer_tag,json=fallbackBalancerTag,proto3" json:"fallback_balancer_tag,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *BalancingRule) Reset() {
@@ -428,6 +430,20 @@ func (x *BalancingRule) GetStrategySettings() *serial.TypedMessage {
 func (x *BalancingRule) GetFallbackTag() string {
 	if x != nil {
 		return x.FallbackTag
+	}
+	return ""
+}
+
+func (x *BalancingRule) GetFallbackOutboundTag() string {
+	if x != nil {
+		return x.FallbackOutboundTag
+	}
+	return ""
+}
+
+func (x *BalancingRule) GetFallbackBalancerTag() string {
+	if x != nil {
+		return x.FallbackBalancerTag
 	}
 	return ""
 }
@@ -673,13 +689,15 @@ const file_app_router_config_proto_rawDesc = "" +
 	"\aheaders\x18\x03 \x03(\v2+.xray.app.router.WebhookConfig.HeadersEntryR\aheaders\x1a:\n" +
 	"\fHeadersEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xdc\x01\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xc4\x02\n" +
 	"\rBalancingRule\x12\x10\n" +
 	"\x03tag\x18\x01 \x01(\tR\x03tag\x12+\n" +
 	"\x11outbound_selector\x18\x02 \x03(\tR\x10outboundSelector\x12\x1a\n" +
 	"\bstrategy\x18\x03 \x01(\tR\bstrategy\x12M\n" +
 	"\x11strategy_settings\x18\x04 \x01(\v2 .xray.common.serial.TypedMessageR\x10strategySettings\x12!\n" +
-	"\ffallback_tag\x18\x05 \x01(\tR\vfallbackTag\"T\n" +
+	"\ffallback_tag\x18\x05 \x01(\tR\vfallbackTag\x122\n" +
+	"\x15fallback_outbound_tag\x18\a \x01(\tR\x13fallbackOutboundTag\x122\n" +
+	"\x15fallback_balancer_tag\x18\b \x01(\tR\x13fallbackBalancerTag\"T\n" +
 	"\x0eStrategyWeight\x12\x16\n" +
 	"\x06regexp\x18\x01 \x01(\bR\x06regexp\x12\x14\n" +
 	"\x05match\x18\x02 \x01(\tR\x05match\x12\x14\n" +

--- a/app/router/config.proto
+++ b/app/router/config.proto
@@ -70,6 +70,8 @@ message BalancingRule {
   string strategy = 3;
   xray.common.serial.TypedMessage strategy_settings = 4;
   string fallback_tag = 5;
+  string fallback_outbound_tag = 7;
+  string fallback_balancer_tag = 8;
 }
 
 message StrategyWeight {

--- a/app/router/router.go
+++ b/app/router/router.go
@@ -52,6 +52,9 @@ func (r *Router) Init(ctx context.Context, config *Config, d dns.Client, ohm out
 		balancer.InjectContext(ctx)
 		r.balancers[rule.Tag] = balancer
 	}
+	if err := r.resolveBalancerFallbacks(); err != nil {
+		return err
+	}
 
 	r.rules = make([]*Rule, 0, len(config.Rule))
 	for _, rule := range config.Rule {
@@ -146,6 +149,9 @@ func (r *Router) ReloadRules(config *Config, shouldAppend bool) error {
 		balancer.InjectContext(r.ctx)
 		r.balancers[rule.Tag] = balancer
 	}
+	if err := r.resolveBalancerFallbacks(); err != nil {
+		return err
+	}
 
 	startIdx := len(r.rules)
 	closeNewWebhooks := func() {
@@ -207,6 +213,47 @@ func (r *Router) RuleExists(tag string) bool {
 		}
 	}
 	return false
+}
+
+func (r *Router) resolveBalancerFallbacks() error {
+	for _, balancer := range r.balancers {
+		balancer.fallbackBalancer = nil
+		if balancer.fallbackBalancerTag == "" {
+			continue
+		}
+		fallbackBalancer, found := r.balancers[balancer.fallbackBalancerTag]
+		if !found {
+			return errors.New("fallback balancer ", balancer.fallbackBalancerTag, " not found for balancer ", balancer.tag)
+		}
+		balancer.fallbackBalancer = fallbackBalancer
+	}
+
+	visited := make(map[string]bool)
+	inStack := make(map[string]bool)
+	var walk func(string) error
+	walk = func(tag string) error {
+		if inStack[tag] {
+			return errors.New("fallback balancer cycle detected at ", tag)
+		}
+		if visited[tag] {
+			return nil
+		}
+		visited[tag] = true
+		inStack[tag] = true
+		if balancer := r.balancers[tag]; balancer != nil && balancer.fallbackBalancerTag != "" {
+			if err := walk(balancer.fallbackBalancerTag); err != nil {
+				return err
+			}
+		}
+		delete(inStack, tag)
+		return nil
+	}
+	for tag := range r.balancers {
+		if err := walk(tag); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // RemoveRule implements routing.Router.

--- a/app/router/router_test.go
+++ b/app/router/router_test.go
@@ -2,23 +2,73 @@ package router_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/xtls/xray-core/app/observatory"
 	. "github.com/xtls/xray-core/app/router"
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/geodata"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/session"
+	"github.com/xtls/xray-core/core"
 	"github.com/xtls/xray-core/features/dns"
+	"github.com/xtls/xray-core/features/extension"
 	"github.com/xtls/xray-core/features/outbound"
 	routing_session "github.com/xtls/xray-core/features/routing/session"
 	"github.com/xtls/xray-core/testing/mocks"
+	"google.golang.org/protobuf/proto"
 )
 
 type mockOutboundManager struct {
 	outbound.Manager
 	outbound.HandlerSelector
+}
+
+type sequencedHandlerSelector struct {
+	sequences map[string][][]string
+	calls     map[string]int
+}
+
+func (s *sequencedHandlerSelector) Select(selectors []string) []string {
+	key := strings.Join(selectors, "\x00")
+	index := s.calls[key]
+	s.calls[key] = index + 1
+	entries := s.sequences[key]
+	if index >= len(entries) {
+		return nil
+	}
+	return entries[index]
+}
+
+type fakeObservatory struct {
+	result *observatory.ObservationResult
+}
+
+func (f *fakeObservatory) Type() interface{} {
+	return extension.ObservatoryType()
+}
+
+func (f *fakeObservatory) Start() error { return nil }
+
+func (f *fakeObservatory) Close() error { return nil }
+
+func (f *fakeObservatory) GetObservation(context.Context) (proto.Message, error) {
+	return f.result, nil
+}
+
+func testContextWithObservatory(t *testing.T, statuses ...*observatory.OutboundStatus) context.Context {
+	t.Helper()
+
+	instance := new(core.Instance)
+	if err := instance.AddFeature(&fakeObservatory{
+		result: &observatory.ObservationResult{Status: statuses},
+	}); err != nil {
+		t.Fatalf("AddFeature() failed: %v", err)
+	}
+
+	return context.WithValue(context.Background(), core.XrayKey(1), instance)
 }
 
 func TestSimpleRouter(t *testing.T) {
@@ -96,6 +146,195 @@ func TestSimpleBalancer(t *testing.T) {
 	common.Must(err)
 	if tag := route.GetOutboundTag(); tag != "test" {
 		t.Error("expect tag 'test', bug actually ", tag)
+	}
+}
+
+func TestBalancerFallsBackToFallbackOutboundTag(t *testing.T) {
+	config := &Config{
+		Rule: []*RoutingRule{
+			{
+				TargetTag: &RoutingRule_BalancingTag{BalancingTag: "balance"},
+				Networks:  []net.Network{net.Network_TCP},
+			},
+		},
+		BalancingRule: []*BalancingRule{
+			{
+				Tag:                 "balance",
+				OutboundSelector:    []string{"test-"},
+				FallbackOutboundTag: "fall",
+			},
+		},
+	}
+
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+
+	mockDNS := mocks.NewDNSClient(mockCtl)
+	mockOhm := mocks.NewOutboundManager(mockCtl)
+	mockHs := mocks.NewOutboundHandlerSelector(mockCtl)
+	mockHs.EXPECT().Select(gomock.Eq([]string{"test-"})).Return([]string{})
+
+	r := new(Router)
+	common.Must(r.Init(testContextWithObservatory(t), config, mockDNS, &mockOutboundManager{
+		Manager:         mockOhm,
+		HandlerSelector: mockHs,
+	}, nil))
+
+	ctx := session.ContextWithOutbounds(context.Background(), []*session.Outbound{{
+		Target: net.TCPDestination(net.DomainAddress("example.com"), 80),
+	}})
+	route, err := r.PickRoute(routing_session.AsRoutingContext(ctx))
+	common.Must(err)
+	if tag := route.GetOutboundTag(); tag != "fall" {
+		t.Fatalf("expect tag 'fall', got %q", tag)
+	}
+}
+
+func TestBalancerFallsBackToFallbackBalancerTag(t *testing.T) {
+	config := &Config{
+		Rule: []*RoutingRule{
+			{
+				TargetTag: &RoutingRule_BalancingTag{BalancingTag: "balance-a"},
+				Networks:  []net.Network{net.Network_TCP},
+			},
+		},
+		BalancingRule: []*BalancingRule{
+			{
+				Tag:                 "balance-a",
+				OutboundSelector:    []string{"test-a-"},
+				FallbackBalancerTag: "balance-b",
+			},
+			{
+				Tag:              "balance-b",
+				OutboundSelector: []string{"test-b-"},
+			},
+		},
+	}
+
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+
+	mockDNS := mocks.NewDNSClient(mockCtl)
+	mockOhm := mocks.NewOutboundManager(mockCtl)
+	mockHs := mocks.NewOutboundHandlerSelector(mockCtl)
+	gomock.InOrder(
+		mockHs.EXPECT().Select(gomock.Eq([]string{"test-a-"})).Return([]string{}),
+		mockHs.EXPECT().Select(gomock.Eq([]string{"test-b-"})).Return([]string{"fallback"}),
+	)
+
+	r := new(Router)
+	common.Must(r.Init(testContextWithObservatory(t), config, mockDNS, &mockOutboundManager{
+		Manager:         mockOhm,
+		HandlerSelector: mockHs,
+	}, nil))
+
+	ctx := session.ContextWithOutbounds(context.Background(), []*session.Outbound{{
+		Target: net.TCPDestination(net.DomainAddress("example.com"), 80),
+	}})
+	route, err := r.PickRoute(routing_session.AsRoutingContext(ctx))
+	common.Must(err)
+	if tag := route.GetOutboundTag(); tag != "fallback" {
+		t.Fatalf("expect tag 'fallback', got %q", tag)
+	}
+}
+
+func TestBalancerRetriesPrimaryBeforeFallbackBalancer(t *testing.T) {
+	config := &Config{
+		Rule: []*RoutingRule{
+			{
+				TargetTag: &RoutingRule_BalancingTag{BalancingTag: "balance-a"},
+				Networks:  []net.Network{net.Network_TCP},
+			},
+		},
+		BalancingRule: []*BalancingRule{
+			{
+				Tag:                 "balance-a",
+				OutboundSelector:    []string{"test-a-"},
+				FallbackBalancerTag: "balance-b",
+			},
+			{
+				Tag:              "balance-b",
+				OutboundSelector: []string{"test-b-"},
+			},
+		},
+	}
+
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+
+	mockDNS := mocks.NewDNSClient(mockCtl)
+	mockOhm := mocks.NewOutboundManager(mockCtl)
+	selector := &sequencedHandlerSelector{
+		sequences: map[string][][]string{
+			"test-a-": {[]string{}, []string{"primary"}},
+			"test-b-": {[]string{"fallback"}},
+		},
+		calls: make(map[string]int),
+	}
+
+	r := new(Router)
+	common.Must(r.Init(testContextWithObservatory(t), config, mockDNS, &mockOutboundManager{
+		Manager:         mockOhm,
+		HandlerSelector: selector,
+	}, nil))
+
+	ctx := session.ContextWithOutbounds(context.Background(), []*session.Outbound{{
+		Target: net.TCPDestination(net.DomainAddress("example.com"), 80),
+	}})
+
+	first, err := r.PickRoute(routing_session.AsRoutingContext(ctx))
+	common.Must(err)
+	if tag := first.GetOutboundTag(); tag != "fallback" {
+		t.Fatalf("expect first tag 'fallback', got %q", tag)
+	}
+
+	second, err := r.PickRoute(routing_session.AsRoutingContext(ctx))
+	common.Must(err)
+	if tag := second.GetOutboundTag(); tag != "primary" {
+		t.Fatalf("expect second tag 'primary', got %q", tag)
+	}
+}
+
+func TestRouterInitRejectsUnknownFallbackBalancerTag(t *testing.T) {
+	config := &Config{
+		BalancingRule: []*BalancingRule{
+			{
+				Tag:                 "balance-a",
+				OutboundSelector:    []string{"test-a-"},
+				FallbackBalancerTag: "missing",
+			},
+		},
+	}
+
+	r := new(Router)
+	if err := r.Init(testContextWithObservatory(t), config, nil, nil, nil); err == nil {
+		t.Fatal("expected unknown fallback balancer tag to fail")
+	} else if !strings.Contains(err.Error(), "missing") || !strings.Contains(err.Error(), "fallback") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRouterInitRejectsFallbackBalancerCycle(t *testing.T) {
+	config := &Config{
+		BalancingRule: []*BalancingRule{
+			{
+				Tag:                 "balance-a",
+				OutboundSelector:    []string{"test-a-"},
+				FallbackBalancerTag: "balance-b",
+			},
+			{
+				Tag:                 "balance-b",
+				OutboundSelector:    []string{"test-b-"},
+				FallbackBalancerTag: "balance-a",
+			},
+		},
+	}
+
+	r := new(Router)
+	if err := r.Init(testContextWithObservatory(t), config, nil, nil, nil); err == nil {
+		t.Fatal("expected fallback balancer cycle to fail")
+	} else if !strings.Contains(err.Error(), "cycle") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/infra/conf/router.go
+++ b/infra/conf/router.go
@@ -19,10 +19,12 @@ type StrategyConfig struct {
 }
 
 type BalancingRule struct {
-	Tag         string         `json:"tag"`
-	Selectors   StringList     `json:"selector"`
-	Strategy    StrategyConfig `json:"strategy"`
-	FallbackTag string         `json:"fallbackTag"`
+	Tag                 string         `json:"tag"`
+	Selectors           StringList     `json:"selector"`
+	Strategy            StrategyConfig `json:"strategy"`
+	FallbackTag         string         `json:"fallbackTag"`
+	FallbackOutboundTag string         `json:"fallbackOutboundTag"`
+	FallbackBalancerTag string         `json:"fallbackBalancerTag"`
 }
 
 // Build builds the balancing rule
@@ -32,6 +34,12 @@ func (r *BalancingRule) Build() (*router.BalancingRule, error) {
 	}
 	if len(r.Selectors) == 0 {
 		return nil, errors.New("empty selector list")
+	}
+	if r.FallbackTag != "" && (r.FallbackOutboundTag != "" || r.FallbackBalancerTag != "") {
+		return nil, errors.New("fallbackTag cannot be used together with fallbackOutboundTag or fallbackBalancerTag")
+	}
+	if r.FallbackOutboundTag != "" && r.FallbackBalancerTag != "" {
+		return nil, errors.New("fallbackOutboundTag and fallbackBalancerTag cannot both be set")
 	}
 
 	r.Strategy.Type = strings.ToLower(r.Strategy.Type)
@@ -59,12 +67,20 @@ func (r *BalancingRule) Build() (*router.BalancingRule, error) {
 		}
 	}
 
+	fallbackTag := r.FallbackTag
+	fallbackOutboundTag := r.FallbackOutboundTag
+	if fallbackTag != "" {
+		fallbackOutboundTag = fallbackTag
+	}
+
 	return &router.BalancingRule{
-		Strategy:         r.Strategy.Type,
-		StrategySettings: serial.ToTypedMessage(ts),
-		FallbackTag:      r.FallbackTag,
-		OutboundSelector: r.Selectors,
-		Tag:              r.Tag,
+		Strategy:            r.Strategy.Type,
+		StrategySettings:    serial.ToTypedMessage(ts),
+		FallbackTag:         fallbackTag,
+		FallbackOutboundTag: fallbackOutboundTag,
+		FallbackBalancerTag: r.FallbackBalancerTag,
+		OutboundSelector:    r.Selectors,
+		Tag:                 r.Tag,
 	}, nil
 }
 

--- a/infra/conf/router_test.go
+++ b/infra/conf/router_test.go
@@ -2,6 +2,7 @@ package conf_test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 	_ "unsafe"
@@ -93,10 +94,11 @@ func TestRouterConfig(t *testing.T) {
 				DomainStrategy: router.Config_AsIs,
 				BalancingRule: []*router.BalancingRule{
 					{
-						Tag:              "b1",
-						OutboundSelector: []string{"test"},
-						Strategy:         "random",
-						FallbackTag:      "fall",
+						Tag:                 "b1",
+						OutboundSelector:    []string{"test"},
+						Strategy:            "random",
+						FallbackTag:         "fall",
+						FallbackOutboundTag: "fall",
 					},
 					{
 						Tag:              "b2",
@@ -118,7 +120,8 @@ func TestRouterConfig(t *testing.T) {
 							MaxRTT:    int64(time.Duration(1000) * time.Millisecond),
 							Tolerance: 0.5,
 						}),
-						FallbackTag: "fall",
+						FallbackTag:         "fall",
+						FallbackOutboundTag: "fall",
 					},
 				},
 				Rule: []*router.RoutingRule{
@@ -239,4 +242,55 @@ func TestRouterConfig(t *testing.T) {
 			},
 		},
 	})
+}
+func TestBalancingRuleBuildMapsLegacyFallbackTagToFallbackOutboundTag(t *testing.T) {
+	rule := &BalancingRule{
+		Tag:         "b1",
+		Selectors:   StringList{"test-"},
+		FallbackTag: "fall",
+	}
+
+	built, err := rule.Build()
+	if err != nil {
+		t.Fatalf("Build() failed: %v", err)
+	}
+	if built.FallbackTag != "fall" {
+		t.Fatalf("unexpected legacy fallbackTag: %q", built.FallbackTag)
+	}
+	if built.FallbackOutboundTag != "fall" {
+		t.Fatalf("unexpected fallbackOutboundTag: %q", built.FallbackOutboundTag)
+	}
+	if built.FallbackBalancerTag != "" {
+		t.Fatalf("unexpected fallbackBalancerTag: %q", built.FallbackBalancerTag)
+	}
+}
+
+func TestBalancingRuleBuildRejectsConflictingFallbackTargets(t *testing.T) {
+	rule := &BalancingRule{
+		Tag:                 "b1",
+		Selectors:           StringList{"test-"},
+		FallbackOutboundTag: "direct",
+		FallbackBalancerTag: "backup",
+	}
+
+	if _, err := rule.Build(); err == nil {
+		t.Fatal("expected conflicting fallback targets to fail")
+	} else if !strings.Contains(err.Error(), "fallbackOutboundTag") || !strings.Contains(err.Error(), "fallbackBalancerTag") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBalancingRuleBuildRejectsLegacyAndExplicitFallbackTargets(t *testing.T) {
+	rule := &BalancingRule{
+		Tag:                 "b1",
+		Selectors:           StringList{"test-"},
+		FallbackTag:         "legacy",
+		FallbackBalancerTag: "backup",
+	}
+
+	if _, err := rule.Build(); err == nil {
+		t.Fatal("expected legacy and explicit fallback targets to fail")
+	} else if !strings.Contains(err.Error(), "fallbackTag") || !strings.Contains(err.Error(), "fallbackBalancerTag") {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }


### PR DESCRIPTION
## Summary
- add `fallbackOutboundTag` and `fallbackBalancerTag` to balancer config
- keep `fallbackTag` as a legacy alias for `fallbackOutboundTag`
- allow layered fallback across balancers without requiring loopback-based workarounds

## Why
I understand the longer-term direction is still selector outbound, as mentioned on September 28, 2025 around #5117.

But as of April 16, 2026, that abstraction is still not available, while the practical config gap for layered fallback remains.

So I see this PR as a small backward-compatible bridge for the current balancer model, not as an attempt to replace or compete with a future selector design.

There has also been repeated demand for this exact gap, for example in #5188 and #3164.

This is currently possible with loopback and extra routing, but that setup is harder to understand and easier to get wrong.

## Compatibility
- existing configs keep working
- `fallbackTag` remains supported as a legacy alias to `fallbackOutboundTag`
- no behavior changes unless the new field is used

## Test Plan
- `go test ./infra/conf -run 'Test(RouterConfig|BalancingRuleBuildMapsLegacyFallbackTagToFallbackOutboundTag|BalancingRuleBuildRejectsConflictingFallbackTargets|BalancingRuleBuildRejectsLegacyAndExplicitFallbackTargets)' -count=1`
- `go test ./app/router -run 'Test(SimpleBalancer|BalancerFallsBackToFallbackOutboundTag|BalancerFallsBackToFallbackBalancerTag|BalancerRetriesPrimaryBeforeFallbackBalancer|RouterInitRejectsUnknownFallbackBalancerTag|RouterInitRejectsFallbackBalancerCycle)' -count=1`
- `go test -race ./app/router -run 'Test(BalancerFallsBackToFallbackOutboundTag|BalancerFallsBackToFallbackBalancerTag|BalancerRetriesPrimaryBeforeFallbackBalancer|RouterInitRejectsUnknownFallbackBalancerTag|RouterInitRejectsFallbackBalancerCycle)' -count=1`
