### PR TITLE
REALITY: close response body per iteration in SpiderX loop

### DIFF
--- a/transport/internet/reality/reality.go
+++ b/transport/internet/reality/reality.go
@@ -239,9 +239,10 @@ func UClient(c net.Conn, config *Config, ctx context.Context, dest net.Destinati
 					if resp, err = client.Do(req); err != nil {
 						break
 					}
-					defer resp.Body.Close()
 					req.Header.Set("Referer", req.URL.String())
-					if body, err = io.ReadAll(resp.Body); err != nil {
+					body, err = io.ReadAll(resp.Body)
+					resp.Body.Close()
+					if err != nil {
 						break
 					}
 					maps.Lock()


### PR DESCRIPTION
## What

In `transport/internet/reality/reality.go`, `resp.Body.Close()` was
deferred inside the `for j := 0; j < times; j++` SpiderX request loop:

```go
for j := 0; j < times; j++ {
    ...
    if resp, err = client.Do(req); err != nil {
        break
    }
    defer resp.Body.Close()   // ← fires at goroutine return, not per iter
    ...
    if body, err = io.ReadAll(resp.Body); err != nil {
        break
    }
    ...
}
```

In Go, `defer` runs at *function* return — so with `times` iterations
(up to `SpiderY[5]`) the closure holds onto `times` un-closed
`resp.Body` objects, each pinning an HTTP/2 stream slot and its reader
state until the goroutine eventually exits.

## Why

Just hygiene — close the body explicitly right after `io.ReadAll`
returns so each iteration releases its stream immediately rather than
piling them up until the spider goroutine finishes. Matches the way
the rest of xray-core handles per-iteration HTTP bodies.

## How

Drop the `defer` and add an explicit `resp.Body.Close()` between
`io.ReadAll` and the error check.

No behaviour change on the success path; on the error path the body
returned by the failed `ReadAll` is still drained-then-closed, same as
before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)