### PR TITLE
fix(fakedns): fix nil pointer dereference and 32-bit integer overflow

### DIFF
--- a/app/dns/fakedns/fake.go
+++ b/app/dns/fakedns/fake.go
@@ -2,7 +2,6 @@ package fakedns
 
 import (
 	"context"
-	"math"
 	"math/big"
 	"sync"
 	"time"
@@ -17,12 +16,19 @@ import (
 type Holder struct {
 	domainToIP cache.Lru
 	ipRange    *net.IPNet
-	mu         *sync.Mutex
+	mu         sync.RWMutex
 
 	config *FakeDnsPool
 }
 
 func (fkdns *Holder) IsIPInIPPool(ip net.Address) bool {
+	fkdns.mu.RLock()
+	defer fkdns.mu.RUnlock()
+
+	if fkdns.ipRange == nil {
+		return false
+	}
+
 	if ip.Family().IsDomain() {
 		return false
 	}
@@ -30,10 +36,19 @@ func (fkdns *Holder) IsIPInIPPool(ip net.Address) bool {
 }
 
 func (fkdns *Holder) GetFakeIPForDomain3(domain string, ipv4, ipv6 bool) []net.Address {
-	isIPv6 := fkdns.ipRange.IP.To4() == nil
-	if (isIPv6 && ipv6) || (!isIPv6 && ipv4) {
-		return fkdns.GetFakeIPForDomain(domain)
+	fkdns.mu.Lock()
+	defer fkdns.mu.Unlock()
+
+	if fkdns.ipRange == nil {
+		return []net.Address{}
 	}
+
+	isIPv4 := fkdns.ipRange.IP.To4() != nil
+
+	if (isIPv4 && ipv4) || (!isIPv4 && ipv6) {
+		return fkdns.getFakeIPForDomainLocked(domain)
+	}
+
 	return []net.Address{}
 }
 
@@ -42,38 +57,41 @@ func (*Holder) Type() interface{} {
 }
 
 func (fkdns *Holder) Start() error {
+	fkdns.mu.Lock()
+	defer fkdns.mu.Unlock()
+
 	if fkdns.config != nil && fkdns.config.IpPool != "" && fkdns.config.LruSize != 0 {
-		return fkdns.initializeFromConfig()
+		return fkdns.initializeFromConfigLocked()
 	}
-	return errors.New("invalid fakeDNS setting")
+	return errors.New("invalid Fake DNS setting")
 }
 
 func (fkdns *Holder) Close() error {
+	fkdns.mu.Lock()
+	defer fkdns.mu.Unlock()
+
 	fkdns.domainToIP = nil
 	fkdns.ipRange = nil
-	fkdns.mu = nil
 	return nil
 }
 
 func NewFakeDNSHolder() (*Holder, error) {
-	var fkdns *Holder
-	var err error
-
-	if fkdns, err = NewFakeDNSHolderConfigOnly(nil); err != nil {
-		return nil, errors.New("Unable to create Fake Dns Engine").Base(err).AtError()
-	}
-	err = fkdns.initialize(dns.FakeIPv4Pool, 65535)
+	fkdns, err := NewFakeDNSHolderConfigOnly(nil)
 	if err != nil {
+		return nil, errors.New("Unable to create Fake DNS Engine").Base(err).AtError()
+	}
+
+	if err := fkdns.initialize(dns.FakeIPv4Pool, 65535); err != nil {
 		return nil, err
 	}
 	return fkdns, nil
 }
 
 func NewFakeDNSHolderConfigOnly(conf *FakeDnsPool) (*Holder, error) {
-	return &Holder{nil, nil, nil, conf}, nil
+	return &Holder{config: conf}, nil
 }
 
-func (fkdns *Holder) initializeFromConfig() error {
+func (fkdns *Holder) initializeFromConfigLocked() error {
 	return fkdns.initialize(fkdns.config.IpPool, int(fkdns.config.LruSize))
 }
 
@@ -87,67 +105,110 @@ func (fkdns *Holder) initialize(ipPoolCidr string, lruSize int) error {
 
 	ones, bits := ipRange.Mask.Size()
 	rooms := bits - ones
-	if math.Log2(float64(lruSize)) >= float64(rooms) {
-		return errors.New("LRU size is bigger than subnet size").AtError()
+
+	if rooms < 64 {
+		maxIPs := uint64(1) << rooms
+
+		if maxIPs <= 3 {
+			return errors.New("Subnet size is too small for Fake DNS").AtError()
+		}
+
+		safeLruLimit := maxIPs - 3
+
+		if uint64(lruSize) >= safeLruLimit {
+			lruSize = int(safeLruLimit)
+		}
 	}
+
 	fkdns.domainToIP = cache.NewLru(lruSize)
 	fkdns.ipRange = ipRange
-	fkdns.mu = new(sync.Mutex)
+
 	return nil
 }
 
-// GetFakeIPForDomain checks and generates a fake IP for a domain name
-func (fkdns *Holder) GetFakeIPForDomain(domain string) []net.Address {
-	fkdns.mu.Lock()
-	defer fkdns.mu.Unlock()
+func (fkdns *Holder) getFakeIPForDomainLocked(domain string) []net.Address {
 	if v, ok := fkdns.domainToIP.Get(domain); ok {
 		return []net.Address{v.(net.Address)}
 	}
-	currentTimeMillis := uint64(time.Now().UnixNano() / 1e6)
+
+	currentTimeMillis := uint64(time.Now().UnixMilli())
+
 	ones, bits := fkdns.ipRange.Mask.Size()
 	rooms := bits - ones
 	if rooms < 64 {
 		currentTimeMillis %= (uint64(1) << rooms)
 	}
+
 	bigIntIP := big.NewInt(0).SetBytes(fkdns.ipRange.IP)
 	bigIntIP = bigIntIP.Add(bigIntIP, new(big.Int).SetUint64(currentTimeMillis))
+
 	var ip net.Address
+	ipLen := len(fkdns.ipRange.IP)
+	buf := make([]byte, ipLen)
+
+	one := big.NewInt(1)
 	for {
-		ip = net.IPAddress(bigIntIP.Bytes())
+		bigIntIP.FillBytes(buf)
+		ip = net.IPAddress(buf)
 
 		// if we run for a long time, we may go back to beginning and start seeing the IP in use
 		if _, ok := fkdns.domainToIP.PeekKeyFromValue(ip); !ok {
 			break
 		}
 
-		bigIntIP = bigIntIP.Add(bigIntIP, big.NewInt(1))
-		if !fkdns.ipRange.Contains(bigIntIP.Bytes()) {
-			bigIntIP = big.NewInt(0).SetBytes(fkdns.ipRange.IP)
+		bigIntIP.Add(bigIntIP, one)
+		bigIntIP.FillBytes(buf)
+		if !fkdns.ipRange.Contains(buf) {
+			bigIntIP.SetBytes(fkdns.ipRange.IP)
 		}
 	}
+
 	fkdns.domainToIP.Put(domain, ip)
 	return []net.Address{ip}
 }
 
+// GetFakeIPForDomain checks and generates a Fake DNS IP for a domain name
+func (fkdns *Holder) GetFakeIPForDomain(domain string) []net.Address {
+	fkdns.mu.Lock()
+	defer fkdns.mu.Unlock()
+
+	if fkdns.ipRange == nil {
+		return []net.Address{}
+	}
+
+	return fkdns.getFakeIPForDomainLocked(domain)
+}
+
 // GetDomainFromFakeDNS checks if an IP is a fake IP and have corresponding domain name
 func (fkdns *Holder) GetDomainFromFakeDNS(ip net.Address) string {
+	fkdns.mu.RLock()
+	defer fkdns.mu.RUnlock()
+
+	if fkdns.ipRange == nil || fkdns.domainToIP == nil {
+		return ""
+	}
+
 	if !ip.Family().IsIP() || !fkdns.ipRange.Contains(ip.IP()) {
 		return ""
 	}
 	if k, ok := fkdns.domainToIP.GetKeyFromValue(ip); ok {
 		return k.(string)
 	}
-	errors.LogInfo(context.Background(), "A fake ip request to ", ip, ", however there is no matching domain name in fake DNS")
+
+	errors.LogInfo(context.Background(), "A fake ip request to ", ip, ", however there is no matching domain name in Fake DNS")
 	return ""
 }
 
 type HolderMulti struct {
 	holders []*Holder
-
-	config *FakeDnsPoolMulti
+	config  *FakeDnsPoolMulti
+	mu      sync.RWMutex
 }
 
 func (h *HolderMulti) IsIPInIPPool(ip net.Address) bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
 	if ip.Family().IsDomain() {
 		return false
 	}
@@ -160,7 +221,10 @@ func (h *HolderMulti) IsIPInIPPool(ip net.Address) bool {
 }
 
 func (h *HolderMulti) GetFakeIPForDomain3(domain string, ipv4, ipv6 bool) []net.Address {
-	var ret []net.Address
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	ret := make([]net.Address, 0, len(h.holders))
 	for _, v := range h.holders {
 		ret = append(ret, v.GetFakeIPForDomain3(domain, ipv4, ipv6)...)
 	}
@@ -168,7 +232,10 @@ func (h *HolderMulti) GetFakeIPForDomain3(domain string, ipv4, ipv6 bool) []net.
 }
 
 func (h *HolderMulti) GetFakeIPForDomain(domain string) []net.Address {
-	var ret []net.Address
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	ret := make([]net.Address, 0, len(h.holders))
 	for _, v := range h.holders {
 		ret = append(ret, v.GetFakeIPForDomain(domain)...)
 	}
@@ -176,6 +243,9 @@ func (h *HolderMulti) GetFakeIPForDomain(domain string) []net.Address {
 }
 
 func (h *HolderMulti) GetDomainFromFakeDNS(ip net.Address) string {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
 	for _, v := range h.holders {
 		if domain := v.GetDomainFromFakeDNS(ip); domain != "" {
 			return domain
@@ -189,23 +259,31 @@ func (h *HolderMulti) Type() interface{} {
 }
 
 func (h *HolderMulti) Start() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	for _, v := range h.holders {
-		if v.config != nil && v.config.IpPool != "" && v.config.LruSize != 0 {
-			if err := v.Start(); err != nil {
-				return errors.New("Cannot start all fake dns pools").Base(err)
-			}
-		} else {
-			return errors.New("invalid fakeDNS setting")
+		if err := v.Start(); err != nil {
+			return errors.New("Cannot start Fake DNS pool").Base(err)
 		}
 	}
 	return nil
 }
 
 func (h *HolderMulti) Close() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	var errs []error
 	for _, v := range h.holders {
 		if err := v.Close(); err != nil {
-			return errors.New("Cannot close all fake dns pools").Base(err)
+			errs = append(errs, err)
 		}
+	}
+	h.holders = nil
+
+	if len(errs) > 0 {
+		return errors.New("Cannot close all Fake DNS pools").Base(errs[0])
 	}
 	return nil
 }
@@ -222,7 +300,10 @@ func (h *HolderMulti) createHolderGroups() error {
 }
 
 func NewFakeDNSHolderMulti(conf *FakeDnsPoolMulti) (*HolderMulti, error) {
-	holderMulti := &HolderMulti{nil, conf}
+	holderMulti := &HolderMulti{
+		holders: nil,
+		config:  conf,
+	}
 	if err := holderMulti.createHolderGroups(); err != nil {
 		return nil, err
 	}
@@ -231,20 +312,10 @@ func NewFakeDNSHolderMulti(conf *FakeDnsPoolMulti) (*HolderMulti, error) {
 
 func init() {
 	common.Must(common.RegisterConfig((*FakeDnsPool)(nil), func(ctx context.Context, config interface{}) (interface{}, error) {
-		var f *Holder
-		var err error
-		if f, err = NewFakeDNSHolderConfigOnly(config.(*FakeDnsPool)); err != nil {
-			return nil, err
-		}
-		return f, nil
+		return NewFakeDNSHolderConfigOnly(config.(*FakeDnsPool))
 	}))
 
 	common.Must(common.RegisterConfig((*FakeDnsPoolMulti)(nil), func(ctx context.Context, config interface{}) (interface{}, error) {
-		var f *HolderMulti
-		var err error
-		if f, err = NewFakeDNSHolderMulti(config.(*FakeDnsPoolMulti)); err != nil {
-			return nil, err
-		}
-		return f, nil
+		return NewFakeDNSHolderMulti(config.(*FakeDnsPoolMulti))
 	}))
 }


### PR DESCRIPTION
## Description

This PR refactors the `fakedns` module to improve concurrency performance, eliminate unnecessary memory allocations, and enhance overall stability. 

## Key Changes

### Concurrency and Thread Safety
* Changed `mu` in the `Holder` struct from a pointer `*sync.Mutex` to a value-based `sync.RWMutex`.
* Introduced a `sync.RWMutex` to the `HolderMulti` struct to ensure thread-safe operations across multiple pools.
* Read-heavy operations (e.g., `IsIPInIPPool`, `GetDomainFromFakeDNS`) now utilize `RLock()`, which reduces lock contention and improves throughput in concurrent environments.
* Refactored internal logic into designated `*Locked` methods (e.g., `getFakeIPForDomainLocked`, `initializeFromConfigLocked`) to prevent deadlocks and eliminate redundant lock acquisitions.

### Performance and Memory Optimizations
* **Zero-allocation loop:** Replaced `bigIntIP.Bytes()` inside the IP generation `for` loop with a pre-allocated buffer (`buf := make([]byte, ipLen)`) and `bigIntIP.FillBytes(buf)`. This mitigates significant GC pressure caused by slice allocations during IP searches.
* Hoisted static variables (e.g., `one := big.NewInt(1)`) out of the IP generation loop.
* Replaced `time.Now().UnixNano() / 1e6` with the native `time.Now().UnixMilli()`.

### Subnet and LRU Cache Logic
* Removed the `math` package dependency. Floating-point calculations (`math.Log2`) for LRU sizing have been replaced with bitwise shift operations (`1 << rooms`).
* Implemented graceful degradation for LRU cache sizing: Instead of returning a hard error when `lruSize` is larger than the subnet capacity, the engine now automatically clamps the LRU size to a calculated `safeLruLimit` (`maxIPs - 3`). An error is only returned if the subnet size is fundamentally too small to function.

### Lifecycle and Robustness
* **Graceful multi-shutdown:** Modified `HolderMulti.Close()` to iterate through all child holders and collect errors, rather than returning immediately on the first failure. The holders slice is explicitly nilled out to prevent memory leaks.
* Added boundary `nil` checks for `ipRange` and `domainToIP` in read methods to prevent potential panics on uninitialized or closed instances.
* Simplified configuration registration callbacks in the `init()` block.