### PR TITLE
Feature: VlessRoute forwarding between incoming and outgoing  VLESS-connections

### DIFF
--- a/proxy/vless/outbound/outbound.go
+++ b/proxy/vless/outbound/outbound.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	gotls "crypto/tls"
 	"encoding/base64"
+	"encoding/binary"
 	"reflect"
 	"strings"
 	"sync"
@@ -231,15 +232,30 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 		}
 	}
 
+	user := rec.User
+	account := user.Account.(*vless.MemoryAccount)
+
+	if inbound := session.InboundFromContext(ctx); inbound != nil && inbound.VlessRoute != 0 {
+		newAccount := *account
+		newAccountID := newAccount.ID.UUID()
+		binary.BigEndian.PutUint16(newAccountID[6:8], inbound.VlessRoute.Value())
+		newAccount.ID = protocol.NewID(newAccountID)
+		account = &newAccount
+
+		user = &protocol.MemoryUser{
+			Account: account,
+			Level:   rec.User.Level,
+			Email:   rec.User.Email,
+		}
+	}
+
 	request := &protocol.RequestHeader{
 		Version: encoding.Version,
-		User:    rec.User,
+		User:    user,
 		Command: command,
 		Address: target.Address,
 		Port:    target.Port,
 	}
-
-	account := request.User.Account.(*vless.MemoryAccount)
 
 	requestAddons := &encoding.Addons{
 		Flow: account.Flow,


### PR DESCRIPTION
Hi. When we have an intermediate server between the client and the end server, the client loses the ability to influence routing on the end server.

For example, when the end server has direct or WARP output, we can allow the client to choose the behavior on the end server without duplicating the configuration on the intermediate server.

In any case, it seems right to me that we will forward the route identifier for the entire chain of servers, if it is a chain of VLESS servers.