### PR TITLE
REALITY: bound SpiderX response body read at 1 MiB

### DIFF
--- a/transport/internet/reality/reality.go
+++ b/transport/internet/reality/reality.go
@@ -34,6 +34,12 @@ import (
 	"golang.org/x/net/http2"
 )
 
+// spiderMaxBodyBytes caps how much of each SpiderX response is read into
+// memory before parsing for href candidates. The crawl only consumes HTML,
+// so 1 MiB is comfortably above realistic page sizes while keeping
+// per-iteration memory bounded.
+const spiderMaxBodyBytes = 1 << 20
+
 type Conn struct {
 	*reality.Conn
 }
@@ -241,7 +247,7 @@ func UClient(c net.Conn, config *Config, ctx context.Context, dest net.Destinati
 					}
 					defer resp.Body.Close()
 					req.Header.Set("Referer", req.URL.String())
-					if body, err = io.ReadAll(resp.Body); err != nil {
+					if body, err = io.ReadAll(io.LimitReader(resp.Body, spiderMaxBodyBytes)); err != nil {
 						break
 					}
 					maps.Lock()


### PR DESCRIPTION
## What

In `transport/internet/reality/reality.go`, each iteration of the
SpiderX request loop reads the response body with an unbounded
`io.ReadAll`:

\`\`\`go
if resp, err = client.Do(req); err != nil { break }
...
if body, err = io.ReadAll(resp.Body); err != nil { break }
\`\`\`

The response body is then only used to scan for \`href=\"...\"\` link
candidates via a regex — i.e., it's expected to be HTML.

Under HTTP/2 the Go transport keeps extending the stream/connection
window as the caller drains, so there's no implicit upper bound on
\`ReadAll\`. Whatever the peer chooses to stream, the SpiderX
goroutine allocates as one contiguous \`[]byte\`. With several
concurrent SpiderX goroutines per session (\`SpiderY[2..3]\`), and
several SpiderX sessions per xray process, the per-iteration buffer
ends up unbounded × N.

## Why

The SpiderX crawl is meant to look like browser navigation reading
HTML pages, so a small fixed cap is consistent with the intent:

- HTTP Archive median HTML payload is ~30-50 KiB; 1 MiB is generous
  even for outliers.
- The cap is on bytes-read-into-buffer, not on the wire — a censor
  observing the TLS stream sees the same handshake and traffic
  pattern as before, just truncated at the transport layer.
- href candidates beyond 1 MiB into a single response are not
  realistic targets for a \"blend in like a browser\" crawl anyway.

## How

Wrap the body in \`io.LimitReader(resp.Body, spiderMaxBodyBytes)\`
where \`spiderMaxBodyBytes = 1 << 20\` is a package-level const with
a short comment explaining the intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)