### PR TITLE
Prevent XHTTP response padding on invalid requests

### DIFF
--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -106,24 +106,26 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 	}
 
 	h.config.WriteResponseHeader(writer, request.Method, request.Header)
-	length := int(h.config.GetNormalizedXPaddingBytes().rand())
-	config := XPaddingConfig{Length: length}
+	applyResponsePadding := func() {
+		length := int(h.config.GetNormalizedXPaddingBytes().rand())
+		config := XPaddingConfig{Length: length}
 
-	if h.config.XPaddingObfsMode {
-		config.Placement = XPaddingPlacement{
-			Placement: h.config.XPaddingPlacement,
-			Key:       h.config.XPaddingKey,
-			Header:    h.config.XPaddingHeader,
+		if h.config.XPaddingObfsMode {
+			config.Placement = XPaddingPlacement{
+				Placement: h.config.XPaddingPlacement,
+				Key:       h.config.XPaddingKey,
+				Header:    h.config.XPaddingHeader,
+			}
+			config.Method = PaddingMethod(h.config.XPaddingMethod)
+		} else {
+			config.Placement = XPaddingPlacement{
+				Placement: PlacementHeader,
+				Header:    "X-Padding",
+			}
 		}
-		config.Method = PaddingMethod(h.config.XPaddingMethod)
-	} else {
-		config.Placement = XPaddingPlacement{
-			Placement: PlacementHeader,
-			Header:    "X-Padding",
-		}
+
+		h.config.ApplyXPaddingToResponse(writer, config)
 	}
-
-	h.config.ApplyXPaddingToResponse(writer, config)
 
 	if request.Method == "OPTIONS" {
 		writer.WriteHeader(http.StatusOK)
@@ -225,6 +227,7 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 			} else {
 				writer.Header().Set("X-Accel-Buffering", "no")
 				writer.Header().Set("Cache-Control", "no-store")
+				applyResponsePadding()
 				writer.WriteHeader(http.StatusOK)
 				scStreamUpServerSecs := h.config.GetNormalizedScStreamUpServerSecs()
 				referrer := request.Header.Get("Referer")
@@ -355,6 +358,7 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 			writer.Header().Set("Cache-Control", "no-store")
 		}
 
+		applyResponsePadding()
 		writer.WriteHeader(http.StatusOK)
 	} else if request.Method == "GET" || sessionId == "" { // stream-down, stream-one
 		if sessionId != "" {
@@ -376,6 +380,7 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 			writer.Header().Set("Content-Type", "text/event-stream")
 		}
 
+		applyResponsePadding()
 		writer.WriteHeader(http.StatusOK)
 		writer.(http.Flusher).Flush()
 


### PR DESCRIPTION
## Summary

This PR changes when XHTTP response padding is added.

Before this change, the server added response padding very early in `ServeHTTP`, before the request was fully validated. Because of that, even invalid requests could get XHTTP-specific padding in the response headers/cookies together with an error status.

This moves the padding step to the successful response paths only, avoiding XHTTP-specific response padding on requests that are rejected anyway.

## Details

Response padding is still added for normal successful XHTTP traffic:

- `stream-up`
- `packet-up`
- `stream-down`
- `stream-one`

It is no longer added to error responses such as invalid padding, unsupported method, oversized upload, or failed upload queue operations.

`OPTIONS` responses also no longer get response padding. They are used for CORS/preflight handling, so they should not need XHTTP padding.

## Compatibility / risk

This should be low risk for existing clients. Valid XHTTP requests keep the same response padding behavior.

The only intended behavior change is for invalid/error responses: they now return the error without adding XHTTP response padding.

No request validation, session handling, upload/download handling, or padding generation logic is changed.