### PR TITLE
Restore "legacy reverse"

### DIFF
--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -547,7 +547,7 @@ func (c *Config) Build() (*core.Config, error) {
 	}
 
 	if c.Reverse != nil {
-		return nil, errors.PrintRemovedFeatureError(`"legacy reverse"`, `"VLESS Reverse Proxy"`)
+		//return nil, errors.PrintRemovedFeatureError(`"legacy reverse"`, `"VLESS Reverse Proxy"`)
 		r, err := c.Reverse.Build()
 		if err != nil {
 			return nil, errors.New("failed to build reverse configuration").Base(err)


### PR DESCRIPTION
One of the advantages of legacy-reverse-code was that you could connect to an portal-inbound from two different bridge-servers, then users could choose which one to connect (after vless-route) or use them for load-balance.

this is because you could define different domain-name for each bridge, and corresponding portal-domain-name at portal-side.

but now we have only one outbound-reverse-tag at portal-side, and you can't do these.

///

i also remember that i used N bridge in one config (because it is list you can define as many as you want, and each one operates independently) and then used non-mux-transport for bridge-to-portal outbound, and then I connected each of my N users to one of the N bridges in portal side (or two-to-one if the number of users is greater), so each user used distinct TCP-connection and they did not affect each other.

///

but vless-reverse is very limited (one-bridge, one-tag) and you can't use vless-route, load-balance, distinc-users-connections, ...