### PR TITLE
feat: support outbound mTLS client certificates

### DIFF
--- a/transport/internet/tls/config.go
+++ b/transport/internet/tls/config.go
@@ -243,6 +243,22 @@ func getGetCertificateFunc(c *tls.Config, ca []*Certificate) func(hello *tls.Cli
 	}
 }
 
+func getGetClientCertificateFunc(certs []*tls.Certificate) func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	return func(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+		for _, cert := range certs {
+			if cert == nil {
+				continue
+			}
+
+			if err := cri.SupportsCertificate(cert); err == nil {
+				return cert, nil
+			}
+		}
+
+		return new(tls.Certificate), nil
+	}
+}
+
 func getNewGetCertificateFunc(certs []*tls.Certificate, rejectUnknownSNI bool) func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	return func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 		if len(certs) == 0 {
@@ -408,7 +424,11 @@ func (c *Config) GetTLSConfig(opts ...Option) *tls.Config {
 	if len(caCerts) > 0 {
 		config.GetCertificate = getGetCertificateFunc(config, caCerts)
 	} else {
-		config.GetCertificate = getNewGetCertificateFunc(c.BuildCertificates(), c.RejectUnknownSni)
+		encCerts := c.BuildCertificates()
+		config.GetCertificate = getNewGetCertificateFunc(encCerts, c.RejectUnknownSni)
+		if len(encCerts) > 0 {
+			config.GetClientCertificate = getGetClientCertificateFunc(encCerts)
+		}
 	}
 
 	if sn := c.parseServerName(); len(sn) > 0 {

--- a/transport/internet/tls/tls.go
+++ b/transport/internet/tls/tls.go
@@ -157,6 +157,41 @@ func copyConfig(c *tls.Config) *utls.Config {
 		EncryptedClientHelloConfigList: c.EncryptedClientHelloConfigList,
 		NextProtos:                     c.NextProtos,
 	}
+
+	if c.GetClientCertificate != nil {
+		config.GetClientCertificate = func(cri *utls.CertificateRequestInfo) (*utls.Certificate, error) {
+			tlsCRI := &tls.CertificateRequestInfo{
+				AcceptableCAs:    cri.AcceptableCAs,
+				SignatureSchemes: make([]tls.SignatureScheme, len(cri.SignatureSchemes)),
+				Version:          cri.Version,
+			}
+			for i, scheme := range cri.SignatureSchemes {
+				tlsCRI.SignatureSchemes[i] = tls.SignatureScheme(scheme)
+			}
+			cert, err := c.GetClientCertificate(tlsCRI)
+			if err != nil {
+				return nil, err
+			}
+			if cert == nil {
+				return new(utls.Certificate), nil
+			}
+			utlsCert := &utls.Certificate{
+				Certificate:                 cert.Certificate,
+				PrivateKey:                  cert.PrivateKey,
+				OCSPStaple:                  cert.OCSPStaple,
+				SignedCertificateTimestamps: cert.SignedCertificateTimestamps,
+				Leaf:                        cert.Leaf,
+			}
+			if cert.SupportedSignatureAlgorithms != nil {
+				utlsCert.SupportedSignatureAlgorithms = make([]utls.SignatureScheme, len(cert.SupportedSignatureAlgorithms))
+				for i, alg := range cert.SupportedSignatureAlgorithms {
+					utlsCert.SupportedSignatureAlgorithms[i] = utls.SignatureScheme(alg)
+				}
+			}
+			return utlsCert, nil
+		}
+	}
+
 	return config
 }
 


### PR DESCRIPTION
Added support for mTLS client authentication for outbound connections by reusing existing `tlsSettings.certificates` entries with `usage: "encipherment"`.

No schema changes, backwards compatible.

Example config:

```json
{
  "streamSettings": {
    "security": "tls",
    "tlsSettings": {
      "serverName": "mtls-server.com",
      "certificates": [
        {
          "usage": "encipherment",
          "certificateFile": "/etc/xray/client.crt",
          "keyFile": "/etc/xray/client.key"
        }
      ]
    }
  }
}
```
