### PR TITLE
tls: present client certificate on outbound connections

### DIFF
--- a/transport/internet/tls/config.go
+++ b/transport/internet/tls/config.go
@@ -411,6 +411,24 @@ func (c *Config) GetTLSConfig(opts ...Option) *tls.Config {
 		config.GetCertificate = getNewGetCertificateFunc(c.BuildCertificates(), c.RejectUnknownSni)
 	}
 
+	// Present a client certificate for mutual TLS on outbound connections.
+	// Configured certificates are otherwise wired only into GetCertificate (the
+	// server-side selection callback), so an Xray client never offers a
+	// certificate when a server requests one. Set both Certificates (so the
+	// standard tls.Client path works and copyConfig can carry them to the
+	// uTLS/fingerprinted path) and GetClientCertificate. Client-only; harmless
+	// server-side, where GetCertificate takes precedence.
+	if built := c.BuildCertificates(); len(built) > 0 {
+		clientCerts := make([]tls.Certificate, 0, len(built))
+		for _, bc := range built {
+			clientCerts = append(clientCerts, *bc)
+		}
+		config.Certificates = clientCerts
+		config.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return &clientCerts[0], nil
+		}
+	}
+
 	if sn := c.parseServerName(); len(sn) > 0 {
 		config.ServerName = sn
 	}

--- a/transport/internet/tls/tls.go
+++ b/transport/internet/tls/tls.go
@@ -157,6 +157,23 @@ func copyConfig(c *tls.Config) *utls.Config {
 		EncryptedClientHelloConfigList: c.EncryptedClientHelloConfigList,
 		NextProtos:                     c.NextProtos,
 	}
+	// Carry client certificates into the uTLS config so mutual TLS works on the
+	// uTLS (fingerprinted) path. Without this, certificates set on the
+	// crypto/tls config are dropped and a server requiring a client certificate
+	// rejects the handshake.
+	for _, cert := range c.Certificates {
+		config.Certificates = append(config.Certificates, utls.Certificate{
+			Certificate: cert.Certificate,
+			PrivateKey:  cert.PrivateKey,
+			Leaf:        cert.Leaf,
+		})
+	}
+	if len(config.Certificates) > 0 {
+		certs := config.Certificates
+		config.GetClientCertificate = func(*utls.CertificateRequestInfo) (*utls.Certificate, error) {
+			return &certs[0], nil
+		}
+	}
 	return config
 }
 


### PR DESCRIPTION
Configured tlsSettings.certificates were wired only into GetTLSConfig's server-side GetCertificate callback, so an Xray client never offered a certificate when a server requested one, making outbound mutual TLS impossible. copyConfig (crypto/tls.Config -> utls.Config) also dropped the certificate fields, so even a manually set client certificate was lost on the default uTLS/fingerprinted path.

Set config.Certificates and GetClientCertificate in GetTLSConfig when ENCIPHERMENT certificates are configured (client-only; server still uses GetCertificate), and carry the certificates through copyConfig so mutual TLS works on the uTLS path.