### PR TITLE
Bound shutdown after termination signal

### DIFF
--- a/main/run.go
+++ b/main/run.go
@@ -91,7 +91,6 @@ func executeRun(cmd *base.Command, args []string) {
 		fmt.Println("Failed to start:", err)
 		os.Exit(-1)
 	}
-	defer server.Close()
 
 	// Explicitly triggering GC to remove garbage from config loading.
 	runtime.GC()
@@ -101,6 +100,22 @@ func executeRun(cmd *base.Command, args []string) {
 		osSignals := make(chan os.Signal, 1)
 		signal.Notify(osSignals, os.Interrupt, syscall.SIGTERM)
 		<-osSignals
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- server.Close()
+	}()
+
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			fmt.Println("Failed to close:", err)
+			os.Exit(1)
+		}
+	case <-time.After(10 * time.Second):
+		fmt.Println("Timed out while closing Xray.")
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
This change prevents Xray from waiting indefinitely during graceful shutdown after receiving SIGTERM or interrupt.

Previously, shutdown depended on the deferred server.Close() call returning. If any feature Close() path blocked, the process could stay alive while listeners or active connections continued operating. This made stale Xray processes difficult to detect, especially when another process could bind the same port.

Now Xray runs server.Close() explicitly after receiving a termination signal and waits up to 10 seconds. If shutdown does not complete in time, the process exits with code 1 so supervisors can treat it as a failed shutdown and avoid leaving a functional stale process behind.

This issue was most visible on mobile clients. Some apps, such as Telegram proxy-style traffic, may continue using an already-established path even when the VPN/client UI appears disabled. If the old Xray process remains alive during a stuck shutdown, those connections can continue transferring traffic and updating usage counters, making the node look stopped from the client side while traffic is still flowing server-side.

