### PR TITLE
Propagate the real error on copy/close failure

### DIFF
--- a/proxy/trojan/server.go
+++ b/proxy/trojan/server.go
@@ -336,7 +336,7 @@ func (s *Server) handleConnection(ctx context.Context, sessionPolicy policy.Sess
 
 	requestDone := func() error {
 		defer timer.SetTimeout(sessionPolicy.Timeouts.DownlinkOnly)
-		if buf.Copy(clientReader, link.Writer, buf.UpdateActivity(timer)) != nil {
+		if err := buf.Copy(clientReader, link.Writer, buf.UpdateActivity(timer)); err != nil {
 			return errors.New("failed to transfer request").Base(err)
 		}
 		return nil

--- a/transport/internet/splithttp/connection.go
+++ b/transport/internet/splithttp/connection.go
@@ -34,7 +34,7 @@ func (c *splitConn) Close() error {
 	}
 
 	if err2 != nil {
-		return err
+		return err2
 	}
 
 	return nil


### PR DESCRIPTION
Two error/return paths discard the real failure cause.

- **`proxy/trojan/server.go`** — in `requestDone`, `buf.Copy(...) != nil` discards the copy error, then returns `.Base(err)` where `err` is the *outer* variable from `dispatcher.Dispatch` (already nil by this point), so the log wraps nil instead of the actual transport failure. The symmetric `responseDone` does it correctly. Capture the copy error in a local variable, matching `responseDone` and the idiom in `trojan/client.go`, `vmess/inbound`, and `vless/outbound`.
- **`transport/internet/splithttp/connection.go`** — `splitConn.Close` returns `err` (guaranteed nil at that point) when only the reader's `Close` fails, silently dropping `err2`. Return `err2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
