### PR TITLE
Add per-user per-inbound traffic statistics counters

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -198,12 +198,30 @@ func WrapLink(ctx context.Context, policyManager policy.Manager, statsManager st
 
 	if user != nil && len(user.Email) > 0 {
 		p := policyManager.ForLevel(user.Level)
+
+		// тег inbound для комбинированного счётчика
+		inboundTag := ""
+		if sessionInbound != nil {
+			inboundTag = sessionInbound.Tag
+		}
+
 		if p.Stats.UserUplink {
 			name := "user>>>" + user.Email + ">>>traffic>>>uplink"
+			counters := []stats.Counter{}
 			if c, _ := stats.GetOrRegisterCounter(statsManager, name); c != nil {
-				link.Reader.(*buf.TimeoutWrapperReader).Counter = c
+				counters = append(counters, c)
+			}
+			if inboundTag != "" {
+				combName := "user>>>" + user.Email + ">>>inbound>>>" + inboundTag + ">>>traffic>>>uplink"
+				if cc, _ := stats.GetOrRegisterCounter(statsManager, combName); cc != nil {
+					counters = append(counters, cc)
+				}
+			}
+			if len(counters) > 0 {
+				link.Reader.(*buf.TimeoutWrapperReader).Counter = &multiCounter{counters: counters}
 			}
 		}
+
 		if p.Stats.UserDownlink {
 			name := "user>>>" + user.Email + ">>>traffic>>>downlink"
 			if c, _ := stats.GetOrRegisterCounter(statsManager, name); c != nil {
@@ -212,7 +230,17 @@ func WrapLink(ctx context.Context, policyManager policy.Manager, statsManager st
 					Writer:  link.Writer,
 				}
 			}
+			if inboundTag != "" {
+				combName := "user>>>" + user.Email + ">>>inbound>>>" + inboundTag + ">>>traffic>>>downlink"
+				if cc, _ := stats.GetOrRegisterCounter(statsManager, combName); cc != nil {
+					link.Writer = &SizeStatWriter{
+						Counter: cc,
+						Writer:  link.Writer,
+					}
+				}
+			}
 		}
+
 		if p.Stats.UserOnline {
 			trackOnlineIP(ctx, statsManager, user.Email, sessionInbound.Source.Address.String())
 		}

--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -199,7 +199,6 @@ func WrapLink(ctx context.Context, policyManager policy.Manager, statsManager st
 	if user != nil && len(user.Email) > 0 {
 		p := policyManager.ForLevel(user.Level)
 
-		// тег inbound для комбинированного счётчика
 		inboundTag := ""
 		if sessionInbound != nil {
 			inboundTag = sessionInbound.Tag

--- a/app/dispatcher/stats.go
+++ b/app/dispatcher/stats.go
@@ -6,6 +6,33 @@ import (
 	"github.com/xtls/xray-core/features/stats"
 )
 
+type multiCounter struct {
+	counters []stats.Counter
+}
+
+func (m *multiCounter) Value() int64 {
+	if len(m.counters) > 0 {
+		return m.counters[0].Value()
+	}
+	return 0
+}
+
+func (m *multiCounter) Set(v int64) int64 {
+	var prev int64
+	for _, c := range m.counters {
+		prev = c.Set(v)
+	}
+	return prev
+}
+
+func (m *multiCounter) Add(v int64) int64 {
+	var r int64
+	for _, c := range m.counters {
+		r = c.Add(v)
+	}
+	return r
+}
+
 type SizeStatWriter struct {
 	Counter stats.Counter
 	Writer  buf.Writer


### PR DESCRIPTION
Adds traffic counters that break down a user's traffic by the inbound it
went through. Currently the stats system exposes traffic either per user
(`user>>>email>>>traffic>>>...`) or per inbound (`inbound>>>tag>>>traffic>>>...`),
but never the intersection of the two. This PR adds the missing cross-product:
```
user>>>{email}>>>inbound>>>{tag}>>>traffic>>>uplink
user>>>{email}>>>inbound>>>{tag}>>>traffic>>>downlink
```