### PR TITLE
README.md: replace Xray4Magisk with box4magisk and add AsteriskNG And…

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@
 - Android
   - [v2rayNG](https://github.com/2dust/v2rayNG)
   - [X-flutter](https://github.com/XTLS/X-flutter)
-  - [AsteriskNG](https://github.com/Asterisk4Magisk/AsteriskNG)
   - [SaeedDev94/Xray](https://github.com/SaeedDev94/Xray)
   - [SimpleXray](https://github.com/lhear/SimpleXray)
   - [XrayFA](https://github.com/Q7DF1/XrayFA)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@
   - [Xray_bash_onekey](https://github.com/hello-yunshu/Xray_bash_onekey), [XTool](https://github.com/LordPenguin666/XTool), [VPainLess](https://github.com/vpainless/vpainless)
   - [v2ray-agent](https://github.com/mack-a/v2ray-agent), [Xray_onekey](https://github.com/wulabing/Xray_onekey), [ProxySU](https://github.com/proxysu/ProxySU)
 - Magisk
-  - [box4magisk](https://github.com/CHIZI-0618/box4magisk)
+  - [Box4Magisk](https://github.com/CHIZI-0618/box4magisk)
   - [Xray_For_Magisk](https://github.com/E7KMbb/Xray_For_Magisk)
 - Homebrew
   - `brew install xray`

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@
   - [XrayFA](https://github.com/Q7DF1/XrayFA)
   - [AnyPortal](https://github.com/AnyPortal/AnyPortal)
   - [OneXray](https://github.com/OneXray/OneXray)
+  - [AsteriskNG](https://github.com/Asterisk4Magisk/AsteriskNG)
 - iOS & macOS arm64 & tvOS
   - [Happ](https://apps.apple.com/app/happ-proxy-utility/id6504287215) | [Happ RU](https://apps.apple.com/ru/app/happ-proxy-utility-plus/id6746188973) | [Happ tvOS](https://apps.apple.com/us/app/happ-proxy-utility-for-tv/id6748297274)
   - [Streisand](https://apps.apple.com/app/streisand/id6450534064)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@
   - [Xray_bash_onekey](https://github.com/hello-yunshu/Xray_bash_onekey), [XTool](https://github.com/LordPenguin666/XTool), [VPainLess](https://github.com/vpainless/vpainless)
   - [v2ray-agent](https://github.com/mack-a/v2ray-agent), [Xray_onekey](https://github.com/wulabing/Xray_onekey), [ProxySU](https://github.com/proxysu/ProxySU)
 - Magisk
-  - [Xray4Magisk](https://github.com/Asterisk4Magisk/Xray4Magisk)
+  - [box4magisk](https://github.com/CHIZI-0618/box4magisk)
   - [Xray_For_Magisk](https://github.com/E7KMbb/Xray_For_Magisk)
 - Homebrew
   - `brew install xray`
@@ -115,6 +115,7 @@
 - Android
   - [v2rayNG](https://github.com/2dust/v2rayNG)
   - [X-flutter](https://github.com/XTLS/X-flutter)
+  - [AsteriskNG](https://github.com/Asterisk4Magisk/AsteriskNG)
   - [SaeedDev94/Xray](https://github.com/SaeedDev94/Xray)
   - [SimpleXray](https://github.com/lhear/SimpleXray)
   - [XrayFA](https://github.com/Q7DF1/XrayFA)


### PR DESCRIPTION
…roid client

Xray4Magisk is no longer maintained, and the team has developed a new Android client, AsteriskNG, see https://github.com/Asterisk4Magisk/Xray4Magisk/commit/6f3bdbe7b7886af182f84d915bb10fe89bf119d1