### PR TITLE
TUN & WireGuard inbounds: Ignore b.UDP's domain when receiving it from outbound

### DIFF
--- a/proxy/tun/udp_fullcone.go
+++ b/proxy/tun/udp_fullcone.go
@@ -98,18 +98,22 @@ type udpConn struct {
 }
 
 func (c *udpConn) ReadMultiBuffer() (buf.MultiBuffer, error) {
-	e, ok := <-c.egress
-	if !ok {
-		return nil, io.EOF
-	}
+	for {
+		e, ok := <-c.egress
+		if !ok {
+			return nil, io.EOF
+		}
 
-	b := buf.New()
-	if _, err := b.Write(e.data); err != nil {
-		return nil, err
-	}
-	b.UDP = e.dest
+		b := buf.New()
+		if _, err := b.Write(e.data); err != nil {
+			errors.LogErrorInner(context.Background(), err, "drop packet to ", e.dest, " with size ", len(e.data))
+			b.Release()
+			continue
+		}
+		b.UDP = e.dest
 
-	return buf.MultiBuffer{b}, nil
+		return buf.MultiBuffer{b}, nil
+	}
 }
 
 // Read packets from the connection
@@ -129,7 +133,11 @@ func (c *udpConn) WriteMultiBuffer(mb buf.MultiBuffer) error {
 	for i, b := range mb {
 		dst := c.dst
 		if b.UDP != nil {
-			dst = *b.UDP
+			if b.UDP.Address.Family().IsDomain() {
+				errors.LogError(context.Background(), "impossible domain packet ", b.UDP, " reply via original target ", dst)
+			} else {
+				dst = *b.UDP
+			}
 		}
 		err := c.handler.writePacket(b.Bytes(), dst, c.src)
 		if err != nil {

--- a/proxy/wireguard/tun.go
+++ b/proxy/wireguard/tun.go
@@ -345,19 +345,23 @@ type udpConn struct {
 }
 
 func (c *udpConn) ReadMultiBuffer() (buf.MultiBuffer, error) {
-	q, ok := <-c.queue
-	if !ok {
-		return nil, io.EOF
+	for {
+		q, ok := <-c.queue
+		if !ok {
+			return nil, io.EOF
+		}
+
+		b := buf.New()
+		if _, err := b.Write(q.p); err != nil {
+			errors.LogErrorInner(context.Background(), err, "drop packet to ", q.dest, " with size ", len(q.p))
+			b.Release()
+			continue
+		}
+
+		b.UDP = q.dest
+
+		return buf.MultiBuffer{b}, nil
 	}
-
-	b := buf.New()
-	if _, err := b.Write(q.p); err != nil {
-		return nil, err
-	}
-
-	b.UDP = q.dest
-
-	return buf.MultiBuffer{b}, nil
 }
 
 func (c *udpConn) Read(p []byte) (int, error) {
@@ -376,7 +380,13 @@ func (c *udpConn) WriteMultiBuffer(mb buf.MultiBuffer) error {
 	for i, b := range mb {
 		dst := c.dst
 		if b.UDP != nil {
-			dst = *b.UDP
+			if b.UDP != nil {
+				if b.UDP.Address.Family().IsDomain() {
+					errors.LogError(context.Background(), "impossible domain packet ", b.UDP, " reply via original target ", dst)
+				} else {
+					dst = *b.UDP
+				}
+			}
 		}
 		err := c.writeFunc(b.Bytes(), dst, c.src)
 		if err != nil {

--- a/proxy/wireguard/tun.go
+++ b/proxy/wireguard/tun.go
@@ -380,12 +380,10 @@ func (c *udpConn) WriteMultiBuffer(mb buf.MultiBuffer) error {
 	for i, b := range mb {
 		dst := c.dst
 		if b.UDP != nil {
-			if b.UDP != nil {
-				if b.UDP.Address.Family().IsDomain() {
-					errors.LogError(context.Background(), "impossible domain packet ", b.UDP, " reply via original target ", dst)
-				} else {
-					dst = *b.UDP
-				}
+			if b.UDP.Address.Family().IsDomain() {
+				errors.LogError(context.Background(), "impossible domain packet ", b.UDP, " reply via original target ", dst)
+			} else {
+				dst = *b.UDP
 			}
 		}
 		err := c.writeFunc(b.Bytes(), dst, c.src)


### PR DESCRIPTION
~到底什么情况会用域名返回啊，懒得看了，先用原始目标返回，继续去看我的wg，有更好的修复可以提出~

#6279 