### PR TITLE
XHTTP: fix nil request crash 

### DIFF
--- a/transport/internet/splithttp/client.go
+++ b/transport/internet/splithttp/client.go
@@ -59,7 +59,10 @@ func (c *DefaultDialerClient) OpenStream(ctx context.Context, url string, sessio
 	if body != nil {
 		method = c.transportConfig.GetNormalizedUplinkHTTPMethod() // stream-up/one
 	}
-	req, _ := http.NewRequestWithContext(context.WithoutCancel(ctx), method, url, body)
+	req, err := http.NewRequestWithContext(context.WithoutCancel(ctx), method, url, body)
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	c.transportConfig.FillStreamRequest(req, sessionId, "")
 
 	wrc = &WaitReadCloser{Wait: make(chan struct{})}


### PR DESCRIPTION
```
Crashed: Thread
0 0x10f06cc github.com/xtls/xray-core/transport/internet/splithttp.(*Config).FillStreamRequest + 60
1 0x10f06c8 github.com/xtls/xray-core/transport/internet/splithttp.(*Config).FillStreamRequest + 56
2 0x10ed5bc github.com/xtls/xray-core/transport/internet/splithttp.(*DefaultDialerClient).OpenStream + 508
3 0x10f5618 github.com/xtls/xray-core/transport/internet/splithttp.Dial + 3992
4 0xd19de0 github.com/xtls/xray-core/transport/internet.Dial + 320
5 0x126167c github.com/xtls/xray-core/app/proxyman/outbound.(*Handler).Dial + 1836
6 0x1267f10 github.com/xtls/xray-core/proxy/vless/outbound.(*Handler).Process.func2 + 64
7 0xfbe2bc github.com/xtls/xray-core/common/retry.(*retryer).On + 188
8 0x1265220 github.com/xtls/xray-core/proxy/vless/outbound.(*Handler).Process + 720
9 0x1260a94 github.com/xtls/xray-core/app/proxyman/outbound.(*Handler).Dispatch + 2116
10 0xe31230 github.com/xtls/xray-core/app/dispatcher.(*DefaultDispatcher).routedDispatch + 2224
11 0xe30284 github.com/xtls/xray-core/app/dispatcher.(*DefaultDispatcher).DispatchLink + 1428
12 0x1032f90 github.com/xtls/xray-core/common/mux.(*Server).DispatchLink + 160
13 0x109968c github.com/xtls/xray-core/proxy/socks.(*Server).processTCP + 2140
14 0x1098cf4 github.com/xtls/xray-core/proxy/socks.(*Server).Process + 708
15 0x13107e8 github.com/xtls/xray-core/app/proxyman/inbound.(*tcpWorker).callback + 1976
16 0x1310ba4 github.com/xtls/xray-core/app/proxyman/inbound.(*tcpWorker).Start.func1.gowrap1 + 36
17 0x7c6e24 runtime.goexit.abi0 + 4
```