### PR TITLE
Geodata: Support hash files for asset updates

### DIFF
--- a/app/geodata/config.pb.go
+++ b/app/geodata/config.pb.go
@@ -25,6 +25,9 @@ type Asset struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Url           string                 `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
 	File          string                 `protobuf:"bytes,2,opt,name=file,proto3" json:"file,omitempty"`
+	HashUrl       string                 `protobuf:"bytes,3,opt,name=hash_url,json=hashUrl,proto3" json:"hash_url,omitempty"`
+	HashFile      string                 `protobuf:"bytes,4,opt,name=hash_file,json=hashFile,proto3" json:"hash_file,omitempty"`
+	HashType      string                 `protobuf:"bytes,5,opt,name=hash_type,json=hashType,proto3" json:"hash_type,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -69,6 +72,27 @@ func (x *Asset) GetUrl() string {
 func (x *Asset) GetFile() string {
 	if x != nil {
 		return x.File
+	}
+	return ""
+}
+
+func (x *Asset) GetHashUrl() string {
+	if x != nil {
+		return x.HashUrl
+	}
+	return ""
+}
+
+func (x *Asset) GetHashFile() string {
+	if x != nil {
+		return x.HashFile
+	}
+	return ""
+}
+
+func (x *Asset) GetHashType() string {
+	if x != nil {
+		return x.HashType
 	}
 	return ""
 }
@@ -137,10 +161,13 @@ var File_app_geodata_config_proto protoreflect.FileDescriptor
 
 const file_app_geodata_config_proto_rawDesc = "" +
 	"\n" +
-	"\x18app/geodata/config.proto\x12\x10xray.app.geodata\"-\n" +
+	"\x18app/geodata/config.proto\x12\x10xray.app.geodata\"\x82\x01\n" +
 	"\x05Asset\x12\x10\n" +
 	"\x03url\x18\x01 \x01(\tR\x03url\x12\x12\n" +
-	"\x04file\x18\x02 \x01(\tR\x04file\"i\n" +
+	"\x04file\x18\x02 \x01(\tR\x04file\x12\x19\n" +
+	"\bhash_url\x18\x03 \x01(\tR\ahashUrl\x12\x1b\n" +
+	"\thash_file\x18\x04 \x01(\tR\bhashFile\x12\x1b\n" +
+	"\thash_type\x18\x05 \x01(\tR\bhashType\"i\n" +
 	"\x06Config\x12\x12\n" +
 	"\x04cron\x18\x01 \x01(\tR\x04cron\x12\x1a\n" +
 	"\boutbound\x18\x02 \x01(\tR\boutbound\x12/\n" +

--- a/app/geodata/config.proto
+++ b/app/geodata/config.proto
@@ -10,6 +10,12 @@ message Asset {
   string url = 1;
 
   string file = 2;
+
+  string hash_url = 3;
+
+  string hash_file = 4;
+
+  string hash_type = 5;
 }
 
 message Config {

--- a/app/geodata/download.go
+++ b/app/geodata/download.go
@@ -264,10 +264,10 @@ func validateHashAsset(asset *Asset) error {
 		return nil
 	}
 	if asset.HashUrl == "" || asset.HashFile == "" {
-		return errors.New("geodata hash_url and hash_file must be set together")
+		return errors.New("geodata hashUrl and hashFile must be set together")
 	}
 	if asset.HashFile == asset.File {
-		return errors.New("geodata hash_file must be different from file")
+		return errors.New("geodata hashFile must be different from file")
 	}
 	return ValidateHashType(asset.HashType)
 }

