### PR TITLE
splithttp: fix resource leaks on client reconnects

### DIFF
--- a/transport/internet/splithttp/browser_client.go
+++ b/transport/internet/splithttp/browser_client.go
@@ -21,6 +21,12 @@ func (c *BrowserDialerClient) IsClosed() bool {
 	panic("not implemented yet")
 }
 
+// Close is a no-op for the browser dialer client; the browser itself
+// owns the underlying connection lifecycle.
+func (c *BrowserDialerClient) Close() error {
+	return nil
+}
+
 func (c *BrowserDialerClient) OpenStream(ctx context.Context, url string, sessionId string, body io.Reader, uploadOnly bool) (io.ReadCloser, net.Addr, net.Addr, error) {
 	if body != nil {
 		return nil, nil, nil, errors.New("bidirectional streaming for browser dialer not implemented yet")

--- a/transport/internet/splithttp/client.go
+++ b/transport/internet/splithttp/client.go
@@ -8,17 +8,24 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"sync"
+	"sync/atomic"
 
+	"github.com/apernet/quic-go/http3"
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/buf"
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/signal/done"
+	"golang.org/x/net/http2"
 )
 
 // interface to abstract between use of browser dialer, vs net/http
 type DialerClient interface {
 	IsClosed() bool
+
+	// Close releases any idle transport resources (TCP/TLS/QUIC state)
+	// held by the client. Safe to call multiple times.
+	Close() error
 
 	// ctx, url, sessionId, body, uploadOnly
 	OpenStream(context.Context, string, string, io.Reader, bool) (io.ReadCloser, net.Addr, net.Addr, error)
@@ -31,7 +38,7 @@ type DialerClient interface {
 type DefaultDialerClient struct {
 	transportConfig *Config
 	client          *http.Client
-	closed          bool
+	closed          atomic.Bool
 	httpVersion     string
 	// pool of net.Conn, created using dialUploadConn
 	uploadRawPool  *sync.Pool
@@ -39,7 +46,26 @@ type DefaultDialerClient struct {
 }
 
 func (c *DefaultDialerClient) IsClosed() bool {
-	return c.closed
+	return c.closed.Load()
+}
+
+// Close releases the underlying http2.Transport / http3.Transport idle
+// connections so that TCP/TLS sockets and QUIC state are not held for
+// up to ConnIdleTimeout after this client is discarded from the pool.
+func (c *DefaultDialerClient) Close() error {
+	c.closed.Store(true)
+	if c.client == nil {
+		return nil
+	}
+	switch t := c.client.Transport.(type) {
+	case *http2.Transport:
+		t.CloseIdleConnections()
+	case *http.Transport:
+		t.CloseIdleConnections()
+	case *http3.Transport:
+		return t.Close()
+	}
+	return nil
 }
 
 func (c *DefaultDialerClient) OpenStream(ctx context.Context, url string, sessionId string, body io.Reader, uploadOnly bool) (wrc io.ReadCloser, remoteAddr, localAddr net.Addr, err error) {
@@ -67,7 +93,7 @@ func (c *DefaultDialerClient) OpenStream(ctx context.Context, url string, sessio
 		resp, err := c.client.Do(req)
 		if err != nil {
 			if !uploadOnly { // stream-down is enough
-				c.closed = true
+				c.closed.Store(true)
 				errors.LogInfoInner(ctx, err, "failed to "+method+" "+url)
 			}
 			gotConn.Close()
@@ -101,7 +127,7 @@ func (c *DefaultDialerClient) PostPacket(ctx context.Context, url string, sessio
 	if c.httpVersion != "1.1" {
 		resp, err := c.client.Do(req)
 		if err != nil {
-			c.closed = true
+			c.closed.Store(true)
 			return err
 		}
 
@@ -141,7 +167,7 @@ func (c *DefaultDialerClient) PostPacket(ctx context.Context, url string, sessio
 				if h1UploadConn.UnreadedResponsesCount > 0 {
 					resp, err := http.ReadResponse(h1UploadConn.RespBufReader, req)
 					if err != nil {
-						c.closed = true
+						c.closed.Store(true)
 						return fmt.Errorf("error while reading response: %s", err.Error())
 					}
 					io.Copy(io.Discard, resp.Body)
@@ -160,8 +186,12 @@ func (c *DefaultDialerClient) PostPacket(ctx context.Context, url string, sessio
 			if err == nil {
 				break
 			} else if newConnection {
+				h1UploadConn.Close()
 				return err
 			}
+			// the pooled connection is dead; close it so its TCP socket
+			// is released instead of leaking, then try the next one.
+			h1UploadConn.Close()
 		}
 
 		c.uploadRawPool.Put(uploadConn)

--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -464,6 +464,31 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 		},
 	}
 
+	// Roll back OpenUsage bumps and tear down any partially-initialised
+	// stream if Dial returns an error further down. Without this, a
+	// failure between "stream-down opened" and "stream-up opened" leaks
+	// the already-running stream-down goroutine and two OpenUsage refs.
+	dialSucceeded := false
+	defer func() {
+		if dialSucceeded {
+			return
+		}
+		if closed.Add(1) == 1 {
+			if xmuxClient != nil {
+				xmuxClient.OpenUsage.Add(-1)
+			}
+			if xmuxClient2 != nil && xmuxClient2 != xmuxClient {
+				xmuxClient2.OpenUsage.Add(-1)
+			}
+		}
+		if conn.reader != nil {
+			conn.reader.Close()
+		}
+		if conn.writer != nil {
+			conn.writer.Close()
+		}
+	}()
+
 	var err error
 	if mode == "stream-one" {
 		requestURL.Path = transportConfiguration.GetNormalizedPath()
@@ -474,6 +499,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 		if err != nil { // browser dialer only
 			return nil, err
 		}
+		dialSucceeded = true
 		return stat.Connection(&conn), nil
 	} else { // stream-down
 		if xmuxClient2 != nil {
@@ -492,6 +518,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 		if err != nil { // browser dialer only
 			return nil, err
 		}
+		dialSucceeded = true
 		return stat.Connection(&conn), nil
 	}
 
@@ -517,12 +544,23 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 	go func() {
 		var seq int64
 		var lastWrite time.Time
+		var remainder buf.MultiBuffer
+
+		defer func() {
+			// Release any pooled buffers still held by remainder; otherwise
+			// an early exit (pipe error, doSplit=false) would leak them back
+			// into the pool as unreachable garbage.
+			if !remainder.IsEmpty() {
+				buf.ReleaseMulti(remainder)
+			}
+		}()
 
 		for {
 			// by offloading the uploads into a buffered pipe, multiple conn.Write
 			// calls get automatically batched together into larger POST requests.
 			// without batching, bandwidth is extremely limited.
-			remainder, err := uploadPipeReader.ReadMultiBuffer()
+			var err error
+			remainder, err = uploadPipeReader.ReadMultiBuffer()
 			if err != nil {
 				break
 			}
@@ -580,6 +618,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 		}
 	}()
 
+	dialSucceeded = true
 	return stat.Connection(&conn), nil
 }
 
@@ -607,9 +646,14 @@ func (w uploadWriter) Write(b []byte) (int, error) {
 	common.Must2(buffer.Write(b))
 
 	var writed int
-	for _, buff := range buffer.MultiBuffer {
+	for i, buff := range buffer.MultiBuffer {
 		err := w.WriteMultiBuffer(buf.MultiBuffer{buff})
 		if err != nil {
+			// Release the buffers that were not handed off to the pipe;
+			// without this they leak back into the pool as unreachable.
+			// The current `buff` was consumed by WriteMultiBuffer even on
+			// error, so only release the tail starting at i+1.
+			buf.ReleaseMulti(buffer.MultiBuffer[i+1:])
 			return writed, err
 		}
 		writed += int(buff.Len())

--- a/transport/internet/splithttp/mux.go
+++ b/transport/internet/splithttp/mux.go
@@ -13,6 +13,11 @@ import (
 
 type XmuxConn interface {
 	IsClosed() bool
+	// Close releases any idle transport resources held by the underlying
+	// client (TCP/TLS/QUIC state). It is called when the XmuxClient is
+	// pruned from the manager so that dead transports do not sit around
+	// holding sockets for up to ConnIdleTimeout.
+	Close() error
 }
 
 type XmuxClient struct {
@@ -72,6 +77,13 @@ func (m *XmuxManager) GetXmuxClient(ctx context.Context) *XmuxClient { // when l
 				", leftUsage = ", xmuxClient.leftUsage,
 				", LeftRequests = ", xmuxClient.LeftRequests.Load(),
 				", UnreusableAt = ", xmuxClient.UnreusableAt)
+			// Release the underlying transport's idle connections before
+			// dropping the last reference, otherwise the http2/http3
+			// transport keeps holding TCP+TLS / QUIC state for up to
+			// ConnIdleTimeout (~5 minutes) even though nothing will use it.
+			if err := xmuxClient.XmuxConn.Close(); err != nil {
+				errors.LogDebug(ctx, "XMUX: error closing xmuxClient: ", err)
+			}
 			m.xmuxClients = append(m.xmuxClients[:i], m.xmuxClients[i+1:]...)
 		} else {
 			i++


### PR DESCRIPTION
Just the leak/release/race subset of #5944. Small and localized

- `DialerClient` now has a `Close()` method that calls `CloseIdleConnections` on the underlying http2/http3 transport. `GetXmuxClient` calls it before pruning a client from the pool (`mux.go`). Before, the dead transport sat there holding its sockets for up to `ConnIdleTimeout` (~5 min) while a new one was being spun up right next to it, which is the overlap pattern the issue describes.

- `DefaultDialerClient.closed` was a plain bool written from the `client.Do` goroutine and read from `IsClosed()` with no sync (`client.go:34`). `go build -race` catches it. Moved to `atomic.Bool`.

- Two upload paths that were leaking pooled `MultiBuffer`s: `remainder` in the packet-up upload goroutine (`dialer.go:525`) is now released via a `defer` (before it was silently overwritten on the next outer-loop read), and the tail in `uploadWriter.Write` (`dialer.go:610`) when `WriteMultiBuffer` errors mid-loop.

- H1 retry loop in `PostPacket` (`client.go:155`) closes the failed `H1Conn` before grabbing a new one from the pool. Before, the dead pooled socket just leaked.

- `Dial` (`dialer.go:443`) has a rollback `defer`. If stream-down opens and stream-up fails after, `OpenUsage.Add(1)` gets undone and the already-running stream-down goroutine is torn down. Before, every partial-dial failure leaked a stream goroutine and two refcounts.

Things I spotted but left out of this PR, can do follow-ups if useful:

- `SetDeadline` / `SetReadDeadline` / `SetWriteDeadline` in `connection.go:51-64` are `return nil` stubs. Fixing properly means replacing `io.Pipe` with something that actually supports deadlines.
- `context.WithoutCancel` in `OpenStream` / `PostPacket`, plus the upload goroutine spawned per chunk in packet-up (`dialer.go:560`) is never awaited or cancelled.
- `http2.Transport` flow-control windows. `x/net/http2` doesn't let you set per-stream / per-connection receive windows from outside `Transport` cleanly, needs discussion on approach.
- `PostPacket` body-placement wraps `MultiBuffer` in `io.NopCloser`, which leaks on error (NopCloser.Close is a no-op).
- `globalDialerMap` never removes entries.