### PR TITLE
Add authFailureResponse option to hide SOCKS/HTTP proxy on auth failure

### DIFF
--- a/infra/conf/http.go
+++ b/infra/conf/http.go
@@ -23,15 +23,27 @@ func (v *HTTPAccount) Build() *http.Account {
 }
 
 type HTTPServerConfig struct {
-	Accounts    []*HTTPAccount `json:"accounts"`
-	Transparent bool           `json:"allowTransparent"`
-	UserLevel   uint32         `json:"userLevel"`
+	Accounts            []*HTTPAccount `json:"accounts"`
+	Transparent         bool           `json:"allowTransparent"`
+	UserLevel           uint32         `json:"userLevel"`
+	AuthFailureResponse string         `json:"authFailureResponse"`
 }
 
 func (c *HTTPServerConfig) Build() (proto.Message, error) {
 	config := &http.ServerConfig{
 		AllowTransparent: c.Transparent,
 		UserLevel:        c.UserLevel,
+	}
+
+	switch c.AuthFailureResponse {
+	case "", "reject":
+		config.AuthFailureBehavior = http.AuthFailureBehavior_REJECT
+	case "drop":
+		config.AuthFailureBehavior = http.AuthFailureBehavior_DROP
+	case "http400":
+		config.AuthFailureBehavior = http.AuthFailureBehavior_HTTP400
+	default:
+		return nil, errors.New(`unknown http "authFailureResponse": `, c.AuthFailureResponse, ` (expected "reject", "drop", or "http400")`)
 	}
 
 	if len(c.Accounts) > 0 {

--- a/infra/conf/socks.go
+++ b/infra/conf/socks.go
@@ -28,11 +28,12 @@ const (
 )
 
 type SocksServerConfig struct {
-	AuthMethod string          `json:"auth"`
-	Accounts   []*SocksAccount `json:"accounts"`
-	UDP        bool            `json:"udp"`
-	Host       *Address        `json:"ip"`
-	UserLevel  uint32          `json:"userLevel"`
+	AuthMethod          string          `json:"auth"`
+	Accounts            []*SocksAccount `json:"accounts"`
+	UDP                 bool            `json:"udp"`
+	Host                *Address        `json:"ip"`
+	UserLevel           uint32          `json:"userLevel"`
+	AuthFailureResponse string          `json:"authFailureResponse"`
 }
 
 func (v *SocksServerConfig) Build() (proto.Message, error) {
@@ -45,6 +46,17 @@ func (v *SocksServerConfig) Build() (proto.Message, error) {
 	default:
 		// errors.New("unknown socks auth method: ", v.AuthMethod, ". Default to noauth.").AtWarning().WriteToLog()
 		config.AuthType = socks.AuthType_NO_AUTH
+	}
+
+	switch v.AuthFailureResponse {
+	case "", "reject":
+		config.AuthFailureBehavior = socks.AuthFailureBehavior_REJECT
+	case "drop":
+		config.AuthFailureBehavior = socks.AuthFailureBehavior_DROP
+	case "http400":
+		config.AuthFailureBehavior = socks.AuthFailureBehavior_HTTP400
+	default:
+		return nil, errors.New(`unknown socks "authFailureResponse": `, v.AuthFailureResponse, ` (expected "reject", "drop", or "http400")`)
 	}
 
 	if len(v.Accounts) > 0 {

--- a/proxy/http/auth_failure_test.go
+++ b/proxy/http/auth_failure_test.go
@@ -1,0 +1,45 @@
+package http
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestWriteHTTPAuthFailure_Reject(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeHTTPAuthFailure(&buf, AuthFailureBehavior_REJECT); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.HasPrefix(out, "HTTP/1.1 407 Proxy Authentication Required\r\n") {
+		t.Fatalf("REJECT: unexpected status line: %q", out)
+	}
+	if !strings.Contains(out, "Proxy-Authenticate: Basic realm=\"proxy\"") {
+		t.Fatalf("REJECT: missing Proxy-Authenticate header: %q", out)
+	}
+}
+
+func TestWriteHTTPAuthFailure_Drop(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeHTTPAuthFailure(&buf, AuthFailureBehavior_DROP); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("DROP: expected empty output, got %v", buf.Bytes())
+	}
+}
+
+func TestWriteHTTPAuthFailure_HTTP400(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeHTTPAuthFailure(&buf, AuthFailureBehavior_HTTP400); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.HasPrefix(out, "HTTP/1.1 400 Bad Request\r\n") {
+		t.Fatalf("HTTP400: unexpected status line: %q", out)
+	}
+	if strings.Contains(out, "Proxy-") {
+		t.Fatalf("HTTP400: response must not advertise proxy headers: %q", out)
+	}
+}

--- a/proxy/http/config.pb.go
+++ b/proxy/http/config.pb.go
@@ -22,6 +22,60 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// AuthFailureBehavior controls what the server returns when HTTP proxy
+// authentication is missing or invalid. REJECT preserves the RFC 7235 "407
+// Proxy Authentication Required" response (the default). DROP closes the
+// connection silently. HTTP400 writes a generic "HTTP/1.1 400 Bad Request"
+// reply so port scanners cannot fingerprint the service as a proxy.
+type AuthFailureBehavior int32
+
+const (
+	AuthFailureBehavior_REJECT  AuthFailureBehavior = 0
+	AuthFailureBehavior_DROP    AuthFailureBehavior = 1
+	AuthFailureBehavior_HTTP400 AuthFailureBehavior = 2
+)
+
+// Enum value maps for AuthFailureBehavior.
+var (
+	AuthFailureBehavior_name = map[int32]string{
+		0: "REJECT",
+		1: "DROP",
+		2: "HTTP400",
+	}
+	AuthFailureBehavior_value = map[string]int32{
+		"REJECT":  0,
+		"DROP":    1,
+		"HTTP400": 2,
+	}
+)
+
+func (x AuthFailureBehavior) Enum() *AuthFailureBehavior {
+	p := new(AuthFailureBehavior)
+	*p = x
+	return p
+}
+
+func (x AuthFailureBehavior) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (AuthFailureBehavior) Descriptor() protoreflect.EnumDescriptor {
+	return file_proxy_http_config_proto_enumTypes[0].Descriptor()
+}
+
+func (AuthFailureBehavior) Type() protoreflect.EnumType {
+	return &file_proxy_http_config_proto_enumTypes[0]
+}
+
+func (x AuthFailureBehavior) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use AuthFailureBehavior.Descriptor instead.
+func (AuthFailureBehavior) EnumDescriptor() ([]byte, []int) {
+	return file_proxy_http_config_proto_rawDescGZIP(), []int{0}
+}
+
 type Account struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Username      string                 `protobuf:"bytes,1,opt,name=username,proto3" json:"username,omitempty"`
@@ -76,12 +130,13 @@ func (x *Account) GetPassword() string {
 
 // Config for HTTP proxy server.
 type ServerConfig struct {
-	state            protoimpl.MessageState `protogen:"open.v1"`
-	Accounts         map[string]string      `protobuf:"bytes,2,rep,name=accounts,proto3" json:"accounts,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	AllowTransparent bool                   `protobuf:"varint,3,opt,name=allow_transparent,json=allowTransparent,proto3" json:"allow_transparent,omitempty"`
-	UserLevel        uint32                 `protobuf:"varint,4,opt,name=user_level,json=userLevel,proto3" json:"user_level,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	state               protoimpl.MessageState `protogen:"open.v1"`
+	Accounts            map[string]string      `protobuf:"bytes,2,rep,name=accounts,proto3" json:"accounts,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	AllowTransparent    bool                   `protobuf:"varint,3,opt,name=allow_transparent,json=allowTransparent,proto3" json:"allow_transparent,omitempty"`
+	UserLevel           uint32                 `protobuf:"varint,4,opt,name=user_level,json=userLevel,proto3" json:"user_level,omitempty"`
+	AuthFailureBehavior AuthFailureBehavior    `protobuf:"varint,5,opt,name=auth_failure_behavior,json=authFailureBehavior,proto3,enum=xray.proxy.http.AuthFailureBehavior" json:"auth_failure_behavior,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *ServerConfig) Reset() {
@@ -133,6 +188,13 @@ func (x *ServerConfig) GetUserLevel() uint32 {
 		return x.UserLevel
 	}
 	return 0
+}
+
+func (x *ServerConfig) GetAuthFailureBehavior() AuthFailureBehavior {
+	if x != nil {
+		return x.AuthFailureBehavior
+	}
+	return AuthFailureBehavior_REJECT
 }
 
 type Header struct {
@@ -248,12 +310,13 @@ const file_proxy_http_config_proto_rawDesc = "" +
 	"\x17proxy/http/config.proto\x12\x0fxray.proxy.http\x1a!common/protocol/server_spec.proto\"A\n" +
 	"\aAccount\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\x1a\n" +
-	"\bpassword\x18\x02 \x01(\tR\bpassword\"\xe0\x01\n" +
+	"\bpassword\x18\x02 \x01(\tR\bpassword\"\xba\x02\n" +
 	"\fServerConfig\x12G\n" +
 	"\baccounts\x18\x02 \x03(\v2+.xray.proxy.http.ServerConfig.AccountsEntryR\baccounts\x12+\n" +
 	"\x11allow_transparent\x18\x03 \x01(\bR\x10allowTransparent\x12\x1d\n" +
 	"\n" +
-	"user_level\x18\x04 \x01(\rR\tuserLevel\x1a;\n" +
+	"user_level\x18\x04 \x01(\rR\tuserLevel\x12X\n" +
+	"\x15auth_failure_behavior\x18\x05 \x01(\x0e2$.xray.proxy.http.AuthFailureBehaviorR\x13authFailureBehavior\x1a;\n" +
 	"\rAccountsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"0\n" +
@@ -262,7 +325,12 @@ const file_proxy_http_config_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05value\"}\n" +
 	"\fClientConfig\x12<\n" +
 	"\x06server\x18\x01 \x01(\v2$.xray.common.protocol.ServerEndpointR\x06server\x12/\n" +
-	"\x06header\x18\x02 \x03(\v2\x17.xray.proxy.http.HeaderR\x06headerBO\n" +
+	"\x06header\x18\x02 \x03(\v2\x17.xray.proxy.http.HeaderR\x06header*8\n" +
+	"\x13AuthFailureBehavior\x12\n" +
+	"\n" +
+	"\x06REJECT\x10\x00\x12\b\n" +
+	"\x04DROP\x10\x01\x12\v\n" +
+	"\aHTTP400\x10\x02BO\n" +
 	"\x13com.xray.proxy.httpP\x01Z$github.com/xtls/xray-core/proxy/http\xaa\x02\x0fXray.Proxy.Httpb\x06proto3"
 
 var (
@@ -277,24 +345,27 @@ func file_proxy_http_config_proto_rawDescGZIP() []byte {
 	return file_proxy_http_config_proto_rawDescData
 }
 
+var file_proxy_http_config_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_proxy_http_config_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_proxy_http_config_proto_goTypes = []any{
-	(*Account)(nil),                 // 0: xray.proxy.http.Account
-	(*ServerConfig)(nil),            // 1: xray.proxy.http.ServerConfig
-	(*Header)(nil),                  // 2: xray.proxy.http.Header
-	(*ClientConfig)(nil),            // 3: xray.proxy.http.ClientConfig
-	nil,                             // 4: xray.proxy.http.ServerConfig.AccountsEntry
-	(*protocol.ServerEndpoint)(nil), // 5: xray.common.protocol.ServerEndpoint
+	(AuthFailureBehavior)(0),        // 0: xray.proxy.http.AuthFailureBehavior
+	(*Account)(nil),                 // 1: xray.proxy.http.Account
+	(*ServerConfig)(nil),            // 2: xray.proxy.http.ServerConfig
+	(*Header)(nil),                  // 3: xray.proxy.http.Header
+	(*ClientConfig)(nil),            // 4: xray.proxy.http.ClientConfig
+	nil,                             // 5: xray.proxy.http.ServerConfig.AccountsEntry
+	(*protocol.ServerEndpoint)(nil), // 6: xray.common.protocol.ServerEndpoint
 }
 var file_proxy_http_config_proto_depIdxs = []int32{
-	4, // 0: xray.proxy.http.ServerConfig.accounts:type_name -> xray.proxy.http.ServerConfig.AccountsEntry
-	5, // 1: xray.proxy.http.ClientConfig.server:type_name -> xray.common.protocol.ServerEndpoint
-	2, // 2: xray.proxy.http.ClientConfig.header:type_name -> xray.proxy.http.Header
-	3, // [3:3] is the sub-list for method output_type
-	3, // [3:3] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	5, // 0: xray.proxy.http.ServerConfig.accounts:type_name -> xray.proxy.http.ServerConfig.AccountsEntry
+	0, // 1: xray.proxy.http.ServerConfig.auth_failure_behavior:type_name -> xray.proxy.http.AuthFailureBehavior
+	6, // 2: xray.proxy.http.ClientConfig.server:type_name -> xray.common.protocol.ServerEndpoint
+	3, // 3: xray.proxy.http.ClientConfig.header:type_name -> xray.proxy.http.Header
+	4, // [4:4] is the sub-list for method output_type
+	4, // [4:4] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_proxy_http_config_proto_init() }
@@ -307,13 +378,14 @@ func file_proxy_http_config_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proxy_http_config_proto_rawDesc), len(file_proxy_http_config_proto_rawDesc)),
-			NumEnums:      0,
+			NumEnums:      1,
 			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_proxy_http_config_proto_goTypes,
 		DependencyIndexes: file_proxy_http_config_proto_depIdxs,
+		EnumInfos:         file_proxy_http_config_proto_enumTypes,
 		MessageInfos:      file_proxy_http_config_proto_msgTypes,
 	}.Build()
 	File_proxy_http_config_proto = out.File

--- a/proxy/http/config.proto
+++ b/proxy/http/config.proto
@@ -13,11 +13,23 @@ message Account {
   string password = 2;
 }
 
+// AuthFailureBehavior controls what the server returns when HTTP proxy
+// authentication is missing or invalid. REJECT preserves the RFC 7235 "407
+// Proxy Authentication Required" response (the default). DROP closes the
+// connection silently. HTTP400 writes a generic "HTTP/1.1 400 Bad Request"
+// reply so port scanners cannot fingerprint the service as a proxy.
+enum AuthFailureBehavior {
+  REJECT = 0;
+  DROP = 1;
+  HTTP400 = 2;
+}
+
 // Config for HTTP proxy server.
 message ServerConfig {
   map<string, string> accounts = 2;
   bool allow_transparent = 3;
   uint32 user_level = 4;
+  AuthFailureBehavior auth_failure_behavior = 5;
 }
 
 message Header {

--- a/proxy/http/server.go
+++ b/proxy/http/server.go
@@ -60,6 +60,28 @@ func isTimeout(err error) bool {
 	return ok && nerr.Timeout()
 }
 
+// http407Response is the standard RFC 7235 reply that explicitly identifies
+// the listener as an HTTP proxy. http400Response is a generic web-server
+// reply used to camouflage the port from proxy fingerprinting.
+var (
+	http407Response = []byte("HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm=\"proxy\"\r\n\r\n")
+	http400Response = []byte("HTTP/1.1 400 Bad Request\r\nServer: nginx\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+)
+
+// writeHTTPAuthFailure writes the auth-failure response according to the
+// configured behavior. REJECT preserves RFC 7235 ("407"). DROP writes
+// nothing. HTTP400 writes a generic 400 to camouflage the port.
+func writeHTTPAuthFailure(w io.Writer, behavior AuthFailureBehavior) error {
+	switch behavior {
+	case AuthFailureBehavior_DROP:
+		return nil
+	case AuthFailureBehavior_HTTP400:
+		return common.Error2(w.Write(http400Response))
+	default:
+		return common.Error2(w.Write(http407Response))
+	}
+}
+
 func parseBasicAuth(auth string) (username, password string, ok bool) {
 	const prefix = "Basic "
 	if !strings.HasPrefix(auth, prefix) {
@@ -125,7 +147,10 @@ Start:
 	if len(s.config.Accounts) > 0 {
 		user, pass, ok := parseBasicAuth(request.Header.Get("Proxy-Authorization"))
 		if !ok || !s.config.HasAccount(user, pass) {
-			return common.Error2(conn.Write([]byte("HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm=\"proxy\"\r\n\r\n")))
+			if err := writeHTTPAuthFailure(conn, s.config.AuthFailureBehavior); err != nil {
+				return err
+			}
+			return errors.New("http proxy auth failed").AtInfo()
 		}
 		if inbound != nil {
 			inbound.User.Email = user

--- a/proxy/socks/auth_failure_test.go
+++ b/proxy/socks/auth_failure_test.go
@@ -1,0 +1,199 @@
+package socks_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	. "github.com/xtls/xray-core/proxy/socks"
+)
+
+func TestWriteSocks5AuthFailure_Reject(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteSocks5AuthFailureForTest(&buf, AuthFailureBehavior_REJECT, 0x05, 0xFF); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := buf.Bytes()
+	want := []byte{0x05, 0xFF}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("REJECT: got %v, want %v", got, want)
+	}
+}
+
+func TestWriteSocks5AuthFailure_Drop(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteSocks5AuthFailureForTest(&buf, AuthFailureBehavior_DROP, 0x05, 0xFF); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("DROP: expected empty output, got %v", buf.Bytes())
+	}
+}
+
+func TestWriteSocks5AuthFailure_HTTP400(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteSocks5AuthFailureForTest(&buf, AuthFailureBehavior_HTTP400, 0x05, 0xFF); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.HasPrefix(out, "HTTP/1.1 400 Bad Request\r\n") {
+		t.Fatalf("HTTP400: unexpected status line: %q", out)
+	}
+	if strings.Contains(out, "Proxy-") {
+		t.Fatalf("HTTP400: response must not advertise proxy headers: %q", out)
+	}
+	if !strings.HasSuffix(out, "\r\n\r\n") {
+		t.Fatalf("HTTP400: response must end with CRLFCRLF: %q", out)
+	}
+}
+
+func TestSocks4AuthFailureBehaviorWithPassword(t *testing.T) {
+	tests := []struct {
+		name     string
+		behavior AuthFailureBehavior
+		check    func(t *testing.T, out string)
+	}{
+		{
+			name:     "reject",
+			behavior: AuthFailureBehavior_REJECT,
+			check: func(t *testing.T, out string) {
+				want := string([]byte{0x00, 0x5B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
+				if out != want {
+					t.Fatalf("unexpected SOCKS4 reject response: got % X, want % X", []byte(out), []byte(want))
+				}
+			},
+		},
+		{
+			name:     "drop",
+			behavior: AuthFailureBehavior_DROP,
+			check: func(t *testing.T, out string) {
+				if out != "" {
+					t.Fatalf("DROP: expected empty response, got % X", []byte(out))
+				}
+			},
+		},
+		{
+			name:     "http400",
+			behavior: AuthFailureBehavior_HTTP400,
+			check: func(t *testing.T, out string) {
+				if !strings.HasPrefix(out, "HTTP/1.1 400 Bad Request\r\n") {
+					t.Fatalf("HTTP400: unexpected response: %q", out)
+				}
+				if strings.Contains(out, "Proxy-") {
+					t.Fatalf("HTTP400: response must not advertise proxy headers: %q", out)
+				}
+			},
+		},
+	}
+
+	input := []byte{0x04, 0x01, 0x00, 0x50, 0x01, 0x02, 0x03, 0x04, 0x00}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			session := NewServerSessionForTest(&ServerConfig{
+				AuthType:            AuthType_PASSWORD,
+				AuthFailureBehavior: test.behavior,
+			})
+			var out bytes.Buffer
+			_, err := session.Handshake(bytes.NewReader(input), &out)
+			if err == nil {
+				t.Fatal("expected SOCKS4 auth error")
+			}
+			test.check(t, out.String())
+		})
+	}
+}
+
+func TestSocks5BadPasswordDoesNotLeakMethodInStealthModes(t *testing.T) {
+	tests := []struct {
+		name     string
+		behavior AuthFailureBehavior
+		check    func(t *testing.T, out string)
+	}{
+		{
+			name:     "reject",
+			behavior: AuthFailureBehavior_REJECT,
+			check: func(t *testing.T, out string) {
+				want := string([]byte{0x05, 0x02, 0x01, 0xFF})
+				if out != want {
+					t.Fatalf("REJECT: got % X, want % X", []byte(out), []byte(want))
+				}
+			},
+		},
+		{
+			name:     "drop",
+			behavior: AuthFailureBehavior_DROP,
+			check: func(t *testing.T, out string) {
+				if out != "" {
+					t.Fatalf("DROP: expected empty response, got % X", []byte(out))
+				}
+			},
+		},
+		{
+			name:     "http400",
+			behavior: AuthFailureBehavior_HTTP400,
+			check: func(t *testing.T, out string) {
+				if strings.HasPrefix(out, string([]byte{0x05, 0x02})) {
+					t.Fatalf("HTTP400 leaked SOCKS method selection before auth failure: % X", []byte(out))
+				}
+				if !strings.HasPrefix(out, "HTTP/1.1 400 Bad Request\r\n") {
+					t.Fatalf("HTTP400: unexpected response: %q", out)
+				}
+			},
+		},
+	}
+
+	input := []byte{0x05, 0x01, 0x02, 0x01, 0x01, 'u', 0x03, 'b', 'a', 'd'}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			session := NewServerSessionForTest(&ServerConfig{
+				AuthType:            AuthType_PASSWORD,
+				Accounts:            map[string]string{"u": "p"},
+				AuthFailureBehavior: test.behavior,
+			})
+			var out bytes.Buffer
+			_, err := session.Handshake(bytes.NewReader(input), &out)
+			if err == nil {
+				t.Fatal("expected bad-password auth error")
+			}
+			test.check(t, out.String())
+		})
+	}
+}
+
+func TestSocks5OptimisticPasswordAuthSucceedsInStealthModes(t *testing.T) {
+	tests := []struct {
+		name     string
+		behavior AuthFailureBehavior
+	}{
+		{name: "drop", behavior: AuthFailureBehavior_DROP},
+		{name: "http400", behavior: AuthFailureBehavior_HTTP400},
+	}
+
+	input := []byte{
+		0x05, 0x01, 0x02,
+		0x01, 0x01, 'u', 0x01, 'p',
+		0x05, 0x01, 0x00, 0x01, 127, 0, 0, 1, 0x00, 0x50,
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			session := NewServerSessionForTest(&ServerConfig{
+				AuthType:            AuthType_PASSWORD,
+				Accounts:            map[string]string{"u": "p"},
+				AuthFailureBehavior: test.behavior,
+			})
+			var out bytes.Buffer
+			request, err := session.Handshake(bytes.NewReader(input), &out)
+			if err != nil {
+				t.Fatalf("unexpected optimistic auth error: %v", err)
+			}
+			if request == nil {
+				t.Fatal("expected request after successful optimistic auth")
+			}
+			got := out.Bytes()
+			wantPrefix := []byte{0x05, 0x02, 0x01, 0x00}
+			if !bytes.HasPrefix(got, wantPrefix) {
+				t.Fatalf("unexpected optimistic auth response: got % X, want prefix % X", got, wantPrefix)
+			}
+		})
+	}
+}

--- a/proxy/socks/auth_failure_test.go
+++ b/proxy/socks/auth_failure_test.go
@@ -1,0 +1,48 @@
+package socks_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	. "github.com/xtls/xray-core/proxy/socks"
+)
+
+func TestWriteSocks5AuthFailure_Reject(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteSocks5AuthFailureForTest(&buf, AuthFailureBehavior_REJECT, 0x05, 0xFF); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := buf.Bytes()
+	want := []byte{0x05, 0xFF}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("REJECT: got %v, want %v", got, want)
+	}
+}
+
+func TestWriteSocks5AuthFailure_Drop(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteSocks5AuthFailureForTest(&buf, AuthFailureBehavior_DROP, 0x05, 0xFF); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("DROP: expected empty output, got %v", buf.Bytes())
+	}
+}
+
+func TestWriteSocks5AuthFailure_HTTP400(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteSocks5AuthFailureForTest(&buf, AuthFailureBehavior_HTTP400, 0x05, 0xFF); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.HasPrefix(out, "HTTP/1.1 400 Bad Request\r\n") {
+		t.Fatalf("HTTP400: unexpected status line: %q", out)
+	}
+	if strings.Contains(out, "Proxy-") {
+		t.Fatalf("HTTP400: response must not advertise proxy headers: %q", out)
+	}
+	if !strings.HasSuffix(out, "\r\n\r\n") {
+		t.Fatalf("HTTP400: response must end with CRLFCRLF: %q", out)
+	}
+}

