### PR TITLE
XHTTP: Add zstd and lz4 compression

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,11 @@ require (
 	github.com/golang/mock v1.7.0-rc.1
 	github.com/google/go-cmp v0.7.0
 	github.com/gorilla/websocket v1.5.3
+	github.com/klauspost/compress v1.17.4
 	github.com/klauspost/cpuid/v2 v2.3.0
 	github.com/miekg/dns v1.1.72
 	github.com/pelletier/go-toml v1.9.5
+	github.com/pierrec/lz4/v4 v4.1.26
 	github.com/pires/go-proxyproto v0.12.0
 	github.com/refraction-networking/utls v1.8.3-0.20260301010127-aa6edf4b11af
 	github.com/robfig/cron/v3 v3.0.1
@@ -41,7 +43,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/juju/ratelimit v1.0.2 // indirect
-	github.com/klauspost/compress v1.17.4 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3v
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
+github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=
+github.com/pierrec/lz4/v4 v4.1.26/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/pires/go-proxyproto v0.12.0 h1:TTCxD66dU898tahivkqc3hoceZp7P44FnorWyo9d5vM=
 github.com/pires/go-proxyproto v0.12.0/go.mod h1:qUvfqUMEoX7T8g0q7TQLDnhMjdTrxnG0hvpMn+7ePNI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/xtls/xray-core/common"
+	"github.com/xtls/xray-core/common/buf"
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/platform/filesystem"
@@ -214,34 +215,41 @@ func (c *HttpUpgradeConfig) Build() (proto.Message, error) {
 }
 
 type SplitHTTPConfig struct {
-	Host                 string            `json:"host"`
-	Path                 string            `json:"path"`
-	Mode                 string            `json:"mode"`
-	Headers              map[string]string `json:"headers"`
-	XPaddingBytes        Int32Range        `json:"xPaddingBytes"`
-	XPaddingObfsMode     bool              `json:"xPaddingObfsMode"`
-	XPaddingKey          string            `json:"xPaddingKey"`
-	XPaddingHeader       string            `json:"xPaddingHeader"`
-	XPaddingPlacement    string            `json:"xPaddingPlacement"`
-	XPaddingMethod       string            `json:"xPaddingMethod"`
-	UplinkHTTPMethod     string            `json:"uplinkHTTPMethod"`
-	SessionPlacement     string            `json:"sessionPlacement"`
-	SessionKey           string            `json:"sessionKey"`
-	SeqPlacement         string            `json:"seqPlacement"`
-	SeqKey               string            `json:"seqKey"`
-	UplinkDataPlacement  string            `json:"uplinkDataPlacement"`
-	UplinkDataKey        string            `json:"uplinkDataKey"`
-	UplinkChunkSize      Int32Range        `json:"uplinkChunkSize"`
-	NoGRPCHeader         bool              `json:"noGRPCHeader"`
-	NoSSEHeader          bool              `json:"noSSEHeader"`
-	ScMaxEachPostBytes   Int32Range        `json:"scMaxEachPostBytes"`
-	ScMinPostsIntervalMs Int32Range        `json:"scMinPostsIntervalMs"`
-	ScMaxBufferedPosts   int64             `json:"scMaxBufferedPosts"`
-	ScStreamUpServerSecs Int32Range        `json:"scStreamUpServerSecs"`
-	ServerMaxHeaderBytes int32             `json:"serverMaxHeaderBytes"`
-	Xmux                 XmuxConfig        `json:"xmux"`
-	DownloadSettings     *StreamConfig     `json:"downloadSettings"`
-	Extra                json.RawMessage   `json:"extra"`
+	Host                 string             `json:"host"`
+	Path                 string             `json:"path"`
+	Mode                 string             `json:"mode"`
+	Headers              map[string]string  `json:"headers"`
+	XPaddingBytes        Int32Range         `json:"xPaddingBytes"`
+	XPaddingObfsMode     bool               `json:"xPaddingObfsMode"`
+	XPaddingKey          string             `json:"xPaddingKey"`
+	XPaddingHeader       string             `json:"xPaddingHeader"`
+	XPaddingPlacement    string             `json:"xPaddingPlacement"`
+	XPaddingMethod       string             `json:"xPaddingMethod"`
+	UplinkHTTPMethod     string             `json:"uplinkHTTPMethod"`
+	SessionPlacement     string             `json:"sessionPlacement"`
+	SessionKey           string             `json:"sessionKey"`
+	SeqPlacement         string             `json:"seqPlacement"`
+	SeqKey               string             `json:"seqKey"`
+	UplinkDataPlacement  string             `json:"uplinkDataPlacement"`
+	UplinkDataKey        string             `json:"uplinkDataKey"`
+	UplinkChunkSize      Int32Range         `json:"uplinkChunkSize"`
+	NoGRPCHeader         bool               `json:"noGRPCHeader"`
+	NoSSEHeader          bool               `json:"noSSEHeader"`
+	ScMaxEachPostBytes   Int32Range         `json:"scMaxEachPostBytes"`
+	ScMinPostsIntervalMs Int32Range         `json:"scMinPostsIntervalMs"`
+	ScMaxBufferedPosts   int64              `json:"scMaxBufferedPosts"`
+	ScStreamUpServerSecs Int32Range         `json:"scStreamUpServerSecs"`
+	ServerMaxHeaderBytes int32              `json:"serverMaxHeaderBytes"`
+	Compression          *CompressionConfig `json:"compression"`
+	Xmux                 XmuxConfig         `json:"xmux"`
+	DownloadSettings     *StreamConfig      `json:"downloadSettings"`
+	Extra                json.RawMessage    `json:"extra"`
+}
+
+type CompressionConfig struct {
+	Type          string `json:"type"`
+	BufferSize    int32  `json:"bufferSize"`
+	CompressLevel int32  `json:"compressLevel"`
 }
 
 type XmuxConfig struct {
@@ -384,6 +392,34 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 		return nil, errors.New("invalid negative value of maxHeaderBytes")
 	}
 
+	var compression *splithttp.CompressionConfig
+	if c.Compression != nil {
+		c.Compression.Type = strings.ToLower(c.Compression.Type)
+		switch c.Compression.Type {
+		case "", "none":
+			c.Compression.Type = "none"
+		case "zstd", "lz4":
+			if c.Compression.BufferSize > 0 && c.Compression.BufferSize < buf.Size {
+				return nil, errors.New("compression bufferSize must be at least ", buf.Size)
+			}
+			if c.Compression.Type == "lz4" && c.Compression.CompressLevel > 9 {
+				return nil, errors.New("unsupported lz4 compressLevel: ", c.Compression.CompressLevel)
+			}
+			if c.Mode == "packet-up" && (c.UplinkDataPlacement == splithttp.PlacementHeader || c.UplinkDataPlacement == splithttp.PlacementCookie) {
+				return nil, errors.New("compression cannot be used with uplinkDataPlacement: " + c.UplinkDataPlacement)
+			}
+		default:
+			return nil, errors.New("unsupported compression type: " + c.Compression.Type)
+		}
+		if c.Compression.Type != "none" {
+			compression = &splithttp.CompressionConfig{
+				Type:          c.Compression.Type,
+				BufferSize:    c.Compression.BufferSize,
+				CompressLevel: c.Compression.CompressLevel,
+			}
+		}
+	}
+
 	if c.Xmux.MaxConnections.To > 0 && c.Xmux.MaxConcurrency.To > 0 {
 		return nil, errors.New("maxConnections cannot be specified together with maxConcurrency")
 	}
@@ -422,6 +458,7 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 		ScMaxBufferedPosts:   c.ScMaxBufferedPosts,
 		ScStreamUpServerSecs: newRangeConfig(c.ScStreamUpServerSecs),
 		ServerMaxHeaderBytes: c.ServerMaxHeaderBytes,
+		Compression:          compression,
 		Xmux: &splithttp.XmuxConfig{
 			MaxConcurrency:   newRangeConfig(c.Xmux.MaxConcurrency),
 			MaxConnections:   newRangeConfig(c.Xmux.MaxConnections),

--- a/infra/conf/transport_test.go
+++ b/infra/conf/transport_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/xtls/xray-core/infra/conf"
 	"github.com/xtls/xray-core/transport/internet"
 	finalmaskcustom "github.com/xtls/xray-core/transport/internet/finalmask/header/custom"
+	"github.com/xtls/xray-core/transport/internet/splithttp"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -290,5 +291,94 @@ func TestHeaderCustomUDPBuildRejectsExprWithoutArgs(t *testing.T) {
 	}`)
 	if err == nil || !strings.Contains(err.Error(), "transform args") {
 		t.Fatalf("expected transform arg rejection, got %v", err)
+	}
+}
+
+func TestSplitHTTPCompressionBuild(t *testing.T) {
+	parser := loadJSON(func() Buildable { return new(SplitHTTPConfig) })
+
+	msg, err := parser(`{
+		"mode": "packet-up",
+		"uplinkDataPlacement": "body",
+		"compression": {
+			"type": "zstd",
+			"bufferSize": 262144,
+			"compressLevel": 3
+		}
+	}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config := msg.(*splithttp.Config)
+	if config.Compression == nil {
+		t.Fatal("expected compression config")
+	}
+	if config.Compression.Type != "zstd" {
+		t.Fatalf("unexpected compression type: %q", config.Compression.Type)
+	}
+	if config.Compression.BufferSize != 262144 {
+		t.Fatalf("unexpected buffer size: %d", config.Compression.BufferSize)
+	}
+	if config.Compression.CompressLevel != 3 {
+		t.Fatalf("unexpected compress level: %d", config.Compression.CompressLevel)
+	}
+}
+
+func TestSplitHTTPCompressionBuildRejectsUnsupportedType(t *testing.T) {
+	parser := loadJSON(func() Buildable { return new(SplitHTTPConfig) })
+
+	_, err := parser(`{
+		"compression": {
+			"type": "br"
+		}
+	}`)
+	if err == nil || !strings.Contains(err.Error(), "unsupported compression type") {
+		t.Fatalf("expected unsupported compression type rejection, got %v", err)
+	}
+}
+
+func TestSplitHTTPCompressionBuildRejectsSmallBuffer(t *testing.T) {
+	parser := loadJSON(func() Buildable { return new(SplitHTTPConfig) })
+
+	_, err := parser(`{
+		"compression": {
+			"type": "zstd",
+			"bufferSize": 1
+		}
+	}`)
+	if err == nil || !strings.Contains(err.Error(), "compression bufferSize") {
+		t.Fatalf("expected compression buffer size rejection, got %v", err)
+	}
+}
+
+func TestSplitHTTPCompressionBuildRejectsHeaderAndCookiePayload(t *testing.T) {
+	parser := loadJSON(func() Buildable { return new(SplitHTTPConfig) })
+
+	for _, placement := range []string{"header", "cookie"} {
+		_, err := parser(`{
+			"mode": "packet-up",
+			"uplinkDataPlacement": "` + placement + `",
+			"compression": {
+				"type": "zstd"
+			}
+		}`)
+		if err == nil || !strings.Contains(err.Error(), "compression cannot be used with uplinkDataPlacement") {
+			t.Fatalf("expected %s payload placement rejection, got %v", placement, err)
+		}
+	}
+}
+
+func TestSplitHTTPCompressionBuildRejectsInvalidLz4Level(t *testing.T) {
+	parser := loadJSON(func() Buildable { return new(SplitHTTPConfig) })
+
+	_, err := parser(`{
+		"compression": {
+			"type": "lz4",
+			"compressLevel": 10
+		}
+	}`)
+	if err == nil || !strings.Contains(err.Error(), "unsupported lz4 compressLevel") {
+		t.Fatalf("expected lz4 compressLevel rejection, got %v", err)
 	}
 }

--- a/transport/internet/splithttp/compression.go
+++ b/transport/internet/splithttp/compression.go
@@ -1,0 +1,213 @@
+package splithttp
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"sync"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/pierrec/lz4/v4"
+	"github.com/xtls/xray-core/common/errors"
+)
+
+const (
+	compressionNone = "none"
+	compressionZstd = "zstd"
+	compressionLz4  = "lz4"
+)
+
+func normalizedCompressionType(config *Config) string {
+	if config == nil || config.Compression == nil || config.Compression.Type == "" {
+		return compressionNone
+	}
+	return config.Compression.Type
+}
+
+func compressionEnabled(config *Config) bool {
+	return normalizedCompressionType(config) != compressionNone
+}
+
+func compressPayload(config *Config, payload []byte) ([]byte, error) {
+	switch normalizedCompressionType(config) {
+	case compressionNone:
+		return payload, nil
+	case compressionZstd:
+		options := []zstd.EOption{zstd.WithEncoderConcurrency(1)}
+		if config.Compression.CompressLevel != 0 {
+			options = append(options, zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(int(config.Compression.CompressLevel))))
+		}
+		encoder, err := zstd.NewWriter(nil, options...)
+		if err != nil {
+			return nil, err
+		}
+		defer encoder.Close()
+		return encoder.EncodeAll(payload, nil), nil
+	case compressionLz4:
+		var out bytes.Buffer
+		writer := lz4.NewWriter(&out)
+		level, err := lz4CompressionLevel(config.Compression.CompressLevel)
+		if err != nil {
+			return nil, err
+		}
+		if err := writer.Apply(lz4.CompressionLevelOption(level)); err != nil {
+			return nil, err
+		}
+		if _, err := writer.Write(payload); err != nil {
+			return nil, err
+		}
+		if err := writer.Close(); err != nil {
+			return nil, err
+		}
+		return out.Bytes(), nil
+	default:
+		return nil, errors.New("unsupported compression type: " + config.Compression.Type)
+	}
+}
+
+func decompressPayload(config *Config, payload []byte) ([]byte, error) {
+	switch normalizedCompressionType(config) {
+	case compressionNone:
+		return payload, nil
+	case compressionZstd:
+		decoder, err := zstd.NewReader(nil)
+		if err != nil {
+			return nil, err
+		}
+		defer decoder.Close()
+		return decoder.DecodeAll(payload, nil)
+	case compressionLz4:
+		var out bytes.Buffer
+		if _, err := io.Copy(&out, lz4.NewReader(bytes.NewReader(payload))); err != nil {
+			return nil, err
+		}
+		return out.Bytes(), nil
+	default:
+		return nil, errors.New("unsupported compression type: " + config.Compression.Type)
+	}
+}
+
+type compressedWriteCloser struct {
+	io.WriteCloser
+	config *Config
+	mu     sync.Mutex
+}
+
+func newCompressedWriteCloser(config *Config, writer io.WriteCloser) io.WriteCloser {
+	if !compressionEnabled(config) {
+		return writer
+	}
+	return &compressedWriteCloser{
+		WriteCloser: writer,
+		config:      config,
+	}
+}
+
+func (w *compressedWriteCloser) Write(payload []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	compressed, err := compressPayload(w.config, payload)
+	if err != nil {
+		return 0, err
+	}
+	if uint64(len(compressed)) > uint64(^uint32(0)) {
+		return 0, errors.New("compressed frame is too large: ", len(compressed))
+	}
+
+	var header [4]byte
+	binary.BigEndian.PutUint32(header[:], uint32(len(compressed)))
+	if err := writeFull(w.WriteCloser, header[:]); err != nil {
+		return 0, err
+	}
+	if err := writeFull(w.WriteCloser, compressed); err != nil {
+		return 0, err
+	}
+	return len(payload), nil
+}
+
+type compressedReadCloser struct {
+	io.ReadCloser
+	config  *Config
+	pending []byte
+}
+
+func newCompressedReadCloser(config *Config, reader io.ReadCloser) io.ReadCloser {
+	if !compressionEnabled(config) {
+		return reader
+	}
+	return &compressedReadCloser{
+		ReadCloser: reader,
+		config:     config,
+	}
+}
+
+func (r *compressedReadCloser) Read(payload []byte) (int, error) {
+	for len(r.pending) == 0 {
+		var header [4]byte
+		if _, err := io.ReadFull(r.ReadCloser, header[:]); err != nil {
+			return 0, err
+		}
+		frameLen := binary.BigEndian.Uint32(header[:])
+		if frameLen == 0 {
+			continue
+		}
+		frame := make([]byte, frameLen)
+		if _, err := io.ReadFull(r.ReadCloser, frame); err != nil {
+			return 0, err
+		}
+		decompressed, err := decompressPayload(r.config, frame)
+		if err != nil {
+			return 0, err
+		}
+		r.pending = decompressed
+	}
+
+	n := copy(payload, r.pending)
+	r.pending = r.pending[n:]
+	return n, nil
+}
+
+func writeFull(writer io.Writer, payload []byte) error {
+	for len(payload) > 0 {
+		n, err := writer.Write(payload)
+		if err != nil {
+			return err
+		}
+		payload = payload[n:]
+		if n == 0 {
+			return io.ErrShortWrite
+		}
+	}
+	return nil
+}
+
+func lz4CompressionLevel(level int32) (lz4.CompressionLevel, error) {
+	switch level {
+	case 0:
+		return lz4.Fast, nil
+	case 1:
+		return lz4.Level1, nil
+	case 2:
+		return lz4.Level2, nil
+	case 3:
+		return lz4.Level3, nil
+	case 4:
+		return lz4.Level4, nil
+	case 5:
+		return lz4.Level5, nil
+	case 6:
+		return lz4.Level6, nil
+	case 7:
+		return lz4.Level7, nil
+	case 8:
+		return lz4.Level8, nil
+	case 9:
+		return lz4.Level9, nil
+	default:
+		if level < 0 {
+			return lz4.Fast, nil
+		}
+		return lz4.Fast, errors.New("unsupported lz4 compressLevel: ", level)
+	}
+}

