### PR TITLE
header-custom finalmask: Remove headerConnMode headerReadAddrAware interface

### DIFF
--- a/common/serial/typed_message_test.go
+++ b/common/serial/typed_message_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	. "github.com/xtls/xray-core/common/serial"
-	"github.com/xtls/xray-core/transport/internet/finalmask/header/custom"
 )
 
 func TestGetInstance(t *testing.T) {
@@ -21,33 +20,5 @@ func TestConvertingNilMessage(t *testing.T) {
 	x := ToTypedMessage(nil)
 	if x != nil {
 		t.Error("expect nil, but actually not")
-	}
-}
-
-func TestTypedMessageRoundTripPreservesFinalmaskCustomUDPMode(t *testing.T) {
-	msg := &custom.UDPConfig{
-		Mode: "standalone",
-		Client: []*custom.UDPItem{
-			{Rand: 12, Save: "txid"},
-		},
-	}
-
-	tm := ToTypedMessage(msg)
-	if tm == nil {
-		t.Fatal("expected typed message")
-	}
-
-	roundTrip, err := tm.GetInstance()
-	if err != nil {
-		t.Fatalf("GetInstance() failed: %v", err)
-	}
-
-	udp, ok := roundTrip.(*custom.UDPConfig)
-	if !ok {
-		t.Fatalf("unexpected round-trip type: %T", roundTrip)
-	}
-
-	if udp.GetMode() != "standalone" {
-		t.Fatalf("mode lost during typed message round-trip: got %q", udp.GetMode())
 	}
 }

--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -1734,11 +1734,17 @@ func (c *HeaderCustomUDP) Build() (proto.Message, error) {
 		})
 	}
 
