### PR TITLE
leastPing balancer: prefer reliable outbounds over fast-but-flaky ones

### DIFF
--- a/app/router/strategy_leastping.go
+++ b/app/router/strategy_leastping.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"context"
+	"math"
 
 	"github.com/xtls/xray-core/app/observatory"
 	"github.com/xtls/xray-core/common"
@@ -9,6 +10,18 @@ import (
 	"github.com/xtls/xray-core/core"
 	"github.com/xtls/xray-core/features/extension"
 )
+
+// leastPingFailureTolerance is the fraction of recent health-check probes an
+// outbound may fail before leastPing stops treating it as a low-latency
+// candidate. The burst observatory derives Delay from the average of only the
+// successful probes, so an outbound that is being throttled or blocked can keep
+// a very low Delay while dropping most of its traffic. When reliability data is
+// available, excluding such outbounds prevents leastPing from locking onto a
+// fast-but-mostly-dead tunnel. The bar is deliberately lenient: only genuinely
+// flaky outbounds are skipped, and if every candidate is flaky the selection
+// falls back to the original lowest-Delay behavior, so the result is never
+// worse than a pure least-ping pick.
+const leastPingFailureTolerance = 0.5
 
 type LeastPingStrategy struct {
 	ctx         context.Context
@@ -27,7 +40,7 @@ func (l *LeastPingStrategy) InjectContext(ctx context.Context) {
 	}))
 }
 
