### PR TITLE
Fix remote panic in QUIC sniffer on crafted Initial packet

### DIFF
--- a/common/protocol/quic/sniff.go
+++ b/common/protocol/quic/sniff.go
@@ -144,6 +144,14 @@ func SniffQUIC(b []byte) (*SniffHeader, error) {
 			return nil, err
 		}
 
+		// Header protection samples block.BlockSize() bytes starting 4 bytes
+		// into the packet number field. A packet that passed the length check
+		// above can still be too short to contain that sample (e.g. a crafted
+		// Initial with a small Length field), which would slice out of range.
+		if len(b) < hdrLen+4+block.BlockSize() {
+			return nil, common.ErrNoClue
+		}
+
 		cache.Clear()
 		mask := cache.Extend(int32(block.BlockSize()))
 		block.Encrypt(mask, b[hdrLen+4:hdrLen+4+len(mask)])

--- a/common/protocol/quic/sniff_test.go
+++ b/common/protocol/quic/sniff_test.go
@@ -285,3 +285,16 @@ func TestSniffFakeQUICPacketWithTooShortData(t *testing.T) {
 		t.Error("failed")
 	}
 }
+
+func TestSniffFakeQUICPacketWithShortHeaderProtectionSample(t *testing.T) {
+	// A crafted Initial packet whose Length field (4) is large enough to pass
+	// the length check but too small to contain the 16-byte header-protection
+	// sample. This used to slice out of range and panic, which crashes the
+	// process because the sniffer runs in a goroutine without recover.
+	pkt, err := hex.DecodeString("c0000000010000000400000000")
+	common.Must(err)
+	_, err = quic.SniffQUIC(pkt)
+	if err == nil {
+		t.Error("failed")
+	}
+}


### PR DESCRIPTION
## Problem

`SniffQUIC` parses untrusted inbound UDP payloads. After validating the QUIC long header it checks `len(b) >= hdrLen + packetLen` with `packetLen >= 4`, but then reads the 16‑byte header‑protection sample at `b[hdrLen+4 : hdrLen+4+block.BlockSize()]` (`common/protocol/quic/sniff.go:149`). Neither check guarantees `len(b) >= hdrLen+20`, so a crafted Initial packet with a small `Length` field (e.g. 4) slices out of range and **panics**.

The sniffer runs inside a goroutine with no `recover()` (`app/dispatcher/default.go`), so this panic crashes the whole process — a remotely‑triggerable denial of service against any inbound that sniffs UDP/QUIC traffic.

Minimal repro (13 bytes): `c0000000010000000400000000` → `panic: slice bounds out of range [:29] with capacity 13`.

## Fix

Guard the sample length before reading it. A packet too short to contain the header‑protection sample is treated as not‑enough‑data (`common.ErrNoClue`), exactly like the existing truncation check a few lines above.

## Tests

Adds `TestSniffFakeQUICPacketWithShortHeaderProtectionSample`, which panics before the fix and returns an error after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
