### PR TITLE
fakedns: handle IP pools whose network base has leading zero bytes

### DIFF
--- a/app/dns/fakedns/fake.go
+++ b/app/dns/fakedns/fake.go
@@ -108,9 +108,10 @@ func (fkdns *Holder) GetFakeIPForDomain(domain string) []net.Address {
 	}
 	bigIntIP := big.NewInt(0).SetBytes(fkdns.ipRange.IP)
 	bigIntIP = bigIntIP.Add(bigIntIP, new(big.Int).SetUint64(currentTimeMillis))
+	ipSize := len(fkdns.ipRange.IP)
 	var ip net.Address
 	for {
-		ip = net.IPAddress(bigIntIP.Bytes())
+		ip = net.IPAddress(fixedSizeBytes(bigIntIP, ipSize))
 
 		// if we run for a long time, we may go back to beginning and start seeing the IP in use
 		if _, ok := fkdns.domainToIP.PeekKeyFromValue(ip); !ok {
@@ -118,12 +119,27 @@ func (fkdns *Holder) GetFakeIPForDomain(domain string) []net.Address {
 		}
 
 		bigIntIP = bigIntIP.Add(bigIntIP, big.NewInt(1))
-		if !fkdns.ipRange.Contains(bigIntIP.Bytes()) {
+		if !fkdns.ipRange.Contains(fixedSizeBytes(bigIntIP, ipSize)) {
 			bigIntIP = big.NewInt(0).SetBytes(fkdns.ipRange.IP)
 		}
 	}
 	fkdns.domainToIP.Put(domain, ip)
 	return []net.Address{ip}
+}
+
+// fixedSizeBytes returns the big-endian representation of n in exactly size
+// bytes. big.Int.Bytes() strips leading zero bytes, so a pool whose network
+// base begins with a zero byte (e.g. the NAT64 prefix 64:ff9b::/96) would
+// otherwise yield a short slice that net.IPAddress rejects (returning nil) and
+// that IPNet.Contains never matches.
+func fixedSizeBytes(n *big.Int, size int) []byte {
+	raw := n.Bytes()
+	if len(raw) >= size {
+		return raw[len(raw)-size:]
+	}
+	fixed := make([]byte, size)
+	copy(fixed[size-len(raw):], raw)
+	return fixed
 }
 
 // GetDomainFromFakeDNS checks if an IP is a fake IP and have corresponding domain name

--- a/app/dns/fakedns/fake_leadingzero_test.go
+++ b/app/dns/fakedns/fake_leadingzero_test.go
@@ -1,0 +1,34 @@
+package fakedns
+
+import (
+	"testing"
+)
+
+// TestFakeDNSLeadingZeroPool covers IP pools whose network base begins with a
+// zero byte, e.g. the NAT64 prefix 64:ff9b::/96. big.Int.Bytes() strips the
+// leading zero, so the generated IP used to come back nil/short, corrupting the
+// answer (and looping forever once the nil value was cached).
+func TestFakeDNSLeadingZeroPool(t *testing.T) {
+	fkdns, err := NewFakeDNSHolderConfigOnly(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fkdns.initialize("64:ff9b::/96", 65535); err != nil {
+		t.Fatal(err)
+	}
+
+	ips := fkdns.GetFakeIPForDomain("example.com")
+	if len(ips) != 1 {
+		t.Fatalf("expected 1 ip, got %d", len(ips))
+	}
+	ip := ips[0]
+	if ip == nil || !ip.Family().IsIP() {
+		t.Fatalf("got invalid fake ip: %v", ip)
+	}
+	if !fkdns.IsIPInIPPool(ip) {
+		t.Errorf("fake ip %v is not inside the pool", ip)
+	}
+	if got := fkdns.GetDomainFromFakeDNS(ip); got != "example.com" {
+		t.Errorf("reverse lookup = %q, want example.com", got)
+	}
+}


### PR DESCRIPTION
`GetFakeIPForDomain` builds the candidate IP with `big.Int` and converts it back via `net.IPAddress(bigIntIP.Bytes())`. `big.Int.Bytes()` returns the minimal big‑endian representation, stripping high‑order zero bytes. When the pool's network base begins with a zero byte — a realistic config such as the NAT64 prefix `64:ff9b::/96` (first byte `0x00`) — the result is 15 bytes instead of 16, so `net.IPAddress` returns nil. The nil address is then cached and returned, corrupting the fake‑DNS answer; on the next lookup into the same pool the cached nil makes the wrap‑around loop (whose `IPNet.Contains` check also fails on the short slice) spin forever while holding the pool lock.

## Fix

Left‑pad the bytes to the pool's fixed width (`len(ipRange.IP)`) before every use, so `net.IPAddress`/`Contains` always receive a 4‑ or 16‑byte slice. Default pools are unaffected; this only changes pools whose base starts with `0x00`.

## Tests

Adds `TestFakeDNSLeadingZeroPool` using `64:ff9b::/96`, asserting a non‑nil, in‑range IP that round‑trips through `GetDomainFromFakeDNS`. It fails before the fix and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