-func (l *LeastPingStrategy) PickOutbound(strings []string) string {
+func (l *LeastPingStrategy) PickOutbound(candidates []string) string {
 	if l.observatory == nil {
 		errors.LogError(l.ctx, "observer is nil")
 		return ""
@@ -37,22 +50,67 @@ func (l *LeastPingStrategy) PickOutbound(strings []string) string {
 		errors.LogInfoInner(l.ctx, err, "cannot get observer report")
 		return ""
 	}
-	outboundsList := outboundList(strings)
-	if result, ok := observeReport.(*observatory.ObservationResult); ok {
-		status := result.Status
-		leastPing := int64(99999999)
-		selectedOutboundName := ""
-		for _, v := range status {
-			if outboundsList.contains(v.OutboundTag) && v.Alive && v.Delay < leastPing {
-				selectedOutboundName = v.OutboundTag
-				leastPing = v.Delay
+	result, ok := observeReport.(*observatory.ObservationResult)
+	if !ok {
+		// No way to understand observeReport
+		return ""
+	}
+	return pickLeastPing(result.Status, candidates)
+}
+
+// pickLeastPing chooses the lowest-latency outbound among the alive candidates.
+// It skips outbounds whose recent health-check failure rate exceeds
+// leastPingFailureTolerance (when such data is available) and breaks exact Delay
+// ties in favor of the lower latency deviation (the steadier outbound). If the
+// reliability filter removes every candidate, it falls back to the lowest-Delay
+// alive outbound, reproducing the previous behavior so the result is never worse
+// than a pure least-ping selection.
+func pickLeastPing(status []*observatory.OutboundStatus, candidates []string) string {
+	cand := outboundList(candidates)
+
+	reliableTag := ""
+	reliableDelay := int64(math.MaxInt64)
+	reliableDeviation := int64(math.MaxInt64)
+
+	fallbackTag := ""
+	fallbackDelay := int64(math.MaxInt64)
+
+	for _, v := range status {
+		if !v.Alive || !cand.contains(v.OutboundTag) {
+			continue
+		}
+
+		// Lowest-Delay alive outbound, ignoring reliability. This reproduces
+		// the original least-ping selection and is used as a safe fallback when
+		// no outbound passes the reliability filter below.
+		if v.Delay < fallbackDelay {
+			fallbackTag = v.OutboundTag
+			fallbackDelay = v.Delay
+		}
+
+		// Skip outbounds that fail most of their recent probes. Without health
+		// statistics (e.g. the plain observer, which leaves HealthPing nil)
+		// every alive outbound stays eligible, preserving previous behavior.
+		deviation := int64(math.MaxInt64)
+		if v.HealthPing != nil {
+			deviation = v.HealthPing.Deviation
+			if v.HealthPing.All > 0 &&
+				float64(v.HealthPing.Fail)/float64(v.HealthPing.All) > leastPingFailureTolerance {
+				continue
 			}
 		}
-		return selectedOutboundName
+
+		if v.Delay < reliableDelay || (v.Delay == reliableDelay && deviation < reliableDeviation) {
+			reliableTag = v.OutboundTag
+			reliableDelay = v.Delay
+			reliableDeviation = deviation
+		}
 	}
 
-	// No way to understand observeReport
-	return ""
+	if reliableTag != "" {
+		return reliableTag
+	}
+	return fallbackTag
 }
 
 type outboundList []string

--- a/app/router/strategy_leastping_test.go
+++ b/app/router/strategy_leastping_test.go
@@ -1,0 +1,111 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/xtls/xray-core/app/observatory"
+)
+
+func leastPingStatus(tag string, alive bool, delayMs int64, hp *observatory.HealthPingMeasurementResult) *observatory.OutboundStatus {
+	return &observatory.OutboundStatus{
+		OutboundTag: tag,
+		Alive:       alive,
+		Delay:       delayMs,
+		HealthPing:  hp,
+	}
+}
+
+func leastPingHealth(all, fail, deviation int64) *observatory.HealthPingMeasurementResult {
+	return &observatory.HealthPingMeasurementResult{All: all, Fail: fail, Deviation: deviation}
+}
+
+func TestPickLeastPing(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     []*observatory.OutboundStatus
+		candidates []string
+		expected   string
+	}{
+		{
+			// Regression guard: with healthy outbounds and no health stats the
+			// selection is unchanged — the lowest Delay still wins.
+			name: "lowest delay wins when all healthy",
+			status: []*observatory.OutboundStatus{
+				leastPingStatus("a", true, 50, nil),
+				leastPingStatus("b", true, 20, nil),
+				leastPingStatus("c", true, 80, nil),
+			},
+			candidates: []string{"a", "b", "c"},
+			expected:   "b",
+		},
+		{
+			// Core fix: a 20ms tunnel that fails 9/10 probes must lose to a
+			// slower but reliable one, because its low Delay is only the average
+			// of the few successful probes.
+			name: "reject fast but flaky node",
+			status: []*observatory.OutboundStatus{
+				leastPingStatus("a", true, 20, leastPingHealth(10, 9, 0)),
+				leastPingStatus("b", true, 60, leastPingHealth(10, 0, 0)),
+			},
+			candidates: []string{"a", "b"},
+			expected:   "b",
+		},
+		{
+			// Backward compatibility with the plain observer, which leaves
+			// HealthPing nil: selection is by Delay only.
+			name: "nil health ping falls back to pure delay",
+			status: []*observatory.OutboundStatus{
+				leastPingStatus("a", true, 20, nil),
+				leastPingStatus("b", true, 50, nil),
+			},
+			candidates: []string{"a", "b"},
+			expected:   "a",
+		},
+		{
+			name: "equal delay broken by lower deviation",
+			status: []*observatory.OutboundStatus{
+				leastPingStatus("a", true, 30, leastPingHealth(10, 0, 20)),
+				leastPingStatus("b", true, 30, leastPingHealth(10, 0, 5)),
+			},
+			candidates: []string{"a", "b"},
+			expected:   "b",
+		},
+		{
+			// When every candidate is flaky, never return worse than the old
+			// behavior: fall back to the lowest-Delay alive outbound.
+			name: "all flaky falls back to lowest delay",
+			status: []*observatory.OutboundStatus{
+				leastPingStatus("a", true, 20, leastPingHealth(10, 9, 0)),
+				leastPingStatus("b", true, 50, leastPingHealth(10, 8, 0)),
+			},
+			candidates: []string{"a", "b"},
+			expected:   "a",
+		},
+		{
+			name: "skips dead and non-candidate outbounds",
+			status: []*observatory.OutboundStatus{
+				leastPingStatus("dead", false, 5, nil),
+				leastPingStatus("other", true, 1, nil),
+				leastPingStatus("a", true, 40, nil),
+			},
+			candidates: []string{"a", "dead"},
+			expected:   "a",
+		},
+		{
+			name: "empty when nothing qualifies",
+			status: []*observatory.OutboundStatus{
+				leastPingStatus("a", true, 10, nil),
+			},
+			candidates: []string{"x"},
+			expected:   "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := pickLeastPing(c.status, c.candidates); got != c.expected {
+				t.Errorf("pickLeastPing() = %q, want %q", got, c.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`leastPing` selects purely on `Alive && Delay`. With a `burstObservatory`, `Delay` is derived from the average of only the **successful** probes (`app/observatory/burst/healthping_result.go`, `getStatistics`), and `Alive` is true as long as a single probe in the window succeeded. So an outbound that is being throttled or blocked — succeeding on a few probes and failing the rest — keeps a tiny `Delay` while dropping most of its traffic, and `leastPing` locks onto that fast‑but‑mostly‑dead tunnel instead of a slower but healthy one. This is a common failure mode under DPI‑based throttling.

## Change

Use the reliability data the observatory already collects:

- skip candidates whose recent health‑check failure rate exceeds 50% (`HealthPing.Fail / HealthPing.All`);
- break exact `Delay` ties by the lower latency deviation (the steadier link).

## Compatibility

Fully backward compatible:

- the plain observer leaves `HealthPing` nil → selection stays by `Delay` only;
- if every candidate is flaky, it falls back to the original lowest‑`Delay` pick, so the result is never worse than before.

No config or proto changes. The `leastPing` name and its behavior on healthy networks are unchanged (covered by a regression test).

## Tests

Adds `app/router/strategy_leastping_test.go` — offline, table‑driven tests covering: lowest‑delay‑wins (regression guard), rejecting a fast‑but‑flaky node, nil‑`HealthPing` pure‑delay fallback, deviation tie‑break, all‑flaky graceful fallback, dead/non‑candidate filtering, and the empty case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
