### PR TITLE
conf: return errors instead of panicking on configs missing "address"

### DIFF
--- a/infra/conf/conf_nil_address_test.go
+++ b/infra/conf/conf_nil_address_test.go
@@ -1,0 +1,24 @@
+package conf
+
+import "testing"
+
+func TestHysteriaClientConfigMissingAddress(t *testing.T) {
+	// "version": 2 without "address" must return an error, not panic.
+	c := &HysteriaClientConfig{Version: 2}
+	if _, err := c.Build(); err == nil {
+		t.Error("expected an error for missing address, got nil")
+	}
+}
+
+func TestFakeDNSPostProcessingMissingServerAddress(t *testing.T) {
+	// A DNS server entry without "address" must not panic during config
+	// post-processing; the descriptive error is emitted later by Build().
+	config := &Config{
+		DNSConfig: &DNSConfig{
+			Servers: []*NameServerConfig{{Port: 53}},
+		},
+	}
+	if err := (FakeDNSPostProcessingStage{}).Process(config); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/infra/conf/fakedns.go
+++ b/infra/conf/fakedns.go
@@ -76,6 +76,9 @@ func (FakeDNSPostProcessingStage) Process(config *Config) error {
 
 	if config.DNSConfig != nil {
 		for _, v := range config.DNSConfig.Servers {
+			if v == nil || v.Address == nil {
+				continue
+			}
 			if v.Address.Family().IsDomain() && strings.EqualFold(v.Address.Domain(), "fakedns") {
 				fakeDNSInUse = true
 			}

--- a/infra/conf/hysteria.go
+++ b/infra/conf/hysteria.go
@@ -20,6 +20,9 @@ func (c *HysteriaClientConfig) Build() (proto.Message, error) {
 	if c.Version != 2 {
 		return nil, errors.New("version != 2")
 	}
+	if c.Address == nil {
+		return nil, errors.New("Hysteria client: \"address\" is not set")
+	}
 
 	config := &hysteria.ClientConfig{}
 	config.Version = c.Version


### PR DESCRIPTION
Two config builders dereference an optional `*Address` without a nil check, so a malformed config panics during load instead of producing a clean error. Every other outbound/DNS builder already guards `Address == nil` and returns a descriptive error.

- **`infra/conf/hysteria.go`** — a Hysteria outbound with `"version": 2` but no `"address"` makes `c.Address.Build()` panic. Add the same guard used by the VLESS/VMess/Trojan builders.
- **`infra/conf/fakedns.go`** — `FakeDNSPostProcessingStage.Process` (run before any `NameServerConfig.Build` validation) calls `v.Address.Family()` on every DNS server; a server entry without `"address"` (e.g. `{"port": 53}`) panics. Skip address‑less entries so the later `Build()` emits the intended "nameserver address is not specified" error.

## Tests

Adds regression tests that panicked before the fix and now return cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
