### PR TITLE
DNS outbound: Add `rules` (matches `qtype` and `domain`, then `action`)

### DIFF
--- a/infra/conf/dns_proxy.go
+++ b/infra/conf/dns_proxy.go
@@ -1,19 +1,111 @@
 package conf
 
 import (
+	"encoding/json"
+	"sort"
+	"strconv"
+
 	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/common/geodata"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/proxy/dns"
 	"google.golang.org/protobuf/proto"
 )
 
+type DNSQueryRulesConfig map[string]json.RawMessage
+
+// UnmarshalJSON implements encoding/json.Unmarshaler.UnmarshalJSON.
+func (c *DNSQueryRulesConfig) UnmarshalJSON(data []byte) error {
+	m := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(data, &m); err != nil {
+		return errors.New("invalid dns query rules").Base(err)
+	}
+	*c = m
+	return nil
+}
+
+func (c DNSQueryRulesConfig) Build() ([]*dns.Config_QueryRule, error) {
+	if len(c) == 0 {
+		return nil, nil
+	}
+
+	keys := make([]string, 0, len(c))
+	for key := range c {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var rules [256]*dns.Config_QueryRule
+	for _, key := range keys {
+		var qtypes PortList
+		if err := qtypes.UnmarshalJSON([]byte(strconv.Quote(key))); err != nil {
+			return nil, errors.New("failed to parse dns query rule qtype: ", key).Base(err)
+		}
+
+		domains, err := parseQueryDomains(c[key], key)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, r := range qtypes.Range {
+			if r.To > 255 {
+				return nil, errors.New("dns query rule qtype out of range: ", r.String())
+			}
+			for qtype := r.From; qtype <= r.To; qtype++ {
+				if rules[qtype] == nil {
+					rules[qtype] = &dns.Config_QueryRule{Qtype: int32(qtype)}
+				}
+				rules[qtype].Domain = appendUniqueDomains(rules[qtype].Domain, domains)
+			}
+		}
+	}
+
+	out := make([]*dns.Config_QueryRule, 0)
+	for _, rule := range rules {
+		if rule != nil {
+			out = append(out, rule)
+		}
+	}
+	return out, nil
+}
+
+func parseQueryDomains(data json.RawMessage, key string) ([]*geodata.DomainRule, error) {
+	var domains *StringList
+	if err := json.Unmarshal(data, &domains); err != nil {
+		return nil, errors.New("failed to parse dns query rule domains for qtype: ", key).Base(err)
+	}
+	if domains == nil {
+		return nil, nil
+	}
+	return geodata.ParseDomainRules(*domains, geodata.Domain_Substr)
+}
+
+func appendUniqueDomains(dst, src []*geodata.DomainRule) []*geodata.DomainRule {
+	for _, rule := range src {
+		dup := false
+		for _, r := range dst {
+			if proto.Equal(r, rule) {
+				dup = true
+				break
+			}
+		}
+		if !dup {
+			dst = append(dst, rule)
+		}
+	}
+	return dst
+}
+
 type DNSOutboundConfig struct {
-	Network    Network  `json:"network"`
-	Address    *Address `json:"address"`
-	Port       uint16   `json:"port"`
-	UserLevel  uint32   `json:"userLevel"`
-	NonIPQuery string   `json:"nonIPQuery"`
-	BlockTypes []int32  `json:"blockTypes"`
+	Network     Network              `json:"network"`
+	Address     *Address             `json:"address"`
+	Port        uint16               `json:"port"`
+	UserLevel   uint32               `json:"userLevel"`
+	BlockMethod string               `json:"blockMethod"`
+	Blacklist   *DNSQueryRulesConfig `json:"blacklist"`
+	Whitelist   *DNSQueryRulesConfig `json:"whitelist"`
+	NonIPQuery  *string              `json:"nonIPQuery"` // todo: remove legacy
+	BlockTypes  *[]int32             `json:"blockTypes"` // todo: remove legacy
 }
 
 func (c *DNSOutboundConfig) Build() (proto.Message, error) {
@@ -27,12 +119,94 @@ func (c *DNSOutboundConfig) Build() (proto.Message, error) {
 	if c.Address != nil {
 		config.Server.Address = c.Address.Build()
 	}
-	switch c.NonIPQuery {
-	case "", "reject", "drop", "skip":
-	default:
-		return nil, errors.New(`unknown "nonIPQuery": `, c.NonIPQuery)
+
+	// todo: remove legacy
+	if c.NonIPQuery != nil || c.BlockTypes != nil {
+		if c.BlockMethod != "" || c.Blacklist != nil || c.Whitelist != nil {
+			return nil, errors.New(`legacy "nonIPQuery" and "blockTypes" cannot be mixed with "blockMethod", "blacklist", or "whitelist"`)
+		}
+		block, reject, rules, err := c.buildLegacyDNSPolicy()
+		if err != nil {
+			return nil, err
+		}
+		config.BlockMatched = block
+		config.RejectBlocked = reject
+		config.QueryRule = rules
+		return config, nil
 	}
-	config.Non_IPQuery = c.NonIPQuery
-	config.BlockTypes = c.BlockTypes
+
+	block, rules, err := c.buildDNSQueryPolicy()
+	if err != nil {
+		return nil, err
+	}
+	config.BlockMatched = block
+	config.QueryRule = rules
+
+	switch c.BlockMethod {
+	case "drop":
+		config.RejectBlocked = false
+	case "", "reject":
+		config.RejectBlocked = true
+	default:
+		return nil, errors.New(`unknown "blockMethod": `, c.BlockMethod)
+	}
+
 	return config, nil
+}
+
+func (c *DNSOutboundConfig) buildDNSQueryPolicy() (bool, []*dns.Config_QueryRule, error) {
+	switch {
+	case c.Blacklist != nil && c.Whitelist != nil:
+		return false, nil, errors.New(`"blacklist" and "whitelist" are mutually exclusive`)
+	case c.Whitelist != nil:
+		rules, err := c.Whitelist.Build()
+		return false, rules, err
+	case c.Blacklist != nil:
+		rules, err := c.Blacklist.Build()
+		return true, rules, err
+	default:
+		return true, nil, nil // default: blacklist mode
+	}
+}
+
+// todo: remove legacy
+func (c *DNSOutboundConfig) buildLegacyDNSPolicy() (bool, bool, []*dns.Config_QueryRule, error) {
+	mode := "reject"
+	if c.NonIPQuery != nil && *c.NonIPQuery != "" {
+		mode = *c.NonIPQuery
+	}
+
+	switch mode {
+	case "reject", "drop", "skip":
+	default:
+		return false, false, nil, errors.New(`unknown "nonIPQuery": `, mode)
+	}
+
+	var blocked [256]bool
+	if c.BlockTypes != nil {
+		for _, qtype := range *c.BlockTypes {
+			if qtype < 0 || qtype > 255 {
+				return false, false, nil, errors.New("legacy blockTypes qtype out of range: ", qtype)
+			}
+			blocked[qtype] = true
+		}
+	}
+
+	var rules []*dns.Config_QueryRule
+	block := mode == "skip"
+	if block {
+		for qtype, hit := range blocked {
+			if hit {
+				rules = append(rules, &dns.Config_QueryRule{Qtype: int32(qtype)})
+			}
+		}
+	} else {
+		for _, qtype := range [...]int{1, 28} {
+			if !blocked[qtype] {
+				rules = append(rules, &dns.Config_QueryRule{Qtype: int32(qtype)})
+			}
+		}
+	}
+
+	return block, mode == "reject", rules, nil
 }

--- a/infra/conf/dns_proxy.go
+++ b/infra/conf/dns_proxy.go
@@ -84,6 +84,7 @@ func (c *DNSOutboundConfig) Build() (proto.Message, error) {
 		if c.Rules != nil {
 			return nil, errors.New("legacy nonIPQuery and blockTypes cannot be mixed with rules")
 		}
+		errors.PrintDeprecatedFeatureWarning(`"nonIPQuery" and "blockTypes" in DNS outbound`, `"rules"`)
 		rules, err := c.buildLegacyDNSPolicy()
 		if err != nil {
 			return nil, err

--- a/infra/conf/dns_proxy.go
+++ b/infra/conf/dns_proxy.go
@@ -136,20 +136,22 @@ func (c *DNSOutboundConfig) buildLegacyDNSPolicy() ([]*dns.DNSRuleConfig, error)
 	}
 
 	{
-		rule := &dns.DNSRuleConfig{Action: dns.RuleAction_Accept}
+		rule := &dns.DNSRuleConfig{Action: dns.RuleAction_Hijack}
 		rule.Qtype = append(rule.Qtype, 1)
 		rule.Qtype = append(rule.Qtype, 28)
 		rules = append(rules, rule)
 	}
 
 	{
-		rule := &dns.DNSRuleConfig{Action: dns.RuleAction_Drop}
+		rule := &dns.DNSRuleConfig{Action: dns.RuleAction_Refuse}
 		for i := 0; i < 256; i++ {
 			rule.Qtype = append(rule.Qtype, int32(i))
 		}
 		if mode == "reject" {
 			rule.Action = dns.RuleAction_Refuse
-		} else {
+		} else if mode == "drop" {
+			rule.Action = dns.RuleAction_Drop
+		} else if mode == "skip" {
 			rule.Action = dns.RuleAction_Accept
 		}
 		rules = append(rules, rule)

--- a/infra/conf/dns_proxy.go
+++ b/infra/conf/dns_proxy.go
@@ -37,16 +37,12 @@ func (c *DNSOutboundRuleConfig) Build() (*dns.DNSRuleConfig, error) {
 			if r.From > r.To {
 				return nil, errors.New("invalid qtype range: ", r.String())
 			}
-			if r.To > 255 {
+			if r.To > 65535 {
 				return nil, errors.New("dns rule qtype out of range: ", r.String())
 			}
 			for qtype := r.From; qtype <= r.To; qtype++ {
 				rule.Qtype = append(rule.Qtype, int32(qtype))
 			}
-		}
-	} else {
-		for i := 0; i < 256; i++ {
-			rule.Qtype = append(rule.Qtype, int32(i))
 		}
 	}
 
@@ -127,7 +123,7 @@ func (c *DNSOutboundConfig) buildLegacyDNSPolicy() ([]*dns.DNSRuleConfig, error)
 			rule.Action = dns.RuleAction_Refuse
 		}
 		for _, qtype := range *c.BlockTypes {
-			if qtype < 0 || qtype > 255 {
+			if qtype < 0 || qtype > 65535 {
 				return nil, errors.New("legacy blockTypes qtype out of range: ", qtype)
 			}
 			rule.Qtype = append(rule.Qtype, qtype)
@@ -144,9 +140,6 @@ func (c *DNSOutboundConfig) buildLegacyDNSPolicy() ([]*dns.DNSRuleConfig, error)
 
 	{
 		rule := &dns.DNSRuleConfig{Action: dns.RuleAction_Refuse}
-		for i := 0; i < 256; i++ {
-			rule.Qtype = append(rule.Qtype, int32(i))
-		}
 		if mode == "reject" {
 			rule.Action = dns.RuleAction_Refuse
 		} else if mode == "drop" {

--- a/infra/conf/dns_proxy.go
+++ b/infra/conf/dns_proxy.go
@@ -20,12 +20,12 @@ func (c *DNSOutboundRuleConfig) Build() (*dns.DNSRuleConfig, error) {
 	rule := &dns.DNSRuleConfig{}
 
 	switch strings.ToLower(c.Action) {
-	case "accept":
-		rule.Action = dns.RuleAction_Accept
+	case "direct":
+		rule.Action = dns.RuleAction_Direct
 	case "drop":
 		rule.Action = dns.RuleAction_Drop
-	case "refuse":
-		rule.Action = dns.RuleAction_Refuse
+	case "reject":
+		rule.Action = dns.RuleAction_Reject
 	case "hijack":
 		rule.Action = dns.RuleAction_Hijack
 	default:
@@ -121,7 +121,7 @@ func (c *DNSOutboundConfig) buildLegacyDNSPolicy() ([]*dns.DNSRuleConfig, error)
 	if c.BlockTypes != nil && len(*c.BlockTypes) > 0 {
 		rule := &dns.DNSRuleConfig{Action: dns.RuleAction_Drop}
 		if mode == "reject" {
-			rule.Action = dns.RuleAction_Refuse
+			rule.Action = dns.RuleAction_Reject
 		}
 		for _, qtype := range *c.BlockTypes {
 			if qtype < 0 || qtype > 65535 {
@@ -140,13 +140,13 @@ func (c *DNSOutboundConfig) buildLegacyDNSPolicy() ([]*dns.DNSRuleConfig, error)
 	}
 
 	{
-		rule := &dns.DNSRuleConfig{Action: dns.RuleAction_Refuse}
+		rule := &dns.DNSRuleConfig{Action: dns.RuleAction_Reject}
 		if mode == "reject" {
-			rule.Action = dns.RuleAction_Refuse
+			rule.Action = dns.RuleAction_Reject
 		} else if mode == "drop" {
 			rule.Action = dns.RuleAction_Drop
 		} else if mode == "skip" {
-			rule.Action = dns.RuleAction_Accept
+			rule.Action = dns.RuleAction_Direct
 		}
 		rules = append(rules, rule)
 	}

--- a/infra/conf/dns_proxy.go
+++ b/infra/conf/dns_proxy.go
@@ -105,7 +105,7 @@ func (c *DNSOutboundConfig) Build() (proto.Message, error) {
 
 // todo: remove legacy
 func (c *DNSOutboundConfig) buildLegacyDNSPolicy() ([]*dns.DNSRuleConfig, error) {
-	rules := make([]*dns.DNSRuleConfig, 0, 2)
+	rules := make([]*dns.DNSRuleConfig, 0, 3)
 
 	mode := "reject"
 	if c.NonIPQuery != nil && *c.NonIPQuery != "" {

--- a/infra/conf/dns_proxy.go
+++ b/infra/conf/dns_proxy.go
@@ -1,9 +1,7 @@
 package conf
 
 import (
-	"encoding/json"
-	"sort"
-	"strconv"
+	"strings"
 
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/geodata"
@@ -12,100 +10,65 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-type DNSQueryRulesConfig map[string]json.RawMessage
-
-// UnmarshalJSON implements encoding/json.Unmarshaler.UnmarshalJSON.
-func (c *DNSQueryRulesConfig) UnmarshalJSON(data []byte) error {
-	m := make(map[string]json.RawMessage)
-	if err := json.Unmarshal(data, &m); err != nil {
-		return errors.New("invalid dns query rules").Base(err)
-	}
-	*c = m
-	return nil
+type DNSOutboundRuleConfig struct {
+	Action string      `json:"action"`
+	QType  *PortList   `json:"qtype"`
+	Domain *StringList `json:"domain"`
 }
 
-func (c DNSQueryRulesConfig) Build() ([]*dns.Config_QueryRule, error) {
-	if len(c) == 0 {
-		return nil, nil
+func (c *DNSOutboundRuleConfig) Build() (*dns.DNSRuleConfig, error) {
+	rule := &dns.DNSRuleConfig{}
+
+	switch strings.ToLower(c.Action) {
+	case "accept":
+		rule.Action = dns.RuleAction_Accept
+	case "drop":
+		rule.Action = dns.RuleAction_Drop
+	case "refuse":
+		rule.Action = dns.RuleAction_Refuse
+	case "hijack":
+		rule.Action = dns.RuleAction_Hijack
+	default:
+		return nil, errors.New("unknown action: ", c.Action)
 	}
 
-	keys := make([]string, 0, len(c))
-	for key := range c {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-
-	var rules [256]*dns.Config_QueryRule
-	for _, key := range keys {
-		var qtypes PortList
-		if err := qtypes.UnmarshalJSON([]byte(strconv.Quote(key))); err != nil {
-			return nil, errors.New("failed to parse dns query rule qtype: ", key).Base(err)
+	if c.QType != nil {
+		for _, r := range c.QType.Range {
+			if r.From > r.To {
+				return nil, errors.New("invalid qtype range: ", r.String())
+			}
+			if r.To > 255 {
+				return nil, errors.New("dns rule qtype out of range: ", r.String())
+			}
+			for qtype := r.From; qtype <= r.To; qtype++ {
+				rule.Qtype = append(rule.Qtype, int32(qtype))
+			}
 		}
+	} else {
+		for i := 0; i < 256; i++ {
+			rule.Qtype = append(rule.Qtype, int32(i))
+		}
+	}
 
-		domains, err := parseQueryDomains(c[key], key)
+	if c.Domain != nil {
+		rules, err := geodata.ParseDomainRules(*c.Domain, geodata.Domain_Substr)
 		if err != nil {
 			return nil, err
 		}
-
-		for _, r := range qtypes.Range {
-			if r.To > 255 {
-				return nil, errors.New("dns query rule qtype out of range: ", r.String())
-			}
-			for qtype := r.From; qtype <= r.To; qtype++ {
-				if rules[qtype] == nil {
-					rules[qtype] = &dns.Config_QueryRule{Qtype: int32(qtype)}
-				}
-				rules[qtype].Domain = appendUniqueDomains(rules[qtype].Domain, domains)
-			}
-		}
+		rule.Domain = rules
 	}
 
-	out := make([]*dns.Config_QueryRule, 0)
-	for _, rule := range rules {
-		if rule != nil {
-			out = append(out, rule)
-		}
-	}
-	return out, nil
-}
-
-func parseQueryDomains(data json.RawMessage, key string) ([]*geodata.DomainRule, error) {
-	var domains *StringList
-	if err := json.Unmarshal(data, &domains); err != nil {
-		return nil, errors.New("failed to parse dns query rule domains for qtype: ", key).Base(err)
-	}
-	if domains == nil {
-		return nil, nil
-	}
-	return geodata.ParseDomainRules(*domains, geodata.Domain_Substr)
-}
-
-func appendUniqueDomains(dst, src []*geodata.DomainRule) []*geodata.DomainRule {
-	for _, rule := range src {
-		dup := false
-		for _, r := range dst {
-			if proto.Equal(r, rule) {
-				dup = true
-				break
-			}
-		}
-		if !dup {
-			dst = append(dst, rule)
-		}
-	}
-	return dst
+	return rule, nil
 }
 
 type DNSOutboundConfig struct {
-	Network     Network              `json:"network"`
-	Address     *Address             `json:"address"`
-	Port        uint16               `json:"port"`
-	UserLevel   uint32               `json:"userLevel"`
-	BlockMethod string               `json:"blockMethod"`
-	Blacklist   *DNSQueryRulesConfig `json:"blacklist"`
-	Whitelist   *DNSQueryRulesConfig `json:"whitelist"`
-	NonIPQuery  *string              `json:"nonIPQuery"` // todo: remove legacy
-	BlockTypes  *[]int32             `json:"blockTypes"` // todo: remove legacy
+	Network    Network                  `json:"network"`
+	Address    *Address                 `json:"address"`
+	Port       uint16                   `json:"port"`
+	UserLevel  uint32                   `json:"userLevel"`
+	Rules      []*DNSOutboundRuleConfig `json:"rules"`
+	NonIPQuery *string                  `json:"nonIPQuery"` // todo: remove legacy
+	BlockTypes *[]int32                 `json:"blockTypes"` // todo: remove legacy
 }
 
 func (c *DNSOutboundConfig) Build() (proto.Message, error) {
@@ -122,91 +85,75 @@ func (c *DNSOutboundConfig) Build() (proto.Message, error) {
 
 	// todo: remove legacy
 	if c.NonIPQuery != nil || c.BlockTypes != nil {
-		if c.BlockMethod != "" || c.Blacklist != nil || c.Whitelist != nil {
-			return nil, errors.New(`legacy "nonIPQuery" and "blockTypes" cannot be mixed with "blockMethod", "blacklist", or "whitelist"`)
+		if c.Rules != nil {
+			return nil, errors.New("legacy nonIPQuery and blockTypes cannot be mixed with rules")
 		}
-		block, reject, rules, err := c.buildLegacyDNSPolicy()
+		rules, err := c.buildLegacyDNSPolicy()
 		if err != nil {
 			return nil, err
 		}
-		config.BlockMatched = block
-		config.RejectBlocked = reject
-		config.QueryRule = rules
+		config.Rule = rules
 		return config, nil
 	}
 
-	block, rules, err := c.buildDNSQueryPolicy()
-	if err != nil {
-		return nil, err
-	}
-	config.BlockMatched = block
-	config.QueryRule = rules
-
-	switch c.BlockMethod {
-	case "drop":
-		config.RejectBlocked = false
-	case "", "reject":
-		config.RejectBlocked = true
-	default:
-		return nil, errors.New(`unknown "blockMethod": `, c.BlockMethod)
+	for _, r := range c.Rules {
+		rule, err := r.Build()
+		if err != nil {
+			return nil, err
+		}
+		config.Rule = append(config.Rule, rule)
 	}
 
 	return config, nil
 }
 
-func (c *DNSOutboundConfig) buildDNSQueryPolicy() (bool, []*dns.Config_QueryRule, error) {
-	switch {
-	case c.Blacklist != nil && c.Whitelist != nil:
-		return false, nil, errors.New(`"blacklist" and "whitelist" are mutually exclusive`)
-	case c.Whitelist != nil:
-		rules, err := c.Whitelist.Build()
-		return false, rules, err
-	case c.Blacklist != nil:
-		rules, err := c.Blacklist.Build()
-		return true, rules, err
-	default:
-		return true, nil, nil // default: blacklist mode
-	}
-}
-
 // todo: remove legacy
-func (c *DNSOutboundConfig) buildLegacyDNSPolicy() (bool, bool, []*dns.Config_QueryRule, error) {
+func (c *DNSOutboundConfig) buildLegacyDNSPolicy() ([]*dns.DNSRuleConfig, error) {
+	rules := make([]*dns.DNSRuleConfig, 0, 2)
+
 	mode := "reject"
 	if c.NonIPQuery != nil && *c.NonIPQuery != "" {
 		mode = *c.NonIPQuery
 	}
-
 	switch mode {
-	case "reject", "drop", "skip":
+	case "", "reject", "drop", "skip":
 	default:
-		return false, false, nil, errors.New(`unknown "nonIPQuery": `, mode)
+		return nil, errors.New("unknown nonIPQuery: ", mode)
 	}
 
-	var blocked [256]bool
-	if c.BlockTypes != nil {
+	if c.BlockTypes != nil && len(*c.BlockTypes) > 0 {
+		rule := &dns.DNSRuleConfig{Action: dns.RuleAction_Drop}
+		if mode == "reject" {
+			rule.Action = dns.RuleAction_Refuse
+		}
 		for _, qtype := range *c.BlockTypes {
 			if qtype < 0 || qtype > 255 {
-				return false, false, nil, errors.New("legacy blockTypes qtype out of range: ", qtype)
+				return nil, errors.New("legacy blockTypes qtype out of range: ", qtype)
 			}
-			blocked[qtype] = true
+			rule.Qtype = append(rule.Qtype, qtype)
 		}
+		rules = append(rules, rule)
 	}
 
-	var rules []*dns.Config_QueryRule
-	block := mode == "skip"
-	if block {
-		for qtype, hit := range blocked {
-			if hit {
-				rules = append(rules, &dns.Config_QueryRule{Qtype: int32(qtype)})
-			}
-		}
-	} else {
-		for _, qtype := range [...]int{1, 28} {
-			if !blocked[qtype] {
-				rules = append(rules, &dns.Config_QueryRule{Qtype: int32(qtype)})
-			}
-		}
+	{
+		rule := &dns.DNSRuleConfig{Action: dns.RuleAction_Accept}
+		rule.Qtype = append(rule.Qtype, 1)
+		rule.Qtype = append(rule.Qtype, 28)
+		rules = append(rules, rule)
 	}
 
-	return block, mode == "reject", rules, nil
+	{
+		rule := &dns.DNSRuleConfig{Action: dns.RuleAction_Drop}
+		for i := 0; i < 256; i++ {
+			rule.Qtype = append(rule.Qtype, int32(i))
+		}
+		if mode == "reject" {
+			rule.Action = dns.RuleAction_Refuse
+		} else {
+			rule.Action = dns.RuleAction_Accept
+		}
+		rules = append(rules, rule)
+	}
+
+	return rules, nil
 }

--- a/infra/conf/dns_proxy_test.go
+++ b/infra/conf/dns_proxy_test.go
@@ -10,14 +10,6 @@ import (
 	"github.com/xtls/xray-core/proxy/dns"
 )
 
-func allQTypes() []int32 {
-	out := make([]int32, 256)
-	for i := 0; i < 256; i++ {
-		out[i] = int32(i)
-	}
-	return out
-}
-
 func TestDnsProxyConfig(t *testing.T) {
 	creator := func() Buildable {
 		return new(DNSOutboundConfig)
@@ -96,7 +88,6 @@ func TestDnsProxyConfig(t *testing.T) {
 				Rule: []*dns.DNSRuleConfig{
 					{
 						Action: dns.RuleAction_Refuse,
-						Qtype:  allQTypes(),
 						Domain: []*geodata.DomainRule{
 							{
 								Value: &geodata.DomainRule_Custom{
@@ -107,6 +98,24 @@ func TestDnsProxyConfig(t *testing.T) {
 								},
 							},
 						},
+					},
+				},
+			},
+		},
+		{
+			Input: `{
+				"rules": [{
+					"action": "drop",
+					"qtype": 257
+				}]
+			}`,
+			Parser: loadJSON(creator),
+			Output: &dns.Config{
+				Server: &net.Endpoint{},
+				Rule: []*dns.DNSRuleConfig{
+					{
+						Action: dns.RuleAction_Drop,
+						Qtype:  []int32{257},
 					},
 				},
 			},
@@ -135,7 +144,6 @@ func TestDnsProxyConfigLegacyCompatibility(t *testing.T) {
 					},
 					{
 						Action: dns.RuleAction_Refuse,
-						Qtype:  allQTypes(),
 					},
 				},
 			},
@@ -158,7 +166,6 @@ func TestDnsProxyConfigLegacyCompatibility(t *testing.T) {
 					},
 					{
 						Action: dns.RuleAction_Refuse,
-						Qtype:  allQTypes(),
 					},
 				},
 			},
@@ -182,7 +189,6 @@ func TestDnsProxyConfigLegacyCompatibility(t *testing.T) {
 					},
 					{
 						Action: dns.RuleAction_Drop,
-						Qtype:  allQTypes(),
 					},
 				},
 			},
@@ -206,7 +212,6 @@ func TestDnsProxyConfigLegacyCompatibility(t *testing.T) {
 					},
 					{
 						Action: dns.RuleAction_Accept,
-						Qtype:  allQTypes(),
 					},
 				},
 			},

--- a/infra/conf/dns_proxy_test.go
+++ b/infra/conf/dns_proxy_test.go
@@ -1,8 +1,10 @@
 package conf_test
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/xtls/xray-core/common/geodata"
 	"github.com/xtls/xray-core/common/net"
 	. "github.com/xtls/xray-core/infra/conf"
 	"github.com/xtls/xray-core/proxy/dns"
@@ -27,7 +29,186 @@ func TestDnsProxyConfig(t *testing.T) {
 					Address: net.NewIPOrDomain(net.IPAddress([]byte{8, 8, 8, 8})),
 					Port:    53,
 				},
+				BlockMatched:  true,
+				RejectBlocked: true,
+			},
+		},
+		{
+			Input: `{
+				"blockMethod": "drop"
+			}`,
+			Parser: loadJSON(creator),
+			Output: &dns.Config{
+				Server:       &net.Endpoint{},
+				BlockMatched: true,
+			},
+		},
+		{
+			Input: `{
+				"blacklist": {
+					"1,3,23-24": null,
+					"28": ["domain:example.com", "full:example.com"]
+				}
+			}`,
+			Parser: loadJSON(creator),
+			Output: &dns.Config{
+				Server:        &net.Endpoint{},
+				BlockMatched:  true,
+				RejectBlocked: true,
+				QueryRule: []*dns.Config_QueryRule{
+					{Qtype: 1},
+					{Qtype: 3},
+					{Qtype: 23},
+					{Qtype: 24},
+					{
+						Qtype: 28,
+						Domain: []*geodata.DomainRule{
+							{
+								Value: &geodata.DomainRule_Custom{
+									Custom: &geodata.Domain{
+										Type:  geodata.Domain_Domain,
+										Value: "example.com",
+									},
+								},
+							},
+							{
+								Value: &geodata.DomainRule_Custom{
+									Custom: &geodata.Domain{
+										Type:  geodata.Domain_Full,
+										Value: "example.com",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Input: `{
+				"whitelist": {
+					"1,3,23-24": null,
+					"28": "keyword:example"
+				}
+			}`,
+			Parser: loadJSON(creator),
+			Output: &dns.Config{
+				Server:        &net.Endpoint{},
+				RejectBlocked: true,
+				QueryRule: []*dns.Config_QueryRule{
+					{Qtype: 1},
+					{Qtype: 3},
+					{Qtype: 23},
+					{Qtype: 24},
+					{
+						Qtype: 28,
+						Domain: []*geodata.DomainRule{
+							{
+								Value: &geodata.DomainRule_Custom{
+									Custom: &geodata.Domain{
+										Type:  geodata.Domain_Substr,
+										Value: "example",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Input: `{
+				"blockMethod": "drop",
+				"whitelist": {}
+			}`,
+			Parser: loadJSON(creator),
+			Output: &dns.Config{
+				Server: &net.Endpoint{},
+			},
+		},
+		{
+			Input: `{
+				"nonIPQuery": "drop",
+				"blockTypes": []
+			}`,
+			Parser: loadJSON(creator),
+			Output: &dns.Config{
+				Server: &net.Endpoint{},
+				QueryRule: []*dns.Config_QueryRule{
+					{Qtype: 1},
+					{Qtype: 28},
+				},
+			},
+		},
+		{
+			Input: `{
+				"blockTypes": []
+			}`,
+			Parser: loadJSON(creator),
+			Output: &dns.Config{
+				Server:        &net.Endpoint{},
+				RejectBlocked: true,
+				QueryRule: []*dns.Config_QueryRule{
+					{Qtype: 1},
+					{Qtype: 28},
+				},
+			},
+		},
+		{
+			Input: `{
+				"nonIPQuery": "drop",
+				"blockTypes": [1]
+			}`,
+			Parser: loadJSON(creator),
+			Output: &dns.Config{
+				Server: &net.Endpoint{},
+				QueryRule: []*dns.Config_QueryRule{
+					{Qtype: 28},
+				},
+			},
+		},
+		{
+			Input: `{
+				"nonIPQuery": "skip",
+				"blockTypes": [65, 28]
+			}`,
+			Parser: loadJSON(creator),
+			Output: &dns.Config{
+				Server:       &net.Endpoint{},
+				BlockMatched: true,
+				QueryRule: []*dns.Config_QueryRule{
+					{Qtype: 28},
+					{Qtype: 65},
+				},
 			},
 		},
 	})
+}
+
+func TestDnsProxyConfigRejectsMixedLists(t *testing.T) {
+	creator := func() Buildable {
+		return new(DNSOutboundConfig)
+	}
+
+	_, err := loadJSON(creator)(`{
+		"blacklist": {"1": null},
+		"whitelist": {"28": null}
+	}`)
+	if err == nil || !strings.Contains(err.Error(), `"blacklist" and "whitelist" are mutually exclusive`) {
+		t.Fatal("expected mixed list error, but got ", err)
+	}
+}
+
+func TestDnsProxyConfigRejectsMixedLegacyAndNewFields(t *testing.T) {
+	creator := func() Buildable {
+		return new(DNSOutboundConfig)
+	}
+
+	_, err := loadJSON(creator)(`{
+		"blockMethod": "reject",
+		"blockTypes": [65]
+	}`)
+	if err == nil || !strings.Contains(err.Error(), `legacy "nonIPQuery" and "blockTypes" cannot be mixed`) {
+		t.Fatal("expected mixed legacy/new config error, but got ", err)
+	}
 }

--- a/infra/conf/dns_proxy_test.go
+++ b/infra/conf/dns_proxy_test.go
@@ -111,6 +111,16 @@ func TestDnsProxyConfig(t *testing.T) {
 				},
 			},
 		},
+	})
+}
+
+// todo: remove legacy
+func TestDnsProxyConfigLegacyCompatibility(t *testing.T) {
+	creator := func() Buildable {
+		return new(DNSOutboundConfig)
+	}
+
+	runMultiTestCase(t, []TestCase{
 		{
 			Input: `{
 				"blockTypes": []
@@ -120,7 +130,7 @@ func TestDnsProxyConfig(t *testing.T) {
 				Server: &net.Endpoint{},
 				Rule: []*dns.DNSRuleConfig{
 					{
-						Action: dns.RuleAction_Accept,
+						Action: dns.RuleAction_Hijack,
 						Qtype:  []int32{1, 28},
 					},
 					{
@@ -143,7 +153,7 @@ func TestDnsProxyConfig(t *testing.T) {
 						Qtype:  []int32{1, 65},
 					},
 					{
-						Action: dns.RuleAction_Accept,
+						Action: dns.RuleAction_Hijack,
 						Qtype:  []int32{1, 28},
 					},
 					{
@@ -167,11 +177,11 @@ func TestDnsProxyConfig(t *testing.T) {
 						Qtype:  []int32{1},
 					},
 					{
-						Action: dns.RuleAction_Accept,
+						Action: dns.RuleAction_Hijack,
 						Qtype:  []int32{1, 28},
 					},
 					{
-						Action: dns.RuleAction_Accept,
+						Action: dns.RuleAction_Drop,
 						Qtype:  allQTypes(),
 					},
 				},
@@ -191,7 +201,7 @@ func TestDnsProxyConfig(t *testing.T) {
 						Qtype:  []int32{65, 28},
 					},
 					{
-						Action: dns.RuleAction_Accept,
+						Action: dns.RuleAction_Hijack,
 						Qtype:  []int32{1, 28},
 					},
 					{
@@ -204,6 +214,7 @@ func TestDnsProxyConfig(t *testing.T) {
 	})
 }
 
+// todo: remove legacy
 func TestDnsProxyConfigRejectsMixedLegacyAndNewFields(t *testing.T) {
 	creator := func() Buildable {
 		return new(DNSOutboundConfig)

--- a/infra/conf/dns_proxy_test.go
+++ b/infra/conf/dns_proxy_test.go
@@ -34,7 +34,7 @@ func TestDnsProxyConfig(t *testing.T) {
 		{
 			Input: `{
 				"rules": [{
-					"action": "accept",
+					"action": "direct",
 					"qtype": "1,3,23-24"
 				}, {
 					"action": "drop",
@@ -47,7 +47,7 @@ func TestDnsProxyConfig(t *testing.T) {
 				Server: &net.Endpoint{},
 				Rule: []*dns.DNSRuleConfig{
 					{
-						Action: dns.RuleAction_Accept,
+						Action: dns.RuleAction_Direct,
 						Qtype:  []int32{1, 3, 23, 24},
 					},
 					{
@@ -78,7 +78,7 @@ func TestDnsProxyConfig(t *testing.T) {
 		{
 			Input: `{
 				"rules": [{
-					"action": "refuse",
+					"action": "reject",
 					"domain": "keyword:example"
 				}]
 			}`,
@@ -87,7 +87,7 @@ func TestDnsProxyConfig(t *testing.T) {
 				Server: &net.Endpoint{},
 				Rule: []*dns.DNSRuleConfig{
 					{
-						Action: dns.RuleAction_Refuse,
+						Action: dns.RuleAction_Reject,
 						Domain: []*geodata.DomainRule{
 							{
 								Value: &geodata.DomainRule_Custom{
@@ -143,7 +143,7 @@ func TestDnsProxyConfigLegacyCompatibility(t *testing.T) {
 						Qtype:  []int32{1, 28},
 					},
 					{
-						Action: dns.RuleAction_Refuse,
+						Action: dns.RuleAction_Reject,
 					},
 				},
 			},
@@ -157,7 +157,7 @@ func TestDnsProxyConfigLegacyCompatibility(t *testing.T) {
 				Server: &net.Endpoint{},
 				Rule: []*dns.DNSRuleConfig{
 					{
-						Action: dns.RuleAction_Refuse,
+						Action: dns.RuleAction_Reject,
 						Qtype:  []int32{1, 65},
 					},
 					{
@@ -165,7 +165,7 @@ func TestDnsProxyConfigLegacyCompatibility(t *testing.T) {
 						Qtype:  []int32{1, 28},
 					},
 					{
-						Action: dns.RuleAction_Refuse,
+						Action: dns.RuleAction_Reject,
 					},
 				},
 			},
@@ -211,7 +211,7 @@ func TestDnsProxyConfigLegacyCompatibility(t *testing.T) {
 						Qtype:  []int32{1, 28},
 					},
 					{
-						Action: dns.RuleAction_Accept,
+						Action: dns.RuleAction_Direct,
 					},
 				},
 			},
@@ -227,7 +227,7 @@ func TestDnsProxyConfigRejectsMixedLegacyAndNewFields(t *testing.T) {
 
 	_, err := loadJSON(creator)(`{
 		"rules": [{
-			"action": "accept",
+			"action": "direct",
 			"qtype": 65
 		}],
 		"blockTypes": [65]

--- a/infra/conf/dns_proxy_test.go
+++ b/infra/conf/dns_proxy_test.go
@@ -10,6 +10,14 @@ import (
 	"github.com/xtls/xray-core/proxy/dns"
 )
 
+func allQTypes() []int32 {
+	out := make([]int32, 256)
+	for i := 0; i < 256; i++ {
+		out[i] = int32(i)
+	}
+	return out
+}
+
 func TestDnsProxyConfig(t *testing.T) {
 	creator := func() Buildable {
 		return new(DNSOutboundConfig)
@@ -29,39 +37,30 @@ func TestDnsProxyConfig(t *testing.T) {
 					Address: net.NewIPOrDomain(net.IPAddress([]byte{8, 8, 8, 8})),
 					Port:    53,
 				},
-				BlockMatched:  true,
-				RejectBlocked: true,
 			},
 		},
 		{
 			Input: `{
-				"blockMethod": "drop"
+				"rules": [{
+					"action": "accept",
+					"qtype": "1,3,23-24"
+				}, {
+					"action": "drop",
+					"qtype": 28,
+					"domain": ["domain:example.com", "full:example.com"]
+				}]
 			}`,
 			Parser: loadJSON(creator),
 			Output: &dns.Config{
-				Server:       &net.Endpoint{},
-				BlockMatched: true,
-			},
-		},
-		{
-			Input: `{
-				"blacklist": {
-					"1,3,23-24": null,
-					"28": ["domain:example.com", "full:example.com"]
-				}
-			}`,
-			Parser: loadJSON(creator),
-			Output: &dns.Config{
-				Server:        &net.Endpoint{},
-				BlockMatched:  true,
-				RejectBlocked: true,
-				QueryRule: []*dns.Config_QueryRule{
-					{Qtype: 1},
-					{Qtype: 3},
-					{Qtype: 23},
-					{Qtype: 24},
+				Server: &net.Endpoint{},
+				Rule: []*dns.DNSRuleConfig{
 					{
-						Qtype: 28,
+						Action: dns.RuleAction_Accept,
+						Qtype:  []int32{1, 3, 23, 24},
+					},
+					{
+						Action: dns.RuleAction_Drop,
+						Qtype:  []int32{28},
 						Domain: []*geodata.DomainRule{
 							{
 								Value: &geodata.DomainRule_Custom{
@@ -86,22 +85,18 @@ func TestDnsProxyConfig(t *testing.T) {
 		},
 		{
 			Input: `{
-				"whitelist": {
-					"1,3,23-24": null,
-					"28": "keyword:example"
-				}
+				"rules": [{
+					"action": "refuse",
+					"domain": "keyword:example"
+				}]
 			}`,
 			Parser: loadJSON(creator),
 			Output: &dns.Config{
-				Server:        &net.Endpoint{},
-				RejectBlocked: true,
-				QueryRule: []*dns.Config_QueryRule{
-					{Qtype: 1},
-					{Qtype: 3},
-					{Qtype: 23},
-					{Qtype: 24},
+				Server: &net.Endpoint{},
+				Rule: []*dns.DNSRuleConfig{
 					{
-						Qtype: 28,
+						Action: dns.RuleAction_Refuse,
+						Qtype:  allQTypes(),
 						Domain: []*geodata.DomainRule{
 							{
 								Value: &geodata.DomainRule_Custom{
@@ -118,39 +113,43 @@ func TestDnsProxyConfig(t *testing.T) {
 		},
 		{
 			Input: `{
-				"blockMethod": "drop",
-				"whitelist": {}
-			}`,
-			Parser: loadJSON(creator),
-			Output: &dns.Config{
-				Server: &net.Endpoint{},
-			},
-		},
-		{
-			Input: `{
-				"nonIPQuery": "drop",
 				"blockTypes": []
 			}`,
 			Parser: loadJSON(creator),
 			Output: &dns.Config{
 				Server: &net.Endpoint{},
-				QueryRule: []*dns.Config_QueryRule{
-					{Qtype: 1},
-					{Qtype: 28},
+				Rule: []*dns.DNSRuleConfig{
+					{
+						Action: dns.RuleAction_Accept,
+						Qtype:  []int32{1, 28},
+					},
+					{
+						Action: dns.RuleAction_Refuse,
+						Qtype:  allQTypes(),
+					},
 				},
 			},
 		},
 		{
 			Input: `{
-				"blockTypes": []
+				"blockTypes": [1, 65]
 			}`,
 			Parser: loadJSON(creator),
 			Output: &dns.Config{
-				Server:        &net.Endpoint{},
-				RejectBlocked: true,
-				QueryRule: []*dns.Config_QueryRule{
-					{Qtype: 1},
-					{Qtype: 28},
+				Server: &net.Endpoint{},
+				Rule: []*dns.DNSRuleConfig{
+					{
+						Action: dns.RuleAction_Refuse,
+						Qtype:  []int32{1, 65},
+					},
+					{
+						Action: dns.RuleAction_Accept,
+						Qtype:  []int32{1, 28},
+					},
+					{
+						Action: dns.RuleAction_Refuse,
+						Qtype:  allQTypes(),
+					},
 				},
 			},
 		},
@@ -162,8 +161,19 @@ func TestDnsProxyConfig(t *testing.T) {
 			Parser: loadJSON(creator),
 			Output: &dns.Config{
 				Server: &net.Endpoint{},
-				QueryRule: []*dns.Config_QueryRule{
-					{Qtype: 28},
+				Rule: []*dns.DNSRuleConfig{
+					{
+						Action: dns.RuleAction_Drop,
+						Qtype:  []int32{1},
+					},
+					{
+						Action: dns.RuleAction_Accept,
+						Qtype:  []int32{1, 28},
+					},
+					{
+						Action: dns.RuleAction_Accept,
+						Qtype:  allQTypes(),
+					},
 				},
 			},
 		},
@@ -174,29 +184,24 @@ func TestDnsProxyConfig(t *testing.T) {
 			}`,
 			Parser: loadJSON(creator),
 			Output: &dns.Config{
-				Server:       &net.Endpoint{},
-				BlockMatched: true,
-				QueryRule: []*dns.Config_QueryRule{
-					{Qtype: 28},
-					{Qtype: 65},
+				Server: &net.Endpoint{},
+				Rule: []*dns.DNSRuleConfig{
+					{
+						Action: dns.RuleAction_Drop,
+						Qtype:  []int32{65, 28},
+					},
+					{
+						Action: dns.RuleAction_Accept,
+						Qtype:  []int32{1, 28},
+					},
+					{
+						Action: dns.RuleAction_Accept,
+						Qtype:  allQTypes(),
+					},
 				},
 			},
 		},
 	})
-}
-
-func TestDnsProxyConfigRejectsMixedLists(t *testing.T) {
-	creator := func() Buildable {
-		return new(DNSOutboundConfig)
-	}
-
-	_, err := loadJSON(creator)(`{
-		"blacklist": {"1": null},
-		"whitelist": {"28": null}
-	}`)
-	if err == nil || !strings.Contains(err.Error(), `"blacklist" and "whitelist" are mutually exclusive`) {
-		t.Fatal("expected mixed list error, but got ", err)
-	}
 }
 
 func TestDnsProxyConfigRejectsMixedLegacyAndNewFields(t *testing.T) {
@@ -205,10 +210,13 @@ func TestDnsProxyConfigRejectsMixedLegacyAndNewFields(t *testing.T) {
 	}
 
 	_, err := loadJSON(creator)(`{
-		"blockMethod": "reject",
+		"rules": [{
+			"action": "accept",
+			"qtype": 65
+		}],
 		"blockTypes": [65]
 	}`)
-	if err == nil || !strings.Contains(err.Error(), `legacy "nonIPQuery" and "blockTypes" cannot be mixed`) {
+	if err == nil || !strings.Contains(err.Error(), `legacy nonIPQuery and blockTypes cannot be mixed with rules`) {
 		t.Fatal("expected mixed legacy/new config error, but got ", err)
 	}
 }

--- a/proxy/dns/config.pb.go
+++ b/proxy/dns/config.pb.go
@@ -23,22 +23,130 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type RuleAction int32
+
+const (
+	RuleAction_Accept RuleAction = 0
+	RuleAction_Drop   RuleAction = 1
+	RuleAction_Refuse RuleAction = 2
+	RuleAction_Hijack RuleAction = 3
+)
+
+// Enum value maps for RuleAction.
+var (
+	RuleAction_name = map[int32]string{
+		0: "Accept",
+		1: "Drop",
+		2: "Refuse",
+		3: "Hijack",
+	}
+	RuleAction_value = map[string]int32{
+		"Accept": 0,
+		"Drop":   1,
+		"Refuse": 2,
+		"Hijack": 3,
+	}
+)
+
+func (x RuleAction) Enum() *RuleAction {
+	p := new(RuleAction)
+	*p = x
+	return p
+}
+
+func (x RuleAction) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (RuleAction) Descriptor() protoreflect.EnumDescriptor {
+	return file_proxy_dns_config_proto_enumTypes[0].Descriptor()
+}
+
+func (RuleAction) Type() protoreflect.EnumType {
+	return &file_proxy_dns_config_proto_enumTypes[0]
+}
+
+func (x RuleAction) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use RuleAction.Descriptor instead.
+func (RuleAction) EnumDescriptor() ([]byte, []int) {
+	return file_proxy_dns_config_proto_rawDescGZIP(), []int{0}
+}
+
+type DNSRuleConfig struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Action        RuleAction             `protobuf:"varint,1,opt,name=action,proto3,enum=xray.proxy.dns.RuleAction" json:"action,omitempty"`
+	Qtype         []int32                `protobuf:"varint,2,rep,packed,name=qtype,proto3" json:"qtype,omitempty"`
+	Domain        []*geodata.DomainRule  `protobuf:"bytes,3,rep,name=domain,proto3" json:"domain,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DNSRuleConfig) Reset() {
+	*x = DNSRuleConfig{}
+	mi := &file_proxy_dns_config_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DNSRuleConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DNSRuleConfig) ProtoMessage() {}
+
+func (x *DNSRuleConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_proxy_dns_config_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DNSRuleConfig.ProtoReflect.Descriptor instead.
+func (*DNSRuleConfig) Descriptor() ([]byte, []int) {
+	return file_proxy_dns_config_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *DNSRuleConfig) GetAction() RuleAction {
+	if x != nil {
+		return x.Action
+	}
+	return RuleAction_Accept
+}
+
+func (x *DNSRuleConfig) GetQtype() []int32 {
+	if x != nil {
+		return x.Qtype
+	}
+	return nil
+}
+
+func (x *DNSRuleConfig) GetDomain() []*geodata.DomainRule {
+	if x != nil {
+		return x.Domain
+	}
+	return nil
+}
+
 type Config struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Server is the DNS server address. If specified, this address overrides the
-	// original one.
-	Server        *net.Endpoint       `protobuf:"bytes,1,opt,name=server,proto3" json:"server,omitempty"`
-	UserLevel     uint32              `protobuf:"varint,2,opt,name=user_level,json=userLevel,proto3" json:"user_level,omitempty"`
-	BlockMatched  bool                `protobuf:"varint,3,opt,name=block_matched,json=blockMatched,proto3" json:"block_matched,omitempty"`
-	RejectBlocked bool                `protobuf:"varint,4,opt,name=reject_blocked,json=rejectBlocked,proto3" json:"reject_blocked,omitempty"`
-	QueryRule     []*Config_QueryRule `protobuf:"bytes,5,rep,name=query_rule,json=queryRule,proto3" json:"query_rule,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserLevel     uint32                 `protobuf:"varint,1,opt,name=user_level,json=userLevel,proto3" json:"user_level,omitempty"`
+	Rule          []*DNSRuleConfig       `protobuf:"bytes,2,rep,name=rule,proto3" json:"rule,omitempty"`
+	Server        *net.Endpoint          `protobuf:"bytes,3,opt,name=server,proto3" json:"server,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Config) Reset() {
 	*x = Config{}
-	mi := &file_proxy_dns_config_proto_msgTypes[0]
+	mi := &file_proxy_dns_config_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -50,7 +158,7 @@ func (x *Config) String() string {
 func (*Config) ProtoMessage() {}
 
 func (x *Config) ProtoReflect() protoreflect.Message {
-	mi := &file_proxy_dns_config_proto_msgTypes[0]
+	mi := &file_proxy_dns_config_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -63,14 +171,7 @@ func (x *Config) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Config.ProtoReflect.Descriptor instead.
 func (*Config) Descriptor() ([]byte, []int) {
-	return file_proxy_dns_config_proto_rawDescGZIP(), []int{0}
-}
-
-func (x *Config) GetServer() *net.Endpoint {
-	if x != nil {
-		return x.Server
-	}
-	return nil
+	return file_proxy_dns_config_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *Config) GetUserLevel() uint32 {
@@ -80,75 +181,16 @@ func (x *Config) GetUserLevel() uint32 {
 	return 0
 }
 
-func (x *Config) GetBlockMatched() bool {
+func (x *Config) GetRule() []*DNSRuleConfig {
 	if x != nil {
-		return x.BlockMatched
-	}
-	return false
-}
-
-func (x *Config) GetRejectBlocked() bool {
-	if x != nil {
-		return x.RejectBlocked
-	}
-	return false
-}
-
-func (x *Config) GetQueryRule() []*Config_QueryRule {
-	if x != nil {
-		return x.QueryRule
+		return x.Rule
 	}
 	return nil
 }
 
-type Config_QueryRule struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Qtype         int32                  `protobuf:"varint,1,opt,name=qtype,proto3" json:"qtype,omitempty"`
-	Domain        []*geodata.DomainRule  `protobuf:"bytes,2,rep,name=domain,proto3" json:"domain,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *Config_QueryRule) Reset() {
-	*x = Config_QueryRule{}
-	mi := &file_proxy_dns_config_proto_msgTypes[1]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *Config_QueryRule) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*Config_QueryRule) ProtoMessage() {}
-
-func (x *Config_QueryRule) ProtoReflect() protoreflect.Message {
-	mi := &file_proxy_dns_config_proto_msgTypes[1]
+func (x *Config) GetServer() *net.Endpoint {
 	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use Config_QueryRule.ProtoReflect.Descriptor instead.
-func (*Config_QueryRule) Descriptor() ([]byte, []int) {
-	return file_proxy_dns_config_proto_rawDescGZIP(), []int{0, 0}
-}
-
-func (x *Config_QueryRule) GetQtype() int32 {
-	if x != nil {
-		return x.Qtype
-	}
-	return 0
-}
-
-func (x *Config_QueryRule) GetDomain() []*geodata.DomainRule {
-	if x != nil {
-		return x.Domain
+		return x.Server
 	}
 	return nil
 }
@@ -157,18 +199,25 @@ var File_proxy_dns_config_proto protoreflect.FileDescriptor
 
 const file_proxy_dns_config_proto_rawDesc = "" +
 	"\n" +
-	"\x16proxy/dns/config.proto\x12\x0exray.proxy.dns\x1a\x1ccommon/net/destination.proto\x1a\x1bcommon/geodata/geodat.proto\"\xc3\x02\n" +
-	"\x06Config\x121\n" +
-	"\x06server\x18\x01 \x01(\v2\x19.xray.common.net.EndpointR\x06server\x12\x1d\n" +
+	"\x16proxy/dns/config.proto\x12\x0exray.proxy.dns\x1a\x1ccommon/net/destination.proto\x1a\x1bcommon/geodata/geodat.proto\"\x92\x01\n" +
+	"\rDNSRuleConfig\x122\n" +
+	"\x06action\x18\x01 \x01(\x0e2\x1a.xray.proxy.dns.RuleActionR\x06action\x12\x14\n" +
+	"\x05qtype\x18\x02 \x03(\x05R\x05qtype\x127\n" +
+	"\x06domain\x18\x03 \x03(\v2\x1f.xray.common.geodata.DomainRuleR\x06domain\"\x8d\x01\n" +
+	"\x06Config\x12\x1d\n" +
 	"\n" +
-	"user_level\x18\x02 \x01(\rR\tuserLevel\x12#\n" +
-	"\rblock_matched\x18\x03 \x01(\bR\fblockMatched\x12%\n" +
-	"\x0ereject_blocked\x18\x04 \x01(\bR\rrejectBlocked\x12?\n" +
+	"user_level\x18\x01 \x01(\rR\tuserLevel\x121\n" +
+	"\x04rule\x18\x02 \x03(\v2\x1d.xray.proxy.dns.DNSRuleConfigR\x04rule\x121\n" +
+	"\x06server\x18\x03 \x01(\v2\x19.xray.common.net.EndpointR\x06server*:\n" +
 	"\n" +
-	"query_rule\x18\x05 \x03(\v2 .xray.proxy.dns.Config.QueryRuleR\tqueryRule\x1aZ\n" +
-	"\tQueryRule\x12\x14\n" +
-	"\x05qtype\x18\x01 \x01(\x05R\x05qtype\x127\n" +
-	"\x06domain\x18\x02 \x03(\v2\x1f.xray.common.geodata.DomainRuleR\x06domainBL\n" +
+	"RuleAction\x12\n" +
+	"\n" +
+	"\x06Accept\x10\x00\x12\b\n" +
+	"\x04Drop\x10\x01\x12\n" +
+	"\n" +
+	"\x06Refuse\x10\x02\x12\n" +
+	"\n" +
+	"\x06Hijack\x10\x03BL\n" +
 	"\x12com.xray.proxy.dnsP\x01Z#github.com/xtls/xray-core/proxy/dns\xaa\x02\x0eXray.Proxy.Dnsb\x06proto3"
 
 var (
@@ -183,22 +232,25 @@ func file_proxy_dns_config_proto_rawDescGZIP() []byte {
 	return file_proxy_dns_config_proto_rawDescData
 }
 
+var file_proxy_dns_config_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_proxy_dns_config_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_proxy_dns_config_proto_goTypes = []any{
-	(*Config)(nil),             // 0: xray.proxy.dns.Config
-	(*Config_QueryRule)(nil),   // 1: xray.proxy.dns.Config.QueryRule
-	(*net.Endpoint)(nil),       // 2: xray.common.net.Endpoint
+	(RuleAction)(0),            // 0: xray.proxy.dns.RuleAction
+	(*DNSRuleConfig)(nil),      // 1: xray.proxy.dns.DNSRuleConfig
+	(*Config)(nil),             // 2: xray.proxy.dns.Config
 	(*geodata.DomainRule)(nil), // 3: xray.common.geodata.DomainRule
+	(*net.Endpoint)(nil),       // 4: xray.common.net.Endpoint
 }
 var file_proxy_dns_config_proto_depIdxs = []int32{
-	2, // 0: xray.proxy.dns.Config.server:type_name -> xray.common.net.Endpoint
-	1, // 1: xray.proxy.dns.Config.query_rule:type_name -> xray.proxy.dns.Config.QueryRule
-	3, // 2: xray.proxy.dns.Config.QueryRule.domain:type_name -> xray.common.geodata.DomainRule
-	3, // [3:3] is the sub-list for method output_type
-	3, // [3:3] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	0, // 0: xray.proxy.dns.DNSRuleConfig.action:type_name -> xray.proxy.dns.RuleAction
+	3, // 1: xray.proxy.dns.DNSRuleConfig.domain:type_name -> xray.common.geodata.DomainRule
+	1, // 2: xray.proxy.dns.Config.rule:type_name -> xray.proxy.dns.DNSRuleConfig
+	4, // 3: xray.proxy.dns.Config.server:type_name -> xray.common.net.Endpoint
+	4, // [4:4] is the sub-list for method output_type
+	4, // [4:4] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_proxy_dns_config_proto_init() }
@@ -211,13 +263,14 @@ func file_proxy_dns_config_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proxy_dns_config_proto_rawDesc), len(file_proxy_dns_config_proto_rawDesc)),
-			NumEnums:      0,
+			NumEnums:      1,
 			NumMessages:   2,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_proxy_dns_config_proto_goTypes,
 		DependencyIndexes: file_proxy_dns_config_proto_depIdxs,
+		EnumInfos:         file_proxy_dns_config_proto_enumTypes,
 		MessageInfos:      file_proxy_dns_config_proto_msgTypes,
 	}.Build()
 	File_proxy_dns_config_proto = out.File

--- a/proxy/dns/config.pb.go
+++ b/proxy/dns/config.pb.go
@@ -26,24 +26,24 @@ const (
 type RuleAction int32
 
 const (
-	RuleAction_Accept RuleAction = 0
+	RuleAction_Direct RuleAction = 0
 	RuleAction_Drop   RuleAction = 1
-	RuleAction_Refuse RuleAction = 2
+	RuleAction_Reject RuleAction = 2
 	RuleAction_Hijack RuleAction = 3
 )
 
 // Enum value maps for RuleAction.
 var (
 	RuleAction_name = map[int32]string{
-		0: "Accept",
+		0: "Direct",
 		1: "Drop",
-		2: "Refuse",
+		2: "Reject",
 		3: "Hijack",
 	}
 	RuleAction_value = map[string]int32{
-		"Accept": 0,
+		"Direct": 0,
 		"Drop":   1,
-		"Refuse": 2,
+		"Reject": 2,
 		"Hijack": 3,
 	}
 )
@@ -118,7 +118,7 @@ func (x *DNSRuleConfig) GetAction() RuleAction {
 	if x != nil {
 		return x.Action
 	}
-	return RuleAction_Accept
+	return RuleAction_Direct
 }
 
 func (x *DNSRuleConfig) GetQtype() []int32 {
@@ -212,10 +212,10 @@ const file_proxy_dns_config_proto_rawDesc = "" +
 	"\n" +
 	"RuleAction\x12\n" +
 	"\n" +
-	"\x06Accept\x10\x00\x12\b\n" +
+	"\x06Direct\x10\x00\x12\b\n" +
 	"\x04Drop\x10\x01\x12\n" +
 	"\n" +
-	"\x06Refuse\x10\x02\x12\n" +
+	"\x06Reject\x10\x02\x12\n" +
 	"\n" +
 	"\x06Hijack\x10\x03BL\n" +
 	"\x12com.xray.proxy.dnsP\x01Z#github.com/xtls/xray-core/proxy/dns\xaa\x02\x0eXray.Proxy.Dnsb\x06proto3"

--- a/proxy/dns/config.pb.go
+++ b/proxy/dns/config.pb.go
@@ -7,6 +7,7 @@
 package dns
 
 import (
+	geodata "github.com/xtls/xray-core/common/geodata"
 	net "github.com/xtls/xray-core/common/net"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -26,10 +27,11 @@ type Config struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Server is the DNS server address. If specified, this address overrides the
 	// original one.
-	Server        *net.Endpoint `protobuf:"bytes,1,opt,name=server,proto3" json:"server,omitempty"`
-	UserLevel     uint32        `protobuf:"varint,2,opt,name=user_level,json=userLevel,proto3" json:"user_level,omitempty"`
-	Non_IPQuery   string        `protobuf:"bytes,3,opt,name=non_IP_query,json=nonIPQuery,proto3" json:"non_IP_query,omitempty"`
-	BlockTypes    []int32       `protobuf:"varint,4,rep,packed,name=block_types,json=blockTypes,proto3" json:"block_types,omitempty"`
+	Server        *net.Endpoint       `protobuf:"bytes,1,opt,name=server,proto3" json:"server,omitempty"`
+	UserLevel     uint32              `protobuf:"varint,2,opt,name=user_level,json=userLevel,proto3" json:"user_level,omitempty"`
+	BlockMatched  bool                `protobuf:"varint,3,opt,name=block_matched,json=blockMatched,proto3" json:"block_matched,omitempty"`
+	RejectBlocked bool                `protobuf:"varint,4,opt,name=reject_blocked,json=rejectBlocked,proto3" json:"reject_blocked,omitempty"`
+	QueryRule     []*Config_QueryRule `protobuf:"bytes,5,rep,name=query_rule,json=queryRule,proto3" json:"query_rule,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -78,16 +80,75 @@ func (x *Config) GetUserLevel() uint32 {
 	return 0
 }
 
-func (x *Config) GetNon_IPQuery() string {
+func (x *Config) GetBlockMatched() bool {
 	if x != nil {
-		return x.Non_IPQuery
+		return x.BlockMatched
 	}
-	return ""
+	return false
 }
 
-func (x *Config) GetBlockTypes() []int32 {
+func (x *Config) GetRejectBlocked() bool {
 	if x != nil {
-		return x.BlockTypes
+		return x.RejectBlocked
+	}
+	return false
+}
+
+func (x *Config) GetQueryRule() []*Config_QueryRule {
+	if x != nil {
+		return x.QueryRule
+	}
+	return nil
+}
+
+type Config_QueryRule struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Qtype         int32                  `protobuf:"varint,1,opt,name=qtype,proto3" json:"qtype,omitempty"`
+	Domain        []*geodata.DomainRule  `protobuf:"bytes,2,rep,name=domain,proto3" json:"domain,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Config_QueryRule) Reset() {
+	*x = Config_QueryRule{}
+	mi := &file_proxy_dns_config_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Config_QueryRule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Config_QueryRule) ProtoMessage() {}
+
+func (x *Config_QueryRule) ProtoReflect() protoreflect.Message {
+	mi := &file_proxy_dns_config_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Config_QueryRule.ProtoReflect.Descriptor instead.
+func (*Config_QueryRule) Descriptor() ([]byte, []int) {
+	return file_proxy_dns_config_proto_rawDescGZIP(), []int{0, 0}
+}
+
+func (x *Config_QueryRule) GetQtype() int32 {
+	if x != nil {
+		return x.Qtype
+	}
+	return 0
+}
+
+func (x *Config_QueryRule) GetDomain() []*geodata.DomainRule {
+	if x != nil {
+		return x.Domain
 	}
 	return nil
 }
@@ -96,15 +157,18 @@ var File_proxy_dns_config_proto protoreflect.FileDescriptor
 
 const file_proxy_dns_config_proto_rawDesc = "" +
 	"\n" +
-	"\x16proxy/dns/config.proto\x12\x0exray.proxy.dns\x1a\x1ccommon/net/destination.proto\"\x9d\x01\n" +
+	"\x16proxy/dns/config.proto\x12\x0exray.proxy.dns\x1a\x1ccommon/net/destination.proto\x1a\x1bcommon/geodata/geodat.proto\"\xc3\x02\n" +
 	"\x06Config\x121\n" +
 	"\x06server\x18\x01 \x01(\v2\x19.xray.common.net.EndpointR\x06server\x12\x1d\n" +
 	"\n" +
-	"user_level\x18\x02 \x01(\rR\tuserLevel\x12 \n" +
-	"\fnon_IP_query\x18\x03 \x01(\tR\n" +
-	"nonIPQuery\x12\x1f\n" +
-	"\vblock_types\x18\x04 \x03(\x05R\n" +
-	"blockTypesBL\n" +
+	"user_level\x18\x02 \x01(\rR\tuserLevel\x12#\n" +
+	"\rblock_matched\x18\x03 \x01(\bR\fblockMatched\x12%\n" +
+	"\x0ereject_blocked\x18\x04 \x01(\bR\rrejectBlocked\x12?\n" +
+	"\n" +
+	"query_rule\x18\x05 \x03(\v2 .xray.proxy.dns.Config.QueryRuleR\tqueryRule\x1aZ\n" +
+	"\tQueryRule\x12\x14\n" +
+	"\x05qtype\x18\x01 \x01(\x05R\x05qtype\x127\n" +
+	"\x06domain\x18\x02 \x03(\v2\x1f.xray.common.geodata.DomainRuleR\x06domainBL\n" +
 	"\x12com.xray.proxy.dnsP\x01Z#github.com/xtls/xray-core/proxy/dns\xaa\x02\x0eXray.Proxy.Dnsb\x06proto3"
 
 var (
@@ -119,18 +183,22 @@ func file_proxy_dns_config_proto_rawDescGZIP() []byte {
 	return file_proxy_dns_config_proto_rawDescData
 }
 
-var file_proxy_dns_config_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_proxy_dns_config_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_proxy_dns_config_proto_goTypes = []any{
-	(*Config)(nil),       // 0: xray.proxy.dns.Config
-	(*net.Endpoint)(nil), // 1: xray.common.net.Endpoint
+	(*Config)(nil),             // 0: xray.proxy.dns.Config
+	(*Config_QueryRule)(nil),   // 1: xray.proxy.dns.Config.QueryRule
+	(*net.Endpoint)(nil),       // 2: xray.common.net.Endpoint
+	(*geodata.DomainRule)(nil), // 3: xray.common.geodata.DomainRule
 }
 var file_proxy_dns_config_proto_depIdxs = []int32{
-	1, // 0: xray.proxy.dns.Config.server:type_name -> xray.common.net.Endpoint
-	1, // [1:1] is the sub-list for method output_type
-	1, // [1:1] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	2, // 0: xray.proxy.dns.Config.server:type_name -> xray.common.net.Endpoint
+	1, // 1: xray.proxy.dns.Config.query_rule:type_name -> xray.proxy.dns.Config.QueryRule
+	3, // 2: xray.proxy.dns.Config.QueryRule.domain:type_name -> xray.common.geodata.DomainRule
+	3, // [3:3] is the sub-list for method output_type
+	3, // [3:3] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_proxy_dns_config_proto_init() }
@@ -144,7 +212,7 @@ func file_proxy_dns_config_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proxy_dns_config_proto_rawDesc), len(file_proxy_dns_config_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   1,
+			NumMessages:   2,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proxy/dns/config.proto
+++ b/proxy/dns/config.proto
@@ -7,12 +7,22 @@ option java_package = "com.xray.proxy.dns";
 option java_multiple_files = true;
 
 import "common/net/destination.proto";
+import "common/geodata/geodat.proto";
 
 message Config {
   // Server is the DNS server address. If specified, this address overrides the
   // original one.
   xray.common.net.Endpoint server = 1;
+
   uint32 user_level = 2;
-  string non_IP_query = 3;
-  repeated int32 block_types = 4;
+
+  bool block_matched = 3;
+
+  bool reject_blocked = 4;
+
+  message QueryRule {
+    int32 qtype = 1;
+    repeated xray.common.geodata.DomainRule domain = 2;
+  }
+  repeated QueryRule query_rule = 5;
 }

--- a/proxy/dns/config.proto
+++ b/proxy/dns/config.proto
@@ -10,9 +10,9 @@ import "common/net/destination.proto";
 import "common/geodata/geodat.proto";
 
 enum RuleAction {
-  Accept = 0;
+  Direct = 0;
   Drop = 1;
-  Refuse = 2;
+  Reject = 2;
   Hijack = 3;
 }
 

--- a/proxy/dns/config.proto
+++ b/proxy/dns/config.proto
@@ -9,20 +9,21 @@ option java_multiple_files = true;
 import "common/net/destination.proto";
 import "common/geodata/geodat.proto";
 
+enum RuleAction {
+  Accept = 0;
+  Drop = 1;
+  Refuse = 2;
+  Hijack = 3;
+}
+
+message DNSRuleConfig {
+  RuleAction action = 1;
+  repeated int32 qtype = 2;
+  repeated xray.common.geodata.DomainRule domain = 3;
+}
+
 message Config {
-  // Server is the DNS server address. If specified, this address overrides the
-  // original one.
-  xray.common.net.Endpoint server = 1;
-
-  uint32 user_level = 2;
-
-  bool block_matched = 3;
-
-  bool reject_blocked = 4;
-
-  message QueryRule {
-    int32 qtype = 1;
-    repeated xray.common.geodata.DomainRule domain = 2;
-  }
-  repeated QueryRule query_rule = 5;
+  uint32 user_level = 1;
+  repeated DNSRuleConfig rule = 2;
+  xray.common.net.Endpoint server = 3;
 }

--- a/proxy/dns/dns.go
+++ b/proxy/dns/dns.go
@@ -43,15 +43,26 @@ func init() {
 
 type DNSRule struct {
 	action  RuleAction
-	qTypes  [256]bool
+	qTypes  []uint16
 	domains geodata.DomainMatcher
 }
 
+func (r *DNSRule) matchQType(qType uint16) bool {
+	if len(r.qTypes) == 0 {
+		return true
+	}
+	for _, t := range r.qTypes {
+		if t == qType {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *DNSRule) Apply(qType uint16, domain string) bool {
-	if qType > 255 || !r.qTypes[qType] {
+	if !r.matchQType(qType) {
 		return false
 	}
-
 	return r.domains == nil || r.domains.MatchAny(strings.TrimSuffix(strings.ToLower(domain), "."))
 }
 
@@ -82,12 +93,12 @@ func (h *Handler) Init(config *Config, dnsClient dns.Client, policyManager polic
 
 	h.rules = make([]*DNSRule, 0, len(config.Rule))
 	for _, r := range config.Rule {
-		rule := &DNSRule{action: r.Action}
+		rule := &DNSRule{
+			action: r.Action,
+			qTypes: make([]uint16, 0, len(r.Qtype)),
+		}
 		for _, t := range r.Qtype {
-			if t < 0 || t > 255 {
-				return errors.New("invalid qtype: ", t)
-			}
-			rule.qTypes[t] = true
+			rule.qTypes = append(rule.qTypes, uint16(t))
 		}
 		if len(r.Domain) > 0 {
 			m, err := geodata.DomainReg.BuildDomainMatcher(r.Domain)

--- a/proxy/dns/dns.go
+++ b/proxy/dns/dns.go
@@ -146,7 +146,7 @@ func (h *Handler) applyRules(qType dnsmessage.Type, domain string) RuleAction {
 	if qType == dnsmessage.TypeA || qType == dnsmessage.TypeAAAA {
 		return RuleAction_Hijack
 	}
-	return RuleAction_Refuse
+	return RuleAction_Reject
 }
 
 // Process implements proxy.Outbound.
@@ -254,9 +254,9 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, d internet.
 			case RuleAction_Drop:
 				b.Release()
 				errors.LogInfo(ctx, "blocked type ", qType, " query for domain ", domain)
-			case RuleAction_Refuse:
+			case RuleAction_Reject:
 				b.Release()
-				errors.LogInfo(ctx, "refused type ", qType, " query for domain ", domain)
+				errors.LogInfo(ctx, "rejected type ", qType, " query for domain ", domain)
 				if err := h.rejectNonIPQuery(id, qType, domain, writer); err != nil {
 					return err
 				}
@@ -270,7 +270,7 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, d internet.
 				} else {
 					go h.handleIPQuery(id, qType, domain, writer, timer)
 				}
-			case RuleAction_Accept:
+			case RuleAction_Direct:
 				if err := connWriter.WriteMessage(b); err != nil {
 					return err
 				}

--- a/proxy/dns/dns.go
+++ b/proxy/dns/dns.go
@@ -41,6 +41,20 @@ func init() {
 	}))
 }
 
+type DNSRule struct {
+	action  RuleAction
+	qTypes  [256]bool
+	domains geodata.DomainMatcher
+}
+
+func (r *DNSRule) Apply(qType uint16, domain string) bool {
+	if qType > 255 || !r.qTypes[qType] {
+		return false
+	}
+
+	return r.domains == nil || r.domains.MatchAny(strings.TrimSuffix(strings.ToLower(domain), "."))
+}
+
 type ownLinkVerifier interface {
 	IsOwnLink(ctx context.Context) bool
 }
@@ -51,11 +65,7 @@ type Handler struct {
 	ownLinkVerifier ownLinkVerifier
 	server          net.Destination
 	timeout         time.Duration
-
-	blockMatched  bool
-	rejectBlocked bool
-	qTypes        [256]bool
-	qMatchers     [256]geodata.DomainMatcher
+	rules           []*DNSRule
 }
 
 func (h *Handler) Init(config *Config, dnsClient dns.Client, policyManager policy.Manager) error {
@@ -70,23 +80,23 @@ func (h *Handler) Init(config *Config, dnsClient dns.Client, policyManager polic
 		h.server = config.Server.AsDestination()
 	}
 
-	h.blockMatched = config.BlockMatched
-	h.rejectBlocked = config.RejectBlocked
-	for _, r := range config.QueryRule {
-		if r.Qtype < 0 || r.Qtype > 255 {
-			return errors.New("invalid qtype: ", r.Qtype)
+	h.rules = make([]*DNSRule, 0, len(config.Rule))
+	for _, r := range config.Rule {
+		rule := &DNSRule{action: r.Action}
+		for _, t := range r.Qtype {
+			if t < 0 || t > 255 {
+				return errors.New("invalid qtype: ", t)
+			}
+			rule.qTypes[t] = true
 		}
-		if h.qTypes[r.Qtype] {
-			return errors.New("illegal query rules; duplicate entries exist, qtype: ", r.Qtype)
-		}
-		h.qTypes[r.Qtype] = true
 		if len(r.Domain) > 0 {
 			m, err := geodata.DomainReg.BuildDomainMatcher(r.Domain)
 			if err != nil {
 				return err
 			}
-			h.qMatchers[r.Qtype] = m
+			rule.domains = m
 		}
+		h.rules = append(h.rules, rule)
 	}
 
 	return nil
@@ -94,19 +104,6 @@ func (h *Handler) Init(config *Config, dnsClient dns.Client, policyManager polic
 
 func (h *Handler) isOwnLink(ctx context.Context) bool {
 	return h.ownLinkVerifier != nil && h.ownLinkVerifier.IsOwnLink(ctx)
-}
-
-func (h *Handler) matchQuery(qType uint16, domain string) bool {
-	if qType > 255 {
-		return false
-	}
-
-	if !h.qTypes[qType] {
-		return false
-	}
-
-	m := h.qMatchers[qType]
-	return m == nil || m.MatchAny(strings.TrimSuffix(strings.ToLower(domain), "."))
 }
 
 func parseQuery(b []byte) (id uint16, qType dnsmessage.Type, domain string, ok bool) {
@@ -126,6 +123,19 @@ func parseQuery(b []byte) (id uint16, qType dnsmessage.Type, domain string, ok b
 	domain = q.Name.String()
 	ok = true
 	return
+}
+
+func (h *Handler) applyRules(qType dnsmessage.Type, domain string) RuleAction {
+	qCode := uint16(qType)
+	for _, r := range h.rules {
+		if r.Apply(qCode, domain) {
+			return r.action
+		}
+	}
+	if qType == dnsmessage.TypeA || qType == dnsmessage.TypeAAAA {
+		return RuleAction_Hijack
+	}
+	return RuleAction_Refuse
 }
 
 // Process implements proxy.Outbound.
@@ -210,37 +220,51 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, d internet.
 			if err == io.EOF {
 				return nil
 			}
-
 			if err != nil {
 				return err
 			}
 
 			timer.Update()
 
-			if !h.isOwnLink(ctx) {
-				id, qType, domain, ok := parseQuery(b.Bytes())
-				if !ok {
-					b.Release()
-					continue
+			if h.isOwnLink(ctx) {
+				if err := connWriter.WriteMessage(b); err != nil {
+					return err
 				}
-				if h.blockMatched == h.matchQuery(uint16(qType), domain) {
-					b.Release()
-					errors.LogInfo(ctx, "blocked type ", qType, " query for domain ", domain)
-					if h.rejectBlocked {
-						if err := h.rejectNonIPQuery(id, qType, domain, writer); err != nil {
-							return err
-						}
-					}
-					continue
-				}
-				if qType == dnsmessage.TypeA || qType == dnsmessage.TypeAAAA {
-					b.Release()
-					go h.handleIPQuery(id, qType, domain, writer, timer)
-					continue
-				}
+				continue
 			}
-			if err := connWriter.WriteMessage(b); err != nil {
-				return err
+
+			id, qType, domain, ok := parseQuery(b.Bytes())
+			if !ok {
+				b.Release()
+				continue
+			}
+
+			switch h.applyRules(qType, domain) {
+			case RuleAction_Drop:
+				b.Release()
+				errors.LogInfo(ctx, "blocked type ", qType, " query for domain ", domain)
+			case RuleAction_Refuse:
+				b.Release()
+				errors.LogInfo(ctx, "refused type ", qType, " query for domain ", domain)
+				if err := h.rejectNonIPQuery(id, qType, domain, writer); err != nil {
+					return err
+				}
+			case RuleAction_Hijack:
+				b.Release()
+				if qType != dnsmessage.TypeA && qType != dnsmessage.TypeAAAA {
+					errors.LogError(ctx, "can only hijack A/AAAA records")
+					if err := h.rejectNonIPQuery(id, qType, domain, writer); err != nil {
+						return err
+					}
+				} else {
+					go h.handleIPQuery(id, qType, domain, writer, timer)
+				}
+			case RuleAction_Accept:
+				if err := connWriter.WriteMessage(b); err != nil {
+					return err
+				}
+			default:
+				panic("unknown rule action")
 			}
 		}
 	}

--- a/proxy/dns/dns.go
+++ b/proxy/dns/dns.go
@@ -11,6 +11,7 @@ import (
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/buf"
 	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/common/geodata"
 	"github.com/xtls/xray-core/common/net"
 	dns_proto "github.com/xtls/xray-core/common/protocol/dns"
 	"github.com/xtls/xray-core/common/session"
@@ -50,8 +51,11 @@ type Handler struct {
 	ownLinkVerifier ownLinkVerifier
 	server          net.Destination
 	timeout         time.Duration
-	nonIPQuery      string
-	blockTypes      []int32
+
+	blockMatched  bool
+	rejectBlocked bool
+	qTypes        [256]bool
+	qMatchers     [256]geodata.DomainMatcher
 }
 
 func (h *Handler) Init(config *Config, dnsClient dns.Client, policyManager policy.Manager) error {
@@ -65,11 +69,26 @@ func (h *Handler) Init(config *Config, dnsClient dns.Client, policyManager polic
 	if config.Server != nil {
 		h.server = config.Server.AsDestination()
 	}
-	h.nonIPQuery = config.Non_IPQuery
-	if h.nonIPQuery == "" {
-		h.nonIPQuery = "reject"
+
+	h.blockMatched = config.BlockMatched
+	h.rejectBlocked = config.RejectBlocked
+	for _, r := range config.QueryRule {
+		if r.Qtype < 0 || r.Qtype > 255 {
+			return errors.New("invalid qtype: ", r.Qtype)
+		}
+		if h.qTypes[r.Qtype] {
+			return errors.New("illegal query rules; duplicate entries exist, qtype: ", r.Qtype)
+		}
+		h.qTypes[r.Qtype] = true
+		if len(r.Domain) > 0 {
+			m, err := geodata.DomainReg.BuildDomainMatcher(r.Domain)
+			if err != nil {
+				return err
+			}
+			h.qMatchers[r.Qtype] = m
+		}
 	}
-	h.blockTypes = config.BlockTypes
+
 	return nil
 }
 
@@ -77,27 +96,35 @@ func (h *Handler) isOwnLink(ctx context.Context) bool {
 	return h.ownLinkVerifier != nil && h.ownLinkVerifier.IsOwnLink(ctx)
 }
 
-func parseIPQuery(b []byte) (r bool, domain string, id uint16, qType dnsmessage.Type) {
+func (h *Handler) matchQuery(qType uint16, domain string) bool {
+	if qType > 255 {
+		return false
+	}
+
+	if !h.qTypes[qType] {
+		return false
+	}
+
+	m := h.qMatchers[qType]
+	return m == nil || m.MatchAny(strings.TrimSuffix(strings.ToLower(domain), "."))
+}
+
+func parseQuery(b []byte) (id uint16, qType dnsmessage.Type, domain string, ok bool) {
 	var parser dnsmessage.Parser
 	header, err := parser.Start(b)
 	if err != nil {
 		errors.LogInfoInner(context.Background(), err, "parser start")
 		return
 	}
-
 	id = header.ID
 	q, err := parser.Question()
 	if err != nil {
 		errors.LogInfoInner(context.Background(), err, "question")
 		return
 	}
-	domain = q.Name.String()
 	qType = q.Type
-	if qType != dnsmessage.TypeA && qType != dnsmessage.TypeAAAA {
-		return
-	}
-
-	r = true
+	domain = q.Name.String()
+	ok = true
 	return
 }
 
@@ -191,41 +218,27 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, d internet.
 			timer.Update()
 
 			if !h.isOwnLink(ctx) {
-				isIPQuery, domain, id, qType := parseIPQuery(b.Bytes())
-				if len(h.blockTypes) > 0 {
-					for _, blocktype := range h.blockTypes {
-						if blocktype == int32(qType) {
-							b.Release()
-							errors.LogInfo(ctx, "blocked type ", qType, " query for domain ", domain)
-							if h.nonIPQuery == "reject" {
-								err := h.rejectNonIPQuery(id, qType, domain, writer)
-								if err != nil {
-									return err
-								}
-							}
-							return nil
+				id, qType, domain, ok := parseQuery(b.Bytes())
+				if !ok {
+					b.Release()
+					continue
+				}
+				if h.blockMatched == h.matchQuery(uint16(qType), domain) {
+					b.Release()
+					errors.LogInfo(ctx, "blocked type ", qType, " query for domain ", domain)
+					if h.rejectBlocked {
+						if err := h.rejectNonIPQuery(id, qType, domain, writer); err != nil {
+							return err
 						}
 					}
+					continue
 				}
-				if isIPQuery {
+				if qType == dnsmessage.TypeA || qType == dnsmessage.TypeAAAA {
 					b.Release()
 					go h.handleIPQuery(id, qType, domain, writer, timer)
 					continue
 				}
-				if h.nonIPQuery == "drop" {
-					b.Release()
-					continue
-				}
-				if h.nonIPQuery == "reject" {
-					b.Release()
-					err := h.rejectNonIPQuery(id, qType, domain, writer)
-					if err != nil {
-						return err
-					}
-					continue
-				}
 			}
-
 			if err := connWriter.WriteMessage(b); err != nil {
 				return err
 			}

--- a/proxy/dns/dns_test.go
+++ b/proxy/dns/dns_test.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/xtls/xray-core/app/proxyman/inbound"
 	_ "github.com/xtls/xray-core/app/proxyman/outbound"
 	"github.com/xtls/xray-core/common"
+	"github.com/xtls/xray-core/common/geodata"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/serial"
 	"github.com/xtls/xray-core/core"
@@ -125,7 +126,7 @@ func TestUDPDNSTunnel(t *testing.T) {
 		},
 		Outbound: []*core.OutboundHandlerConfig{
 			{
-				ProxySettings: serial.ToTypedMessage(&dns_proxy.Config{}),
+				ProxySettings: serial.ToTypedMessage(&dns_proxy.Config{BlockMatched: true}),
 			},
 		},
 	}
@@ -244,7 +245,7 @@ func TestTCPDNSTunnel(t *testing.T) {
 		},
 		Outbound: []*core.OutboundHandlerConfig{
 			{
-				ProxySettings: serial.ToTypedMessage(&dns_proxy.Config{}),
+				ProxySettings: serial.ToTypedMessage(&dns_proxy.Config{BlockMatched: true}),
 			},
 		},
 	}
@@ -331,6 +332,7 @@ func TestUDP2TCPDNSTunnel(t *testing.T) {
 		Outbound: []*core.OutboundHandlerConfig{
 			{
 				ProxySettings: serial.ToTypedMessage(&dns_proxy.Config{
+					BlockMatched: true,
 					Server: &net.Endpoint{
 						Network: net.Network_TCP,
 					},
@@ -366,5 +368,190 @@ func TestUDP2TCPDNSTunnel(t *testing.T) {
 	}
 	if r := cmp.Diff(rr.A[:], net.IP{8, 8, 8, 8}); r != "" {
 		t.Error(r)
+	}
+}
+
+func TestBlacklistDNSQuery(t *testing.T) {
+	port := udp.PickPort()
+
+	dnsServer := dns.Server{
+		Addr:    "127.0.0.1:" + port.String(),
+		Net:     "udp",
+		Handler: &staticHandler{},
+	}
+	defer dnsServer.Shutdown()
+
+	go dnsServer.ListenAndServe()
+	time.Sleep(time.Second)
+
+	serverPort := udp.PickPort()
+	config := &core.Config{
+		App: []*serial.TypedMessage{
+			serial.ToTypedMessage(&dnsapp.Config{
+				NameServer: []*dnsapp.NameServer{
+					{
+						Address: &net.Endpoint{
+							Network: net.Network_UDP,
+							Address: &net.IPOrDomain{
+								Address: &net.IPOrDomain_Ip{
+									Ip: []byte{127, 0, 0, 1},
+								},
+							},
+							Port: uint32(port),
+						},
+					},
+				},
+			}),
+			serial.ToTypedMessage(&dispatcher.Config{}),
+			serial.ToTypedMessage(&proxyman.OutboundConfig{}),
+			serial.ToTypedMessage(&proxyman.InboundConfig{}),
+			serial.ToTypedMessage(&policy.Config{}),
+		},
+		Inbound: []*core.InboundHandlerConfig{
+			{
+				ProxySettings: serial.ToTypedMessage(&dokodemo.Config{
+					Address:  net.NewIPOrDomain(net.LocalHostIP),
+					Port:     uint32(port),
+					Networks: []net.Network{net.Network_UDP},
+				}),
+				ReceiverSettings: serial.ToTypedMessage(&proxyman.ReceiverConfig{
+					PortList: &net.PortList{Range: []*net.PortRange{net.SinglePortRange(serverPort)}},
+					Listen:   net.NewIPOrDomain(net.LocalHostIP),
+				}),
+			},
+		},
+		Outbound: []*core.OutboundHandlerConfig{
+			{
+				ProxySettings: serial.ToTypedMessage(&dns_proxy.Config{
+					BlockMatched:  true,
+					RejectBlocked: true,
+					QueryRule: []*dns_proxy.Config_QueryRule{
+						{
+							Qtype: int32(dns.TypeA),
+							Domain: []*geodata.DomainRule{
+								{
+									Value: &geodata.DomainRule_Custom{
+										Custom: &geodata.Domain{
+											Type:  geodata.Domain_Full,
+											Value: "google.com",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+			},
+		},
+	}
+
+	v, err := core.New(config)
+	common.Must(err)
+	common.Must(v.Start())
+	defer v.Close()
+
+	m1 := new(dns.Msg)
+	m1.Id = dns.Id()
+	m1.RecursionDesired = true
+	m1.Question = []dns.Question{{Name: "google.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}}
+
+	c := new(dns.Client)
+	in, _, err := c.Exchange(m1, "127.0.0.1:"+strconv.Itoa(int(serverPort)))
+	common.Must(err)
+
+	if in.Rcode != dns.RcodeRefused {
+		t.Fatal("expected Refused, but got ", in.Rcode)
+	}
+}
+
+func TestWhitelistDNSQuery(t *testing.T) {
+	port := udp.PickPort()
+
+	dnsServer := dns.Server{
+		Addr:    "127.0.0.1:" + port.String(),
+		Net:     "udp",
+		Handler: &staticHandler{},
+	}
+	defer dnsServer.Shutdown()
+
+	go dnsServer.ListenAndServe()
+	time.Sleep(time.Second)
+
+	serverPort := udp.PickPort()
+	config := &core.Config{
+		App: []*serial.TypedMessage{
+			serial.ToTypedMessage(&dnsapp.Config{
+				NameServer: []*dnsapp.NameServer{
+					{
+						Address: &net.Endpoint{
+							Network: net.Network_UDP,
+							Address: &net.IPOrDomain{
+								Address: &net.IPOrDomain_Ip{
+									Ip: []byte{127, 0, 0, 1},
+								},
+							},
+							Port: uint32(port),
+						},
+					},
+				},
+			}),
+			serial.ToTypedMessage(&dispatcher.Config{}),
+			serial.ToTypedMessage(&proxyman.OutboundConfig{}),
+			serial.ToTypedMessage(&proxyman.InboundConfig{}),
+			serial.ToTypedMessage(&policy.Config{}),
+		},
+		Inbound: []*core.InboundHandlerConfig{
+			{
+				ProxySettings: serial.ToTypedMessage(&dokodemo.Config{
+					Address:  net.NewIPOrDomain(net.LocalHostIP),
+					Port:     uint32(port),
+					Networks: []net.Network{net.Network_UDP},
+				}),
+				ReceiverSettings: serial.ToTypedMessage(&proxyman.ReceiverConfig{
+					PortList: &net.PortList{Range: []*net.PortRange{net.SinglePortRange(serverPort)}},
+					Listen:   net.NewIPOrDomain(net.LocalHostIP),
+				}),
+			},
+		},
+		Outbound: []*core.OutboundHandlerConfig{
+			{
+				ProxySettings: serial.ToTypedMessage(&dns_proxy.Config{
+					RejectBlocked: true,
+					QueryRule: []*dns_proxy.Config_QueryRule{
+						{
+							Qtype: int32(dns.TypeA),
+							Domain: []*geodata.DomainRule{
+								{
+									Value: &geodata.DomainRule_Custom{
+										Custom: &geodata.Domain{
+											Type:  geodata.Domain_Full,
+											Value: "google.com",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+			},
+		},
+	}
+
+	v, err := core.New(config)
+	common.Must(err)
+	common.Must(v.Start())
+	defer v.Close()
+
+	m1 := new(dns.Msg)
+	m1.Id = dns.Id()
+	m1.RecursionDesired = true
+	m1.Question = []dns.Question{{Name: "facebook.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}}
+
+	c := new(dns.Client)
+	in, _, err := c.Exchange(m1, "127.0.0.1:"+strconv.Itoa(int(serverPort)))
+	common.Must(err)
+
+	if in.Rcode != dns.RcodeRefused {
+		t.Fatal("expected Refused, but got ", in.Rcode)
 	}
 }

--- a/proxy/dns/dns_test.go
+++ b/proxy/dns/dns_test.go
@@ -435,7 +435,7 @@ func TestDNSRules(t *testing.T) {
 									},
 								},
 							},
-							Action: dns_proxy.RuleAction_Accept,
+							Action: dns_proxy.RuleAction_Direct,
 						},
 						{
 							Qtype: []int32{int32(dns.TypeA)},
@@ -449,7 +449,7 @@ func TestDNSRules(t *testing.T) {
 									},
 								},
 							},
-							Action: dns_proxy.RuleAction_Refuse,
+							Action: dns_proxy.RuleAction_Reject,
 						},
 					},
 				}),
@@ -488,7 +488,7 @@ func TestDNSRules(t *testing.T) {
 		common.Must(err)
 
 		if in.Rcode != dns.RcodeSuccess {
-			t.Fatal("expected Accepted, but got ", in.Rcode)
+			t.Fatal("expected Success, but got ", in.Rcode)
 		}
 	}
 }

--- a/proxy/dns/dns_test.go
+++ b/proxy/dns/dns_test.go
@@ -126,7 +126,7 @@ func TestUDPDNSTunnel(t *testing.T) {
 		},
 		Outbound: []*core.OutboundHandlerConfig{
 			{
-				ProxySettings: serial.ToTypedMessage(&dns_proxy.Config{BlockMatched: true}),
+				ProxySettings: serial.ToTypedMessage(&dns_proxy.Config{}),
 			},
 		},
 	}
@@ -245,7 +245,7 @@ func TestTCPDNSTunnel(t *testing.T) {
 		},
 		Outbound: []*core.OutboundHandlerConfig{
 			{
-				ProxySettings: serial.ToTypedMessage(&dns_proxy.Config{BlockMatched: true}),
+				ProxySettings: serial.ToTypedMessage(&dns_proxy.Config{}),
 			},
 		},
 	}
@@ -332,7 +332,6 @@ func TestUDP2TCPDNSTunnel(t *testing.T) {
 		Outbound: []*core.OutboundHandlerConfig{
 			{
 				ProxySettings: serial.ToTypedMessage(&dns_proxy.Config{
-					BlockMatched: true,
 					Server: &net.Endpoint{
 						Network: net.Network_TCP,
 					},
@@ -371,7 +370,7 @@ func TestUDP2TCPDNSTunnel(t *testing.T) {
 	}
 }
 
-func TestBlacklistDNSQuery(t *testing.T) {
+func TestDNSRules(t *testing.T) {
 	port := udp.PickPort()
 
 	dnsServer := dns.Server{
@@ -423,11 +422,23 @@ func TestBlacklistDNSQuery(t *testing.T) {
 		Outbound: []*core.OutboundHandlerConfig{
 			{
 				ProxySettings: serial.ToTypedMessage(&dns_proxy.Config{
-					BlockMatched:  true,
-					RejectBlocked: true,
-					QueryRule: []*dns_proxy.Config_QueryRule{
+					Rule: []*dns_proxy.DNSRuleConfig{
 						{
-							Qtype: int32(dns.TypeA),
+							Qtype: []int32{int32(dns.TypeA)},
+							Domain: []*geodata.DomainRule{
+								{
+									Value: &geodata.DomainRule_Custom{
+										Custom: &geodata.Domain{
+											Type:  geodata.Domain_Domain,
+											Value: "facebook.com",
+										},
+									},
+								},
+							},
+							Action: dns_proxy.RuleAction_Accept,
+						},
+						{
+							Qtype: []int32{int32(dns.TypeA)},
 							Domain: []*geodata.DomainRule{
 								{
 									Value: &geodata.DomainRule_Custom{
@@ -438,6 +449,7 @@ func TestBlacklistDNSQuery(t *testing.T) {
 									},
 								},
 							},
+							Action: dns_proxy.RuleAction_Refuse,
 						},
 					},
 				}),
@@ -450,108 +462,33 @@ func TestBlacklistDNSQuery(t *testing.T) {
 	common.Must(v.Start())
 	defer v.Close()
 
-	m1 := new(dns.Msg)
-	m1.Id = dns.Id()
-	m1.RecursionDesired = true
-	m1.Question = []dns.Question{{Name: "google.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}}
+	{
+		m1 := new(dns.Msg)
+		m1.Id = dns.Id()
+		m1.RecursionDesired = true
+		m1.Question = []dns.Question{{Name: "google.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}}
 
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m1, "127.0.0.1:"+strconv.Itoa(int(serverPort)))
-	common.Must(err)
+		c := new(dns.Client)
+		in, _, err := c.Exchange(m1, "127.0.0.1:"+strconv.Itoa(int(serverPort)))
+		common.Must(err)
 
-	if in.Rcode != dns.RcodeRefused {
-		t.Fatal("expected Refused, but got ", in.Rcode)
-	}
-}
-
-func TestWhitelistDNSQuery(t *testing.T) {
-	port := udp.PickPort()
-
-	dnsServer := dns.Server{
-		Addr:    "127.0.0.1:" + port.String(),
-		Net:     "udp",
-		Handler: &staticHandler{},
-	}
-	defer dnsServer.Shutdown()
-
-	go dnsServer.ListenAndServe()
-	time.Sleep(time.Second)
-
-	serverPort := udp.PickPort()
-	config := &core.Config{
-		App: []*serial.TypedMessage{
-			serial.ToTypedMessage(&dnsapp.Config{
-				NameServer: []*dnsapp.NameServer{
-					{
-						Address: &net.Endpoint{
-							Network: net.Network_UDP,
-							Address: &net.IPOrDomain{
-								Address: &net.IPOrDomain_Ip{
-									Ip: []byte{127, 0, 0, 1},
-								},
-							},
-							Port: uint32(port),
-						},
-					},
-				},
-			}),
-			serial.ToTypedMessage(&dispatcher.Config{}),
-			serial.ToTypedMessage(&proxyman.OutboundConfig{}),
-			serial.ToTypedMessage(&proxyman.InboundConfig{}),
-			serial.ToTypedMessage(&policy.Config{}),
-		},
-		Inbound: []*core.InboundHandlerConfig{
-			{
-				ProxySettings: serial.ToTypedMessage(&dokodemo.Config{
-					Address:  net.NewIPOrDomain(net.LocalHostIP),
-					Port:     uint32(port),
-					Networks: []net.Network{net.Network_UDP},
-				}),
-				ReceiverSettings: serial.ToTypedMessage(&proxyman.ReceiverConfig{
-					PortList: &net.PortList{Range: []*net.PortRange{net.SinglePortRange(serverPort)}},
-					Listen:   net.NewIPOrDomain(net.LocalHostIP),
-				}),
-			},
-		},
-		Outbound: []*core.OutboundHandlerConfig{
-			{
-				ProxySettings: serial.ToTypedMessage(&dns_proxy.Config{
-					RejectBlocked: true,
-					QueryRule: []*dns_proxy.Config_QueryRule{
-						{
-							Qtype: int32(dns.TypeA),
-							Domain: []*geodata.DomainRule{
-								{
-									Value: &geodata.DomainRule_Custom{
-										Custom: &geodata.Domain{
-											Type:  geodata.Domain_Full,
-											Value: "google.com",
-										},
-									},
-								},
-							},
-						},
-					},
-				}),
-			},
-		},
+		if in.Rcode != dns.RcodeRefused {
+			t.Fatal("expected Refused, but got ", in.Rcode)
+		}
 	}
 
-	v, err := core.New(config)
-	common.Must(err)
-	common.Must(v.Start())
-	defer v.Close()
+	{
+		m1 := new(dns.Msg)
+		m1.Id = dns.Id()
+		m1.RecursionDesired = true
+		m1.Question = []dns.Question{{Name: "facebook.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}}
 
-	m1 := new(dns.Msg)
-	m1.Id = dns.Id()
-	m1.RecursionDesired = true
-	m1.Question = []dns.Question{{Name: "facebook.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}}
+		c := new(dns.Client)
+		in, _, err := c.Exchange(m1, "127.0.0.1:"+strconv.Itoa(int(serverPort)))
+		common.Must(err)
 
-	c := new(dns.Client)
-	in, _, err := c.Exchange(m1, "127.0.0.1:"+strconv.Itoa(int(serverPort)))
-	common.Must(err)
-
-	if in.Rcode != dns.RcodeRefused {
-		t.Fatal("expected Refused, but got ", in.Rcode)
+		if in.Rcode != dns.RcodeSuccess {
+			t.Fatal("expected Accepted, but got ", in.Rcode)
+		}
 	}
 }


### PR DESCRIPTION
Close #5218

需要封锁特定域名的 ech 否则 sni 分流不可用
以前只能封锁整个 qtype 不支持按域名封
~现在这样就能既要...又要...还要...了~

加此功能的时候觉得这块原有设计不太合理，重构了一下
以前用的时候就觉得卡手，不够直观，行为比较奇怪

现在兼容原配置语义

```jsonc
{
  "network": "tcp",
  "address": "1.1.1.1",
  "port": 53,
  "userLevel": 0,

  // 新选项，替代旧有的 nonIPQuery 和 blockTypes
  "rules": [
    {
      "action": "direct",
      "qtype": "1,3,23-24", // 这些类型直接全部放行
    },
    {
      "action": "hijack",
      "qtype": 1,
      "domain": ["q.com"], // *q.com 被导入内置 DNS 模块
    },
    {
      "action": "drop",
      // qtype 可省略，即所有 qtype 都会被匹配
      "domain": ["domain:example.com", "full:example.com"], // 这些域名的所有类型全部丢弃
    },
    {
      "action": "reject",
      "qtype": 28,
      "domain": ["geosite:cn"], // 这些域名的 AAAA 显式拒绝
    },
    // 默认内置兜底规则：A、AAAA 将被导入内置 DNS 模块，其它类型显式拒绝
  ],
}
```