--- a/proxy/socks/config.pb.go
+++ b/proxy/socks/config.pb.go
@@ -72,6 +72,61 @@ func (AuthType) EnumDescriptor() ([]byte, []int) {
 	return file_proxy_socks_config_proto_rawDescGZIP(), []int{0}
 }
 
+// AuthFailureBehavior controls what the server returns when SOCKS5
+// authentication fails or when the client offers no acceptable method.
+// REJECT preserves the RFC 1928/1929 responses (0x05 0xFF, 0x01 0xFF) and is
+// the default. DROP closes the connection silently. HTTP400 writes a generic
+// "HTTP/1.1 400 Bad Request" reply so port scanners cannot fingerprint the
+// service as a SOCKS proxy.
+type AuthFailureBehavior int32
+
+const (
+	AuthFailureBehavior_REJECT  AuthFailureBehavior = 0
+	AuthFailureBehavior_DROP    AuthFailureBehavior = 1
+	AuthFailureBehavior_HTTP400 AuthFailureBehavior = 2
+)
+
+// Enum value maps for AuthFailureBehavior.
+var (
+	AuthFailureBehavior_name = map[int32]string{
+		0: "REJECT",
+		1: "DROP",
+		2: "HTTP400",
+	}
+	AuthFailureBehavior_value = map[string]int32{
+		"REJECT":  0,
+		"DROP":    1,
+		"HTTP400": 2,
+	}
+)
+
+func (x AuthFailureBehavior) Enum() *AuthFailureBehavior {
+	p := new(AuthFailureBehavior)
+	*p = x
+	return p
+}
+
+func (x AuthFailureBehavior) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (AuthFailureBehavior) Descriptor() protoreflect.EnumDescriptor {
+	return file_proxy_socks_config_proto_enumTypes[1].Descriptor()
+}
+
+func (AuthFailureBehavior) Type() protoreflect.EnumType {
+	return &file_proxy_socks_config_proto_enumTypes[1]
+}
+
+func (x AuthFailureBehavior) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use AuthFailureBehavior.Descriptor instead.
+func (AuthFailureBehavior) EnumDescriptor() ([]byte, []int) {
+	return file_proxy_socks_config_proto_rawDescGZIP(), []int{1}
+}
+
 // Account represents a Socks account.
 type Account struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -127,14 +182,15 @@ func (x *Account) GetPassword() string {
 
 // ServerConfig is the protobuf config for Socks server.
 type ServerConfig struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	AuthType      AuthType               `protobuf:"varint,1,opt,name=auth_type,json=authType,proto3,enum=xray.proxy.socks.AuthType" json:"auth_type,omitempty"`
-	Accounts      map[string]string      `protobuf:"bytes,2,rep,name=accounts,proto3" json:"accounts,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Address       *net.IPOrDomain        `protobuf:"bytes,3,opt,name=address,proto3" json:"address,omitempty"`
-	UdpEnabled    bool                   `protobuf:"varint,4,opt,name=udp_enabled,json=udpEnabled,proto3" json:"udp_enabled,omitempty"`
-	UserLevel     uint32                 `protobuf:"varint,6,opt,name=user_level,json=userLevel,proto3" json:"user_level,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state               protoimpl.MessageState `protogen:"open.v1"`
+	AuthType            AuthType               `protobuf:"varint,1,opt,name=auth_type,json=authType,proto3,enum=xray.proxy.socks.AuthType" json:"auth_type,omitempty"`
+	Accounts            map[string]string      `protobuf:"bytes,2,rep,name=accounts,proto3" json:"accounts,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Address             *net.IPOrDomain        `protobuf:"bytes,3,opt,name=address,proto3" json:"address,omitempty"`
+	UdpEnabled          bool                   `protobuf:"varint,4,opt,name=udp_enabled,json=udpEnabled,proto3" json:"udp_enabled,omitempty"`
+	UserLevel           uint32                 `protobuf:"varint,6,opt,name=user_level,json=userLevel,proto3" json:"user_level,omitempty"`
+	AuthFailureBehavior AuthFailureBehavior    `protobuf:"varint,7,opt,name=auth_failure_behavior,json=authFailureBehavior,proto3,enum=xray.proxy.socks.AuthFailureBehavior" json:"auth_failure_behavior,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *ServerConfig) Reset() {
@@ -202,6 +258,13 @@ func (x *ServerConfig) GetUserLevel() uint32 {
 	return 0
 }
 
+func (x *ServerConfig) GetAuthFailureBehavior() AuthFailureBehavior {
+	if x != nil {
+		return x.AuthFailureBehavior
+	}
+	return AuthFailureBehavior_REJECT
+}
+
 // ClientConfig is the protobuf config for Socks client.
 type ClientConfig struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -255,7 +318,7 @@ const file_proxy_socks_config_proto_rawDesc = "" +
 	"\x18proxy/socks/config.proto\x12\x10xray.proxy.socks\x1a\x18common/net/address.proto\x1a!common/protocol/server_spec.proto\"A\n" +
 	"\aAccount\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\x1a\n" +
-	"\bpassword\x18\x02 \x01(\tR\bpassword\"\xc5\x02\n" +
+	"\bpassword\x18\x02 \x01(\tR\bpassword\"\xa0\x03\n" +
 	"\fServerConfig\x127\n" +
 	"\tauth_type\x18\x01 \x01(\x0e2\x1a.xray.proxy.socks.AuthTypeR\bauthType\x12H\n" +
 	"\baccounts\x18\x02 \x03(\v2,.xray.proxy.socks.ServerConfig.AccountsEntryR\baccounts\x125\n" +
@@ -263,7 +326,8 @@ const file_proxy_socks_config_proto_rawDesc = "" +
 	"\vudp_enabled\x18\x04 \x01(\bR\n" +
 	"udpEnabled\x12\x1d\n" +
 	"\n" +
-	"user_level\x18\x06 \x01(\rR\tuserLevel\x1a;\n" +
+	"user_level\x18\x06 \x01(\rR\tuserLevel\x12Y\n" +
+	"\x15auth_failure_behavior\x18\a \x01(\x0e2%.xray.proxy.socks.AuthFailureBehaviorR\x13authFailureBehavior\x1a;\n" +
 	"\rAccountsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"L\n" +
@@ -271,7 +335,12 @@ const file_proxy_socks_config_proto_rawDesc = "" +
 	"\x06server\x18\x01 \x01(\v2$.xray.common.protocol.ServerEndpointR\x06server*%\n" +
 	"\bAuthType\x12\v\n" +
 	"\aNO_AUTH\x10\x00\x12\f\n" +
-	"\bPASSWORD\x10\x01BR\n" +
+	"\bPASSWORD\x10\x01*8\n" +
+	"\x13AuthFailureBehavior\x12\n" +
+	"\n" +
+	"\x06REJECT\x10\x00\x12\b\n" +
+	"\x04DROP\x10\x01\x12\v\n" +
+	"\aHTTP400\x10\x02BR\n" +
 	"\x14com.xray.proxy.socksP\x01Z%github.com/xtls/xray-core/proxy/socks\xaa\x02\x10Xray.Proxy.Socksb\x06proto3"
 
 var (
@@ -286,27 +355,29 @@ func file_proxy_socks_config_proto_rawDescGZIP() []byte {
 	return file_proxy_socks_config_proto_rawDescData
 }
 
-var file_proxy_socks_config_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_proxy_socks_config_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_proxy_socks_config_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_proxy_socks_config_proto_goTypes = []any{
 	(AuthType)(0),                   // 0: xray.proxy.socks.AuthType
-	(*Account)(nil),                 // 1: xray.proxy.socks.Account
-	(*ServerConfig)(nil),            // 2: xray.proxy.socks.ServerConfig
-	(*ClientConfig)(nil),            // 3: xray.proxy.socks.ClientConfig
-	nil,                             // 4: xray.proxy.socks.ServerConfig.AccountsEntry
-	(*net.IPOrDomain)(nil),          // 5: xray.common.net.IPOrDomain
-	(*protocol.ServerEndpoint)(nil), // 6: xray.common.protocol.ServerEndpoint
+	(AuthFailureBehavior)(0),        // 1: xray.proxy.socks.AuthFailureBehavior
+	(*Account)(nil),                 // 2: xray.proxy.socks.Account
+	(*ServerConfig)(nil),            // 3: xray.proxy.socks.ServerConfig
+	(*ClientConfig)(nil),            // 4: xray.proxy.socks.ClientConfig
+	nil,                             // 5: xray.proxy.socks.ServerConfig.AccountsEntry
+	(*net.IPOrDomain)(nil),          // 6: xray.common.net.IPOrDomain
+	(*protocol.ServerEndpoint)(nil), // 7: xray.common.protocol.ServerEndpoint
 }
 var file_proxy_socks_config_proto_depIdxs = []int32{
 	0, // 0: xray.proxy.socks.ServerConfig.auth_type:type_name -> xray.proxy.socks.AuthType
-	4, // 1: xray.proxy.socks.ServerConfig.accounts:type_name -> xray.proxy.socks.ServerConfig.AccountsEntry
-	5, // 2: xray.proxy.socks.ServerConfig.address:type_name -> xray.common.net.IPOrDomain
-	6, // 3: xray.proxy.socks.ClientConfig.server:type_name -> xray.common.protocol.ServerEndpoint
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	5, // 1: xray.proxy.socks.ServerConfig.accounts:type_name -> xray.proxy.socks.ServerConfig.AccountsEntry
+	6, // 2: xray.proxy.socks.ServerConfig.address:type_name -> xray.common.net.IPOrDomain
+	1, // 3: xray.proxy.socks.ServerConfig.auth_failure_behavior:type_name -> xray.proxy.socks.AuthFailureBehavior
+	7, // 4: xray.proxy.socks.ClientConfig.server:type_name -> xray.common.protocol.ServerEndpoint
+	5, // [5:5] is the sub-list for method output_type
+	5, // [5:5] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_proxy_socks_config_proto_init() }
@@ -319,7 +390,7 @@ func file_proxy_socks_config_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proxy_socks_config_proto_rawDesc), len(file_proxy_socks_config_proto_rawDesc)),
-			NumEnums:      1,
+			NumEnums:      2,
 			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/proxy/socks/config.proto
+++ b/proxy/socks/config.proto
@@ -23,6 +23,18 @@ enum AuthType {
   PASSWORD = 1;
 }
 
+// AuthFailureBehavior controls what the server returns when SOCKS5
+// authentication fails or when the client offers no acceptable method.
+// REJECT preserves the RFC 1928/1929 responses (0x05 0xFF, 0x01 0xFF) and is
+// the default. DROP closes the connection silently. HTTP400 writes a generic
+// "HTTP/1.1 400 Bad Request" reply so port scanners cannot fingerprint the
+// service as a SOCKS proxy.
+enum AuthFailureBehavior {
+  REJECT = 0;
+  DROP = 1;
+  HTTP400 = 2;
+}
+
 // ServerConfig is the protobuf config for Socks server.
 message ServerConfig {
   AuthType auth_type = 1;
@@ -30,6 +42,7 @@ message ServerConfig {
   xray.common.net.IPOrDomain address = 3;
   bool udp_enabled = 4;
   uint32 user_level = 6;
+  AuthFailureBehavior auth_failure_behavior = 7;
 }
 
 // ClientConfig is the protobuf config for Socks client.

--- a/proxy/socks/export_test.go
+++ b/proxy/socks/export_test.go
@@ -1,0 +1,9 @@
+package socks
+
+import "io"
+
+// WriteSocks5AuthFailureForTest exposes writeSocks5AuthFailure to external
+// test packages. It is only compiled into test binaries.
+func WriteSocks5AuthFailureForTest(w io.Writer, behavior AuthFailureBehavior, version, auth byte) error {
+	return writeSocks5AuthFailure(w, behavior, version, auth)
+}

--- a/proxy/socks/export_test.go
+++ b/proxy/socks/export_test.go
@@ -1,0 +1,23 @@
+package socks
+
+import (
+	"io"
+
+	"github.com/xtls/xray-core/common/net"
+)
+
+// WriteSocks5AuthFailureForTest exposes writeSocks5AuthFailure to external
+// test packages. It is only compiled into test binaries.
+func WriteSocks5AuthFailureForTest(w io.Writer, behavior AuthFailureBehavior, version, auth byte) error {
+	return writeSocks5AuthFailure(w, behavior, version, auth)
+}
+
+// NewServerSessionForTest exposes a minimal server session to external tests.
+func NewServerSessionForTest(config *ServerConfig) *ServerSession {
+	return &ServerSession{
+		config:       config,
+		address:      net.AnyIP,
+		port:         net.Port(0),
+		localAddress: net.AnyIP,
+	}
+}

--- a/proxy/socks/protocol.go
+++ b/proxy/socks/protocol.go
@@ -48,7 +48,7 @@ type ServerSession struct {
 
 func (s *ServerSession) handshake4(cmd byte, reader io.Reader, writer io.Writer) (*protocol.RequestHeader, error) {
 	if s.config.AuthType == AuthType_PASSWORD {
-		writeSocks4Response(writer, socks4RequestRejected, net.AnyIP, net.Port(0))
+		writeSocks4AuthFailure(writer, s.config.AuthFailureBehavior)
 		return nil, errors.New("socks 4 is not allowed when auth is required.")
 	}
 
@@ -109,8 +109,29 @@ func (s *ServerSession) auth5(nMethod byte, reader io.Reader, writer io.Writer) 
 	}
 
 	if !hasAuthMethod(expectedAuth, buffer.BytesRange(0, int32(nMethod))) {
-		writeSocks5AuthenticationResponse(writer, socks5Version, authNoMatchingMethod)
+		writeSocks5AuthFailure(writer, s.config.AuthFailureBehavior, socks5Version, authNoMatchingMethod)
 		return "", errors.New("no matching auth method")
+	}
+
+	if expectedAuth == authPassword && s.config.AuthFailureBehavior != AuthFailureBehavior_REJECT {
+		username, password, err := ReadUsernamePassword(reader)
+		if err != nil {
+			writeSocks5AuthFailure(writer, s.config.AuthFailureBehavior, 0x01, 0xFF)
+			return "", errors.New("failed to read username and password for authentication").Base(err)
+		}
+
+		if !s.config.HasAccount(username, password) {
+			writeSocks5AuthFailure(writer, s.config.AuthFailureBehavior, 0x01, 0xFF)
+			return "", errors.New("invalid username or password")
+		}
+
+		if err := writeSocks5AuthenticationResponse(writer, socks5Version, expectedAuth); err != nil {
+			return "", errors.New("failed to write auth response").Base(err)
+		}
+		if err := writeSocks5AuthenticationResponse(writer, 0x01, 0x00); err != nil {
+			return "", errors.New("failed to write auth response").Base(err)
+		}
+		return username, nil
 	}
 
 	if err := writeSocks5AuthenticationResponse(writer, socks5Version, expectedAuth); err != nil {
@@ -124,7 +145,7 @@ func (s *ServerSession) auth5(nMethod byte, reader io.Reader, writer io.Writer) 
 		}
 
 		if !s.config.HasAccount(username, password) {
-			writeSocks5AuthenticationResponse(writer, 0x01, 0xFF)
+			writeSocks5AuthFailure(writer, s.config.AuthFailureBehavior, 0x01, 0xFF)
 			return "", errors.New("invalid username or password")
 		}
 
@@ -295,6 +316,37 @@ func hasAuthMethod(expectedAuth byte, authCandidates []byte) bool {
 
 func writeSocks5AuthenticationResponse(writer io.Writer, version byte, auth byte) error {
 	return buf.WriteAllBytes(writer, []byte{version, auth}, nil)
+}
+
+// http400Response is a generic "Bad Request" reply that does not advertise any
+// proxy-specific headers. It is used to mask SOCKS/HTTP inbound ports as
+// ordinary web servers when authentication fails.
+var http400Response = []byte("HTTP/1.1 400 Bad Request\r\nServer: nginx\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+
+// writeSocks5AuthFailure writes the auth-failure response according to the
+// configured behavior. REJECT preserves the standard RFC 1928/1929 reply.
+// DROP writes nothing (the caller will close the connection). HTTP400 writes
+// a generic HTTP 400 to camouflage the port from proxy fingerprinting.
+func writeSocks5AuthFailure(writer io.Writer, behavior AuthFailureBehavior, version byte, auth byte) error {
+	switch behavior {
+	case AuthFailureBehavior_DROP:
+		return nil
+	case AuthFailureBehavior_HTTP400:
+		return buf.WriteAllBytes(writer, http400Response, nil)
+	default:
+		return writeSocks5AuthenticationResponse(writer, version, auth)
+	}
+}
+
+func writeSocks4AuthFailure(writer io.Writer, behavior AuthFailureBehavior) error {
+	switch behavior {
+	case AuthFailureBehavior_DROP:
+		return nil
+	case AuthFailureBehavior_HTTP400:
+		return buf.WriteAllBytes(writer, http400Response, nil)
+	default:
+		return writeSocks4Response(writer, socks4RequestRejected, net.AnyIP, net.Port(0))
+	}
 }
 
 func writeSocks5Response(writer io.Writer, errCode byte, address net.Address, port net.Port) error {

--- a/proxy/socks/protocol.go
+++ b/proxy/socks/protocol.go
@@ -110,7 +110,6 @@ func (s *ServerSession) auth5(nMethod byte, reader io.Reader, writer io.Writer) 
 
 	if !hasAuthMethod(expectedAuth, buffer.BytesRange(0, int32(nMethod))) {
 		writeSocks5AuthFailure(writer, s.config.AuthFailureBehavior, socks5Version, authNoMatchingMethod)
-		writeSocks5AuthFailure(writer, s.config.AuthFailureBehavior, socks5Version, authNoMatchingMethod)
 		return "", errors.New("no matching auth method")
 	}
 
@@ -146,7 +145,6 @@ func (s *ServerSession) auth5(nMethod byte, reader io.Reader, writer io.Writer) 
 		}
 
 		if !s.config.HasAccount(username, password) {
-			writeSocks5AuthFailure(writer, s.config.AuthFailureBehavior, 0x01, 0xFF)
 			writeSocks5AuthFailure(writer, s.config.AuthFailureBehavior, 0x01, 0xFF)
 			return "", errors.New("invalid username or password")
 		}

--- a/proxy/socks/protocol.go
+++ b/proxy/socks/protocol.go
@@ -109,7 +109,7 @@ func (s *ServerSession) auth5(nMethod byte, reader io.Reader, writer io.Writer) 
 	}
 
 	if !hasAuthMethod(expectedAuth, buffer.BytesRange(0, int32(nMethod))) {
-		writeSocks5AuthenticationResponse(writer, socks5Version, authNoMatchingMethod)
+		writeSocks5AuthFailure(writer, s.config.AuthFailureBehavior, socks5Version, authNoMatchingMethod)
 		return "", errors.New("no matching auth method")
 	}
 
@@ -124,7 +124,7 @@ func (s *ServerSession) auth5(nMethod byte, reader io.Reader, writer io.Writer) 
 		}
 
 		if !s.config.HasAccount(username, password) {
-			writeSocks5AuthenticationResponse(writer, 0x01, 0xFF)
+			writeSocks5AuthFailure(writer, s.config.AuthFailureBehavior, 0x01, 0xFF)
 			return "", errors.New("invalid username or password")
 		}
 
@@ -295,6 +295,26 @@ func hasAuthMethod(expectedAuth byte, authCandidates []byte) bool {
 
 func writeSocks5AuthenticationResponse(writer io.Writer, version byte, auth byte) error {
 	return buf.WriteAllBytes(writer, []byte{version, auth}, nil)
+}
+
+// http400Response is a generic "Bad Request" reply that does not advertise any
+// proxy-specific headers. It is used to mask SOCKS/HTTP inbound ports as
+// ordinary web servers when authentication fails.
+var http400Response = []byte("HTTP/1.1 400 Bad Request\r\nServer: nginx\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+
+// writeSocks5AuthFailure writes the auth-failure response according to the
+// configured behavior. REJECT preserves the standard RFC 1928/1929 reply.
+// DROP writes nothing (the caller will close the connection). HTTP400 writes
+// a generic HTTP 400 to camouflage the port from proxy fingerprinting.
+func writeSocks5AuthFailure(writer io.Writer, behavior AuthFailureBehavior, version byte, auth byte) error {
+	switch behavior {
+	case AuthFailureBehavior_DROP:
+		return nil
+	case AuthFailureBehavior_HTTP400:
+		return buf.WriteAllBytes(writer, http400Response, nil)
+	default:
+		return writeSocks5AuthenticationResponse(writer, version, auth)
+	}
 }
 
 func writeSocks5Response(writer io.Writer, errCode byte, address net.Address, port net.Port) error {

--- a/proxy/socks/server.go
+++ b/proxy/socks/server.go
@@ -33,6 +33,20 @@ type Server struct {
 	httpServer    *http.Server
 }
 
+// mapAuthFailureBehaviorToHTTP translates the SOCKS-side auth-failure
+// behavior into the HTTP-side enum so the embedded HTTP fallback does not
+// expose the proxy fingerprint when the SOCKS inbound is configured to hide.
+func mapAuthFailureBehaviorToHTTP(b AuthFailureBehavior) http.AuthFailureBehavior {
+	switch b {
+	case AuthFailureBehavior_DROP:
+		return http.AuthFailureBehavior_DROP
+	case AuthFailureBehavior_HTTP400:
+		return http.AuthFailureBehavior_HTTP400
+	default:
+		return http.AuthFailureBehavior_REJECT
+	}
+}
+
 // NewServer creates a new Server object.
 func NewServer(ctx context.Context, config *ServerConfig) (*Server, error) {
 	v := core.MustFromContext(ctx)
@@ -42,7 +56,8 @@ func NewServer(ctx context.Context, config *ServerConfig) (*Server, error) {
 		cone:          ctx.Value("cone").(bool),
 	}
 	httpConfig := &http.ServerConfig{
-		UserLevel: config.UserLevel,
+		UserLevel:           config.UserLevel,
+		AuthFailureBehavior: mapAuthFailureBehaviorToHTTP(config.AuthFailureBehavior),
 	}
 	if config.AuthType == AuthType_PASSWORD {
 		httpConfig.Accounts = config.Accounts


### PR DESCRIPTION
## Why

This targets active probing from the user's own device.

Some jurisdictions ship on-device scanners (apps or sideloaded probes, mostly it's may be Russian apps) that enumerate listeners on `127.0.0.1` and classify them. Any app with the `INTERNET` permission can do the same with two `connect()` calls:

- Send `\x05\x01\x00`. Any `\x05\xXX` reply identifies a SOCKS5 listener (RFC 1928 §3).
- Send a bare `CONNECT`. A `407 Proxy Authentication Required` with `Proxy-Authenticate: Basic realm="proxy"` identifies an HTTP proxy (RFC 7235 §3.2). The auth scheme and realm leak in the same response.

Password protection on the inbound doesn't help. Both responses are mandated by the RFCs and emitted before any auth exchange. The classification completes with zero traffic ever proxied.

The standard mitigation (binding to a UNIX socket or sitting behind a reverse proxy) isn't available on mobile. Xray clients like Happ and v2rayNG listen on local TCP because that is the only IPC the platform exposes to system VPN service consumers. Hardening the listener itself is the only option.

## What

A new optional `authFailureResponse` field on SOCKS and HTTP inbound settings controls what the server returns when the client offers no acceptable auth method or supplies wrong credentials:

| value | behavior |
|---|---|
| `reject` (default) | current RFC 1928 / RFC 7235 responses, full backwards compatibility |
| `drop` | close the connection without writing anything |
| `http400` | reply with `HTTP/1.1 400 Bad Request\r\nServer: nginx\r\n…` so the port looks like a generic web service |

The setting is honored at both auth-failure points in SOCKS (no matching method, bad password) and on the HTTP path. It also propagates into the embedded HTTP fallback that the SOCKS inbound uses for non-SOCKS traffic, so a probe sending an HTTP request to a SOCKS port can't bypass the camouflage.

`drop` and `http400` are explicit stealth hardening modes. For SOCKS5 password auth, they intentionally avoid sending the normal `0x05 0x02` method-selection byte before credential validation, because that byte alone fingerprints the listener as SOCKS5. As a result, these modes are not fully compatible with clients that wait for method selection before sending username/password. Such clients should keep using the default `reject` mode. Clients that need `drop` or `http400` with SOCKS5 password auth must send credentials preemptively/optimistically.

## Example config

```json
{
  "protocol": "socks",
  "port": 1080,
  "settings": {
    "auth": "password",
    "accounts": [{"user": "u", "pass": "p"}],
    "authFailureResponse": "http400"
  }
}
```

`authFailureResponse` accepts `"reject"`, `"drop"`, or `"http400"`. Omitted or empty means `reject`. Unknown values are rejected at config load with an explicit error.

## Backwards compatibility

Default `reject` emits the same RFC byte sequences the previous code did. Existing configs and clients behave identically.

The non-default `drop` and `http400` modes are opt-in hardening modes and may require client support for preemptive SOCKS5 username/password auth. They should not be used for generic compatibility-sensitive SOCKS5 password deployments unless the client behavior is known.

## Changes

- `proxy/socks/config.proto`, `proxy/http/config.proto`: new `AuthFailureBehavior` enum and field on `ServerConfig` (regenerated `.pb.go`).
- `infra/conf/socks.go`, `infra/conf/http.go`: JSON field `authFailureResponse` with string→enum mapping. Unknown values return a config error.
- `proxy/socks/protocol.go`: `writeSocks5AuthFailure` dispatcher replaces unconditional failure writes (`0x05 0xFF`, `0x01 0xFF`) and SOCKS4 auth-required rejection.
- `proxy/http/server.go`: `writeHTTPAuthFailure` dispatcher replaces the unconditional 407 write.
- `proxy/socks/server.go`: forwards `AuthFailureBehavior` into the embedded HTTP fallback `ServerConfig` through an explicit enum mapper. Does not rely on numeric equality between the two protobuf enums.

## Test plan

- `go build ./...`
- `go vet ./proxy/socks/... ./proxy/http/...`
- Existing tests in `proxy/socks` still pass.
- New unit tests for `writeSocks5AuthFailure` and `writeHTTPAuthFailure` covering all three behaviors.
- New unit tests for SOCKS4 auth-required responses and SOCKS5 bad-password behavior in stealth modes.
- Integration smoke test on a real binary, all three behaviors, both protocols:
  - `reject` produces the original RFC bytes.
  - `drop` closes the TCP connection with zero bytes written.
  - `http400` produces a generic 400 Bad Request with no proxy headers.
- Happy path verified:
  - `reject` keeps the standard SOCKS5 password flow.
  - `drop` / `http400` work with preemptive SOCKS5 username/password auth.
  - HTTP proxy auth with valid credentials still returns `HTTP/1.1 200 Connection established`.
- HTTP fallback path on the SOCKS inbound respects the setting. A non-SOCKS request to a SOCKS port no longer leaks 407 when `http400` or `drop` is configured.