### PR TITLE
Loopback outbound: Avoid directly modifying potential shared ctx

### DIFF
--- a/proxy/loopback/loopback.go
+++ b/proxy/loopback/loopback.go
@@ -45,9 +45,11 @@ func (l *Loopback) Process(ctx context.Context, link *transport.Link, _ internet
 
 		ctx = session.ContextWithContent(ctx, content)
 
-		inbound := session.InboundFromContext(ctx)
-		if inbound == nil {
-			inbound = &session.Inbound{}
+		inbound := &session.Inbound{}
+		originInbound := session.InboundFromContext(ctx)
+		if originInbound != nil {
+			// get a shallow copy to avoid modifying the inbound tag in upstream context
+			*inbound = *originInbound
 		}
 
 		inbound.Tag = l.config.InboundTag


### PR DESCRIPTION
fix #5958
之前那样原地改会导致和它共享inbound的请求一起错乱