### PR TITLE
Fix DNS parallel query priority group fallback

### DIFF
--- a/app/dns/dns.go
+++ b/app/dns/dns.go
@@ -387,50 +387,30 @@ func (s *DNS) parallelQuery(domain string, option dns.IPOption) ([]net.IP, uint3
 	var errs []error
 	clients := s.sortClients(domain)
 
-	resultsChan := asyncQueryAll(domain, option, clients, s.ctx)
+	groups, _ := makeGroups( /*s.ctx,*/ clients)
 
-	groups, groupOf := makeGroups( /*s.ctx,*/ clients)
-	results := make([]*queryResult, len(clients))
-	pending := make([]int, len(groups))
-	for gi, g := range groups {
-		pending[gi] = g.end - g.start + 1
-	}
+	for _, g := range groups {
+		groupClients := clients[g.start : g.end+1]
+		resultsChan := asyncQueryAll(domain, option, groupClients, s.ctx)
+		results := make([]queryResult, len(groupClients))
 
-	nextGroup := 0
-	for range clients {
-		result := <-resultsChan
-		results[result.index] = &result
+		for i := range groupClients {
+			result := <-resultsChan
+			results[result.index] = result
+			if result.err == nil && len(result.ips) > 0 {
+				return result.ips, result.ttl, nil
+			}
 
-		gi := groupOf[result.index]
-		pending[gi]--
-
-		for nextGroup < len(groups) {
-			g := groups[nextGroup]
-
-			// group race, minimum rtt -> return
-			for j := g.start; j <= g.end; j++ {
-				r := results[j]
-				if r != nil && r.err == nil && len(r.ips) > 0 {
-					return r.ips, r.ttl, nil
+			if i == len(groupClients)-1 {
+				for j, r := range results {
+					e := r.err
+					if e == nil {
+						e = dns.ErrEmptyResponse
+					}
+					errors.LogInfoInner(s.ctx, e, "failed to lookup ip for domain ", domain, " at server ", groupClients[j].Name(), " in parallel query mode")
+					errs = append(errs, e)
 				}
 			}
-
-			// current group is incomplete and no one success -> continue pending
-			if pending[nextGroup] > 0 {
-				break
-			}
-
-			// all failed -> log and continue next group
-			for j := g.start; j <= g.end; j++ {
-				r := results[j]
-				e := r.err
-				if e == nil {
-					e = dns.ErrEmptyResponse
-				}
-				errors.LogInfoInner(s.ctx, e, "failed to lookup ip for domain ", domain, " at server ", clients[j].Name(), " in parallel query mode")
-				errs = append(errs, e)
-			}
-			nextGroup++
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR fixes `enableParallelQuery` so DNS queries follow the same priority/fallback semantics as the grouped DNS selection logic.

Previously, parallel DNS mode started async queries for all selected DNS clients immediately, even when those clients belonged to different policy groups. As a result, lower-priority fallback groups could receive real DNS queries before the higher-priority group had failed.

This was especially visible with configurations that put `fakedns` first and real DNS resolvers in a later group: even when FakeDNS was supposed to answer first, the real resolvers were still queried in parallel.

## Problem

The DNS code already builds dynamic groups based on matching server properties such as:

- `clientIP`
- `skipFallback`
- `queryStrategy`
- `tag`
- `domains`
- `expectedIPs`
- `unexpectedIPs`

The intended behavior is:

1. Race servers inside the current group.
2. If one server in the group succeeds, return that result.
3. Only if the whole group fails, fall back to the next group.

However, the previous implementation called `asyncQueryAll()` for all selected clients before processing groups. This meant grouping only affected which result was accepted, not which DNS servers were actually queried.

## Change

`parallelQuery` now starts async queries group by group:

- all servers inside one group are still queried in parallel;
- the first successful result in the current group is returned;
- the next group is queried only if the current group fully fails.

This preserves parallelism inside each priority group while restoring fallback behavior between groups.

## Why

This makes `enableParallelQuery` respect DNS priority semantics instead of bypassing them at query dispatch time.

It also prevents unintended DNS queries to lower-priority resolvers when a higher-priority group, such as FakeDNS or a domain-specific resolver group, succeeds.