### PR TITLE
TUN inbound: `autoOutboundsInterface` bypasses loopback addresses

### DIFF
--- a/proxy/tun/handler.go
+++ b/proxy/tun/handler.go
@@ -3,6 +3,7 @@ package tun
 import (
 	"context"
 	"net/netip"
+	"strings"
 	"syscall"
 
 	"github.com/xtls/xray-core/common"
@@ -83,7 +84,7 @@ func (t *Handler) Init(ctx context.Context, pm policy.Manager, dispatcher routin
 			return c.Control(func(fd uintptr) {
 				addrPort, _ := netip.ParseAddrPort(address)
 				// skip loopback
-				if addrPort.Addr().IsLoopback() {
+				if addrPort.Addr().IsLoopback() || strings.HasPrefix(strings.ToLower(address), "localhost:") {
 					return
 				}
 				err := setinterface(network, address, fd, iface)

--- a/proxy/tun/handler.go
+++ b/proxy/tun/handler.go
@@ -2,6 +2,7 @@ package tun
 
 import (
 	"context"
+	"net/netip"
 	"syscall"
 
 	"github.com/xtls/xray-core/common"
@@ -80,10 +81,9 @@ func (t *Handler) Init(ctx context.Context, pm policy.Manager, dispatcher routin
 				return nil
 			}
 			return c.Control(func(fd uintptr) {
-				ipStr, _, _ := net.SplitHostPort(address)
-				ip := net.ParseIP(ipStr)
+				addrPort, _ := netip.ParseAddrPort(address)
 				// skip loopback
-				if ip != nil && ip.IsLoopback() {
+				if addrPort.Addr().IsLoopback() {
 					return
 				}
 				err := setinterface(network, address, fd, iface)

--- a/proxy/tun/handler.go
+++ b/proxy/tun/handler.go
@@ -80,6 +80,12 @@ func (t *Handler) Init(ctx context.Context, pm policy.Manager, dispatcher routin
 				return nil
 			}
 			return c.Control(func(fd uintptr) {
+				_, ipStr, _ := net.SplitHostPort(address)
+				ip := net.ParseIP(ipStr)
+				// skip loopback
+				if ip != nil && ip.IsLoopback() {
+					return
+				}
 				err := setinterface(network, address, fd, iface)
 				if err != nil {
 					errors.LogInfoInner(context.Background(), err, "[tun] falied to set interface")

--- a/proxy/tun/handler.go
+++ b/proxy/tun/handler.go
@@ -80,7 +80,7 @@ func (t *Handler) Init(ctx context.Context, pm policy.Manager, dispatcher routin
 				return nil
 			}
 			return c.Control(func(fd uintptr) {
-				_, ipStr, _ := net.SplitHostPort(address)
+				ipStr, _, _ := net.SplitHostPort(address)
 				ip := net.ParseIP(ipStr)
 				// skip loopback
 				if ip != nil && ip.IsLoopback() {


### PR DESCRIPTION
让它正常进系统的lo接口 避免被强行发送到公网 本来想着算了 但是发现刚好这个接口允许看dest 那就顺带处理一下吧
close #6269