### PR TITLE
XHTTP transport: Do not force trailing path `/` when both sessionID and seq are placed elsewhere

### DIFF
--- a/transport/internet/splithttp/config.go
+++ b/transport/internet/splithttp/config.go
@@ -24,8 +24,11 @@ func (c *Config) GetNormalizedPath() string {
 		path = "/" + path
 	}
 
-	if path[len(path)-1] != '/' {
-		path = path + "/"
+	if c.GetNormalizedSessionPlacement() == PlacementPath ||
+		c.GetNormalizedSeqPlacement() == PlacementPath {
+		if path[len(path)-1] != '/' {
+			path = path + "/"
+		}
 	}
 
 	return path

--- a/transport/internet/splithttp/config_test.go
+++ b/transport/internet/splithttp/config_test.go
@@ -3,16 +3,77 @@ package splithttp_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	. "github.com/xtls/xray-core/transport/internet/splithttp"
 )
 
 func Test_GetNormalizedPath(t *testing.T) {
-	c := Config{
-		Path: "/?world",
+	tests := []struct {
+		TestName           string
+		Path               string
+		SessionIDPlacement string
+		SeqPlacement       string
+		Expected           string
+	}{
+		{
+			TestName: "default placement keeps trailing slash",
+			Path:     "/sh",
+			Expected: "/sh/",
+		},
+		{
+			TestName: "query string is stripped",
+			Path:     "/?world",
+			Expected: "/",
+		},
+		{
+			TestName:           "both off path drops trailing slash",
+			Path:               "/stream",
+			SessionIDPlacement: "query",
+			SeqPlacement:       "query",
+			Expected:           "/stream",
+		},
+		{
+			TestName:           "both off path keeps file-like path",
+			Path:               "/stream/filename.extension",
+			SessionIDPlacement: "query",
+			SeqPlacement:       "header",
+			Expected:           "/stream/filename.extension",
+		},
+		{
+			TestName:           "seq in path keeps trailing slash",
+			Path:               "/stream",
+			SessionIDPlacement: "query",
+			Expected:           "/stream/",
+		},
+		{
+			TestName:     "session in path keeps trailing slash",
+			Path:         "/stream",
+			SeqPlacement: "cookie",
+			Expected:     "/stream/",
+		},
+		{
+			TestName:           "existing trailing slash preserved",
+			Path:               "/stream/",
+			SessionIDPlacement: "query",
+			SeqPlacement:       "query",
+			Expected:           "/stream/",
+		},
+		{
+			TestName:           "root unchanged",
+			Path:               "/",
+			SessionIDPlacement: "query",
+			SeqPlacement:       "query",
+			Expected:           "/",
+		},
 	}
-
-	path := c.GetNormalizedPath()
-	if path != "/" {
-		t.Error("Unexpected: ", path)
+	for _, test := range tests {
+		t.Run(test.TestName, func(t *testing.T) {
+			c := Config{
+				Path:               test.Path,
+				SessionIDPlacement: test.SessionIDPlacement,
+				SeqPlacement:       test.SeqPlacement,
+			}
+			assert.Equal(t, test.Expected, c.GetNormalizedPath())
+		})
 	}
 }


### PR DESCRIPTION
`GetNormalizedPath` always appends a trailing slash to the configured path.
That slash is only meaningful when sessionID and/or seq are carried in the
path: it separates the configured base path from the appended segments and
lets the server slice them back off via `req.URL.Path[len(path):]`.

When both sessionID and seq are placed in query/cookie/header, the path
carries no appended segments, so the forced trailing slash is unnecessary.
It also makes URLs look unnatural — a directory-style trailing slash right
before the query string, or a file path that gets a slash appended after its
extension.

This change makes the trailing slash conditional on path placement being
used for sessionID or seq. The default placement is `path`, so any config
that does not move both fields off the path keeps the exact previous
behaviour; only configs that move both fields off the path are affected.

### Examples

**Both meta fields in query**

```json
"xhttpSettings": {
  "mode": "packet-up",
  "path": "/stream",
  "sessionIDPlacement": "query",
  "seqPlacement": "query"
}
```

Before:

```
GET  /stream/?x_session=<id>
POST /stream/?x_seq=0&x_session=<id>
```

After:

```
GET  /stream?x_session=<id>
POST /stream?x_seq=0&x_session=<id>
```

File-like path — `"path": "/stream/filename.extension"`, both in query:
Before → `/stream/filename.extension/?x_session=<id>` 
After → `/stream/filename.extension?x_session=<id>`

Unchanged: default (path) placement — `"path": "/abc"`:

```
GET  /abc/<sessionID>
POST /abc/<sessionID>/<seq>
```

sessionID and seq are in the path, so the trailing slash is still added — identical to the current behaviour.

Unchanged: root path — `"path": "/"` stays `/?...` in all cases.