--- a/app/geodata/download.go
+++ b/app/geodata/download.go
@@ -1,6 +1,7 @@
 package geodata
 
 import (
+	"bytes"
 	"context"
 	go_errors "errors"
 	"io"
@@ -103,24 +104,80 @@ func newClient(baseCtx context.Context, dispatcher routing.Dispatcher, outbound 
 }
 
 func (d *downloader) download(assets []*Asset) ([]stage, error) {
-	staged := make([]stage, 0, len(assets))
+	staged := make([]stage, 0, len(assets)*2)
 	for _, asset := range assets {
-		stage, err := d.downloadOne(asset)
+		assetStages, err := d.downloadOne(asset)
 		if err != nil {
 			clean(staged)
 			return nil, err
 		}
-		staged = append(staged, stage)
+		staged = append(staged, assetStages...)
 	}
 	return staged, nil
 }
 
-func (d *downloader) downloadOne(asset *Asset) (stage, error) {
-	target, err := filesystem.ResolveAsset(asset.File)
+func (d *downloader) downloadOne(asset *Asset) ([]stage, error) {
+	if err := validateHashAsset(asset); err != nil {
+		return nil, err
+	}
+
+	if !hasHashAsset(asset) {
+		assetStage, err := d.downloadFile(asset.Url, asset.File, "geodata asset", false)
+		if err != nil {
+			return nil, err
+		}
+		return []stage{assetStage}, nil
+	}
+
+	hashStage, err := d.downloadFile(asset.HashUrl, asset.HashFile, "geodata hash", true)
+	if err != nil {
+		return nil, err
+	}
+
+	unchanged, known, err := hashStage.compareCurrentHash(asset.HashType, asset.File)
+	if err != nil {
+		clean([]stage{hashStage})
+		return nil, err
+	}
+	if unchanged {
+		clean([]stage{hashStage})
+		errors.LogInfo(d.ctx, "geodata hash is unchanged for ", asset.File, ", skipping asset download")
+		return nil, nil
+	}
+
+	if !known {
+		current, err := d.isAssetCurrent(asset, hashStage)
+		if err != nil {
+			clean([]stage{hashStage})
+			return nil, err
+		}
+		if current {
+			errors.LogInfo(d.ctx, "geodata asset is current for ", asset.File, ", updating hash file only")
+			return []stage{hashStage}, nil
+		}
+	}
+
+	assetStage, err := d.downloadFile(asset.Url, asset.File, "geodata asset", false)
+	if err != nil {
+		clean([]stage{hashStage})
+		return nil, err
+	}
+	staged := []stage{assetStage, hashStage}
+
+	if err := verifyHashFile(asset.HashType, assetStage.temp, hashStage.temp, asset.File); err != nil {
+		clean(staged)
+		return nil, err
+	}
+
+	return staged, nil
+}
+
+func (d *downloader) downloadFile(rawURL string, file string, kind string, allowMissing bool) (stage, error) {
+	target, err := resolveDownloadTarget(file, allowMissing)
 	if err != nil {
 		return stage{}, err
 	}
-	errors.LogInfo(d.ctx, "downloading geodata asset from ", asset.Url, " to ", target)
+	errors.LogInfo(d.ctx, "downloading ", kind, " from ", rawURL, " to ", target)
 
 	temp, err := tempFile(target, ".tmp")
 	if err != nil {
@@ -134,7 +191,7 @@ func (d *downloader) downloadOne(asset *Asset) (stage, error) {
 		}
 	}()
 
-	if err := d.fetch(asset.Url, temp); err != nil {
+	if err := d.fetch(rawURL, temp); err != nil {
 		temp.Close()
 		return stage{}, err
 	}
@@ -151,6 +208,68 @@ func (d *downloader) downloadOne(asset *Asset) (stage, error) {
 		target: target,
 		temp:   tempName,
 	}, nil
+}
+
+func resolveDownloadTarget(file string, allowMissing bool) (string, error) {
+	if !allowMissing {
+		return filesystem.ResolveAsset(file)
+	}
+
+	target, err := filesystem.ResolveAssetPath(file)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		if go_errors.Is(err, os.ErrNotExist) {
+			return target, nil
+		}
+		return "", err
+	}
+	if !info.Mode().IsRegular() {
+		return "", errors.New("asset is not a regular file")
+	}
+	return target, nil
+}
+
+func (s stage) compareCurrentHash(hashType string, expectedFile string) (same bool, known bool, err error) {
+	nextHash, err := readHashFileDigest(hashType, s.temp, expectedFile)
+	if err != nil {
+		return false, false, err
+	}
+	currentHash, err := readHashFileDigest(hashType, s.target, expectedFile)
+	if err != nil {
+		return false, false, nil
+	}
+	return bytes.Equal(nextHash, currentHash), true, nil
+}
+
+func (d *downloader) isAssetCurrent(asset *Asset, hashStage stage) (bool, error) {
+	target, err := filesystem.ResolveAsset(asset.File)
+	if err != nil {
+		return false, err
+	}
+	if err := verifyHashFile(asset.HashType, target, hashStage.temp, asset.File); err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
+func hasHashAsset(asset *Asset) bool {
+	return asset.HashUrl != "" || asset.HashFile != "" || asset.HashType != ""
+}
+
+func validateHashAsset(asset *Asset) error {
+	if !hasHashAsset(asset) {
+		return nil
+	}
+	if asset.HashUrl == "" || asset.HashFile == "" {
+		return errors.New("geodata hash_url and hash_file must be set together")
+	}
+	if asset.HashFile == asset.File {
+		return errors.New("geodata hash_file must be different from file")
+	}
+	return ValidateHashType(asset.HashType)
 }
 
 func (d *downloader) fetch(rawURL string, writer io.Writer) error {

--- a/app/geodata/geodata.go
+++ b/app/geodata/geodata.go
@@ -70,6 +70,9 @@ func (g *Instance) reloadWithUpdate() error {
 		return err
 	}
 	defer clean(staged)
+	if len(staged) == 0 {
+		return nil
+	}
 
 	tx, err := swapAll(staged)
 	if err != nil {

--- a/app/geodata/hash.go
+++ b/app/geodata/hash.go
@@ -1,0 +1,227 @@
+package geodata
+
+import (
+	"bytes"
+	"crypto"
+	_ "crypto/sha256"
+	_ "crypto/sha3"
+	_ "crypto/sha512"
+	"encoding/hex"
+	"io"
+	"os"
+	"path"
+	"slices"
+	"strings"
+	"unicode"
+
+	"github.com/xtls/xray-core/common/errors"
+)
+
+const DefaultHashType = "sha256"
+
+type hashSpec struct {
+	name string
+	hash crypto.Hash
+}
+
+func ValidateHashType(hashType string) error {
+	_, err := hashSpecFor(hashType)
+	return err
+}
+
+func NormalizeHashType(hashType string) (string, error) {
+	spec, err := hashSpecFor(hashType)
+	if err != nil {
+		return "", err
+	}
+	return spec.name, nil
+}
+
+func hashSpecFor(hashType string) (hashSpec, error) {
+	normalized := normalizeHashType(hashType)
+	if normalized == "" {
+		normalized = DefaultHashType
+	}
+	for _, spec := range supportedHashSpecs {
+		if slices.Contains(spec.aliases, normalized) {
+			return hashSpec{
+				name: spec.name,
+				hash: spec.hash,
+			}, nil
+		}
+	}
+	return hashSpec{}, errors.New("unsupported geodata hash type: ", hashType)
+}
+
+func normalizeHashType(hashType string) string {
+	hashType = strings.ToLower(strings.TrimSpace(hashType))
+	hashType = strings.ReplaceAll(hashType, "-", "")
+	hashType = strings.ReplaceAll(hashType, "_", "")
+	hashType = strings.ReplaceAll(hashType, "/", "")
+	return hashType
+}
+
+type hashSpecDef struct {
+	name    string
+	hash    crypto.Hash
+	aliases []string
+}
+
+var supportedHashSpecs = []hashSpecDef{
+	{name: "sha224", hash: crypto.SHA224, aliases: []string{"sha224"}},
+	{name: "sha256", hash: crypto.SHA256, aliases: []string{"sha256"}},
+	{name: "sha384", hash: crypto.SHA384, aliases: []string{"sha384"}},
+	{name: "sha512", hash: crypto.SHA512, aliases: []string{"sha512"}},
+	{name: "sha512/224", hash: crypto.SHA512_224, aliases: []string{"sha512224"}},
+	{name: "sha512/256", hash: crypto.SHA512_256, aliases: []string{"sha512256"}},
+	{name: "sha3-224", hash: crypto.SHA3_224, aliases: []string{"sha3224"}},
+	{name: "sha3-256", hash: crypto.SHA3_256, aliases: []string{"sha3256"}},
+	{name: "sha3-384", hash: crypto.SHA3_384, aliases: []string{"sha3384"}},
+	{name: "sha3-512", hash: crypto.SHA3_512, aliases: []string{"sha3512"}},
+}
+
+func verifyHashFile(hashType string, dataFile string, hashFile string, expectedFile string) error {
+	spec, err := hashSpecFor(hashType)
+	if err != nil {
+		return err
+	}
+
+	expected, err := readHashFileDigestWithSpec(hashFile, spec, expectedFile)
+	if err != nil {
+		return err
+	}
+
+	actual, err := computeFileHash(dataFile, spec)
+	if err != nil {
+		return errors.New("failed to compute geodata asset hash").Base(err)
+	}
+
+	if !bytes.Equal(expected, actual) {
+		return errors.New(
+			"geodata asset hash mismatch for ", dataFile,
+			": expected ", hex.EncodeToString(expected),
+			", actual ", hex.EncodeToString(actual),
+		)
+	}
+	return nil
+}
+
+func readHashFileDigest(hashType string, file string, expectedFile string) ([]byte, error) {
+	spec, err := hashSpecFor(hashType)
+	if err != nil {
+		return nil, err
+	}
+	return readHashFileDigestWithSpec(file, spec, expectedFile)
+}
+
+func computeFileHash(file string, spec hashSpec) ([]byte, error) {
+	reader, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	h := spec.hash.New()
+	if _, err := io.Copy(h, reader); err != nil {
+		return nil, err
+	}
+	return h.Sum(nil), nil
+}
+
+func readHashFileDigestWithSpec(file string, spec hashSpec, expectedFile string) ([]byte, error) {
+	content, err := os.ReadFile(file)
+	if err != nil {
+		return nil, errors.New("failed to read geodata hash file").Base(err)
+	}
+
+	wantHexLen := spec.hash.Size() * 2
+	for line := range strings.SplitSeq(string(content), "\n") {
+		digest, fileName, hasFileName, ok := parseHashLine(line, wantHexLen)
+		if !ok {
+			continue
+		}
+		if hasFileName && !hashFileNameMatches(fileName, expectedFile) {
+			continue
+		}
+
+		expected, err := hex.DecodeString(digest)
+		if err != nil {
+			return nil, errors.New("failed to decode geodata hash file").Base(err)
+		}
+		return expected, nil
+	}
+
+	return nil, errors.New("geodata hash file does not contain a ", spec.name, " hex digest")
+}
+
+func parseHashLine(line string, wantHexLen int) (digest string, fileName string, hasFileName bool, ok bool) {
+	fields := strings.Fields(line)
+	for i, field := range fields {
+		token := normalizeHashToken(field)
+		if len(token) != wantHexLen || !isHexString(token) {
+			continue
+		}
+
+		if name, found := extractBSDChecksumFileName(line); found {
+			return token, name, true, true
+		}
+		if i == 0 && len(fields) > 1 {
+			return token, fields[1], true, true
+		}
+		return token, "", false, true
+	}
+	return "", "", false, false
+}
+
+func extractBSDChecksumFileName(line string) (string, bool) {
+	start := strings.IndexByte(line, '(')
+	end := strings.LastIndexByte(line, ')')
+	if start < 0 || end <= start {
+		return "", false
+	}
+	return line[start+1 : end], true
+}
+
+func hashFileNameMatches(actual string, expected string) bool {
+	actual = normalizeHashFileName(actual)
+	expected = normalizeHashFileName(expected)
+	if expected == "" {
+		return true
+	}
+	if actual == "" {
+		return false
+	}
+	return actual == expected || path.Base(actual) == path.Base(expected)
+}
+
+func normalizeHashFileName(fileName string) string {
+	fileName = strings.TrimSpace(fileName)
+	fileName = strings.TrimPrefix(fileName, "*")
+	fileName = strings.Trim(fileName, "\"'")
+	fileName = strings.ReplaceAll(fileName, "\\", "/")
+	fileName = strings.TrimPrefix(fileName, "./")
+	fileName = path.Clean(fileName)
+	if fileName == "." {
+		return ""
+	}
+	return fileName
+}
+
+func normalizeHashToken(token string) string {
+	token = strings.TrimFunc(token, func(r rune) bool {
+		return unicode.IsSpace(r) || strings.ContainsRune("*()=[]{}<>:,;\"'", r)
+	})
+	token = strings.TrimPrefix(strings.ToLower(token), "0x")
+	token = strings.ReplaceAll(token, ":", "")
+	return token
+}
+
+func isHexString(s string) bool {
+	for _, r := range s {
+		if (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/app/geodata/hash_test.go
+++ b/app/geodata/hash_test.go
@@ -1,0 +1,448 @@
+package geodata
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestVerifyHashFile(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("geodata payload")
+	dataFile := filepath.Join(dir, "geoip.dat")
+	if err := os.WriteFile(dataFile, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sum := sha256.Sum256(data)
+	sumHex := hex.EncodeToString(sum[:])
+	testCases := []string{
+		sumHex + "\n",
+		sumHex + "  geoip.dat\n",
+		sumHex + "  *geoip.dat\n",
+		sumHex + "  geosite.dat\n" + sumHex + "  geoip.dat\n",
+		"SHA256 (geoip.dat) = " + sumHex + "\n",
+	}
+
+	for _, testCase := range testCases {
+		hashFile := filepath.Join(dir, "geoip.dat.sha256sum")
+		if err := os.WriteFile(hashFile, []byte(testCase), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := verifyHashFile("sha-256", dataFile, hashFile, "geoip.dat"); err != nil {
+			t.Fatalf("expected hash verification to pass for %q: %v", testCase, err)
+		}
+	}
+}
+
+func TestHashTypeDefault(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("geodata payload")
+	dataFile := filepath.Join(dir, "geoip.dat")
+	if err := os.WriteFile(dataFile, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sum := sha256.Sum256(data)
+	hashFile := filepath.Join(dir, "geoip.dat.sha256sum")
+	if err := os.WriteFile(hashFile, []byte(hex.EncodeToString(sum[:])), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := verifyHashFile("", dataFile, hashFile, "geoip.dat"); err != nil {
+		t.Fatal(err)
+	}
+
+	hashType, err := NormalizeHashType("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hashType != DefaultHashType {
+		t.Fatalf("unexpected default hash type: %s", hashType)
+	}
+}
+
+func TestSupportedHashTypes(t *testing.T) {
+	testCases := []struct {
+		input string
+		want  string
+		hash  crypto.Hash
+	}{
+		{input: "sha224", want: "sha224", hash: crypto.SHA224},
+		{input: "sha-256", want: "sha256", hash: crypto.SHA256},
+		{input: "SHA_384", want: "sha384", hash: crypto.SHA384},
+		{input: "sha512", want: "sha512", hash: crypto.SHA512},
+		{input: "sha512/224", want: "sha512/224", hash: crypto.SHA512_224},
+		{input: "sha-512-256", want: "sha512/256", hash: crypto.SHA512_256},
+		{input: "sha3-224", want: "sha3-224", hash: crypto.SHA3_224},
+		{input: "sha3_256", want: "sha3-256", hash: crypto.SHA3_256},
+		{input: "sha3384", want: "sha3-384", hash: crypto.SHA3_384},
+		{input: "sha3-512", want: "sha3-512", hash: crypto.SHA3_512},
+	}
+
+	dir := t.TempDir()
+	data := []byte("geodata payload")
+	dataFile := filepath.Join(dir, "geoip.dat")
+	if err := os.WriteFile(dataFile, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, testCase := range testCases {
+		hashType, err := NormalizeHashType(testCase.input)
+		if err != nil {
+			t.Fatalf("expected %s to be supported: %v", testCase.input, err)
+		}
+		if hashType != testCase.want {
+			t.Fatalf("unexpected normalized hash type for %s: got %s want %s", testCase.input, hashType, testCase.want)
+		}
+		if !testCase.hash.Available() {
+			t.Fatalf("hash is not available: %s", testCase.want)
+		}
+
+		h := testCase.hash.New()
+		_, _ = h.Write(data)
+		hashFile := filepath.Join(dir, "geoip.dat."+strings.ReplaceAll(testCase.want, "/", "-")+".sum")
+		if err := os.WriteFile(hashFile, []byte(hex.EncodeToString(h.Sum(nil))), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := verifyHashFile(testCase.input, dataFile, hashFile, "geoip.dat"); err != nil {
+			t.Fatalf("expected %s verification to pass: %v", testCase.input, err)
+		}
+	}
+}
+
+func TestWeakHashTypesAreRejected(t *testing.T) {
+	for _, hashType := range []string{
+		"md4",
+		"md5",
+		"sha1",
+		"md5sha1",
+		"ripemd160",
+		"blake2s-256",
+		"blake2b-256",
+		"blake2b-384",
+		"blake2b-512",
+	} {
+		if err := ValidateHashType(hashType); err == nil {
+			t.Fatalf("expected %s to be rejected", hashType)
+		}
+	}
+}
+
+func TestVerifyHashFileMismatch(t *testing.T) {
+	dir := t.TempDir()
+	dataFile := filepath.Join(dir, "geoip.dat")
+	if err := os.WriteFile(dataFile, []byte("geodata payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	wrongSum := sha256.Sum256([]byte("other payload"))
+	hashFile := filepath.Join(dir, "geoip.dat.sha256sum")
+	if err := os.WriteFile(hashFile, []byte(hex.EncodeToString(wrongSum[:])), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := verifyHashFile("sha256", dataFile, hashFile, "geoip.dat"); err == nil {
+		t.Fatal("expected hash verification to fail")
+	}
+}
+
+func TestVerifyHashFileRejectsMismatchedFileName(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("geodata payload")
+	dataFile := filepath.Join(dir, "geoip.dat")
+	if err := os.WriteFile(dataFile, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sum := sha256.Sum256(data)
+	hashFile := filepath.Join(dir, "geoip.dat.sha256sum")
+	if err := os.WriteFile(hashFile, []byte(hex.EncodeToString(sum[:])+"  geosite.dat\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := verifyHashFile("sha256", dataFile, hashFile, "geoip.dat"); err == nil {
+		t.Fatal("expected hash verification to reject mismatched file name")
+	}
+}
+
+func TestDownloadOneWithHash(t *testing.T) {
+	data := []byte("new geodata payload")
+	sum := sha256.Sum256(data)
+	hashBody := []byte(hex.EncodeToString(sum[:]) + "  geoip.dat\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/geoip.dat":
+			_, _ = writer.Write(data)
+		case "/geoip.dat.sha256sum":
+			_, _ = writer.Write(hashBody)
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	dir := prepareDownloadAssetDir(t)
+	downloader := &downloader{
+		ctx:    context.Background(),
+		client: server.Client(),
+	}
+
+	staged, err := downloader.downloadOne(&Asset{
+		Url:      server.URL + "/geoip.dat",
+		File:     "geoip.dat",
+		HashUrl:  server.URL + "/geoip.dat.sha256sum",
+		HashFile: "geoip.dat.sha256sum",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clean(staged)
+
+	if len(staged) != 2 {
+		t.Fatalf("expected 2 staged files, got %d", len(staged))
+	}
+	if staged[0].target != filepath.Join(dir, "geoip.dat") {
+		t.Fatalf("unexpected asset target: %s", staged[0].target)
+	}
+	if staged[1].target != filepath.Join(dir, "geoip.dat.sha256sum") {
+		t.Fatalf("unexpected hash target: %s", staged[1].target)
+	}
+
+	gotData, err := os.ReadFile(staged[0].temp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotData, data) {
+		t.Fatalf("unexpected asset data: %q", gotData)
+	}
+
+	gotHash, err := os.ReadFile(staged[1].temp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotHash, hashBody) {
+		t.Fatalf("unexpected hash data: %q", gotHash)
+	}
+}
+
+func TestDownloadOneSkipsAssetWhenHashUnchanged(t *testing.T) {
+	data := []byte("remote geodata payload")
+	localData := []byte("stale local geodata payload")
+	sum := sha256.Sum256(data)
+	hashBody := []byte(hex.EncodeToString(sum[:]) + "  geoip.dat\n")
+	var assetRequested atomic.Bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/geoip.dat":
+			assetRequested.Store(true)
+			http.Error(writer, "unexpected asset request", http.StatusInternalServerError)
+		case "/geoip.dat.sha256sum":
+			_, _ = writer.Write(hashBody)
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	prepareDownloadAssetDirWith(t, localData, hashBody)
+	downloader := &downloader{
+		ctx:    context.Background(),
+		client: server.Client(),
+	}
+
+	staged, err := downloader.downloadOne(&Asset{
+		Url:      server.URL + "/geoip.dat",
+		File:     "geoip.dat",
+		HashUrl:  server.URL + "/geoip.dat.sha256sum",
+		HashFile: "geoip.dat.sha256sum",
+		HashType: "sha256",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(staged) != 0 {
+		t.Fatalf("expected no staged files, got %d", len(staged))
+	}
+	if assetRequested.Load() {
+		t.Fatal("asset was requested")
+	}
+}
+
+func TestDownloadOneStagesOnlyHashWhenLocalHashMissing(t *testing.T) {
+	data := []byte("current geodata payload")
+	sum := sha256.Sum256(data)
+	hashBody := []byte(hex.EncodeToString(sum[:]) + "  geoip.dat\n")
+	var assetRequested atomic.Bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/geoip.dat":
+			assetRequested.Store(true)
+			http.Error(writer, "unexpected asset request", http.StatusInternalServerError)
+		case "/geoip.dat.sha256sum":
+			_, _ = writer.Write(hashBody)
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	dir := prepareDownloadAssetDirWith(t, data, hashBody)
+	if err := os.Remove(filepath.Join(dir, "geoip.dat.sha256sum")); err != nil {
+		t.Fatal(err)
+	}
+	downloader := &downloader{
+		ctx:    context.Background(),
+		client: server.Client(),
+	}
+
+	staged, err := downloader.downloadOne(&Asset{
+		Url:      server.URL + "/geoip.dat",
+		File:     "geoip.dat",
+		HashUrl:  server.URL + "/geoip.dat.sha256sum",
+		HashFile: "geoip.dat.sha256sum",
+		HashType: "sha256",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clean(staged)
+
+	if len(staged) != 1 {
+		t.Fatalf("expected only hash file to be staged, got %d", len(staged))
+	}
+	if staged[0].target != filepath.Join(dir, "geoip.dat.sha256sum") {
+		t.Fatalf("unexpected hash target: %s", staged[0].target)
+	}
+	if assetRequested.Load() {
+		t.Fatal("asset was requested")
+	}
+}
+
+func TestDownloadOneDownloadsAssetWhenLocalHashDiffers(t *testing.T) {
+	data := []byte("current geodata payload")
+	sum := sha256.Sum256(data)
+	hashBody := []byte(hex.EncodeToString(sum[:]) + "  geoip.dat\n")
+	oldSum := sha256.Sum256([]byte("old geodata payload"))
+	oldHashBody := []byte(hex.EncodeToString(oldSum[:]) + "  geoip.dat\n")
+	var assetRequested atomic.Bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/geoip.dat":
+			assetRequested.Store(true)
+			_, _ = writer.Write(data)
+		case "/geoip.dat.sha256sum":
+			_, _ = writer.Write(hashBody)
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	dir := prepareDownloadAssetDirWith(t, data, oldHashBody)
+	downloader := &downloader{
+		ctx:    context.Background(),
+		client: server.Client(),
+	}
+
+	staged, err := downloader.downloadOne(&Asset{
+		Url:      server.URL + "/geoip.dat",
+		File:     "geoip.dat",
+		HashUrl:  server.URL + "/geoip.dat.sha256sum",
+		HashFile: "geoip.dat.sha256sum",
+		HashType: "sha256",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clean(staged)
+
+	if len(staged) != 2 {
+		t.Fatalf("expected asset and hash files to be staged, got %d", len(staged))
+	}
+	if staged[0].target != filepath.Join(dir, "geoip.dat") {
+		t.Fatalf("unexpected asset target: %s", staged[0].target)
+	}
+	if staged[1].target != filepath.Join(dir, "geoip.dat.sha256sum") {
+		t.Fatalf("unexpected hash target: %s", staged[1].target)
+	}
+	if !assetRequested.Load() {
+		t.Fatal("asset was not requested")
+	}
+}
+
+func TestDownloadOneRejectsHashMismatch(t *testing.T) {
+	data := []byte("new geodata payload")
+	wrongSum := sha256.Sum256([]byte("other payload"))
+	hashBody := []byte(hex.EncodeToString(wrongSum[:]) + "  geoip.dat\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/geoip.dat":
+			_, _ = writer.Write(data)
+		case "/geoip.dat.sha256sum":
+			_, _ = writer.Write(hashBody)
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	dir := prepareDownloadAssetDir(t)
+	downloader := &downloader{
+		ctx:    context.Background(),
+		client: server.Client(),
+	}
+
+	_, err := downloader.downloadOne(&Asset{
+		Url:      server.URL + "/geoip.dat",
+		File:     "geoip.dat",
+		HashUrl:  server.URL + "/geoip.dat.sha256sum",
+		HashFile: "geoip.dat.sha256sum",
+		HashType: "sha256",
+	})
+	if err == nil {
+		t.Fatal("expected hash mismatch")
+	}
+
+	leftovers, err := filepath.Glob(filepath.Join(dir, ".*.tmp"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leftovers) != 0 {
+		t.Fatalf("expected temp files to be cleaned, got %v", leftovers)
+	}
+}
+
+func prepareDownloadAssetDir(t *testing.T) string {
+	t.Helper()
+
+	return prepareDownloadAssetDirWith(t, []byte("old geoip.dat"), []byte("old geoip.dat.sha256sum"))
+}
+
+func prepareDownloadAssetDirWith(t *testing.T, data []byte, hash []byte) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "geoip.dat"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "geoip.dat.sha256sum"), hash, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("xray.location.asset", dir)
+	return dir
+}

--- a/common/platform/filesystem/file.go
+++ b/common/platform/filesystem/file.go
@@ -52,15 +52,15 @@ func ResolveAsset(file string) (string, error) {
 	return path, err
 }
 
+func ResolveAssetPath(file string) (string, error) {
+	return resolveAssetPath(file)
+}
+
 func getAssetFileLocation(file string) (string, os.FileInfo, error) {
-	if !filepath.IsLocal(file) || file == "." {
-		return "", nil, errors.New("asset path must stay in asset directory")
-	}
-	local, err := filepath.Localize(file)
+	path, err := resolveAssetPath(file)
 	if err != nil {
 		return "", nil, err
 	}
-	path := platform.GetAssetLocation(local)
 	info, err := os.Stat(path)
 	if err != nil {
 		return "", nil, err
@@ -69,6 +69,18 @@ func getAssetFileLocation(file string) (string, os.FileInfo, error) {
 		return "", nil, errors.New("asset is not a regular file")
 	}
 	return path, info, nil
+}
+
+func resolveAssetPath(file string) (string, error) {
+	if !filepath.IsLocal(file) || file == "." {
+		return "", errors.New("asset path must stay in asset directory")
+	}
+	local, err := filepath.Localize(file)
+	if err != nil {
+		return "", err
+	}
+	path := platform.GetAssetLocation(local)
+	return path, nil
 }
 
 func ReadCert(file string) ([]byte, error) {

--- a/common/platform/filesystem/file_test.go
+++ b/common/platform/filesystem/file_test.go
@@ -1,6 +1,7 @@
 package filesystem_test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -26,6 +27,46 @@ func TestStatAssetRejectsInvalidPath(t *testing.T) {
 		filepath.Join(t.TempDir(), "geoip.dat"),
 	} {
 		if _, err := StatAsset(file); err == nil {
+			t.Fatalf("expected error for %q", file)
+		}
+	}
+}
+
+func TestResolveAssetPathAllowsMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("xray.location.asset", dir)
+
+	path, err := ResolveAssetPath("missing.dat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != filepath.Join(dir, "missing.dat") {
+		t.Fatalf("unexpected path: %s", path)
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Fatal("expected file to stay missing")
+	}
+}
+
+func TestResolveAssetPathRejectsInvalidPath(t *testing.T) {
+	for _, file := range []string{
+		"",
+		".",
+		"..",
+		"../geoip.dat",
+		"nested/..",
+		"nested/../geoip.dat",
+		"nested//geoip.dat",
+		"/geoip.dat",
+		"/tmp/geoip.dat",
+		`C:\geoip.dat`,
+		`C:geoip.dat`,
+		`\\server\share\geoip.dat`,
+		`nested\geoip.dat`,
+		`nested\..\geoip.dat`,
+		filepath.Join(t.TempDir(), "geoip.dat"),
+	} {
+		if _, err := ResolveAssetPath(file); err == nil {
 			t.Fatalf("expected error for %q", file)
 		}
 	}

--- a/infra/conf/geodata.go
+++ b/infra/conf/geodata.go
@@ -1,7 +1,9 @@
 package conf
 
 import (
+	go_errors "errors"
 	"net/url"
+	"os"
 
 	"github.com/robfig/cron/v3"
 	"github.com/xtls/xray-core/app/geodata"
@@ -11,8 +13,11 @@ import (
 )
 
 type GeodataAssetConfig struct {
-	URL  string `json:"url"`
-	File string `json:"file"`
+	URL      string `json:"url"`
+	File     string `json:"file"`
+	HashURL  string `json:"hashUrl"`
+	HashFile string `json:"hashFile"`
+	HashType string `json:"hashType"`
 }
 
 func (c *GeodataAssetConfig) Build() (*geodata.Asset, error) {
@@ -22,10 +27,56 @@ func (c *GeodataAssetConfig) Build() (*geodata.Asset, error) {
 	if _, err := filesystem.StatAsset(c.File); err != nil {
 		return nil, errors.New("invalid geodata asset file: ", c.File).Base(err)
 	}
-	return &geodata.Asset{
+	asset := &geodata.Asset{
 		Url:  c.URL,
 		File: c.File,
-	}, nil
+	}
+	if !c.hasHash() {
+		return asset, nil
+	}
+	if c.HashURL == "" || c.HashFile == "" {
+		return nil, errors.New("geodata hashUrl and hashFile must be set together")
+	}
+	if err := validateHTTPS(c.HashURL); err != nil {
+		return nil, errors.New("invalid geodata asset hash url: ", c.HashURL).Base(err)
+	}
+	if c.HashFile == c.File {
+		return nil, errors.New("geodata asset hash file must be different from file: ", c.HashFile)
+	}
+	if err := validateOptionalAssetFile(c.HashFile); err != nil {
+		return nil, errors.New("invalid geodata asset hash file: ", c.HashFile).Base(err)
+	}
+	hashType, err := geodata.NormalizeHashType(c.HashType)
+	if err != nil {
+		return nil, err
+	}
+	asset.HashUrl = c.HashURL
+	asset.HashFile = c.HashFile
+	asset.HashType = hashType
+
+	return asset, nil
+}
+
+func (c *GeodataAssetConfig) hasHash() bool {
+	return c.HashURL != "" || c.HashFile != "" || c.HashType != ""
+}
+
+func validateOptionalAssetFile(file string) error {
+	path, err := filesystem.ResolveAssetPath(file)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if go_errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return errors.New("asset is not a regular file")
+	}
+	return nil
 }
 
 func validateHTTPS(s string) error {

--- a/infra/conf/geodata_test.go
+++ b/infra/conf/geodata_test.go
@@ -1,6 +1,7 @@
 package conf_test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -9,7 +10,7 @@ import (
 )
 
 func TestGeodataConfig(t *testing.T) {
-	t.Setenv("xray.location.asset", filepath.Join("..", "..", "resources"))
+	prepareGeodataAssetDir(t)
 
 	creator := func() Buildable {
 		return new(GeodataConfig)
@@ -35,11 +36,40 @@ func TestGeodataConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			Input: `{
+				"cron": "0 4 * * *",
+				"outbound": "proxy",
+				"assets": [
+					{
+						"url": "https://example.com/geoip.dat",
+						"file": "geoip.dat",
+						"hashUrl": "https://example.com/geoip.dat.sha256sum",
+						"hashFile": "geoip.dat.sha256sum",
+						"hashType": "sha256"
+					}
+				]
+			}`,
+			Parser: loadJSON(creator),
+			Output: &geodata.Config{
+				Cron:     "0 4 * * *",
+				Outbound: "proxy",
+				Assets: []*geodata.Asset{
+					{
+						Url:      "https://example.com/geoip.dat",
+						File:     "geoip.dat",
+						HashUrl:  "https://example.com/geoip.dat.sha256sum",
+						HashFile: "geoip.dat.sha256sum",
+						HashType: "sha256",
+					},
+				},
+			},
+		},
 	})
 }
 
 func TestGeodataAssetConfig(t *testing.T) {
-	t.Setenv("xray.location.asset", filepath.Join("..", "..", "resources"))
+	prepareGeodataAssetDir(t)
 
 	if _, err := (&GeodataAssetConfig{
 		URL:  "https://example.com/geoip.dat",
@@ -56,8 +86,60 @@ func TestGeodataAssetConfig(t *testing.T) {
 	}
 }
 
+func TestGeodataAssetConfigWithHash(t *testing.T) {
+	prepareGeodataAssetDir(t)
+
+	asset, err := (&GeodataAssetConfig{
+		URL:      "https://example.com/geoip.dat",
+		File:     "geoip.dat",
+		HashURL:  "https://example.com/geoip.dat.sha256sum",
+		HashFile: "geoip.dat.sha256sum",
+		HashType: "sha-512/256",
+	}).Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if asset.HashType != "sha512/256" {
+		t.Fatalf("unexpected hash type: %s", asset.HashType)
+	}
+}
+
+func TestGeodataAssetConfigWithDefaultHashType(t *testing.T) {
+	prepareGeodataAssetDir(t)
+
+	asset, err := (&GeodataAssetConfig{
+		URL:      "https://example.com/geoip.dat",
+		File:     "geoip.dat",
+		HashURL:  "https://example.com/geoip.dat.sha256sum",
+		HashFile: "geoip.dat.sha256sum",
+	}).Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if asset.HashType != geodata.DefaultHashType {
+		t.Fatalf("unexpected hash type: %s", asset.HashType)
+	}
+}
+
+func TestGeodataAssetConfigWithMissingHashFile(t *testing.T) {
+	dir := prepareGeodataAssetDir(t)
+	if err := os.Remove(filepath.Join(dir, "geoip.dat.sha256sum")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := (&GeodataAssetConfig{
+		URL:      "https://example.com/geoip.dat",
+		File:     "geoip.dat",
+		HashURL:  "https://example.com/geoip.dat.sha256sum",
+		HashFile: "geoip.dat.sha256sum",
+		HashType: "sha256",
+	}).Build(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestGeodataAssetConfigInvalidURL(t *testing.T) {
-	t.Setenv("xray.location.asset", filepath.Join("..", "..", "resources"))
+	prepareGeodataAssetDir(t)
 
 	for _, rawURL := range []string{
 		"",
@@ -72,4 +154,70 @@ func TestGeodataAssetConfigInvalidURL(t *testing.T) {
 			t.Fatalf("expected error for %q", rawURL)
 		}
 	}
+}
+
+func TestGeodataAssetConfigInvalidHash(t *testing.T) {
+	prepareGeodataAssetDir(t)
+
+	testCases := []GeodataAssetConfig{
+		{
+			URL:      "https://example.com/geoip.dat",
+			File:     "geoip.dat",
+			HashURL:  "http://example.com/geoip.dat.sha256sum",
+			HashFile: "geoip.dat.sha256sum",
+			HashType: "sha256",
+		},
+		{
+			URL:     "https://example.com/geoip.dat",
+			File:    "geoip.dat",
+			HashURL: "https://example.com/geoip.dat.sha256sum",
+		},
+		{
+			URL:      "https://example.com/geoip.dat",
+			File:     "geoip.dat",
+			HashFile: "geoip.dat.sha256sum",
+		},
+		{
+			URL:      "https://example.com/geoip.dat",
+			File:     "geoip.dat",
+			HashType: "sha256",
+		},
+		{
+			URL:      "https://example.com/geoip.dat",
+			File:     "geoip.dat",
+			HashURL:  "https://example.com/geoip.dat.sha256sum",
+			HashFile: "geoip.dat.sha256sum",
+			HashType: "sha1",
+		},
+		{
+			URL:      "https://example.com/geoip.dat",
+			File:     "geoip.dat",
+			HashURL:  "https://example.com/geoip.dat.sha256sum",
+			HashFile: "geoip.dat",
+			HashType: "sha256",
+		},
+	}
+
+	for _, testCase := range testCases {
+		if _, err := testCase.Build(); err == nil {
+			t.Fatalf("expected error for %+v", testCase)
+		}
+	}
+}
+
+func prepareGeodataAssetDir(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	for _, file := range []string{
+		"geoip.dat",
+		"geosite.dat",
+		"geoip.dat.sha256sum",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, file), []byte(file), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("xray.location.asset", dir)
+	return dir
 }


### PR DESCRIPTION
# Geodata Hash File Support

## Purpose

This change adds optional hash-file support to the scheduled geodata updater. It lets Xray verify downloaded geodata assets before replacing local files, and skip downloading large geofiles when the remote hash shows that the local asset is already up to date.

The feature is useful on mobile devices and metered networks, where avoiding unnecessary `geoip.dat` and `geosite.dat` downloads saves bandwidth and battery when only a small checksum file needs to be fetched.

## What Was Added

- Added geodata asset hash configuration fields: `hash_url`, `hash_file`, and `hash_type` in protobuf, exposed as `hashUrl`, `hashFile`, and `hashType` in user-facing config.
- Added hash verification before downloaded geodata files are swapped into the asset directory.
- Added hash-first update logic:
  - download the remote hash file first;
  - compare it with the local hash file when available;
  - skip geofile download when the digest is unchanged;
  - download the geofile immediately when the local hash file exists and the digest differs;
  - verify the local geofile only when the local hash file is missing or unreadable.
- Added support for missing local hash files on first run. The configured `hashFile` path must be valid, but the file itself may not exist yet.
- Added default hash type handling: when `hashType` is omitted, `sha256` is used.
- Added tests for config parsing, hash verification, skipped downloads, missing hash files, and filesystem path validation.

## Update Logic

For assets without hash settings, behavior stays the same:

1. Download the geodata file to a temporary file.
2. Swap it into the asset directory.
3. Reload geodata.
4. Roll back if reload fails.

For assets with hash settings:

1. Download `hashUrl` to a temporary hash file.
2. Parse the expected digest from that hash file.
3. Compare the downloaded digest with the local `hashFile` when possible.
   - If the local `hashFile` exists and contains the same digest, skip both geofile download and reload.
   - If the local `hashFile` exists but contains a different digest, download the geofile from `url`.
   - If the local `hashFile` is missing or unreadable, verify the current local geofile against the downloaded hash.
     - If the current local geofile already matches the downloaded hash, only stage the new hash file.
     - If the current local geofile is outdated or fails verification, download the geofile from `url`.
4. When a geofile is downloaded, verify it against the downloaded hash file.
   - If verification fails, abort the update, remove temporary files, and keep the existing local files unchanged.
5. Atomically swap staged files into place using the existing transaction flow.
6. Reload geodata and roll back swapped files if reload fails.

## Hash Types

`hashType` is optional. The default value is:

```json
"hashType": "sha256"
```

Supported hash types are based on cryptographically strong hash implementations from the Go standard library:

- `sha224`
- `sha256`
- `sha384`
- `sha512`
- `sha512/224`
- `sha512/256`
- `sha3-224`
- `sha3-256`
- `sha3-384`
- `sha3-512`

Hash type names are normalized, so these forms are accepted:

- `sha512/256`
- `sha-512-256`
- `sha512_256`
- `sha512256`

Weak or non-standard-library hash types such as `md5`, `sha1`, `ripemd160`, and `blake2*` are rejected.

## Config Examples

### Existing Behavior Without Hash Verification

```json
{
  "geodata": {
    "cron": "0 4 * * *",
    "outbound": "proxy",
    "assets": [
      {
        "url": "https://example.com/geoip.dat",
        "file": "geoip.dat"
      },
      {
        "url": "https://example.com/geosite.dat",
        "file": "geosite.dat"
      }
    ]
  }
}
```

### Hash Verification With Default SHA-256

`hashType` can be omitted. It defaults to `sha256`.

```json
{
  "geodata": {
    "cron": "0 4 * * *",
    "outbound": "proxy",
    "assets": [
      {
        "url": "https://example.com/geoip.dat",
        "file": "geoip.dat",
        "hashUrl": "https://example.com/geoip.dat.sha256sum",
        "hashFile": "geoip.dat.sha256sum"
      }
    ]
  }
}
```

### Explicit Hash Type

```json
{
  "geodata": {
    "cron": "0 4 * * *",
    "outbound": "proxy",
    "assets": [
      {
        "url": "https://example.com/geosite.dat",
        "file": "geosite.dat",
        "hashUrl": "https://example.com/geosite.dat.sha512sum",
        "hashFile": "geosite.dat.sha512sum",
        "hashType": "sha512"
      }
    ]
  }
}
```

## Compatibility Notes

- Existing geodata updater configurations continue to work unchanged.
- `file` is still required for every asset because it defines the local asset path.
- `hashUrl` and `hashFile` must be provided together.
- `hashType` is optional and defaults to `sha256`.
- The local `hashFile` may be absent on first run; it will be created after a successful update.
- Hash files are stored in the same asset directory rules as geodata files, and invalid paths outside the asset directory are rejected.
- The downloaded hash file may contain a plain hex digest or common checksum-file formats such as:

```text
<hex-digest>
<hex-digest>  geoip.dat
SHA256 (geoip.dat) = <hex-digest>
```

- If the checksum line includes a filename, it must match the configured geodata `file`. This avoids accidentally using a digest for another file when a checksum file contains multiple entries.