### PR TITLE
Fix nil-pointer dereference in WebSocket dialer with Browser Dialer over plain ws

### DIFF
--- a/transport/internet/websocket/dialer.go
+++ b/transport/internet/websocket/dialer.go
@@ -114,7 +114,7 @@ func dialWebSocket(ctx context.Context, dest net.Destination, streamSettings *in
 	if browser_dialer.HasBrowserDialer() {
 		// For Browser Dialer's optimized IP and non-standard port
 		host := wsSettings.Host
-		if host == "" && tConfig.ServerName != "" {
+		if host == "" && tConfig != nil && tConfig.ServerName != "" {
 			host = tConfig.ServerName
 		}
 		if host == "" {


### PR DESCRIPTION
In the WebSocket dialer's Browser Dialer path, `tConfig.ServerName` is read without a nil check (`transport/internet/websocket/dialer.go:117`). `tConfig` (from `tls.ConfigFromStreamSettings`) is nil for a plain `ws://` (non‑TLS) transport.

Every other use of `tConfig` in this function guards `tConfig != nil` (the TLS branch at line 75 and the non‑browser path at line 145) — this one does not. So with a Browser Dialer registered and a plain `ws` transport whose `host` is empty (a valid, common config), `host == ""` is true and Go evaluates the right operand `tConfig.ServerName`, panicking and crashing the dial goroutine.

## Fix

Add the same `tConfig != nil` guard already used a few lines below at line 145. One‑line change with no effect on any currently non‑crashing path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
