### PR TITLE
splithttp: fix resource leaks on client reconnects

### DIFF
--- a/transport/internet/splithttp/browser_client.go
+++ b/transport/internet/splithttp/browser_client.go
@@ -21,6 +21,12 @@ func (c *BrowserDialerClient) IsClosed() bool {
 	panic("not implemented yet")
 }
 
+// Close is a no-op for the browser dialer client; the browser itself
+// owns the underlying connection lifecycle.
+func (c *BrowserDialerClient) Close() error {
+	return nil
+}
+
 func (c *BrowserDialerClient) OpenStream(ctx context.Context, url string, sessionId string, body io.Reader, uploadOnly bool) (io.ReadCloser, net.Addr, net.Addr, error) {
 	if body != nil {
 		return nil, nil, nil, errors.New("bidirectional streaming for browser dialer not implemented yet")

--- a/transport/internet/splithttp/client.go
+++ b/transport/internet/splithttp/client.go
@@ -8,17 +8,24 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"sync"
+	"sync/atomic"
 
+	"github.com/apernet/quic-go/http3"
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/buf"
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/signal/done"
+	"golang.org/x/net/http2"
 )
 
 // interface to abstract between use of browser dialer, vs net/http
 type DialerClient interface {
 	IsClosed() bool
+
+	// Close releases any idle transport resources (TCP/TLS/QUIC state)
+	// held by the client. Safe to call multiple times.
+	Close() error
 
 	// ctx, url, sessionId, body, uploadOnly
 	OpenStream(context.Context, string, string, io.Reader, bool) (io.ReadCloser, net.Addr, net.Addr, error)
@@ -31,7 +38,7 @@ type DialerClient interface {
 type DefaultDialerClient struct {
 	transportConfig *Config
 	client          *http.Client
-	closed          bool
+	closed          atomic.Bool
 	httpVersion     string
 	// pool of net.Conn, created using dialUploadConn
 	uploadRawPool  *sync.Pool
@@ -39,7 +46,26 @@ type DefaultDialerClient struct {
 }
 
 func (c *DefaultDialerClient) IsClosed() bool {
-	return c.closed
+	return c.closed.Load()
+}
+
+// Close releases the underlying http2.Transport / http3.Transport idle
+// connections so that TCP/TLS sockets and QUIC state are not held for
+// up to ConnIdleTimeout after this client is discarded from the pool.
+func (c *DefaultDialerClient) Close() error {
+	c.closed.Store(true)
+	if c.client == nil {
+		return nil
+	}
+	switch t := c.client.Transport.(type) {
+	case *http2.Transport:
+		t.CloseIdleConnections()
+	case *http.Transport:
+		t.CloseIdleConnections()
+	case *http3.Transport:
+		return t.Close()
+	}
+	return nil
 }
 
 func (c *DefaultDialerClient) OpenStream(ctx context.Context, url string, sessionId string, body io.Reader, uploadOnly bool) (wrc io.ReadCloser, remoteAddr, localAddr net.Addr, err error) {
@@ -67,7 +93,7 @@ func (c *DefaultDialerClient) OpenStream(ctx context.Context, url string, sessio
 		resp, err := c.client.Do(req)
 		if err != nil {
 			if !uploadOnly { // stream-down is enough
-				c.closed = true
+				c.closed.Store(true)
 				errors.LogInfoInner(ctx, err, "failed to "+method+" "+url)
 			}
 			gotConn.Close()
@@ -101,7 +127,7 @@ func (c *DefaultDialerClient) PostPacket(ctx context.Context, url string, sessio
 	if c.httpVersion != "1.1" {
 		resp, err := c.client.Do(req)
 		if err != nil {
-			c.closed = true
+			c.closed.Store(true)
 			return err
 		}
 
@@ -141,7 +167,7 @@ func (c *DefaultDialerClient) PostPacket(ctx context.Context, url string, sessio
 				if h1UploadConn.UnreadedResponsesCount > 0 {
 					resp, err := http.ReadResponse(h1UploadConn.RespBufReader, req)
 					if err != nil {
-						c.closed = true
+						c.closed.Store(true)
 						return fmt.Errorf("error while reading response: %s", err.Error())
 					}
 					io.Copy(io.Discard, resp.Body)
@@ -160,8 +186,12 @@ func (c *DefaultDialerClient) PostPacket(ctx context.Context, url string, sessio
 			if err == nil {
 				break
 			} else if newConnection {
+				h1UploadConn.Close()
 				return err
 			}
+			// the pooled connection is dead; close it so its TCP socket
+			// is released instead of leaking, then try the next one.
+			h1UploadConn.Close()
 		}
 
 		c.uploadRawPool.Put(uploadConn)

--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -464,6 +464,31 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 		},
 	}
 
+	// Roll back OpenUsage bumps and tear down any partially-initialised
+	// stream if Dial returns an error further down. Without this, a
+	// failure between "stream-down opened" and "stream-up opened" leaks
+	// the already-running stream-down goroutine and two OpenUsage refs.
+	dialSucceeded := false
+	defer func() {
+		if dialSucceeded {
+			return
+		}
+		if closed.Add(1) == 1 {
+			if xmuxClient != nil {
+				xmuxClient.OpenUsage.Add(-1)
+			}
+			if xmuxClient2 != nil && xmuxClient2 != xmuxClient {
+				xmuxClient2.OpenUsage.Add(-1)
+			}
+		}
+		if conn.reader != nil {
+			conn.reader.Close()
+		}
+		if conn.writer != nil {
+			conn.writer.Close()
+		}
+	}()
+
 	var err error
 	if mode == "stream-one" {
 		requestURL.Path = transportConfiguration.GetNormalizedPath()
@@ -474,6 +499,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 		if err != nil { // browser dialer only
 			return nil, err
 		}
+		dialSucceeded = true
 		return stat.Connection(&conn), nil
 	} else { // stream-down
 		if xmuxClient2 != nil {
@@ -492,6 +518,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 		if err != nil { // browser dialer only
 			return nil, err
 		}
+		dialSucceeded = true
 		return stat.Connection(&conn), nil
 	}
 
@@ -517,12 +544,23 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 	go func() {
 		var seq int64
 		var lastWrite time.Time
+		var remainder buf.MultiBuffer
+
+		defer func() {
+			// Release any pooled buffers still held by remainder; otherwise
+			// an early exit (pipe error, doSplit=false) would leak them back
+			// into the pool as unreachable garbage.
+			if !remainder.IsEmpty() {
+				buf.ReleaseMulti(remainder)
+			}
+		}()
 
 		for {
 			// by offloading the uploads into a buffered pipe, multiple conn.Write
 			// calls get automatically batched together into larger POST requests.
 			// without batching, bandwidth is extremely limited.
-			remainder, err := uploadPipeReader.ReadMultiBuffer()
+			var err error
+			remainder, err = uploadPipeReader.ReadMultiBuffer()
 			if err != nil {
 				break
 			}
@@ -580,6 +618,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 		}
 	}()
 
+	dialSucceeded = true
 	return stat.Connection(&conn), nil
 }
 
@@ -607,9 +646,14 @@ func (w uploadWriter) Write(b []byte) (int, error) {
 	common.Must2(buffer.Write(b))
 
 	var writed int
-	for _, buff := range buffer.MultiBuffer {
+	for i, buff := range buffer.MultiBuffer {
 		err := w.WriteMultiBuffer(buf.MultiBuffer{buff})
 		if err != nil {
+			// Release the buffers that were not handed off to the pipe;
+			// without this they leak back into the pool as unreachable.
+			// The current `buff` was consumed by WriteMultiBuffer even on
+			// error, so only release the tail starting at i+1.
+			buf.ReleaseMulti(buffer.MultiBuffer[i+1:])
 			return writed, err
 		}
 		writed += int(buff.Len())

--- a/transport/internet/splithttp/mux.go
+++ b/transport/internet/splithttp/mux.go
@@ -13,6 +13,11 @@ import (
 
 type XmuxConn interface {
 	IsClosed() bool
+	// Close releases any idle transport resources held by the underlying
+	// client (TCP/TLS/QUIC state). It is called when the XmuxClient is
+	// pruned from the manager so that dead transports do not sit around
+	// holding sockets for up to ConnIdleTimeout.
+	Close() error
 }
 
 type XmuxClient struct {
@@ -72,6 +77,13 @@ func (m *XmuxManager) GetXmuxClient(ctx context.Context) *XmuxClient { // when l
 				", leftUsage = ", xmuxClient.leftUsage,
 				", LeftRequests = ", xmuxClient.LeftRequests.Load(),
 				", UnreusableAt = ", xmuxClient.UnreusableAt)
+			// Release the underlying transport's idle connections before
+			// dropping the last reference, otherwise the http2/http3
+			// transport keeps holding TCP+TLS / QUIC state for up to
+			// ConnIdleTimeout (~5 minutes) even though nothing will use it.
+			if err := xmuxClient.XmuxConn.Close(); err != nil {
+				errors.LogDebug(ctx, "XMUX: error closing xmuxClient: ", err)
+			}
 			m.xmuxClients = append(m.xmuxClients[:i], m.xmuxClients[i+1:]...)
 		} else {
 			i++


### PR DESCRIPTION
Addresses the resource leak subset of #5944 with low-risk, localized fixes. No wire-format or config changes.

## Changes

- `DialerClient` gets a `Close()` method that releases the underlying `http2.Transport` / `http3.Transport` idle connections. `XmuxManager.GetXmuxClient` now calls it before pruning an `XmuxClient` from the pool, so TCP+TLS / QUIC state is released immediately instead of being held for up to `ConnIdleTimeout` (~5 minutes) after the client is discarded. This is the root cause of the "old and new transports overlap during reconnects" memory pattern described in #5944.

- `DefaultDialerClient.closed` is now `atomic.Bool`. It was a plain `bool` written from the `client.Do` goroutine and read from `IsClosed()` with no synchronization (`go build -race` flags it).

- Upload path buffer releases that were previously leaking pooled `buf.Buffer` objects:
  - `remainder` in the packet-up upload goroutine, when the inner loop exits via `doSplit`, is now released via a `defer` instead of being silently overwritten on the next outer-loop iteration.
  - `uploadWriter.Write` now releases the tail of the `MultiBuffer` when `WriteMultiBuffer` errors mid-loop.

- The H1 retry loop in `PostPacket` now closes the failed `H1Conn` before grabbing the next one from the pool, so a write failure on a dead pooled connection does not leak the TCP socket.

- `Dial()` now has a rollback `defer` that undoes `OpenUsage.Add(1)` and tears down the already-opened stream-down reader/writer if later init steps (`stream-up OpenStream`) return an error. Previously each failed partial dial leaked one stream goroutine and two `OpenUsage` refcounts.

## Not in this PR

Intentionally left out to keep the review surface small; happy to open follow-up PRs if any of these are wanted:

- `splitConn.SetDeadline` / `SetReadDeadline` / `SetWriteDeadline` stubs (requires an `io.Pipe` replacement or wrapper with deadline support).
- `context.WithoutCancel` in `OpenStream` / `PostPacket` + upload-goroutine cancellation.
- `http2.Transport` flow-control window tuning (needs discussion; `x/net/http2` doesn't expose per-stream / per-connection windows cleanly).
- `PostPacket` body-placement `io.NopCloser` leak.
- `globalDialerMap` cleanup.

## Testing

- `go build ./...` clean.
- `go vet ./...` clean.
- Existing `transport/internet/splithttp` tests pass.
- No behavior changes observed in local stream-one / packet-up smoke tests.