-	return &custom.UDPConfig{
-		Client: client,
-		Server: server,
-		Mode:   c.Mode,
-	}, nil
+	if c.Mode == "standalone" {
+		return &custom.UDPStandaloneConfig{
+			Client: client,
+			Server: server,
+		}, nil
+	} else {
+		return &custom.UDPConfig{
+			Client: client,
+			Server: server,
+		}, nil
+	}
 }
 
 type Dns struct {

--- a/infra/conf/transport_test.go
+++ b/infra/conf/transport_test.go
@@ -195,8 +195,7 @@ func TestHeaderCustomUDPBuild(t *testing.T) {
 				"mode": "standalone"
 			}`,
 			Parser: parser,
-			Output: &finalmaskcustom.UDPConfig{
-				Mode: "standalone",
+			Output: &finalmaskcustom.UDPStandaloneConfig{
 				Client: []*finalmaskcustom.UDPItem{
 					{
 						RandMax: 255,

--- a/transport/internet/finalmask/finalmask.go
+++ b/transport/internet/finalmask/finalmask.go
@@ -31,19 +31,6 @@ func (m *UdpmaskManager) WrapPacketConnClient(raw net.PacketConn) (net.PacketCon
 	var conns []net.PacketConn
 	for i, mask := range m.udpmasks {
 		if _, ok := mask.(headerConn); ok {
-			if mode, ok := mask.(headerConnMode); ok && !mode.UseHeaderConn() {
-				if len(conns) > 0 {
-					raw = &headerManagerConn{sizes: sizes, conns: conns, PacketConn: raw}
-					sizes = nil
-					conns = nil
-				}
-				var err error
-				raw, err = mask.WrapPacketConnClient(raw, i, len(m.udpmasks)-1)
-				if err != nil {
-					return nil, err
-				}
-				continue
-			}
 			conn, err := mask.WrapPacketConnClient(nil, i, len(m.udpmasks)-1)
 			if err != nil {
 				return nil, err
@@ -77,19 +64,6 @@ func (m *UdpmaskManager) WrapPacketConnServer(raw net.PacketConn) (net.PacketCon
 	var conns []net.PacketConn
 	for i, mask := range m.udpmasks {
 		if _, ok := mask.(headerConn); ok {
-			if mode, ok := mask.(headerConnMode); ok && !mode.UseHeaderConn() {
-				if len(conns) > 0 {
-					raw = &headerManagerConn{sizes: sizes, conns: conns, PacketConn: raw}
-					sizes = nil
-					conns = nil
-				}
-				var err error
-				raw, err = mask.WrapPacketConnServer(raw, i, len(m.udpmasks)-1)
-				if err != nil {
-					return nil, err
-				}
-				continue
-			}
 			conn, err := mask.WrapPacketConnServer(nil, i, len(m.udpmasks)-1)
 			if err != nil {
 				return nil, err
@@ -126,10 +100,6 @@ type headerConn interface {
 	HeaderConn()
 }
 
-type headerConnMode interface {
-	UseHeaderConn() bool
-}
-
 type headerSize interface {
 	Size() int
 }
@@ -141,10 +111,6 @@ type headerManagerConn struct {
 	sizes    []int
 	conns    []net.PacketConn
 	writeBuf [UDPSize]byte
-}
-
-type headerReadAddrAware interface {
-	SetReadAddr(net.Addr)
 }
 
 func (c *headerManagerConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
@@ -173,9 +139,6 @@ func (c *headerManagerConn) ReadFrom(p []byte) (n int, addr net.Addr, err error)
 	}
 
 	for i := range c.conns {
-		if aware, ok := c.conns[i].(headerReadAddrAware); ok {
-			aware.SetReadAddr(addr)
-		}
 		n, _, err = c.conns[i].ReadFrom(newBuf)
 		if n == 0 || err != nil {
 			errors.LogDebug(context.Background(), addr, " mask read err ", err)
@@ -211,7 +174,7 @@ func (c *headerManagerConn) WriteTo(p []byte, addr net.Addr) (n int, err error) 
 	n = copy(c.writeBuf[sum:], p)
 
 	for i := len(c.conns) - 1; i >= 0; i-- {
-		n, err = c.conns[i].WriteTo(c.writeBuf[sum-c.sizes[i]:n+sum], addr)
+		n, err = c.conns[i].WriteTo(c.writeBuf[sum-c.sizes[i]:n+sum], nil)
 		if n == 0 || err != nil {
 			errors.LogDebug(context.Background(), addr, " mask write err ", err)
 			return 0, nil

--- a/transport/internet/finalmask/header/custom/config.go
+++ b/transport/internet/finalmask/header/custom/config.go
@@ -4,8 +4,7 @@ import (
 	"net"
 )
 
-func (c *TCPConfig) TCP() {
-}
+func (c *TCPConfig) TCP() {}
 
 func (c *TCPConfig) WrapConnClient(raw net.Conn) (net.Conn, error) {
 	return NewConnClientTCP(c, raw)
@@ -15,26 +14,24 @@ func (c *TCPConfig) WrapConnServer(raw net.Conn) (net.Conn, error) {
 	return NewConnServerTCP(c, raw)
 }
 
-func (c *UDPConfig) UDP() {
-}
+func (c *UDPConfig) UDP() {}
+
+func (c *UDPConfig) HeaderConn() {}
 
 func (c *UDPConfig) WrapPacketConnClient(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
-	if c.Mode == "standalone" {
-		return NewConnClientUDPStandalone(c, raw)
-	}
 	return NewConnClientUDP(c, raw)
 }
 
 func (c *UDPConfig) WrapPacketConnServer(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
-	if c.Mode == "standalone" {
-		return NewConnServerUDPStandalone(c, raw)
-	}
 	return NewConnServerUDP(c, raw)
 }
 
-func (c *UDPConfig) HeaderConn() {
+func (c *UDPStandaloneConfig) UDP() {}
+
+func (c *UDPStandaloneConfig) WrapPacketConnClient(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+	return NewConnClientUDPStandalone(c, raw)
 }
 
-func (c *UDPConfig) UseHeaderConn() bool {
-	return c.Mode != "standalone"
+func (c *UDPStandaloneConfig) WrapPacketConnServer(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+	return NewConnServerUDPStandalone(c, raw)
 }

--- a/transport/internet/finalmask/header/custom/config.pb.go
+++ b/transport/internet/finalmask/header/custom/config.pb.go
@@ -511,7 +511,6 @@ type UDPConfig struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Client        []*UDPItem             `protobuf:"bytes,1,rep,name=client,proto3" json:"client,omitempty"`
 	Server        []*UDPItem             `protobuf:"bytes,2,rep,name=server,proto3" json:"server,omitempty"`
-	Mode          string                 `protobuf:"bytes,3,opt,name=mode,proto3" json:"mode,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -560,11 +559,56 @@ func (x *UDPConfig) GetServer() []*UDPItem {
 	return nil
 }
 
