### PR TITLE
fix: Fix splithttp uploadQueue off-by-one bug in `Read()` where poppi…

### DIFF
--- a/transport/internet/splithttp/upload_queue.go
+++ b/transport/internet/splithttp/upload_queue.go
@@ -124,7 +124,7 @@ func (h *uploadQueue) Read(b []byte) (int, error) {
 
 		// misordered packet
 		if packet.Seq > h.nextSeq {
-			if len(h.heap) > h.maxPackets {
+			if len(h.heap)+1 > h.maxPackets {
 				// the "reassembly buffer" is too large, and we want to
 				// constrain memory usage somehow. let's tear down the
 				// connection, and hope the application retries.

--- a/transport/internet/splithttp/upload_queue_test.go
+++ b/transport/internet/splithttp/upload_queue_test.go
@@ -1,6 +1,7 @@
 package splithttp_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/xtls/xray-core/common"
@@ -18,5 +19,24 @@ func Test_regression_readzero(t *testing.T) {
 	common.Must(err)
 	if n != 1 {
 		t.Error("n=", n)
+	}
+}
+
+func Test_regression_max_packets(t *testing.T) {
+	q := NewUploadQueue(2)
+
+	go func() {
+		q.Push(Packet{Payload: []byte("x"), Seq: 1})
+		q.Push(Packet{Payload: []byte("y"), Seq: 2})
+		q.Push(Packet{Payload: []byte("z"), Seq: 3})
+	}()
+
+	buf := make([]byte, 20)
+
+	_, err := q.Read(buf)
+	if err == nil {
+		t.Error("expected error, got nil")
+	} else if !strings.Contains(err.Error(), "packet queue is too large") {
+		t.Error("expected 'packet queue is too large' error, got:", err)
 	}
 }


### PR DESCRIPTION
Fix splithttp uploadQueue off-by-one bug in `Read()` where popping a packet https://github.com/XTLS/Xray-core/blob/c5edc122b70ec56e24ea8038e727da6f823e34be/transport/internet/splithttp/upload_queue.go#L107 reduced the heap length, causing the queue to bypass the maxPackets check.
