### PR TITLE
REALITY: drop previous padding cookie before adding new one in SpiderX

### DIFF
--- a/transport/internet/reality/reality.go
+++ b/transport/internet/reality/reality.go
@@ -235,6 +235,7 @@ func UClient(c net.Conn, config *Config, ctx context.Context, dest net.Destinati
 					if !first && j == 0 {
 						req.Header.Set("Referer", firstURL)
 					}
+					req.Header.Del("Cookie") // avoid accumulating padding cookies across iterations
 					req.AddCookie(&http.Cookie{Name: "padding", Value: strings.Repeat("0", int(crypto.RandBetween(config.SpiderY[0], config.SpiderY[1])))})
 					if resp, err = client.Do(req); err != nil {
 						break


### PR DESCRIPTION
## What

In `transport/internet/reality/reality.go`, the SpiderX request loop
adds a `padding` cookie every iteration via `req.AddCookie`:

```go
for j := 0; j < times; j++ {
    ...
    req.AddCookie(&http.Cookie{
        Name:  \"padding\",
        Value: strings.Repeat(\"0\", int(crypto.RandBetween(SpiderY[0], SpiderY[1]))),
    })
    if resp, err = client.Do(req); err != nil { ... }
    ...
}
```

`http.Request.AddCookie` appends to the existing `Cookie` header rather
than replacing it. The same `req` is reused across iterations of the
inner loop, so after `j` iterations the header contains `j+1` padding
cookies — one fresh + `j` stale.

## Why

A real browser navigation sends a single `Cookie:` header value per
request, not a chain of growing stubs. Cleaning the header before each
iteration:

- keeps the request shape consistent with `nav`-style traffic from
  `TryDefaultHeadersWith(req.Header, \"nav\")`, so the SpiderX
  signature doesn't drift as the inner loop progresses,
- caps the `Cookie` header size at ~`SpiderY[1]` bytes per request
  instead of `times * SpiderY[1]`.

No protocol-level meaning is lost — the padding cookie is opaque length
filler.

## How

One-line `req.Header.Del(\"Cookie\")` at the top of the per-iteration
body, immediately before the existing `AddCookie` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)