### PR TITLE
feat(stats): expose inbound online maps in metrics

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -180,7 +180,7 @@ func (d *DefaultDispatcher) getLink(ctx context.Context) (*transport.Link, *tran
 		}
 
 		if p.Stats.UserOnline {
-			trackOnlineIP(ctx, d.stats, user.Email, sessionInbound.Source.Address.String())
+			trackOnlineIP(ctx, d.stats, sessionInbound.Tag, user.Email, sessionInbound.Source.Address.String())
 		}
 	}
 
@@ -214,15 +214,25 @@ func WrapLink(ctx context.Context, policyManager policy.Manager, statsManager st
 			}
 		}
 		if p.Stats.UserOnline {
-			trackOnlineIP(ctx, statsManager, user.Email, sessionInbound.Source.Address.String())
+			trackOnlineIP(ctx, statsManager, sessionInbound.Tag, user.Email, sessionInbound.Source.Address.String())
 		}
 	}
 
 	return link
 }
 
-func trackOnlineIP(ctx context.Context, sm stats.Manager, email, ip string) {
+func trackOnlineIP(ctx context.Context, sm stats.Manager, inboundTag, email, ip string) {
 	name := "user>>>" + email + ">>>online"
+	if om, _ := stats.GetOrRegisterOnlineMap(sm, name); om != nil {
+		om.AddIP(ip)
+		context.AfterFunc(ctx, func() { om.RemoveIP(ip) })
+	}
+
+	if inboundTag == "" {
+		return
+	}
+
+	name = "inbound>>>" + inboundTag + ">>>user>>>" + email + ">>>online"
 	if om, _ := stats.GetOrRegisterOnlineMap(sm, name); om != nil {
 		om.AddIP(ip)
 		context.AfterFunc(ctx, func() { om.RemoveIP(ip) })

--- a/app/metrics/metrics.go
+++ b/app/metrics/metrics.go
@@ -57,6 +57,22 @@ func NewMetricsHandler(ctx context.Context, config *Config) (*MetricsHandler, er
 		})
 		return resp
 	}))
