### PR TITLE
Geodata strmatcher: Restore lenient Type.New(Domain) behavior

### DIFF
--- a/common/geodata/strmatcher/matchers.go
+++ b/common/geodata/strmatcher/matchers.go
@@ -100,10 +100,6 @@ func (t Type) New(pattern string) (Matcher, error) {
 	case Substr:
 		return SubstrMatcher(pattern), nil
 	case Domain:
-		pattern, err := ToDomain(pattern)
-		if err != nil {
-			return nil, err
-		}
 		return DomainMatcher(pattern), nil
 	case Regex: // 1. regex matching is case-sensitive
 		regex, err := regexp.Compile(pattern)

--- a/common/geodata/strmatcher/matchers_test.go
+++ b/common/geodata/strmatcher/matchers_test.go
@@ -74,23 +74,6 @@ func TestMatcher(t *testing.T) {
 	}
 }
 
-func TestTypeNewDomainLenient(t *testing.T) {
-	// Type.New(Domain) is the general-purpose API and must not reject patterns
-	// that were accepted before the geodata refactor (including underscore, which
-	// is common in internal service DNS names and SRV records). Strict validation
-	// lives on Type.NewDomainPattern.
-	patterns := []string{
-		"_sip._tcp.example.com",
-		"api_internal.local",
-		"example.com",
-	}
-	for _, p := range patterns {
-		if _, err := Domain.New(p); err != nil {
-			t.Errorf("Domain.New(%q) returned unexpected error: %v", p, err)
-		}
-	}
-}
-
 func TestToDomain(t *testing.T) {
 	{ // Test normal ASCII domain, which should not trigger new string data allocation
 		input := "example.com"

--- a/common/geodata/strmatcher/matchers_test.go
+++ b/common/geodata/strmatcher/matchers_test.go
@@ -74,6 +74,23 @@ func TestMatcher(t *testing.T) {
 	}
 }
 
+func TestTypeNewDomainLenient(t *testing.T) {
+	// Type.New(Domain) is the general-purpose API and must not reject patterns
+	// that were accepted before the geodata refactor (including underscore, which
+	// is common in internal service DNS names and SRV records). Strict validation
+	// lives on Type.NewDomainPattern.
+	patterns := []string{
+		"_sip._tcp.example.com",
+		"api_internal.local",
+		"example.com",
+	}
+	for _, p := range patterns {
+		if _, err := Domain.New(p); err != nil {
+			t.Errorf("Domain.New(%q) returned unexpected error: %v", p, err)
+		}
+	}
+}
+
 func TestToDomain(t *testing.T) {
 	{ // Test normal ASCII domain, which should not trigger new string data allocation
 		input := "example.com"


### PR DESCRIPTION
## Summary

Restores pre-refactor lenient behavior of `strmatcher.Type.New(Domain)` so existing configs with underscore-containing domain patterns (e.g. `_sip._tcp.example.com`, internal service names) load successfully again.

Fixes #5986.

## Root cause

The geodata refactor (#5814, commit 82624bc) added a `ToDomain()` validation call inside `Type.New(Domain)`:

```go
case Domain:
    pattern, err := ToDomain(pattern)   // added by refactor
    if err != nil {
        return nil, err
    }
    return DomainMatcher(pattern), nil
```

`ToDomain` enforces a strict LDH subset and rejects anything containing `_` (see the existing `TestToDomain` case `"Mijia_Cloud.com" → error`).

In v26.3.27 the same function simply returned `domainMatcher(pattern)` with no validation. So any domain rule containing an underscore — previously accepted (and silently never matching) — now causes a hard startup error:

```
failed to create server > pattern string does not conform to Letter-Digit-Hyphen (LDH) subset
```

The only caller of `strmatcher.Domain.New` is `common/geodata/domain_matcher.go:170`, reached through routing `domain:` rules, DNS `hosts` entries, and geosite rules. (Note: the issue title attributes this to the REALITY `privateKey`, but `privateKey` is decoded with `base64.RawURLEncoding.DecodeString` into `[]byte` and never touches `strmatcher` — I traced the call sites in [this comment](https://github.com/XTLS/Xray-core/issues/5986#issuecomment-4288010800). The real trigger is any routing/DNS rule in the affected user's config that contains `_`.)

## Fix

The refactor intentionally introduced two APIs:

- `Type.New()` — general-purpose, lenient
- `Type.NewDomainPattern()` — explicitly-named, strict (calls `ToDomain` for `Full`/`Substr`/`Domain`)

Collapsing validation into `Type.New(Domain)` defeats that separation. This PR removes the `ToDomain` call from `Type.New(Domain)` so it behaves like `v26.3.27`; `NewDomainPattern` is untouched and remains strict for callers that want validation.

The alternative of relaxing `ToDomain` itself to allow `_` was considered and rejected: it would also loosen `NewDomainPattern` (whose whole point is strictness), and it contradicts the existing `TestToDomain` expectations.

## Test plan
- [x] `go test ./common/geodata/strmatcher/` passes (new regression test `TestTypeNewDomainLenient` added, covering `_sip._tcp.example.com`, `api_internal.local`, `example.com`)
- [x] `go test ./common/geodata/... ./app/dns/...` passes
- [ ] Reporter's original config reproduces cleanly once the full `routing`/`dns` block is shared (the `privateKey` attribution is incorrect — see linked comment)
