### PR TITLE
observatory: fix data race, 32-bit RTT truncation, and redundant stat recompute

### DIFF
--- a/app/observatory/burst/burstobserver.go
+++ b/app/observatory/burst/burstobserver.go
@@ -40,20 +40,24 @@ func (o *Observer) createResult() []*observatory.OutboundStatus {
 	o.hp.access.Lock()
 	defer o.hp.access.Unlock()
 	for name, value := range o.hp.Results {
+		// Compute the statistics once: getStatistics() does a full recompute on
+		// every call and filters samples by the current time, so calling it per
+		// field both wasted work and risked an internally inconsistent status.
+		stats := value.getStatistics()
 		status := observatory.OutboundStatus{
-			Alive:           value.getStatistics().All != value.getStatistics().Fail,
-			Delay:           value.getStatistics().Average.Milliseconds(),
+			Alive:           stats.All != stats.Fail,
+			Delay:           stats.Average.Milliseconds(),
 			LastErrorReason: "",
 			OutboundTag:     name,
 			LastSeenTime:    0,
 			LastTryTime:     0,
 			HealthPing: &observatory.HealthPingMeasurementResult{
-				All:       int64(value.getStatistics().All),
-				Fail:      int64(value.getStatistics().Fail),
-				Deviation: int64(value.getStatistics().Deviation),
-				Average:   int64(value.getStatistics().Average),
-				Max:       int64(value.getStatistics().Max),
-				Min:       int64(value.getStatistics().Min),
+				All:       int64(stats.All),
+				Fail:      int64(stats.Fail),
+				Deviation: int64(stats.Deviation),
+				Average:   int64(stats.Average),
+				Max:       int64(stats.Max),
+				Min:       int64(stats.Min),
 			},
 		}
 		result = append(result, &status)

--- a/app/observatory/burst/healthping_result.go
+++ b/app/observatory/burst/healthping_result.go
@@ -109,7 +109,7 @@ func (h *HealthPingRTTS) getStatistics() *HealthPingStats {
 		stats.Min = 0
 		return stats
 	}
-	stats.Average = time.Duration(int(sum) / cnt)
+	stats.Average = sum / time.Duration(cnt)
 	var std float64
 	if cnt < 2 {
 		// no enough data for standard deviation, we assume it's half of the average rtt

--- a/app/observatory/observer.go
+++ b/app/observatory/observer.go
@@ -39,7 +39,16 @@ type Observer struct {
 }
 
 func (o *Observer) GetObservation(ctx context.Context) (proto.Message, error) {
-	return &ObservationResult{Status: o.status}, nil
+	// Return a snapshot under the lock: the background prober reassigns o.status
+	// and mutates its elements in place, while consumers (router strategies,
+	// metrics, the command service) read the result on other goroutines.
+	o.statusLock.Lock()
+	defer o.statusLock.Unlock()
+	status := make([]*OutboundStatus, len(o.status))
+	for i, s := range o.status {
+		status[i] = proto.Clone(s).(*OutboundStatus)
+	}
+	return &ObservationResult{Status: status}, nil
 }
 
 func (o *Observer) Type() interface{} {

--- a/app/observatory/observer_race_test.go
+++ b/app/observatory/observer_race_test.go
@@ -1,0 +1,45 @@
+package observatory
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// TestObserverGetObservationNoRace exercises GetObservation concurrently with
+// the prober's status updates. Before GetObservation took the status lock and
+// returned a snapshot, this tripped the race detector (go test -race), because
+// the prober reassigns the status slice and mutates the status structs in place
+// while consumers read them on other goroutines.
+func TestObserverGetObservationNoRace(t *testing.T) {
+	o := &Observer{}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 2000; i++ {
+			o.updateStatusForResult("a", &ProbeResult{Alive: true, Delay: int64(i)})
+			o.updateStatusForResult("b", &ProbeResult{Alive: false, LastErrorReason: "x"})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 2000; i++ {
+			report, err := o.GetObservation(context.Background())
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			for _, s := range report.(*ObservationResult).Status {
+				_ = s.GetAlive()
+				_ = s.GetDelay()
+				_ = s.GetOutboundTag()
+			}
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
Three related fixes in the observatory subsystem.

### Data race in the plain observer — `app/observatory/observer.go`

`GetObservation` returned `o.status` (the live slice and the live `*OutboundStatus` pointers) with no lock, while the background prober concurrently reassigns the slice and mutates the structs in place under `statusLock`. Router strategies, the metrics exporter and the gRPC command service all call `GetObservation` from other goroutines, so both the slice header and the struct fields were read while being written — a data race (`go test -race`). The sibling burst observer already returns a freshly‑built copy under its lock. Now the plain observer does the same: it takes the lock and returns a deep copy.

### RTT average truncated to 32 bits — `app/observatory/burst/healthping_result.go`

`stats.Average = time.Duration(int(sum) / cnt)` casts a `time.Duration` (int64 ns) to `int` before dividing. On 32‑bit targets (386/arm/mips, all shipped in releases) `int` is 32 bits, so a single near‑timeout sample (5 s ≈ 5e9 ns) already overflows `math.MaxInt32` and the average becomes garbage, corrupting the load‑balancer's node selection. Keeping the division in `time.Duration` is byte‑identical on 64‑bit and correct on 32‑bit.

### Redundant stat recomputation — `app/observatory/burst/burstobserver.go`

`createResult` called `getStatistics()` eight times per outbound — each a full recompute that re‑filters samples against the current clock — which both wasted work and could yield an internally inconsistent `OutboundStatus` (e.g. `All` and `Fail` taken from different snapshots, driving `Alive`). Compute it once and reuse it.

### Tests

Adds `TestObserverGetObservationNoRace`, which trips `go test -race` before the lock/copy fix and passes after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
