### PR TITLE
Fix remote panic in HTTP proxy on malformed upstream 1xx response

### DIFF
--- a/proxy/http/server.go
+++ b/proxy/http/server.go
@@ -332,7 +332,7 @@ func readResponseAndHandle100Continue(r *bufio.Reader, req *http.Request, writer
 					return nil, errors.New("failed to read http 1xx response").Base(err)
 				}
 				ResponseHeader1xx = append(ResponseHeader1xx, data...)
-				if bytes.Equal(ResponseHeader1xx[len(ResponseHeader1xx)-4:], []byte{'\r', '\n', '\r', '\n'}) {
+				if len(ResponseHeader1xx) >= 4 && bytes.Equal(ResponseHeader1xx[len(ResponseHeader1xx)-4:], []byte{'\r', '\n', '\r', '\n'}) {
 					break
 				}
 				if len(ResponseHeader1xx) > 1024 {

--- a/proxy/http/server_1xx_test.go
+++ b/proxy/http/server_1xx_test.go
@@ -1,0 +1,20 @@
+package http
+
+import (
+	"bufio"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestReadResponseAndHandle100ContinueShortLine(t *testing.T) {
+	// A malformed upstream "1xx" response whose first header line is shorter
+	// than 4 bytes used to slice out of range and panic. responseDone runs in
+	// a goroutine without recover, so the panic crashed the whole process.
+	// The leading space makes strings.Cut classify the status as "1...".
+	input := " 1\n" + strings.Repeat("X", 80)
+	r := bufio.NewReader(strings.NewReader(input))
+	if _, err := readResponseAndHandle100Continue(r, nil, io.Discard); err == nil {
+		t.Error("expected an error, got nil")
+	}
+}


### PR DESCRIPTION
## Problem

`readResponseAndHandle100Continue` forwards 1xx responses from the upstream the client connected to. While reading the 1xx header it checks for the terminating `\r\n\r\n` via `ResponseHeader1xx[len(ResponseHeader1xx)-4:]` (`proxy/http/server.go:335`) with no guard that the accumulated buffer is at least 4 bytes long.

An upstream can return a first line shorter than 4 bytes that still classifies as 1xx (e.g. a line beginning with a space, so `strings.Cut(line, " ")` yields status `"1…"`). The first `ReadSlice('\n')` then returns fewer than 4 bytes and the slice expression panics. `responseDone` runs in a goroutine with no `recover()`, so the panic crashes the whole process — a remotely‑triggerable DoS via a malicious or MITM'd upstream for plain (non‑CONNECT) HTTP proxy requests.

## Fix

Guard the length before slicing. The existing `len > 1024` cap still bounds non‑terminating responses.

## Tests

Adds `TestReadResponseAndHandle100ContinueShortLine`, which panics before the fix and returns an error after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
