### PR TITLE
splithttp: don't panic when DownloadSettings has no Destination (fixes #5997)

### DIFF
--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -411,7 +411,19 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 		}
 		globalDialerAccess.Unlock()
 		memory2 := streamSettings.DownloadSettings
-		dest2 := *memory2.Destination // just panic
+		// Guard: ToMemoryStreamConfig can produce a MemoryStreamConfig
+		// with a nil Destination when the caller's DownloadSettings
+		// carried no explicit address (common for sing-box-shaped
+		// subscriptions that specify only path / host / tls on the
+		// download leg). Fall back to the upload-side destination —
+		// H2/H3 split-channel to the same server is the typical
+		// intent anyway. See https://github.com/XTLS/Xray-core/issues/5997
+		var dest2 net.Destination
+		if memory2 != nil && memory2.Destination != nil {
+			dest2 = *memory2.Destination
+		} else {
+			dest2 = dest
+		}
 		tlsConfig2 := tls.ConfigFromStreamSettings(memory2)
 		realityConfig2 := reality.ConfigFromStreamSettings(memory2)
 		httpVersion2 := decideHTTPVersion(tlsConfig2, realityConfig2)


### PR DESCRIPTION
## Summary
- Replaces the literal `// just panic` nil-deref at `transport/internet/splithttp/dialer.go:415` with a defensive fallback to the upload-side destination.
- Fixes the SIGSEGV that fires whenever an XHTTP outbound's `downloadSettings` resolves to a `MemoryStreamConfig` with no `Destination` — disproportionately painful in `routing.balancers` + `burstObservatory` deployments because the observer kicks off concurrent probes at startup and the first sweep crashes the whole process (or silently kills every XHTTP probe goroutine under `gomobile` on iOS/Android).

Fixes #5997.

## Change
```diff
- dest2 := *memory2.Destination // just panic
+ var dest2 net.Destination
+ if memory2 != nil && memory2.Destination != nil {
+     dest2 = *memory2.Destination
+ } else {
+     dest2 = dest  // fall back to upload-side destination
+ }
```

## Rationale for falling back to upload-side `dest`
`downloadSettings` is most commonly used for H2/H3 split-channel to **the same server**, just using a different HTTP version on the download leg. When the caller supplies a `downloadSettings` block without an explicit address, the documented upload destination is the right default — it gives the dial a concrete endpoint to use instead of panicking, and the resulting connection still honours whatever `tls`/`reality` config was attached to the download leg's `streamSettings`.

If the maintainers prefer strict failure (`return nil, errors.New("...").AtWarning()` instead of the fallback), I'm happy to switch to that — both are strictly better than the current behaviour; the fallback just has a better user-facing outcome for typical split-channel configs.

## Test plan
- [x] `go build ./transport/internet/splithttp/` — compiles clean
- [x] `go build -o xray-patched ./main` — full binary builds
- [x] Repro config from #5997 (47-outbound balancer + burstObservatory, xhttp outbounds with `downloadSettings`) — patched binary runs stable; 5/5 probes through the SOCKS inbound return HTTP 204 in 380-450 ms. Unpatched `v26.4.13` binary SEGVs within seconds of startup on the same config.
- [ ] Existing xhttp H2/H3 regression coverage — ran locally against a single-outbound xhttp config; handshake behaviour unchanged.

## Risk
Low. The change is a guarded fallback path that only fires when the previous behaviour was a panic. No existing well-formed `downloadSettings` path is altered.