### PR TITLE
Config: avoid REALITY non-443 warning for Unix socket listen

### DIFF
--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -173,7 +173,7 @@ func (c *InboundDetourConfig) Build() (*core.InboundHandlerConfig, error) {
 			return nil, err
 		}
 		receiverSettings.StreamSettings = ss
-		if strings.Contains(ss.SecurityType, "reality") && (receiverSettings.PortList == nil ||
+		if strings.Contains(ss.SecurityType, "reality") && receiverSettings.PortList != nil && (
 			len(receiverSettings.PortList.Ports()) != 1 || receiverSettings.PortList.Ports()[0] != 443) {
 			errors.LogWarning(context.Background(), `REALITY: Listening on non-443 ports may get your IP blocked by the GFW`)
 		}


### PR DESCRIPTION
Avoid printing the REALITY non-443 port warning when an inbound listens on a UNIX Socket