### PR TITLE
Loopback outbound: add timeouts (fixes half-closed tcp issue #5917)

### DIFF
--- a/proxy/loopback/config.pb.go
+++ b/proxy/loopback/config.pb.go
@@ -24,6 +24,7 @@ const (
 type Config struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	InboundTag    string                 `protobuf:"bytes,1,opt,name=inbound_tag,json=inboundTag,proto3" json:"inbound_tag,omitempty"`
+	UserLevel     uint32                 `protobuf:"varint,5,opt,name=user_level,json=userLevel,proto3" json:"user_level,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -65,14 +66,23 @@ func (x *Config) GetInboundTag() string {
 	return ""
 }
 
+func (x *Config) GetUserLevel() uint32 {
+	if x != nil {
+		return x.UserLevel
+	}
+	return 0
+}
+
 var File_proxy_loopback_config_proto protoreflect.FileDescriptor
 
 const file_proxy_loopback_config_proto_rawDesc = "" +
 	"\n" +
-	"\x1bproxy/loopback/config.proto\x12\x13xray.proxy.loopback\")\n" +
+	"\x1bproxy/loopback/config.proto\x12\x13xray.proxy.loopback\"H\n" +
 	"\x06Config\x12\x1f\n" +
 	"\vinbound_tag\x18\x01 \x01(\tR\n" +
-	"inboundTagB[\n" +
+	"inboundTag\x12\x1d\n" +
+	"\n" +
+	"user_level\x18\x05 \x01(\rR\tuserLevelB[\n" +
 	"\x17com.xray.proxy.loopbackP\x01Z(github.com/xtls/xray-core/proxy/loopback\xaa\x02\x13Xray.Proxy.Loopbackb\x06proto3"
 
 var (

--- a/proxy/loopback/config.proto
+++ b/proxy/loopback/config.proto
@@ -8,4 +8,5 @@ option java_multiple_files = true;
 
 message Config {
   string inbound_tag = 1;
+  uint32 user_level = 5;
 }

--- a/proxy/loopback/loopback.go
+++ b/proxy/loopback/loopback.go
@@ -10,8 +10,10 @@ import (
 	"github.com/xtls/xray-core/common/net/cnc"
 	"github.com/xtls/xray-core/common/retry"
 	"github.com/xtls/xray-core/common/session"
+	"github.com/xtls/xray-core/common/signal"
 	"github.com/xtls/xray-core/common/task"
 	"github.com/xtls/xray-core/core"
+	"github.com/xtls/xray-core/features/policy"
 	"github.com/xtls/xray-core/features/routing"
 	"github.com/xtls/xray-core/transport"
 	"github.com/xtls/xray-core/transport/internet"
@@ -20,6 +22,7 @@ import (
 type Loopback struct {
 	config             *Config
 	dispatcherInstance routing.Dispatcher
+	policyManager      policy.Manager
 }
 
 func (l *Loopback) Process(ctx context.Context, link *transport.Link, _ internet.Dialer) error {
@@ -76,7 +79,24 @@ func (l *Loopback) Process(ctx context.Context, link *transport.Link, _ internet
 	}
 	defer conn.Close()
 
+	var newCtx context.Context
+	var newCancel context.CancelFunc
+	if session.TimeoutOnlyFromContext(ctx) {
+		newCtx, newCancel = context.WithCancel(context.Background())
+	}
+
+	plcy := l.policy()
+	ctx, cancel := context.WithCancel(ctx)
+	timer := signal.CancelAfterInactivity(ctx, func() {
+		cancel()
+		if newCancel != nil {
+			newCancel()
+		}
+	}, plcy.Timeouts.ConnectionIdle)
+
 	requestDone := func() error {
+		defer timer.SetTimeout(plcy.Timeouts.DownlinkOnly)
+
 		var writer buf.Writer
 		if destination.Network == net.Network_TCP {
 			writer = buf.NewWriter(conn)
@@ -92,6 +112,8 @@ func (l *Loopback) Process(ctx context.Context, link *transport.Link, _ internet
 	}
 
 	responseDone := func() error {
+		defer timer.SetTimeout(plcy.Timeouts.UplinkOnly)
+
 		var reader buf.Reader
 		if destination.Network == net.Network_TCP {
 			reader = buf.NewReader(conn)
@@ -105,6 +127,10 @@ func (l *Loopback) Process(ctx context.Context, link *transport.Link, _ internet
 		return nil
 	}
 
+	if newCtx != nil {
+		ctx = newCtx
+	}
+
 	if err := task.Run(ctx, requestDone, task.OnSuccess(responseDone, task.Close(output))); err != nil {
 		return errors.New("connection ends").Base(err)
 	}
@@ -112,8 +138,14 @@ func (l *Loopback) Process(ctx context.Context, link *transport.Link, _ internet
 	return nil
 }
 
-func (l *Loopback) init(config *Config, dispatcherInstance routing.Dispatcher) error {
+func (l *Loopback) policy() policy.Session {
+	p := l.policyManager.ForLevel(l.config.UserLevel)
+	return p
+}
+
+func (l *Loopback) init(config *Config, dispatcherInstance routing.Dispatcher, pm policy.Manager) error {
 	l.dispatcherInstance = dispatcherInstance
+	l.policyManager = pm
 	l.config = config
 	return nil
 }
@@ -121,8 +153,8 @@ func (l *Loopback) init(config *Config, dispatcherInstance routing.Dispatcher) e
 func init() {
 	common.Must(common.RegisterConfig((*Config)(nil), func(ctx context.Context, config interface{}) (interface{}, error) {
 		l := new(Loopback)
-		err := core.RequireFeatures(ctx, func(dispatcherInstance routing.Dispatcher) error {
-			return l.init(config.(*Config), dispatcherInstance)
+		err := core.RequireFeatures(ctx, func(dispatcherInstance routing.Dispatcher, pm policy.Manager) error {
+			return l.init(config.(*Config), dispatcherInstance, pm)
 		})
 		return l, err
 	}))


### PR DESCRIPTION
fixes #5917.

我遇到的这个问题查明白了，不是tunnel入站的问题，而是loopback出站缺少timeout导致的。这里补上了loopback出站的三个timeout。

luci-app-passwall的默认分流配置目前会使用到loopback，协议链是tunnel inbound -> loopback -> vless outbound。之前tunnel已经改成dispatchlink了，而loopback还是task.Run。应该是这么一接导致outbound没办法close到inbound吧。

PS：loopback原先没有user_level，我为了拿policy的timeout，写了个5的user_level，和tun一样。可能需要修改。
