### PR TITLE
Release pooled buffers on error/return paths

### DIFF
--- a/common/protocol/dns/io.go
+++ b/common/protocol/dns/io.go
@@ -101,6 +101,7 @@ func (r *TCPReader) ReadMessage() (*buf.Buffer, error) {
 	}
 	b := buf.New()
 	if _, err := b.ReadFullFrom(r.reader, int32(size)); err != nil {
+		b.Release()
 		return nil, err
 	}
 	return b, nil

--- a/proxy/vless/encoding/addons.go
+++ b/proxy/vless/encoding/addons.go
@@ -183,6 +183,8 @@ func (r *LengthPacketReader) ReadMultiBuffer() (buf.MultiBuffer, error) {
 		length -= size
 		b := buf.New()
 		if _, err := b.ReadFullFrom(r.Reader, size); err != nil {
+			b.Release()
+			buf.ReleaseMulti(mb)
 			return nil, errors.New("failed to read packet payload").Base(err)
 		}
 		mb = append(mb, b)

--- a/transport/internet/udp/dispatcher.go
+++ b/transport/internet/udp/dispatcher.go
@@ -210,6 +210,8 @@ s:
 		}
 	case packet = <-c.cache:
 	}
+	// Release the pooled payload buffer once its bytes have been copied out.
+	defer packet.Payload.Release()
 	return copy(p, packet.Payload.Bytes()), &net.UDPAddr{
 		IP:   packet.Source.Address.IP(),
 		Port: int(packet.Source.Port),


### PR DESCRIPTION
Three pooled `buf.Buffer`s are dropped to the GC instead of returned to the pool on error/return paths. None is a memory leak (the GC still reclaims them), but each defeats buffer pooling on a reachable path. The fixes mirror the project's existing release idioms.

- **`common/protocol/dns/io.go`** — `TCPReader.ReadMessage` allocates `buf.New()` and returns on a `ReadFullFrom` error without `Release()` (cf. `common/mux/reader.go`, which releases). Release on the error path.
- **`transport/internet/udp/dispatcher.go`** — `dispatcherConn.ReadFrom` copies `packet.Payload` out and returns without `Release()`; the sibling `callback` already releases the payload on its discard paths. `defer packet.Payload.Release()` after the bytes are copied.
- **`proxy/vless/encoding/addons.go`** — `LengthPacketReader.ReadMultiBuffer` leaks the buffers already accumulated in `mb` (and `b`) if a mid‑packet `ReadFullFrom` fails. Release `b` and `buf.ReleaseMulti(mb)` on the error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
