### PR TITLE
Add Orayo to Windows GUI clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@
   - [GenyConnect](https://github.com/genyleap/GenyConnect)
   - [OneXray](https://github.com/OneXray/OneXray)
   - [XrayUI-dev](https://github.com/PhoenixNil/XrayUI-dev)
+  - [Orayo](https://github.com/barkure/Orayo)
 - Android
   - [v2rayNG](https://github.com/2dust/v2rayNG)
   - [X-flutter](https://github.com/XTLS/X-flutter)


### PR DESCRIPTION
I would like to request adding Orayo to the Windows GUI Clients list in README.

Orayo is a modern Windows Xray client built with WinUI 3. It supports TUN mode, system proxy, routing and DNS settings, node management, and geo data updates.

Project: https://github.com/barkure/Orayo

## Screenshots
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/29941b7e-11f4-4227-908d-5c5036c05ef0" /></td>
    <td><img src="https://github.com/user-attachments/assets/55e1ba4e-818a-4144-9c5d-3986da2cfe31" /></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/5d5c5ffb-f25e-45fe-89fc-59fe91aa9301" /></td>
    <td><img src="https://github.com/user-attachments/assets/d7b0c34b-c9c2-45cb-b94b-7dbc57c14229" /></td>
  </tr>
</table>