### PR TITLE
XHTTP client: Fix packet-up `OpenUsage` counting and H3 `keepAlivePeriod` parameter

### DIFF
--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -544,7 +544,9 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 
 				if xmuxClient != nil && (xmuxClient.LeftRequests.Add(-1) <= 0 ||
 					(xmuxClient.UnreusableAt != time.Time{} && lastWrite.After(xmuxClient.UnreusableAt))) {
+					xmuxClient.OpenUsage.Add(-1)
 					httpClient, xmuxClient = getHTTPClient(ctx, dest, streamSettings)
+					xmuxClient.OpenUsage.Add(1)
 				}
 
 				go func() {

--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -183,6 +183,8 @@ func createHTTPClient(dest net.Destination, streamSettings *internet.MemoryStrea
 		if quicParams.KeepAlivePeriod == 0 {
 			if keepAlivePeriod == 0 {
 				quicConfig.KeepAlivePeriod = net.QuicgoH3KeepAlivePeriod
+			} else if keepAlivePeriod > 0 {
+				quicConfig.KeepAlivePeriod = keepAlivePeriod
 			}
 		}
 		if quicParams.MaxIncomingStreams == 0 {

--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -439,17 +439,19 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 	var closed atomic.Int32
 
 	reader, writer := io.Pipe()
+	initXmuxClient := xmuxClient
+	initXmuxClient2 := xmuxClient2
 	conn := splitConn{
 		writer: writer,
 		onClose: func() {
 			if closed.Add(1) > 1 {
 				return
 			}
-			if xmuxClient != nil {
-				xmuxClient.OpenUsage.Add(-1)
+			if initXmuxClient != nil {
+				initXmuxClient.OpenUsage.Add(-1)
 			}
-			if xmuxClient2 != nil && xmuxClient2 != xmuxClient {
-				xmuxClient2.OpenUsage.Add(-1)
+			if initXmuxClient2 != nil && initXmuxClient2 != initXmuxClient {
+				initXmuxClient2.OpenUsage.Add(-1)
 			}
 		},
 	}
@@ -544,9 +546,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 
 				if xmuxClient != nil && (xmuxClient.LeftRequests.Add(-1) <= 0 ||
 					(xmuxClient.UnreusableAt != time.Time{} && lastWrite.After(xmuxClient.UnreusableAt))) {
-					xmuxClient.OpenUsage.Add(-1)
 					httpClient, xmuxClient = getHTTPClient(ctx, dest, streamSettings)
-					xmuxClient.OpenUsage.Add(1)
 				}
 
 				go func() {

--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -439,19 +439,17 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 	var closed atomic.Int32
 
 	reader, writer := io.Pipe()
-	initXmuxClient := xmuxClient
-	initXmuxClient2 := xmuxClient2
 	conn := splitConn{
 		writer: writer,
 		onClose: func() {
 			if closed.Add(1) > 1 {
 				return
 			}
-			if initXmuxClient != nil {
-				initXmuxClient.OpenUsage.Add(-1)
+			if xmuxClient != nil {
+				xmuxClient.OpenUsage.Add(-1)
 			}
-			if initXmuxClient2 != nil && initXmuxClient2 != initXmuxClient {
-				initXmuxClient2.OpenUsage.Add(-1)
+			if xmuxClient2 != nil && xmuxClient2 != xmuxClient {
+				xmuxClient2.OpenUsage.Add(-1)
 			}
 		},
 	}
@@ -510,6 +508,8 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 		var seq int64
 		var lastWrite time.Time
 
+		dynamicHTTPClient := httpClient
+		dynamicXmuxClient := xmuxClient
 		for {
 			// by offloading the uploads into a buffered pipe, multiple conn.Write
 			// calls get automatically batched together into larger POST requests.
@@ -544,13 +544,13 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 
 				lastWrite = time.Now()
 
-				if xmuxClient != nil && (xmuxClient.LeftRequests.Add(-1) <= 0 ||
-					(xmuxClient.UnreusableAt != time.Time{} && lastWrite.After(xmuxClient.UnreusableAt))) {
-					httpClient, xmuxClient = getHTTPClient(ctx, dest, streamSettings)
+				if dynamicXmuxClient != nil && (dynamicXmuxClient.LeftRequests.Add(-1) <= 0 ||
+					(dynamicXmuxClient.UnreusableAt != time.Time{} && lastWrite.After(dynamicXmuxClient.UnreusableAt))) {
+					dynamicHTTPClient, dynamicXmuxClient = getHTTPClient(ctx, dest, streamSettings)
 				}
 
-				go func() {
-					err := httpClient.PostPacket(
+				go func(hClient DialerClient) {
+					err := hClient.PostPacket(
 						ctx,
 						requestURL.String(),
 						sessionId,
@@ -563,9 +563,9 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 						uploadPipeReader.Interrupt()
 						doSplit.Store(false)
 					}
-				}()
+				}(dynamicHTTPClient)
 
-				if _, ok := httpClient.(*DefaultDialerClient); ok {
+				if _, ok := dynamicHTTPClient.(*DefaultDialerClient); ok {
 					<-wroteRequest.Wait()
 				}
 			}


### PR DESCRIPTION
之前加 quicParam 的时候把本来xmux里的keepalive参数直接无视了（虽然它们确实指向一个字段）
所以现在先看 quicParm 再看xmux
顺便修一下一个小计数泄露（不是内存泄漏）