### PR TITLE
Hysteria server: `tls.WithNextProto("h3")` by default

### DIFF
--- a/transport/internet/hysteria/hub.go
+++ b/transport/internet/hysteria/hub.go
@@ -309,7 +309,7 @@ func Listen(ctx context.Context, address net.Address, port net.Port, streamSetti
 
 	tr := &quic.Transport{Conn: pktConn}
 
-	listener, err := tr.Listen(tlsConfig.GetTLSConfig(), quicConfig)
+	listener, err := tr.Listen(tlsConfig.GetTLSConfig(tls.WithNextProto("h3")), quicConfig)
 	if err != nil {
 		_ = tr.Close()
 		_ = pktConn.Close()


### PR DESCRIPTION
把服务端alpn调成默认h3(现阶段需要手动填写) 类似grpc默认h2 不然连不上
客户端不用改 因为quic-go好像客户端强制置h3