-func (x *UDPConfig) GetMode() string {
+type UDPStandaloneConfig struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Client        []*UDPItem             `protobuf:"bytes,1,rep,name=client,proto3" json:"client,omitempty"`
+	Server        []*UDPItem             `protobuf:"bytes,2,rep,name=server,proto3" json:"server,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UDPStandaloneConfig) Reset() {
+	*x = UDPStandaloneConfig{}
+	mi := &file_transport_internet_finalmask_header_custom_config_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UDPStandaloneConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UDPStandaloneConfig) ProtoMessage() {}
+
+func (x *UDPStandaloneConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_transport_internet_finalmask_header_custom_config_proto_msgTypes[7]
 	if x != nil {
-		return x.Mode
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
 	}
-	return ""
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UDPStandaloneConfig.ProtoReflect.Descriptor instead.
+func (*UDPStandaloneConfig) Descriptor() ([]byte, []int) {
+	return file_transport_internet_finalmask_header_custom_config_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *UDPStandaloneConfig) GetClient() []*UDPItem {
+	if x != nil {
+		return x.Client
+	}
+	return nil
+}
+
+func (x *UDPStandaloneConfig) GetServer() []*UDPItem {
+	if x != nil {
+		return x.Server
+	}
+	return nil
 }
 
 var File_transport_internet_finalmask_header_custom_config_proto protoreflect.FileDescriptor
@@ -605,11 +649,13 @@ const file_transport_internet_finalmask_header_custom_config_proto_rawDesc = "" 
 	"\x06packet\x18\x04 \x01(\fR\x06packet\x12\x12\n" +
 	"\x04save\x18\x05 \x01(\tR\x04save\x12\x10\n" +
 	"\x03var\x18\x06 \x01(\tR\x03var\x12I\n" +
-	"\x04expr\x18\a \x01(\v25.xray.transport.internet.finalmask.header.custom.ExprR\x04expr\"\xc3\x01\n" +
+	"\x04expr\x18\a \x01(\v25.xray.transport.internet.finalmask.header.custom.ExprR\x04expr\"\xaf\x01\n" +
 	"\tUDPConfig\x12P\n" +
 	"\x06client\x18\x01 \x03(\v28.xray.transport.internet.finalmask.header.custom.UDPItemR\x06client\x12P\n" +
-	"\x06server\x18\x02 \x03(\v28.xray.transport.internet.finalmask.header.custom.UDPItemR\x06server\x12\x12\n" +
-	"\x04mode\x18\x03 \x01(\tR\x04modeB\xaf\x01\n" +
+	"\x06server\x18\x02 \x03(\v28.xray.transport.internet.finalmask.header.custom.UDPItemR\x06server\"\xb9\x01\n" +
+	"\x13UDPStandaloneConfig\x12P\n" +
+	"\x06client\x18\x01 \x03(\v28.xray.transport.internet.finalmask.header.custom.UDPItemR\x06client\x12P\n" +
+	"\x06server\x18\x02 \x03(\v28.xray.transport.internet.finalmask.header.custom.UDPItemR\x06serverB\xaf\x01\n" +
 	"3com.xray.transport.internet.finalmask.header.customP\x01ZDgithub.com/xtls/xray-core/transport/internet/finalmask/header/custom\xaa\x02/Xray.Transport.Internet.Finalmask.Header.Customb\x06proto3"
 
 var (
@@ -624,15 +670,16 @@ func file_transport_internet_finalmask_header_custom_config_proto_rawDescGZIP() 
 	return file_transport_internet_finalmask_header_custom_config_proto_rawDescData
 }
 
-var file_transport_internet_finalmask_header_custom_config_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_transport_internet_finalmask_header_custom_config_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_transport_internet_finalmask_header_custom_config_proto_goTypes = []any{
-	(*Expr)(nil),        // 0: xray.transport.internet.finalmask.header.custom.Expr
-	(*ExprArg)(nil),     // 1: xray.transport.internet.finalmask.header.custom.ExprArg
-	(*TCPItem)(nil),     // 2: xray.transport.internet.finalmask.header.custom.TCPItem
-	(*TCPSequence)(nil), // 3: xray.transport.internet.finalmask.header.custom.TCPSequence
-	(*TCPConfig)(nil),   // 4: xray.transport.internet.finalmask.header.custom.TCPConfig
-	(*UDPItem)(nil),     // 5: xray.transport.internet.finalmask.header.custom.UDPItem
-	(*UDPConfig)(nil),   // 6: xray.transport.internet.finalmask.header.custom.UDPConfig
+	(*Expr)(nil),                // 0: xray.transport.internet.finalmask.header.custom.Expr
+	(*ExprArg)(nil),             // 1: xray.transport.internet.finalmask.header.custom.ExprArg
+	(*TCPItem)(nil),             // 2: xray.transport.internet.finalmask.header.custom.TCPItem
+	(*TCPSequence)(nil),         // 3: xray.transport.internet.finalmask.header.custom.TCPSequence
+	(*TCPConfig)(nil),           // 4: xray.transport.internet.finalmask.header.custom.TCPConfig
+	(*UDPItem)(nil),             // 5: xray.transport.internet.finalmask.header.custom.UDPItem
+	(*UDPConfig)(nil),           // 6: xray.transport.internet.finalmask.header.custom.UDPConfig
+	(*UDPStandaloneConfig)(nil), // 7: xray.transport.internet.finalmask.header.custom.UDPStandaloneConfig
 }
 var file_transport_internet_finalmask_header_custom_config_proto_depIdxs = []int32{
 	1,  // 0: xray.transport.internet.finalmask.header.custom.Expr.args:type_name -> xray.transport.internet.finalmask.header.custom.ExprArg
@@ -645,11 +692,13 @@ var file_transport_internet_finalmask_header_custom_config_proto_depIdxs = []int
 	0,  // 7: xray.transport.internet.finalmask.header.custom.UDPItem.expr:type_name -> xray.transport.internet.finalmask.header.custom.Expr
 	5,  // 8: xray.transport.internet.finalmask.header.custom.UDPConfig.client:type_name -> xray.transport.internet.finalmask.header.custom.UDPItem
 	5,  // 9: xray.transport.internet.finalmask.header.custom.UDPConfig.server:type_name -> xray.transport.internet.finalmask.header.custom.UDPItem
-	10, // [10:10] is the sub-list for method output_type
-	10, // [10:10] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	5,  // 10: xray.transport.internet.finalmask.header.custom.UDPStandaloneConfig.client:type_name -> xray.transport.internet.finalmask.header.custom.UDPItem
+	5,  // 11: xray.transport.internet.finalmask.header.custom.UDPStandaloneConfig.server:type_name -> xray.transport.internet.finalmask.header.custom.UDPItem
+	12, // [12:12] is the sub-list for method output_type
+	12, // [12:12] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_transport_internet_finalmask_header_custom_config_proto_init() }
@@ -670,7 +719,7 @@ func file_transport_internet_finalmask_header_custom_config_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_transport_internet_finalmask_header_custom_config_proto_rawDesc), len(file_transport_internet_finalmask_header_custom_config_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   7,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/transport/internet/finalmask/header/custom/config.proto
+++ b/transport/internet/finalmask/header/custom/config.proto
@@ -56,5 +56,9 @@ message UDPItem {
 message UDPConfig {
     repeated UDPItem client = 1;
     repeated UDPItem server = 2;
-    string mode = 3;
+}
+
+message UDPStandaloneConfig {
+    repeated UDPItem client = 1;
+    repeated UDPItem server = 2;
 }

--- a/transport/internet/finalmask/header/custom/metadata_test.go
+++ b/transport/internet/finalmask/header/custom/metadata_test.go
@@ -3,6 +3,7 @@ package custom
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"net"
 	"strings"
@@ -124,8 +125,8 @@ func TestMetadataAliasesExposeDstNames(t *testing.T) {
 	}
 }
 
-func TestMetadataUDPWriteUsesRemotePort(t *testing.T) {
-	cfg := &UDPConfig{
+func TestMetadataUDPStandaloneWriteUsesRemotePort(t *testing.T) {
+	cfg := &UDPStandaloneConfig{
 		Client: []*UDPItem{
 			{
 				Expr: &Expr{
@@ -134,6 +135,11 @@ func TestMetadataUDPWriteUsesRemotePort(t *testing.T) {
 						{Value: &ExprArg_Metadata{Metadata: "remote_port"}},
 					},
 				},
+			},
+		},
+		Server: []*UDPItem{
+			{
+				Packet: []byte{0xCA, 0xFE},
 			},
 		},
 	}
@@ -156,25 +162,47 @@ func TestMetadataUDPWriteUsesRemotePort(t *testing.T) {
 	}
 
 	payload := []byte("meta")
+	errCh := make(chan error, 1)
+	go func() {
+		wire := make([]byte, 64)
+		_ = serverRaw.SetDeadline(time.Now().Add(time.Second))
+
+		n, addr, err := serverRaw.ReadFrom(wire)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		wantPort := uint16(serverRaw.LocalAddr().(*net.UDPAddr).Port)
+		if n != 2 {
+			errCh <- fmt.Errorf("unexpected handshake size: %d", n)
+			return
+		}
+		if got := binary.BigEndian.Uint16(wire[:2]); got != wantPort {
+			errCh <- fmt.Errorf("unexpected encoded port: got=%d want=%d", got, wantPort)
+			return
+		}
+		if _, err := serverRaw.WriteTo([]byte{0xCA, 0xFE}, addr); err != nil {
+			errCh <- err
+			return
+		}
+
+		n, _, err = serverRaw.ReadFrom(wire)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		if !bytes.Equal(wire[:n], payload) {
+			errCh <- fmt.Errorf("unexpected payload: %q", wire[:n])
+			return
+		}
+		errCh <- nil
+	}()
+
 	if _, err := client.WriteTo(payload, serverRaw.LocalAddr()); err != nil {
 		t.Fatal(err)
 	}
-
-	wire := make([]byte, 64)
-	_ = serverRaw.SetDeadline(time.Now().Add(time.Second))
-	n, _, err := serverRaw.ReadFrom(wire)
-	if err != nil {
+	if err := <-errCh; err != nil {
 		t.Fatal(err)
-	}
-	if n != len(payload)+2 {
-		t.Fatalf("unexpected wire size: %d", n)
-	}
-	wantPort := uint16(serverRaw.LocalAddr().(*net.UDPAddr).Port)
-	if got := binary.BigEndian.Uint16(wire[:2]); got != wantPort {
-		t.Fatalf("unexpected encoded port: got=%d want=%d", got, wantPort)
-	}
-	if !bytes.Equal(wire[2:n], payload) {
-		t.Fatalf("unexpected payload: %q", wire[2:n])
 	}
 }
 

--- a/transport/internet/finalmask/header/custom/udp.go
+++ b/transport/internet/finalmask/header/custom/udp.go
@@ -16,7 +16,6 @@ type udpCustomClient struct {
 	server []*UDPItem
 	merged []byte
 	read   int
-	addr   net.Addr
 	state  *stateStore
 	vars   map[string][]byte
 }
@@ -33,13 +32,13 @@ func (h *udpCustomClient) Serialize(b []byte) {
 func (h *udpCustomClient) Match(b []byte) bool {
 	var initial map[string][]byte
 	if h.state != nil {
-		initial, _ = h.state.get(udpStateKey(h.addr))
+		initial, _ = h.state.get(udpStateKey(nil))
 	}
 	vars, ok := matchUDPItems(h.server, b, h.read, initial)
 	if ok {
 		h.vars = vars
 		if h.state != nil {
-			h.state.set(udpStateKey(h.addr), vars)
+			h.state.set(udpStateKey(nil), vars)
 		}
 	}
 	return ok
@@ -110,16 +109,11 @@ func (c *udpCustomClientConn) WriteTo(p []byte, addr net.Addr) (n int, err error
 	return len(p), nil
 }
 
-func (c *udpCustomClientConn) SetReadAddr(addr net.Addr) {
-	c.header.addr = addr
-}
-
 type udpCustomServer struct {
 	client []*UDPItem
 	server []*UDPItem
 	merged []byte
 	read   int
-	addr   net.Addr
 	state  *stateStore
 	vars   map[string][]byte
 }
@@ -136,13 +130,13 @@ func (h *udpCustomServer) Serialize(b []byte) {
 func (h *udpCustomServer) Match(b []byte) bool {
 	var initial map[string][]byte
 	if h.state != nil {
-		initial, _ = h.state.get(udpStateKey(h.addr))
+		initial, _ = h.state.get(udpStateKey(nil))
 	}
 	vars, ok := matchUDPItems(h.client, b, h.read, initial)
 	if ok {
 		h.vars = vars
 		if h.state != nil {
-			h.state.set(udpStateKey(h.addr), vars)
+			h.state.set(udpStateKey(nil), vars)
 		}
 	}
 	return ok
@@ -211,10 +205,6 @@ func (c *udpCustomServerConn) WriteTo(p []byte, addr net.Addr) (n int, err error
 	copy(p, evaluated)
 
 	return len(p), nil
-}
-
-func (c *udpCustomServerConn) SetReadAddr(addr net.Addr) {
-	c.header.addr = addr
 }
 
 func matchUDPItems(items []*UDPItem, data []byte, totalSize int, initial map[string][]byte) (map[string][]byte, bool) {
@@ -294,7 +284,7 @@ type udpStandaloneWaiter struct {
 	done chan error
 }
 
-func NewConnClientUDPStandalone(c *UDPConfig, raw net.PacketConn) (net.PacketConn, error) {
+func NewConnClientUDPStandalone(c *UDPStandaloneConfig, raw net.PacketConn) (net.PacketConn, error) {
 	clientSavedSizes := collectSavedUDPSizes(c.Client)
 	read, err := measureUDPItemsWithFallback(c.Server, clientSavedSizes)
 	if err != nil {
@@ -441,7 +431,7 @@ type udpCustomStandaloneServerConn struct {
 	read   int
 }
 
-func NewConnServerUDPStandalone(c *UDPConfig, raw net.PacketConn) (net.PacketConn, error) {
+func NewConnServerUDPStandalone(c *UDPStandaloneConfig, raw net.PacketConn) (net.PacketConn, error) {
 	read, err := measureUDPItems(c.Client)
 	if err != nil {
 		return nil, err

--- a/transport/internet/finalmask/udp_test.go
+++ b/transport/internet/finalmask/udp_test.go
@@ -154,9 +154,8 @@ func (h *captureUDPHandler) NewPacketConnection(_ context.Context, _ singN.Packe
 
 func (h *captureUDPHandler) NewError(_ context.Context, _ error) {}
 
-func newStandaloneEchoUDPConfig() *custom.UDPConfig {
-	return &custom.UDPConfig{
-		Mode: "standalone",
+func newStandaloneEchoUDPConfig() *custom.UDPStandaloneConfig {
+	return &custom.UDPStandaloneConfig{
 		Client: []*custom.UDPItem{
 			{Packet: []byte{0xAA}},
 			{Rand: 2, Save: "txid"},
@@ -168,9 +167,8 @@ func newStandaloneEchoUDPConfig() *custom.UDPConfig {
 	}
 }
 
-func newStandaloneStunLikeUDPConfig() *custom.UDPConfig {
-	return &custom.UDPConfig{
-		Mode: "standalone",
+func newStandaloneStunLikeUDPConfig() *custom.UDPStandaloneConfig {
+	return &custom.UDPStandaloneConfig{
 		Client: []*custom.UDPItem{
 			{Packet: []byte{0x00, 0x01, 0x00, 0x00, 0x21, 0x12, 0xA4, 0x42}},
 			{Rand: 12, RandMin: 0x2A, RandMax: 0x2A, Save: "txid"},
@@ -185,9 +183,8 @@ func newStandaloneStunLikeUDPConfig() *custom.UDPConfig {
 	}
 }
 
-func newStandaloneStunLikeUDPServerConfig() *custom.UDPConfig {
-	return &custom.UDPConfig{
-		Mode: "standalone",
+func newStandaloneStunLikeUDPServerConfig() *custom.UDPStandaloneConfig {
+	return &custom.UDPStandaloneConfig{
 		Client: []*custom.UDPItem{
 			{Packet: []byte{0x00, 0x01, 0x00, 0x00, 0x21, 0x12, 0xA4, 0x42}},
 			{Rand: 12, RandMin: 0x2A, RandMax: 0x2A, Save: "txid"},
@@ -236,7 +233,7 @@ func newStandaloneStunLikeUDPServerConfig() *custom.UDPConfig {
 	}
 }
 
-func newUDPClientServerPair(t *testing.T, cfg *custom.UDPConfig) (net.PacketConn, net.PacketConn, net.PacketConn, net.PacketConn) {
+func newUDPClientServerPair(t *testing.T, cfg *custom.UDPStandaloneConfig) (net.PacketConn, net.PacketConn, net.PacketConn, net.PacketConn) {
 	t.Helper()
 
 	clientRaw, err := net.ListenPacket("udp", "127.0.0.1:0")


### PR DESCRIPTION
先把框架回退到 175502d 之前，唯一的影响就是 udp header 用不了 `src_port_u16` `dst_port_u16` `src_ip4_u32` `dst_ip4_u32` 的变量，不影响 udp standalone，如果 @fatyzzz 认为 udp header 需要 addr，应当把 udp header 移除 header manager 而不是在 manager 改一堆只是为了 udp header