### PR TITLE
wireguard: make netBind.Close idempotent

### DIFF
--- a/proxy/wireguard/bind.go
+++ b/proxy/wireguard/bind.go
@@ -6,6 +6,7 @@ import (
 	"net/netip"
 	"runtime"
 	"strconv"
+	"sync"
 
 	"golang.zx2c4.com/wireguard/conn"
 	"golang.zx2c4.com/wireguard/device"
@@ -30,6 +31,7 @@ type netBind struct {
 	workers   int
 	readQueue chan *netReadInfo
 	closedCh  chan struct{}
+	closeOnce sync.Once
 }
 
 // SetMark implements conn.Bind
@@ -77,7 +79,9 @@ func (bind *netBind) BatchSize() int {
 
 // Open implements conn.Bind
 func (bind *netBind) Open(uport uint16) ([]conn.ReceiveFunc, uint16, error) {
-	bind.closedCh = make(chan struct{})
+	if bind.closedCh == nil {
+		bind.closedCh = make(chan struct{})
+	}
 	errors.LogDebug(context.Background(), "bind opened")
 
 	fun := func(bufs [][]byte, sizes []int, eps []conn.Endpoint) (n int, err error) {
@@ -109,9 +113,11 @@ func (bind *netBind) Open(uport uint16) ([]conn.ReceiveFunc, uint16, error) {
 // Close implements conn.Bind
 func (bind *netBind) Close() error {
 	errors.LogDebug(context.Background(), "bind closed")
-	if bind.closedCh != nil {
-		close(bind.closedCh)
-	}
+	bind.closeOnce.Do(func() {
+		if bind.closedCh != nil {
+			close(bind.closedCh)
+		}
+	})
 	return nil
 }
 

--- a/proxy/wireguard/bind_test.go
+++ b/proxy/wireguard/bind_test.go
@@ -1,0 +1,43 @@
+package wireguard
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestNetBindCloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	bind := &netBind{
+		readQueue: make(chan *netReadInfo),
+		closedCh:  make(chan struct{}),
+	}
+
+	var wg sync.WaitGroup
+	panicCh := make(chan interface{}, 18)
+	closeBind := func() {
+		defer wg.Done()
+		defer func() {
+			if r := recover(); r != nil {
+				panicCh <- r
+			}
+		}()
+		_ = bind.Close()
+	}
+
+	wg.Add(2)
+	go closeBind()
+	go closeBind()
+
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go closeBind()
+	}
+
+	wg.Wait()
+	close(panicCh)
+
+	for p := range panicCh {
+		t.Fatalf("Close panicked: %v", p)
+	}
+}

--- a/proxy/wireguard/client.go
+++ b/proxy/wireguard/client.go
@@ -123,6 +123,7 @@ func (h *Handler) processWireGuard(ctx context.Context, dialer internet.Dialer) 
 			},
 			workers:   int(h.conf.NumWorkers),
 			readQueue: make(chan *netReadInfo),
+			closedCh:  make(chan struct{}),
 		},
 		ctx:      ctx,
 		dialer:   dialer,


### PR DESCRIPTION
WireGuard outbound cleanup could panic when `netBind.Close()` was invoked more than once (including concurrent/deferred paths), due to an unguarded `close(closedCh)`. There was also a lifecycle gap where `closedCh` could be nil before `Open()`, which is unsafe for goroutines selecting on it.

- **Close path hardening**
  - Added `closeOnce sync.Once` to `netBind`.
  - Updated `Close()` to close `closedCh` via `closeOnce.Do(...)`, with nil guard, making repeated/concurrent `Close()` calls safe.

- **Channel lifecycle correctness**
  - Initialized `closedCh` when constructing `netBind` in `processWireGuard` so it exists before any goroutine may select on it.
  - Updated `Open()` to only initialize `closedCh` if it is nil, preserving constructor initialization and avoiding unnecessary re-creation.

- **Regression coverage**
  - Added `proxy/wireguard/bind_test.go` with a focused test that calls `Close()` repeatedly and concurrently, asserting no panic.

```go
func (bind *netBind) Close() error {
	errors.LogDebug(context.Background(), "bind closed")
	bind.closeOnce.Do(func() {
		if bind.closedCh != nil {
			close(bind.closedCh)
		}
	})
	return nil
}
```
