### PR TITLE
router: fix data race between PickRoute and runtime rule reloads

### DIFF
--- a/app/router/router.go
+++ b/app/router/router.go
@@ -24,7 +24,7 @@ type Router struct {
 	ctx        context.Context
 	ohm        outbound.Manager
 	dispatcher routing.Dispatcher
-	mu         sync.Mutex
+	mu         sync.RWMutex
 }
 
 // Route is an implementation of routing.Route.
@@ -230,8 +230,8 @@ func (r *Router) RemoveRule(tag string) error {
 
 // ListRule implements routing.Router
 func (r *Router) ListRule() []routing.Route {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	ruleList := make([]routing.Route, 0)
 	for _, rule := range r.rules {
 		ruleList = append(ruleList, &Route{
@@ -240,6 +240,13 @@ func (r *Router) ListRule() []routing.Route {
 		})
 	}
 	return ruleList
+}
+
+// getRules returns a snapshot of the current rule set under the read lock.
+func (r *Router) getRules() []*Rule {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.rules
 }
 
 func (r *Router) pickRouteInternal(ctx routing.Context) (*Rule, routing.Context, error) {
@@ -252,7 +259,13 @@ func (r *Router) pickRouteInternal(ctx routing.Context) (*Rule, routing.Context,
 		ctx = routing_dns.ContextWithDNSClient(ctx, r.dns)
 	}
 
-	for _, rule := range r.rules {
+	// Snapshot the rule set under the read lock: ReloadRules/RemoveRule replace
+	// it under the write lock (via the routing API) while this runs on the hot
+	// path. The rules are iterated without holding the lock, so rule.Apply (which
+	// may resolve DNS) never blocks reloads.
+	rules := r.getRules()
+
+	for _, rule := range rules {
 		if rule.Apply(ctx) {
 			return rule, ctx, nil
 		}
@@ -265,7 +278,7 @@ func (r *Router) pickRouteInternal(ctx routing.Context) (*Rule, routing.Context,
 	ctx = routing_dns.ContextWithDNSClient(ctx, r.dns)
 
 	// Try applying rules again if we have IPs.
-	for _, rule := range r.rules {
+	for _, rule := range rules {
 		if rule.Apply(ctx) {
 			return rule, ctx, nil
 		}

--- a/app/router/router_race_test.go
+++ b/app/router/router_race_test.go
@@ -1,0 +1,41 @@
+package router_test
+
+import (
+	"sync"
+	"testing"
+
+	. "github.com/xtls/xray-core/app/router"
+)
+
+// TestRouterPickRouteReloadNoRace exercises the hot routing path concurrently
+// with a runtime rule reload. Before PickRoute snapshotted the rule set under
+// the lock, this tripped the race detector (go test -race), because ReloadRules
+// reassigns r.rules under the write lock while PickRoute ranged over it with no
+// synchronization.
+func TestRouterPickRouteReloadNoRace(t *testing.T) {
+	r := new(Router)
+	cfg := &Config{}
+	if err := r.ReloadRules(cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	ctx := withBackground()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 3000; i++ {
+			r.PickRoute(ctx)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 3000; i++ {
+			_ = r.ReloadRules(cfg, false)
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
`PickRoute` → `pickRouteInternal` ranges over `r.rules` with no synchronization, while `ReloadRules`, `AddRule` and `RemoveRule` (reachable at runtime via the routing gRPC API) reassign `r.rules` under `r.mu`. Reassigning a slice header is not atomic under the Go memory model, so a reload concurrent with routing can make `PickRoute` observe a torn header — a data race that can corrupt routing or crash.

`go test -race` flags it as a read in `pickRouteInternal` (`router.go:255`) versus a write in `ReloadRules` (`router.go:134`).

## Fix

Make `mu` a `sync.RWMutex`, snapshot the rule set under the read lock at the start of `pickRouteInternal`, and iterate the snapshot with no lock held (so `rule.Apply`, which may resolve DNS, never blocks reloads). `ListRule` becomes a read‑lock. The rule slice is only ever replaced wholesale (never mutated in place), so the header snapshot is safe to iterate lock‑free.

## Tests

Adds `TestRouterPickRouteReloadNoRace`, which runs `PickRoute` concurrently with `ReloadRules`; it trips the race detector before the fix and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
