### PR TITLE
Fix net.Conn memory leak in case of Handshake error

### DIFF
--- a/proxy/vless/outbound/outbound.go
+++ b/proxy/vless/outbound/outbound.go
@@ -209,10 +209,12 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 	errors.LogInfo(ctx, "tunneling request to ", target, " via ", rec.Destination.NetAddr())
 
 	if h.encryption != nil {
-		var err error
-		if conn, err = h.encryption.Handshake(conn); err != nil {
+		newConn, err := h.encryption.Handshake(conn)
+		if err != nil {
+			conn.Close()
 			return errors.New("ML-KEM-768 handshake failed").Base(err).AtInfo()
 		}
+		conn = newConn
 	}
 
 	command := protocol.RequestCommandTCP


### PR DESCRIPTION
On error, Handshake returns (nil, err) → conn becomes nil.
defer conn.Close() (declared above) attempts to close nil → panic.
The original connection (raw net.Conn) is lost but not closed → descriptor and memory leak.

What modification does:
The original conn is preserved before calling Handshake.
On error, the original connection is explicitly closed → no leak.
defer conn.Close() (the outer one) will no longer panic because conn did not become nil (the error returns before reassignment).