### PR TITLE
core: fix nil pointer handling on object creation

### DIFF
--- a/core/functions.go
+++ b/core/functions.go
@@ -12,12 +12,19 @@ import (
 	"github.com/xtls/xray-core/transport/internet/udp"
 )
 
-// CreateObject creates a new object based on the given Xray instance and config. The Xray instance may be nil.
+// NilInstanceErr is returned when an attempt is made to create an object with a nil instance pointer.
+type NilInstanceErr struct{}
+
+func (e NilInstanceErr) Error() string {
+	return "cannot create object from a nil instance"
+}
+
+// CreateObject creates a new object based on the given Xray instance and config.
 func CreateObject(v *Instance, config interface{}) (interface{}, error) {
-	ctx := v.ctx
-	if v != nil {
-		ctx = toContext(v.ctx, v)
+	if v == nil {
+		return nil, NilInstanceErr{}
 	}
+	ctx := toContext(v.ctx, v)
 	return common.CreateObject(ctx, config)
 }
 

--- a/core/functions_test.go
+++ b/core/functions_test.go
@@ -3,6 +3,7 @@ package core_test
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"io"
 	"testing"
 	"time"
@@ -232,5 +233,16 @@ func TestXrayDialUDP(t *testing.T) {
 		if r := cmp.Diff(xor2(receive), payload); r != "" {
 			t.Error(r)
 		}
+	}
+}
+
+func TestNilInstanceCreateObject(t *testing.T) {
+	var inst *core.Instance
+	var conf string
+	var want core.NilInstanceErr
+
+	_, got := core.CreateObject(inst, conf)
+	if !errors.Is(got, want) {
+		t.Errorf("want:%T got:%T msg:%s", want, got, got)
 	}
 }


### PR DESCRIPTION
The comment on `core.CreateObject()` says that it will accept a `nil` Xray `*core.Instance`. In my testing this is incorrect, as passing a nil pointer will cause a `panic` when trying to dereference the non-existent `context.Context`.

This adds a check for `nil` in `CreateObject()`, the custom error type `NilInstanceErr` for the condition, and a test to verify that `nil` pointers are handled correctly.