### PR TITLE
Add configurable XHTTP session ID format

### DIFF
--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -221,6 +221,7 @@ type SplitHTTPConfig struct {
 	UplinkHTTPMethod     string            `json:"uplinkHTTPMethod"`
 	SessionPlacement     string            `json:"sessionPlacement"`
 	SessionKey           string            `json:"sessionKey"`
+	SessionIdFormat      string            `json:"sessionIdFormat"`
 	SeqPlacement         string            `json:"seqPlacement"`
 	SeqKey               string            `json:"seqKey"`
 	UplinkDataPlacement  string            `json:"uplinkDataPlacement"`
@@ -339,6 +340,15 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 		return nil, errors.New("unsupported session placement: " + c.SessionPlacement)
 	}
 
+	switch c.SessionIdFormat {
+	case "":
+	case splithttp.SessionIdFormatUUID,
+		splithttp.SessionIdFormatRandomHex,
+		splithttp.SessionIdFormatRandomBase62:
+	default:
+		return nil, errors.New("unsupported session id format: " + c.SessionIdFormat)
+	}
+
 	switch c.SeqPlacement {
 	case "":
 		c.SeqPlacement = "path"
@@ -403,6 +413,7 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 		XPaddingMethod:       c.XPaddingMethod,
 		UplinkHTTPMethod:     c.UplinkHTTPMethod,
 		SessionPlacement:     c.SessionPlacement,
+		SessionIdFormat:      c.SessionIdFormat,
 		SeqPlacement:         c.SeqPlacement,
 		SessionKey:           c.SessionKey,
 		SeqKey:               c.SeqKey,

--- a/transport/internet/splithttp/common.go
+++ b/transport/internet/splithttp/common.go
@@ -9,3 +9,9 @@ const (
 	PlacementBody          = "body"
 	PlacementAuto          = "auto"
 )
+
+const (
+	SessionIdFormatUUID         = "uuid"
+	SessionIdFormatRandomHex    = "random-hex"
+	SessionIdFormatRandomBase62 = "random-base62"
+)

--- a/transport/internet/splithttp/config.go
+++ b/transport/internet/splithttp/config.go
@@ -213,6 +213,13 @@ func (c *Config) GetNormalizedSessionPlacement() string {
 	return c.SessionPlacement
 }
 
+func (c *Config) GetNormalizedSessionIdFormat() string {
+	if c.SessionIdFormat == "" {
+		return SessionIdFormatUUID
+	}
+	return c.SessionIdFormat
+}
+
 func (c *Config) GetNormalizedSeqPlacement() string {
 	if c.SeqPlacement == "" {
 		return PlacementPath

--- a/transport/internet/splithttp/config.pb.go
+++ b/transport/internet/splithttp/config.pb.go
@@ -187,6 +187,7 @@ type Config struct {
 	UplinkDataKey        string                 `protobuf:"bytes,25,opt,name=uplinkDataKey,proto3" json:"uplinkDataKey,omitempty"`
 	UplinkChunkSize      *RangeConfig           `protobuf:"bytes,26,opt,name=uplinkChunkSize,proto3" json:"uplinkChunkSize,omitempty"`
 	ServerMaxHeaderBytes int32                  `protobuf:"varint,27,opt,name=serverMaxHeaderBytes,proto3" json:"serverMaxHeaderBytes,omitempty"`
+	SessionIdFormat      string                 `protobuf:"bytes,28,opt,name=sessionIdFormat,proto3" json:"sessionIdFormat,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
@@ -410,6 +411,13 @@ func (x *Config) GetServerMaxHeaderBytes() int32 {
 	return 0
 }
 
+func (x *Config) GetSessionIdFormat() string {
+	if x != nil {
+		return x.SessionIdFormat
+	}
+	return ""
+}
+
 var File_transport_internet_splithttp_config_proto protoreflect.FileDescriptor
 
 const file_transport_internet_splithttp_config_proto_rawDesc = "" +
@@ -425,7 +433,7 @@ const file_transport_internet_splithttp_config_proto_rawDesc = "" +
 	"\x0ecMaxReuseTimes\x18\x03 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x0ecMaxReuseTimes\x12Z\n" +
 	"\x10hMaxRequestTimes\x18\x04 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x10hMaxRequestTimes\x12Z\n" +
 	"\x10hMaxReusableSecs\x18\x05 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x10hMaxReusableSecs\x12*\n" +
-	"\x10hKeepAlivePeriod\x18\x06 \x01(\x03R\x10hKeepAlivePeriod\"\xc2\v\n" +
+	"\x10hKeepAlivePeriod\x18\x06 \x01(\x03R\x10hKeepAlivePeriod\"\xec\v\n" +
 	"\x06Config\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
 	"\x04path\x18\x02 \x01(\tR\x04path\x12\x12\n" +
@@ -456,7 +464,8 @@ const file_transport_internet_splithttp_config_proto_rawDesc = "" +
 	"\x13uplinkDataPlacement\x18\x18 \x01(\tR\x13uplinkDataPlacement\x12$\n" +
 	"\ruplinkDataKey\x18\x19 \x01(\tR\ruplinkDataKey\x12X\n" +
 	"\x0fuplinkChunkSize\x18\x1a \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x0fuplinkChunkSize\x122\n" +
-	"\x14serverMaxHeaderBytes\x18\x1b \x01(\x05R\x14serverMaxHeaderBytes\x1a:\n" +
+	"\x14serverMaxHeaderBytes\x18\x1b \x01(\x05R\x14serverMaxHeaderBytes\x12(\n" +
+	"\x0fsessionIdFormat\x18\x1c \x01(\tR\x0fsessionIdFormat\x1a:\n" +
 	"\fHeadersEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x85\x01\n" +

--- a/transport/internet/splithttp/config.proto
+++ b/transport/internet/splithttp/config.proto
@@ -50,4 +50,5 @@ message Config {
   string uplinkDataKey = 25;
   RangeConfig uplinkChunkSize = 26;
   int32 serverMaxHeaderBytes = 27;
+  string sessionIdFormat = 28;
 }

--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -2,7 +2,9 @@ package splithttp
 
 import (
 	"context"
+	cryptoRand "crypto/rand"
 	gotls "crypto/tls"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"math/rand"
@@ -46,6 +48,52 @@ var (
 	globalDialerMap    map[dialerConf]*XmuxManager
 	globalDialerAccess sync.Mutex
 )
+
+const (
+	sessionIDRandomBytes   = 16
+	sessionIDBase62Length  = 22
+	sessionIDBase62Chars   = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	sessionIDBase62MaxByte = 248 // 62 * 4, used for unbiased rejection sampling.
+)
+
+func newSessionID(format string) string {
+	switch format {
+	case SessionIdFormatRandomHex:
+		return randomHexSessionID()
+	case SessionIdFormatRandomBase62:
+		return randomBase62SessionID()
+	default:
+		sessionID := uuid.New()
+		return sessionID.String()
+	}
+}
+
+func randomHexSessionID() string {
+	token := make([]byte, sessionIDRandomBytes)
+	common.Must2(cryptoRand.Read(token))
+	return hex.EncodeToString(token)
+}
+
+func randomBase62SessionID() string {
+	token := make([]byte, sessionIDBase62Length)
+	randomBytes := make([]byte, sessionIDBase62Length)
+
+	for i := 0; i < len(token); {
+		common.Must2(cryptoRand.Read(randomBytes))
+		for _, b := range randomBytes {
+			if b >= sessionIDBase62MaxByte {
+				continue
+			}
+			token[i] = sessionIDBase62Chars[int(b)%len(sessionIDBase62Chars)]
+			i++
+			if i == len(token) {
+				break
+			}
+		}
+	}
+
+	return string(token)
+}
 
 func getHTTPClient(ctx context.Context, dest net.Destination, streamSettings *internet.MemoryStreamConfig) (DialerClient, *XmuxClient) {
 	realityConfig := reality.ConfigFromStreamSettings(streamSettings)
@@ -376,8 +424,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 
 	sessionId := ""
 	if mode != "stream-one" {
-		sessionIdUuid := uuid.New()
-		sessionId = sessionIdUuid.String()
+		sessionId = newSessionID(transportConfiguration.GetNormalizedSessionIdFormat())
 	}
 
 	errors.LogInfo(ctx, fmt.Sprintf("XHTTP is dialing to %s, mode %s, HTTP version %s, host %s", dest, mode, httpVersion, requestURL.Host))

--- a/transport/internet/splithttp/dialer_test.go
+++ b/transport/internet/splithttp/dialer_test.go
@@ -1,0 +1,44 @@
+package splithttp
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestNewSessionIDFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		pattern string
+	}{
+		{
+			name:    "default",
+			format:  "",
+			pattern: `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
+		},
+		{
+			name:    "uuid",
+			format:  SessionIdFormatUUID,
+			pattern: `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
+		},
+		{
+			name:    "random hex",
+			format:  SessionIdFormatRandomHex,
+			pattern: `^[0-9a-f]{32}$`,
+		},
+		{
+			name:    "random base62",
+			format:  SessionIdFormatRandomBase62,
+			pattern: `^[0-9A-Za-z]{22}$`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sessionID := newSessionID(test.format)
+			if !regexp.MustCompile(test.pattern).MatchString(sessionID) {
+				t.Fatalf("session id %q does not match %q", sessionID, test.pattern)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary

This PR adds an optional `sessionIdFormat` setting for XHTTP client-side session ID generation.

By default, XHTTP keeps the existing canonical UUID behavior. Users can opt into other opaque token shapes when a deployment environment needs session IDs to fit a different HTTP-visible format.

### Motivation

XHTTP session IDs may appear in HTTP-visible locations depending on `sessionPlacement`, such as path, query, header, or cookie. Some HTTP intermediaries apply strict handling or filtering to specific token shapes.

This change makes the textual shape of the client-generated session ID configurable without changing XHTTP protocol semantics.

### Supported values

| Value | Shape | Purpose |
| --- | --- | --- |
| `uuid` | Canonical UUID string, e.g. `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` | Compatibility mode and default behavior. |
| `random-hex` | 32 lowercase hex characters generated from 16 cryptographically random bytes | Hash/fingerprint-like shape, similar to common cache keys, ETags, or asset fingerprints. |
| `random-base62` | 22 cryptographically random base62 characters, e.g. `aZ8pQ2nLm7VxK0sYdE4rBt` | Compact token/id-like shape, similar to common opaque web identifiers. |

Example:

```json
{
  "sessionIdFormat": "random-base62"
}
```
## Compatibility

This change is backward compatible.

Existing configurations are unaffected because an unset sessionIdFormat keeps the existing runtime behavior. The server side does not require special handling because XHTTP session IDs are already handled as opaque strings.
