### PR TITLE
app/router/condition.go: Retrieve original target in net.FindProcess() when "IPIfNonMatch" is enabled

### DIFF
--- a/app/router/condition.go
+++ b/app/router/condition.go
@@ -358,6 +358,7 @@ func (m *ProcessNameMatcher) Apply(ctx routing.Context) bool {
 	var dstIP string
 	var dstPort uint16 = 0
 
+	// do not use resolved IP because Android process lookup needs original dst ip
 	resolvableContext, ok := ctx.(*dns.ResolvableContext)
 	if ok && len(resolvableContext.Context.GetTargetIPs()) > 0 {
 		dstIP = resolvableContext.Context.GetTargetIPs()[0].String()

--- a/app/router/condition.go
+++ b/app/router/condition.go
@@ -12,6 +12,7 @@ import (
 	"github.com/xtls/xray-core/common/geodata"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/features/routing"
+	"github.com/xtls/xray-core/features/routing/dns"
 )
 
 type Condition interface {
@@ -356,7 +357,12 @@ func (m *ProcessNameMatcher) Apply(ctx routing.Context) bool {
 
 	var dstIP string
 	var dstPort uint16 = 0
-	if len(ctx.GetTargetIPs()) > 0 {
+
+	resolvableContext, ok := ctx.(*dns.ResolvableContext)
+	if ok && len(resolvableContext.Context.GetTargetIPs()) > 0 {
+		dstIP = resolvableContext.Context.GetTargetIPs()[0].String()
+		dstPort = uint16(resolvableContext.Context.GetTargetPort())
+	} else if len(ctx.GetTargetIPs()) > 0 {
 		dstIP = ctx.GetTargetIPs()[0].String()
 		dstPort = uint16(ctx.GetTargetPort())
 	}


### PR DESCRIPTION
启用 `IpIfNonMatch` 时，第二遍尝试匹配规则时会把 `routing.Context` 包装成 `ResolvableContext`。 `ResolvableContext` 会把 sniff 出来的域名解析成 IP，这导致 FindProcess 拿到的 IP 和 TUN 入站拿到的 IP 不一样。

本 PR 会尝试把 ctx 转成 `*dns.ResolvableContext` 并调用原始 context 的 `GetTargetIPs`