+	expvar.Publish("online", expvar.Func(func() interface{} {
+		resp := map[string]interface{}{}
+		c.statsManager.VisitOnlineMaps(func(name string, om feature_stats.OnlineMap) bool {
+			ips := map[string]int64{}
+			om.ForEach(func(ip string, lastSeen int64) bool {
+				ips[ip] = lastSeen
+				return true
+			})
+			resp[name] = map[string]interface{}{
+				"count": om.Count(),
+				"ips":   ips,
+			}
+			return true
+		})
+		return resp
+	}))
 	expvar.Publish("observatory", expvar.Func(func() interface{} {
 		if c.observatory == nil {
 			common.Must(core.RequireFeatures(ctx, func(observatory extension.Observatory) error {

--- a/app/stats/command/command.go
+++ b/app/stats/command/command.go
@@ -87,14 +87,20 @@ func (s *statsServer) GetAllOnlineUsers(ctx context.Context, request *GetAllOnli
 
 func (s *statsServer) GetUsersStats(ctx context.Context, request *GetUsersStatsRequest) (*GetUsersStatsResponse, error) {
 	userMap := make(map[string]*UserStat)
+	const (
+		prefixUser   = "user>>>"
+		suffixOnline = ">>>online"
+	)
 
 	s.stats.VisitOnlineMaps(func(name string, om feature_stats.OnlineMap) bool {
 		if om.Count() == 0 {
 			return true
 		}
+		if !strings.HasPrefix(name, prefixUser) || !strings.HasSuffix(name, suffixOnline) {
+			return true
+		}
 
-		_, rest, _ := strings.Cut(name, ">>>")
-		email, _, _ := strings.Cut(rest, ">>>")
+		email := name[len(prefixUser) : len(name)-len(suffixOnline)]
 
 		user := &UserStat{Email: email}
 		om.ForEach(func(ip string, lastSeen int64) bool {

--- a/app/stats/command/command_test.go
+++ b/app/stats/command/command_test.go
@@ -89,3 +89,34 @@ func TestQueryStats(t *testing.T) {
 		t.Error(r)
 	}
 }
+
+func TestGetUsersStatsIgnoresInboundScopedMaps(t *testing.T) {
+	m, err := stats.NewManager(context.Background(), &stats.Config{})
+	common.Must(err)
+
+	userMap, err := m.RegisterOnlineMap("user>>>alice@example.com>>>online")
+	common.Must(err)
+	userMap.AddIP("198.51.100.1")
+
+	inboundMap, err := m.RegisterOnlineMap("inbound>>>vless-443>>>user>>>alice@example.com>>>online")
+	common.Must(err)
+	inboundMap.AddIP("198.51.100.2")
+
+	s := NewStatsServer(m)
+	resp, err := s.GetUsersStats(context.Background(), &GetUsersStatsRequest{})
+	common.Must(err)
+
+	if r := cmp.Diff(resp.Users, []*UserStat{
+		{
+			Email: "alice@example.com",
+			Ips: []*OnlineIPEntry{
+				{Ip: "198.51.100.1"},
+			},
+		},
+	}, cmpopts.SortSlices(func(s1, s2 *UserStat) bool { return s1.Email < s2.Email }),
+		cmpopts.SortSlices(func(s1, s2 *OnlineIPEntry) bool { return s1.Ip < s2.Ip }),
+		cmpopts.IgnoreFields(OnlineIPEntry{}, "LastSeen"),
+		cmpopts.IgnoreUnexported(UserStat{}, OnlineIPEntry{})); r != "" {
+		t.Error(r)
+	}
+}

--- a/app/stats/stats.go
+++ b/app/stats/stats.go
@@ -2,6 +2,7 @@ package stats
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	"github.com/xtls/xray-core/common"
@@ -180,7 +181,7 @@ func (m *Manager) GetAllOnlineUsers() []string {
 
 	usersOnline := make([]string, 0, len(m.onlineMaps))
 	for user, om := range m.onlineMaps {
-		if om.Count() > 0 {
+		if strings.HasPrefix(user, "user>>>") && om.Count() > 0 {
 			usersOnline = append(usersOnline, user)
 		}
 	}

--- a/app/stats/stats_test.go
+++ b/app/stats/stats_test.go
@@ -2,6 +2,7 @@ package stats_test
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
@@ -12,6 +13,31 @@ import (
 
 func TestInterface(t *testing.T) {
 	_ = stats.Manager(new(Manager))
+}
+
+func TestGetAllOnlineUsersIgnoresInboundScopedMaps(t *testing.T) {
+	m, err := NewManager(context.Background(), &Config{})
+	common.Must(err)
+
+	userMap, err := m.RegisterOnlineMap("user>>>alice@example.com>>>online")
+	common.Must(err)
+	userMap.AddIP("198.51.100.1")
+
+	inboundMap, err := m.RegisterOnlineMap("inbound>>>vless-443>>>user>>>alice@example.com>>>online")
+	common.Must(err)
+	inboundMap.AddIP("198.51.100.2")
+
+	emptyUserMap, err := m.RegisterOnlineMap("user>>>bob@example.com>>>online")
+	common.Must(err)
+	emptyUserMap.AddIP("198.51.100.3")
+	emptyUserMap.RemoveIP("198.51.100.3")
+
+	usersOnline := m.GetAllOnlineUsers()
+	slices.Sort(usersOnline)
+
+	if len(usersOnline) != 1 || usersOnline[0] != "user>>>alice@example.com>>>online" {
+		t.Fatalf("unexpected online users: %#v", usersOnline)
+	}
 }
 
 func TestStatsChannelRunnable(t *testing.T) {


### PR DESCRIPTION
## Summary

Expose inbound-scoped online users through OnlineMaps and metrics, without adding a new stats API method.

## Motivation

Xray currently tracks online users under `user>>>EMAIL>>>online`, which is useful for aggregate per-user online status. Some management panels need to know which inbound a user is online through when the same logical user/email is configured on multiple inbounds.

## Changes

- Continue registering the existing `user>>>EMAIL>>>online` map.
- Additionally register `inbound>>>TAG>>>user>>>EMAIL>>>online` when the inbound tag is available.
- Export OnlineMaps through metrics using the full OnlineMap name as the key.
- Keep `GetAllOnlineUsers` and `GetUsersStats` limited to legacy `user>>>...>>>online` maps so existing callers are not affected.
- Add focused tests for legacy filtering.

## Testing

```console
GOPATH=/tmp/xray-go GOMODCACHE=/tmp/xray-go/pkg/mod GOCACHE=/tmp/xray-go/cache go test ./app/stats ./app/stats/command ./app/dispatcher ./app/metrics
```

Result:

```console
ok  	github.com/xtls/xray-core/app/stats	(cached)
ok  	github.com/xtls/xray-core/app/stats/command	0.007s
ok  	github.com/xtls/xray-core/app/dispatcher	(cached)
?   	github.com/xtls/xray-core/app/metrics	[no test files]
```