--- a/transport/internet/splithttp/compression_test.go
+++ b/transport/internet/splithttp/compression_test.go
@@ -1,0 +1,151 @@
+package splithttp
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/xtls/xray-core/common/buf"
+)
+
+func TestCompressionZstdRoundTrip(t *testing.T) {
+	config := &Config{Compression: &CompressionConfig{Type: "zstd", CompressLevel: 3}}
+	payload := bytes.Repeat([]byte("xhttp-zstd-payload-"), 4096)
+
+	compressed, err := compressPayload(config, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(compressed) >= len(payload) {
+		t.Fatalf("expected compressed payload to be smaller than %d, got %d", len(payload), len(compressed))
+	}
+
+	decompressed, err := decompressPayload(config, compressed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(decompressed, payload) {
+		t.Fatal("decompressed payload differs from original")
+	}
+}
+
+func TestCompressionLz4RoundTrip(t *testing.T) {
+	config := &Config{Compression: &CompressionConfig{Type: "lz4", CompressLevel: 1}}
+	payload := bytes.Repeat([]byte("xhttp-lz4-payload-"), 4096)
+
+	compressed, err := compressPayload(config, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decompressed, err := decompressPayload(config, compressed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(decompressed, payload) {
+		t.Fatal("decompressed payload differs from original")
+	}
+}
+
+func TestCompressionDisabledIsNoop(t *testing.T) {
+	payload := []byte("plain payload")
+
+	compressed, err := compressPayload(&Config{}, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(compressed, payload) {
+		t.Fatalf("disabled compression changed payload: %q", compressed)
+	}
+
+	decompressed, err := decompressPayload(&Config{}, compressed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(decompressed, payload) {
+		t.Fatalf("disabled decompression changed payload: %q", decompressed)
+	}
+}
+
+func TestCompressionRejectsUnknownType(t *testing.T) {
+	config := &Config{Compression: &CompressionConfig{Type: "br"}}
+
+	if _, err := compressPayload(config, []byte("payload")); err == nil {
+		t.Fatal("expected unknown compression type error")
+	}
+	if _, err := decompressPayload(config, []byte("payload")); err == nil {
+		t.Fatal("expected unknown compression type error")
+	}
+}
+
+func TestPacketCompressionCompressesBodyPayload(t *testing.T) {
+	config := &Config{
+		UplinkDataPlacement: PlacementBody,
+		Compression: &CompressionConfig{
+			Type:          "zstd",
+			CompressLevel: 3,
+		},
+	}
+	payload := bytes.Repeat([]byte("xhttp-body-payload-"), 4096)
+	request, err := http.NewRequest("POST", "http://example.com/upload", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = config.FillPacketRequest(request, "session", "0", buf.MultiBuffer{buf.FromBytes(payload)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := io.ReadAll(request.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(body) >= len(payload) {
+		t.Fatalf("expected compressed body to be smaller than %d, got %d", len(payload), len(body))
+	}
+	decompressed, err := decompressPayload(config, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(decompressed, payload) {
+		t.Fatal("decompressed request body differs from original")
+	}
+	if request.ContentLength != int64(len(body)) {
+		t.Fatalf("unexpected content length: %d, want %d", request.ContentLength, len(body))
+	}
+}
+
+func TestStreamCompressionFramesPayload(t *testing.T) {
+	config := &Config{Compression: &CompressionConfig{Type: "zstd", CompressLevel: 3}}
+	payload := bytes.Repeat([]byte("xhttp-stream-payload-"), 4096)
+	raw := &bytesWriteCloser{}
+	writer := newCompressedWriteCloser(config, raw)
+
+	n, err := writer.Write(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(payload) {
+		t.Fatalf("unexpected written bytes: %d, want %d", n, len(payload))
+	}
+	if raw.Len() >= len(payload) {
+		t.Fatalf("expected framed compressed stream to be smaller than %d, got %d", len(payload), raw.Len())
+	}
+
+	reader := newCompressedReadCloser(config, io.NopCloser(bytes.NewReader(raw.Bytes())))
+	decoded, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(decoded, payload) {
+		t.Fatal("decoded stream differs from original")
+	}
+}
+
+type bytesWriteCloser struct {
+	bytes.Buffer
+}
+
+func (w *bytesWriteCloser) Close() error {
+	return nil
+}

--- a/transport/internet/splithttp/config.go
+++ b/transport/internet/splithttp/config.go
@@ -1,6 +1,7 @@
 package splithttp
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -327,8 +328,20 @@ func (c *Config) FillPacketRequest(request *http.Request, sessionId string, seqS
 
 	if dataPlacement == PlacementBody || dataPlacement == PlacementAuto {
 		request.Header = c.GetRequestHeader()
-		request.Body = io.NopCloser(&buf.MultiBufferContainer{MultiBuffer: payload})
-		request.ContentLength = int64(payload.Len())
+		if compressionEnabled(c) {
+			data := make([]byte, payload.Len())
+			payload.Copy(data)
+			buf.ReleaseMulti(payload)
+			compressed, err := compressPayload(c, data)
+			if err != nil {
+				return err
+			}
+			request.Body = io.NopCloser(bytes.NewReader(compressed))
+			request.ContentLength = int64(len(compressed))
+		} else {
+			request.Body = io.NopCloser(&buf.MultiBufferContainer{MultiBuffer: payload})
+			request.ContentLength = int64(payload.Len())
+		}
 	} else {
 		data := make([]byte, payload.Len())
 		payload.Copy(data)

--- a/transport/internet/splithttp/config.pb.go
+++ b/transport/internet/splithttp/config.pb.go
@@ -158,6 +158,66 @@ func (x *XmuxConfig) GetHKeepAlivePeriod() int64 {
 	return 0
 }
 
+type CompressionConfig struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Type          string                 `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
+	BufferSize    int32                  `protobuf:"varint,2,opt,name=bufferSize,proto3" json:"bufferSize,omitempty"`
+	CompressLevel int32                  `protobuf:"varint,3,opt,name=compressLevel,proto3" json:"compressLevel,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CompressionConfig) Reset() {
+	*x = CompressionConfig{}
+	mi := &file_transport_internet_splithttp_config_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CompressionConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CompressionConfig) ProtoMessage() {}
+
+func (x *CompressionConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_transport_internet_splithttp_config_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CompressionConfig.ProtoReflect.Descriptor instead.
+func (*CompressionConfig) Descriptor() ([]byte, []int) {
+	return file_transport_internet_splithttp_config_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *CompressionConfig) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *CompressionConfig) GetBufferSize() int32 {
+	if x != nil {
+		return x.BufferSize
+	}
+	return 0
+}
+
+func (x *CompressionConfig) GetCompressLevel() int32 {
+	if x != nil {
+		return x.CompressLevel
+	}
+	return 0
+}
+
 type Config struct {
 	state                protoimpl.MessageState `protogen:"open.v1"`
 	Host                 string                 `protobuf:"bytes,1,opt,name=host,proto3" json:"host,omitempty"`
@@ -187,13 +247,14 @@ type Config struct {
 	UplinkDataKey        string                 `protobuf:"bytes,25,opt,name=uplinkDataKey,proto3" json:"uplinkDataKey,omitempty"`
 	UplinkChunkSize      *RangeConfig           `protobuf:"bytes,26,opt,name=uplinkChunkSize,proto3" json:"uplinkChunkSize,omitempty"`
 	ServerMaxHeaderBytes int32                  `protobuf:"varint,27,opt,name=serverMaxHeaderBytes,proto3" json:"serverMaxHeaderBytes,omitempty"`
+	Compression          *CompressionConfig     `protobuf:"bytes,28,opt,name=compression,proto3" json:"compression,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
 
 func (x *Config) Reset() {
 	*x = Config{}
-	mi := &file_transport_internet_splithttp_config_proto_msgTypes[2]
+	mi := &file_transport_internet_splithttp_config_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -205,7 +266,7 @@ func (x *Config) String() string {
 func (*Config) ProtoMessage() {}
 
 func (x *Config) ProtoReflect() protoreflect.Message {
-	mi := &file_transport_internet_splithttp_config_proto_msgTypes[2]
+	mi := &file_transport_internet_splithttp_config_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -218,7 +279,7 @@ func (x *Config) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Config.ProtoReflect.Descriptor instead.
 func (*Config) Descriptor() ([]byte, []int) {
-	return file_transport_internet_splithttp_config_proto_rawDescGZIP(), []int{2}
+	return file_transport_internet_splithttp_config_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *Config) GetHost() string {
@@ -410,6 +471,13 @@ func (x *Config) GetServerMaxHeaderBytes() int32 {
 	return 0
 }
 
+func (x *Config) GetCompression() *CompressionConfig {
+	if x != nil {
+		return x.Compression
+	}
+	return nil
+}
+
 var File_transport_internet_splithttp_config_proto protoreflect.FileDescriptor
 
 const file_transport_internet_splithttp_config_proto_rawDesc = "" +
@@ -425,7 +493,13 @@ const file_transport_internet_splithttp_config_proto_rawDesc = "" +
 	"\x0ecMaxReuseTimes\x18\x03 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x0ecMaxReuseTimes\x12Z\n" +
 	"\x10hMaxRequestTimes\x18\x04 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x10hMaxRequestTimes\x12Z\n" +
 	"\x10hMaxReusableSecs\x18\x05 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x10hMaxReusableSecs\x12*\n" +
-	"\x10hKeepAlivePeriod\x18\x06 \x01(\x03R\x10hKeepAlivePeriod\"\xc2\v\n" +
+	"\x10hKeepAlivePeriod\x18\x06 \x01(\x03R\x10hKeepAlivePeriod\"m\n" +
+	"\x11CompressionConfig\x12\x12\n" +
+	"\x04type\x18\x01 \x01(\tR\x04type\x12\x1e\n" +
+	"\n" +
+	"bufferSize\x18\x02 \x01(\x05R\n" +
+	"bufferSize\x12$\n" +
+	"\rcompressLevel\x18\x03 \x01(\x05R\rcompressLevel\"\x9a\f\n" +
 	"\x06Config\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
 	"\x04path\x18\x02 \x01(\tR\x04path\x12\x12\n" +
@@ -456,7 +530,8 @@ const file_transport_internet_splithttp_config_proto_rawDesc = "" +
 	"\x13uplinkDataPlacement\x18\x18 \x01(\tR\x13uplinkDataPlacement\x12$\n" +
 	"\ruplinkDataKey\x18\x19 \x01(\tR\ruplinkDataKey\x12X\n" +
 	"\x0fuplinkChunkSize\x18\x1a \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x0fuplinkChunkSize\x122\n" +
-	"\x14serverMaxHeaderBytes\x18\x1b \x01(\x05R\x14serverMaxHeaderBytes\x1a:\n" +
+	"\x14serverMaxHeaderBytes\x18\x1b \x01(\x05R\x14serverMaxHeaderBytes\x12V\n" +
+	"\vcompression\x18\x1c \x01(\v24.xray.transport.internet.splithttp.CompressionConfigR\vcompression\x1a:\n" +
 	"\fHeadersEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x85\x01\n" +
@@ -474,13 +549,14 @@ func file_transport_internet_splithttp_config_proto_rawDescGZIP() []byte {
 	return file_transport_internet_splithttp_config_proto_rawDescData
 }
 
-var file_transport_internet_splithttp_config_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_transport_internet_splithttp_config_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_transport_internet_splithttp_config_proto_goTypes = []any{
 	(*RangeConfig)(nil),           // 0: xray.transport.internet.splithttp.RangeConfig
 	(*XmuxConfig)(nil),            // 1: xray.transport.internet.splithttp.XmuxConfig
-	(*Config)(nil),                // 2: xray.transport.internet.splithttp.Config
-	nil,                           // 3: xray.transport.internet.splithttp.Config.HeadersEntry
-	(*internet.StreamConfig)(nil), // 4: xray.transport.internet.StreamConfig
+	(*CompressionConfig)(nil),     // 2: xray.transport.internet.splithttp.CompressionConfig
+	(*Config)(nil),                // 3: xray.transport.internet.splithttp.Config
+	nil,                           // 4: xray.transport.internet.splithttp.Config.HeadersEntry
+	(*internet.StreamConfig)(nil), // 5: xray.transport.internet.StreamConfig
 }
 var file_transport_internet_splithttp_config_proto_depIdxs = []int32{
 	0,  // 0: xray.transport.internet.splithttp.XmuxConfig.maxConcurrency:type_name -> xray.transport.internet.splithttp.RangeConfig
@@ -488,19 +564,20 @@ var file_transport_internet_splithttp_config_proto_depIdxs = []int32{
 	0,  // 2: xray.transport.internet.splithttp.XmuxConfig.cMaxReuseTimes:type_name -> xray.transport.internet.splithttp.RangeConfig
 	0,  // 3: xray.transport.internet.splithttp.XmuxConfig.hMaxRequestTimes:type_name -> xray.transport.internet.splithttp.RangeConfig
 	0,  // 4: xray.transport.internet.splithttp.XmuxConfig.hMaxReusableSecs:type_name -> xray.transport.internet.splithttp.RangeConfig
-	3,  // 5: xray.transport.internet.splithttp.Config.headers:type_name -> xray.transport.internet.splithttp.Config.HeadersEntry
+	4,  // 5: xray.transport.internet.splithttp.Config.headers:type_name -> xray.transport.internet.splithttp.Config.HeadersEntry
 	0,  // 6: xray.transport.internet.splithttp.Config.xPaddingBytes:type_name -> xray.transport.internet.splithttp.RangeConfig
 	0,  // 7: xray.transport.internet.splithttp.Config.scMaxEachPostBytes:type_name -> xray.transport.internet.splithttp.RangeConfig
 	0,  // 8: xray.transport.internet.splithttp.Config.scMinPostsIntervalMs:type_name -> xray.transport.internet.splithttp.RangeConfig
 	0,  // 9: xray.transport.internet.splithttp.Config.scStreamUpServerSecs:type_name -> xray.transport.internet.splithttp.RangeConfig
 	1,  // 10: xray.transport.internet.splithttp.Config.xmux:type_name -> xray.transport.internet.splithttp.XmuxConfig
-	4,  // 11: xray.transport.internet.splithttp.Config.downloadSettings:type_name -> xray.transport.internet.StreamConfig
+	5,  // 11: xray.transport.internet.splithttp.Config.downloadSettings:type_name -> xray.transport.internet.StreamConfig
 	0,  // 12: xray.transport.internet.splithttp.Config.uplinkChunkSize:type_name -> xray.transport.internet.splithttp.RangeConfig
-	13, // [13:13] is the sub-list for method output_type
-	13, // [13:13] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	2,  // 13: xray.transport.internet.splithttp.Config.compression:type_name -> xray.transport.internet.splithttp.CompressionConfig
+	14, // [14:14] is the sub-list for method output_type
+	14, // [14:14] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_transport_internet_splithttp_config_proto_init() }
@@ -514,7 +591,7 @@ func file_transport_internet_splithttp_config_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_transport_internet_splithttp_config_proto_rawDesc), len(file_transport_internet_splithttp_config_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/transport/internet/splithttp/config.proto
+++ b/transport/internet/splithttp/config.proto
@@ -22,6 +22,12 @@ message XmuxConfig {
   int64 hKeepAlivePeriod = 6;
 }
 
+message CompressionConfig {
+  string type = 1;
+  int32 bufferSize = 2;
+  int32 compressLevel = 3;
+}
+
 message Config {
   string host = 1;
   string path = 2;
@@ -50,4 +56,5 @@ message Config {
   string uplinkDataKey = 25;
   RangeConfig uplinkChunkSize = 26;
   int32 serverMaxHeaderBytes = 27;
+  CompressionConfig compression = 28;
 }

--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -462,6 +462,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 		if err != nil { // browser dialer only
 			return nil, err
 		}
+		applyClientCompression(transportConfiguration, mode, &conn)
 		return stat.Connection(&conn), nil
 	} else { // stream-down
 		if xmuxClient2 != nil {
@@ -480,6 +481,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 		if err != nil { // browser dialer only
 			return nil, err
 		}
+		applyClientCompression(transportConfiguration, mode, &conn)
 		return stat.Connection(&conn), nil
 	}
 
@@ -568,7 +570,18 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 		}
 	}()
 
+	applyClientCompression(transportConfiguration, mode, &conn)
 	return stat.Connection(&conn), nil
+}
+
+func applyClientCompression(config *Config, mode string, conn *splitConn) {
+	if !compressionEnabled(config) {
+		return
+	}
+	conn.reader = newCompressedReadCloser(config, conn.reader)
+	if mode == "stream-one" || mode == "stream-up" {
+		conn.writer = newCompressedWriteCloser(config, conn.writer)
+	}
 }
 
 // A wrapper around pipe that ensures the size limit is exactly honored.

--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -213,7 +213,7 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 			}
 			httpSC := &httpServerConn{
 				Instance:       done.New(),
-				Reader:         request.Body,
+				Reader:         newCompressedReadCloser(h.config, request.Body),
 				ResponseWriter: writer,
 			}
 			err = currentSession.uploadQueue.Push(Packet{
@@ -313,6 +313,14 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 				writer.WriteHeader(http.StatusBadRequest)
 				return
 			}
+			if compressionEnabled(h.config) && len(bodyPayload) > 0 {
+				bodyPayload, readErr = decompressPayload(h.config, bodyPayload)
+				if readErr != nil {
+					errors.LogInfoInner(context.Background(), readErr, "failed to decompress body payload")
+					writer.WriteHeader(http.StatusBadRequest)
+					return
+				}
+			}
 		}
 
 		var payload []byte
@@ -393,6 +401,12 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		}
 		if sessionId != "" { // if not stream-one
 			conn.reader = currentSession.uploadQueue
+		}
+		if compressionEnabled(h.config) {
+			conn.writer = newCompressedWriteCloser(h.config, conn.writer)
+			if sessionId == "" {
+				conn.reader = newCompressedReadCloser(h.config, conn.reader)
+			}
 		}
 
 		h.ln.addConn(stat.Connection(&conn))

--- a/transport/internet/splithttp/splithttp_test.go
+++ b/transport/internet/splithttp/splithttp_test.go
@@ -462,3 +462,108 @@ func Test_maxUpload(t *testing.T) {
 
 	common.Must(listen.Close())
 }
+
+func Test_ListenXHAndDial_PacketCompression(t *testing.T) {
+	listenPort := tcp.PickPort()
+	payload := bytes.Repeat([]byte("xhttp compressed packet payload "), 4096)
+	received := make(chan []byte, 1)
+	streamSettings := &internet.MemoryStreamConfig{
+		ProtocolName: "splithttp",
+		ProtocolSettings: &Config{
+			Path:                "/sh",
+			Mode:                "packet-up",
+			UplinkDataPlacement: PlacementBody,
+			Compression: &CompressionConfig{
+				Type:          "zstd",
+				BufferSize:    65536,
+				CompressLevel: 3,
+			},
+		},
+	}
+
+	listen, err := ListenXH(context.Background(), net.LocalHostIP, listenPort, streamSettings, func(conn stat.Connection) {
+		go func(c stat.Connection) {
+			defer c.Close()
+			c.SetReadDeadline(time.Now().Add(2 * time.Second))
+			got := make([]byte, len(payload))
+			_, err := io.ReadFull(c, got)
+			if err == nil {
+				received <- got
+			}
+			common.Must2(c.Write([]byte("Response")))
+		}(conn)
+	})
+	common.Must(err)
+	defer listen.Close()
+
+	conn, err := Dial(context.Background(), net.TCPDestination(net.DomainAddress("localhost"), listenPort), streamSettings)
+	common.Must(err)
+	_, err = conn.Write(payload)
+	common.Must(err)
+
+	var b [1024]byte
+	n, _ := io.ReadFull(conn, b[:])
+	if string(b[:n]) != "Response" {
+		t.Error("response: ", string(b[:n]))
+	}
+	common.Must(conn.Close())
+
+	select {
+	case got := <-received:
+		if !bytes.Equal(got, payload) {
+			t.Fatal("server received payload different from original")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not receive payload")
+	}
+}
+
+func Test_ListenXHAndDial_StreamOneCompression(t *testing.T) {
+	listenPort := tcp.PickPort()
+	payload := bytes.Repeat([]byte("xhttp stream-one payload "), 4096)
+	responsePayload := bytes.Repeat([]byte("xhttp stream-one response "), 1024)
+	streamSettings := &internet.MemoryStreamConfig{
+		ProtocolName: "splithttp",
+		ProtocolSettings: &Config{
+			Path: "/sh",
+			Mode: "stream-one",
+			Compression: &CompressionConfig{
+				Type:          "zstd",
+				BufferSize:    65536,
+				CompressLevel: 3,
+			},
+		},
+	}
+
+	listen, err := ListenXH(context.Background(), net.LocalHostIP, listenPort, streamSettings, func(conn stat.Connection) {
+		go func(c stat.Connection) {
+			defer c.Close()
+			c.SetReadDeadline(time.Now().Add(2 * time.Second))
+			got := make([]byte, len(payload))
+			_, err := io.ReadFull(c, got)
+			if err != nil {
+				return
+			}
+			if !bytes.Equal(got, payload) {
+				t.Error("server received payload different from original")
+				return
+			}
+			common.Must2(c.Write(responsePayload))
+		}(conn)
+	})
+	common.Must(err)
+	defer listen.Close()
+
+	conn, err := Dial(context.Background(), net.TCPDestination(net.DomainAddress("localhost"), listenPort), streamSettings)
+	common.Must(err)
+	_, err = conn.Write(payload)
+	common.Must(err)
+
+	got := make([]byte, len(responsePayload))
+	_, err = io.ReadFull(conn, got)
+	common.Must(err)
+	if !bytes.Equal(got, responsePayload) {
+		t.Fatal("client received response different from original")
+	}
+	common.Must(conn.Close())
+}


### PR DESCRIPTION
  Adds optional XHTTP payload compression with `zstd` and `lz4`.

  - Adds `compression` config under `xhttpSettings` / `splithttpSettings`
  - Supports `type`, `bufferSize`, and `compressLevel`
  - Compresses only HTTP body / stream body payload data
  - Keeps headers, cookies, padding, session, and seq metadata uncompressed for stealth/compatibility
  - Rejects `packet-up` compression with `uplinkDataPlacement: "header"` or `"cookie"`

  ## Config Example

  ```json
  {
    "xhttpSettings": {
      "compression": {
        "type": "zstd",
        "bufferSize": 262144,
        "compressLevel": 3
      }
    }
  }
```
  Supported type values:

  - none
  - zstd
  - lz4

  ## Notes

  Compression is symmetric and not negotiated on the wire. Client and server must use matching compression settings.

  For packet-up, compression applies only to body payloads. Header/cookie payload placement remains uncompressed and is rejected when compression is enabled to avoid high-entropy payload data appearing in headers or cookies.
