### PR TITLE
README.md: Add ovpn to Xray Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@
 - Xray Tools
   - [xray-knife](https://github.com/lilendian0x00/xray-knife)
   - [xray-checker](https://github.com/kutovoys/xray-checker)
+  - [ovpn](https://github.com/agentram/ovpn)
 - Xray Wrapper
   - [XTLS/libXray](https://github.com/XTLS/libXray)
   - [xtls-sdk](https://github.com/remnawave/xtls-sdk)


### PR DESCRIPTION
Add ovpn to the Xray Tools list.

ovpn is a source-available Go CLI for operating self-hosted Xray VLESS + REALITY servers over SSH. It renders Docker Compose runtime files, manages users and client links, supports rolling quotas, monitoring, backups, and optional HAProxy entrypoints.

I placed it under Xray Tools because it is operator tooling rather than a GUI client or web panel. Happy to move it if another category fits better.