### PR TITLE
VLESS inbound: Add "reverses" to set reverse tag by client email

### DIFF
--- a/infra/conf/vless.go
+++ b/infra/conf/vless.go
@@ -30,12 +30,18 @@ type VLessInboundFallback struct {
 	Xver uint64          `json:"xver"`
 }
 
+type VLessInboundReverse struct {
+	Tag   string   `json:"tag"`
+	Email []string `json:"email"`
+}
+
 type VLessInboundConfig struct {
 	Users      []json.RawMessage       `json:"users"`
 	Clients    []json.RawMessage       `json:"clients"`
 	Decryption string                  `json:"decryption"`
 	Fallbacks  []*VLessInboundFallback `json:"fallbacks"`
 	Flow       string                  `json:"flow"`
+	Reverses   []*VLessInboundReverse  `json:"reverses"`
 	Testseed   []uint32                `json:"testseed"`
 }
 
@@ -52,6 +58,24 @@ func (c *VLessInboundConfig) Build() (proto.Message, error) {
 	default:
 		return nil, errors.New(`VLESS "settings.flow" doesn't support "` + c.Flow + `" in this version`)
 	}
+
+	reverseTagByEmail := make(map[string]string)
+	for _, rv := range c.Reverses {
+		if rv.Tag == "" {
+			return nil, errors.New(`VLESS reverses: "tag" can't be empty`)
+		}
+		for _, e := range rv.Email {
+			if e == "" {
+				return nil, errors.New(`VLESS reverses: "email" can't be empty`)
+			}
+			le := strings.ToLower(e)
+			if _, ok := reverseTagByEmail[le]; ok {
+				return nil, errors.New(`VLESS reverses: duplicated "email": ` + e)
+			}
+			reverseTagByEmail[le] = rv.Tag
+		}
+	}
+
 	processClient := func(idx int) error {
 		rawUser := c.Users[idx]
 		user := new(protocol.User)
@@ -83,6 +107,13 @@ func (c *VLessInboundConfig) Build() (proto.Message, error) {
 
 		if account.Encryption != "" {
 			return errors.New(`VLESS users: "encryption" should not be in inbound settings`)
+		}
+
+		if tag, ok := reverseTagByEmail[strings.ToLower(user.Email)]; ok && user.Email != "" {
+			if account.Reverse != nil {
+				return errors.New(`VLESS users: "` + user.Email + `" has both per-client "reverse" and inbound-level "reverses"`)
+			}
+			account.Reverse = &vless.Reverse{Tag: tag}
 		}
 
 		if account.Reverse != nil {

--- a/infra/conf/vless_test.go
+++ b/infra/conf/vless_test.go
@@ -155,5 +155,49 @@ func TestVLessInbound(t *testing.T) {
 				},
 			},
 		},
+		{
+			Input: `{
+				"clients": [
+					{
+						"id": "27848739-7e62-4138-9fd3-098a63964b6b",
+						"flow": "xtls-rprx-vision",
+						"email": "home@example.com"
+					},
+					{
+						"id": "ac04551d-6ebf-4685-86e2-17c12491f7f4",
+						"flow": "xtls-rprx-vision",
+						"email": "roam@example.com"
+					}
+				],
+				"decryption": "none",
+				"reverses": [
+					{
+						"tag": "reverse-out",
+						"email": ["HOME@example.com"]
+					}
+				]
+			}`,
+			Parser: loadJSON(creator),
+			Output: &inbound.Config{
+				Users: []*protocol.User{
+					{
+						Account: serial.ToTypedMessage(&vless.Account{
+							Id:      "27848739-7e62-4138-9fd3-098a63964b6b",
+							Flow:    "xtls-rprx-vision",
+							Reverse: &vless.Reverse{Tag: "reverse-out"},
+						}),
+						Email: "home@example.com",
+					},
+					{
+						Account: serial.ToTypedMessage(&vless.Account{
+							Id:   "ac04551d-6ebf-4685-86e2-17c12491f7f4",
+							Flow: "xtls-rprx-vision",
+						}),
+						Email: "roam@example.com",
+					},
+				},
+				Decryption: "none",
+			},
+		},
 	})
 }


### PR DESCRIPTION
```json
{
  "protocol": "vless",
  "settings": {
    "decryption": "none",
    "flow": "xtls-rprx-vision",
    "clients": [
      {
        "id": "27848739-7e62-4138-9fd3-098a63964b6b",
        "email": "home@example.com"
      },
      {
        "id": "ac04551d-6ebf-4685-86e2-17c12491f7f4",
        "email": "roam@example.com"
      }
    ],
    "reverses": [
      {
        "tag": "reverse-out",
        "email": [
          "home@example.com",
          "roam@example.com"
        ]
      }
    ]
  }
}
```