### PR TITLE
Browser Dialer: Allow being switched on runtime when Xray is used as a lib

### DIFF
--- a/transport/internet/browser_dialer/dialer.go
+++ b/transport/internet/browser_dialer/dialer.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -26,6 +27,8 @@ type task struct {
 }
 
 var conns chan *websocket.Conn
+var server *http.Server
+var mu sync.Mutex
 
 var upgrader = &websocket.Upgrader{
 	ReadBufferSize:   0,
@@ -36,27 +39,47 @@ var upgrader = &websocket.Upgrader{
 	},
 }
 
-func init() {
+func Init() {
 	addr := platform.NewEnvFlag(platform.BrowserDialerAddress).GetValue(func() string { return "" })
+	mu.Lock()
+	defer mu.Unlock()
+
+	if server != nil {
+		server.Close()
+	}
+	if HasBrowserDialer() {
+		for len(conns) > 0 {
+			select {
+				case c := <-conns:
+					c.Close()
+				default:
+			}
+		}
+		conns = nil
+	}
 	if addr != "" {
 		token := uuid.New()
 		csrfToken := token.String()
-		webpage = bytes.ReplaceAll(webpage, []byte("csrfToken"), []byte(csrfToken))
+		webpage := bytes.ReplaceAll(webpage, []byte("csrfToken"), []byte(csrfToken))
 		conns = make(chan *websocket.Conn, 256)
-		go http.ListenAndServe(addr, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/websocket" {
-				if r.URL.Query().Get("token") == csrfToken {
-					if conn, err := upgrader.Upgrade(w, r, nil); err == nil {
-						conns <- conn
-					} else {
-						errors.LogError(context.Background(), "Browser dialer http upgrade unexpected error")
+		server = &http.Server{
+			Addr: addr,
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/websocket" {
+					if r.URL.Query().Get("token") == csrfToken {
+						if conn, err := upgrader.Upgrade(w, r, nil); err == nil {
+							conns <- conn
+						} else {
+							errors.LogError(context.Background(), "Browser dialer http upgrade unexpected error")
+						}
 					}
+				} else {
+					w.Header().Set("Access-Control-Allow-Origin", "*");
+					w.Write(webpage)
 				}
-			} else {
-				w.Header().Set("Access-Control-Allow-Origin", "*");
-				w.Write(webpage)
-			}
-		}))
+			}),
+		}
+		go server.ListenAndServe()
 	}
 }
 
@@ -194,3 +217,8 @@ func CheckOK(conn *websocket.Conn) error {
 
 	return nil
 }
+
+func init() {
+	Init()
+}
+

--- a/transport/internet/browser_dialer/dialer.go
+++ b/transport/internet/browser_dialer/dialer.go
@@ -39,7 +39,8 @@ var upgrader = &websocket.Upgrader{
 	},
 }
 
-func Init() {
+// Used by external projects when using xray as a go module
+func Reload() {
 	addr := platform.NewEnvFlag(platform.BrowserDialerAddress).GetValue(func() string { return "" })
 	mu.Lock()
 	defer mu.Unlock()
@@ -219,6 +220,6 @@ func CheckOK(conn *websocket.Conn) error {
 }
 
 func init() {
-	Init()
+	Reload()
 }
 


### PR DESCRIPTION
這個PR主要是為了解決我在給v2rayNG增加browser dialer的支持的時候遇到的問題. 因為原有邏輯是在browser_dialer包的init()裡讀環境變量來開啟browser dialer, 這導致在Xray作為library的時候(比如作為一個安卓aar的一部分)無法使用環境變量控制browser dialer(讀環境變量這一步在加載這個.so的時候就已經進行完畢了)
把init()裡的邏輯單獨提出來, 這樣安卓下作為庫調用Xray的時候每次修改環境變量後只要重新調用一下Init()就行
不是很清楚golang的運作方式, 實際測試(在我修改過尚未發佈的v2rayNG版本)可以正常使用, 這也使其他安卓客戶端(不清楚蘋果的情況)增加browser dialer支持變得可能
對原本的browser dialer的使用方式沒有任何修改.