### PR TITLE
Geodata: Cleanup unneeded matchers & `domain:` ignore case

### DIFF
--- a/common/geodata/domain_matcher.go
+++ b/common/geodata/domain_matcher.go
@@ -220,7 +220,7 @@ func parseDomain(d *Domain) (strmatcher.Matcher, error) {
 	case Domain_Regex:
 		return strmatcher.Regex.New(d.Value)
 	case Domain_Domain:
-		return strmatcher.Domain.New(d.Value)
+		return strmatcher.Domain.New(strings.ToLower(d.Value))
 	case Domain_Full:
 		return strmatcher.Full.New(strings.ToLower(d.Value))
 	default:

--- a/common/geodata/domain_registry.go
+++ b/common/geodata/domain_registry.go
@@ -6,12 +6,13 @@ import (
 	"sync/atomic"
 
 	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/common/utils"
 )
 
 type DomainRegistry struct {
 	mu       sync.Mutex
 	factory  DomainMatcherFactory
-	matchers []*DynamicDomainMatcher
+	matchers *utils.WeakCacheList[DynamicDomainMatcher]
 }
 
 func (r *DomainRegistry) BuildDomainMatcher(rules []*DomainRule) (DomainMatcher, error) {
@@ -24,7 +25,7 @@ func (r *DomainRegistry) BuildDomainMatcher(rules []*DomainRule) (DomainMatcher,
 	}
 
 	d := NewDynamicDomainMatcher(rules, m)
-	r.matchers = append(r.matchers, d)
+	r.matchers.Add(d)
 	return d, nil
 }
 
@@ -32,15 +33,16 @@ func (r *DomainRegistry) Reload() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	errors.LogInfo(context.Background(), "reloading GeoSite data for ", len(r.matchers), " domain matcher(s)")
+	matchers := r.matchers.Values()
+	errors.LogInfo(context.Background(), "reloading GeoSite data for ", len(matchers), " domain matcher(s)")
 
 	factory := newDomainMatcherFactory()
 	type reloadEntry struct {
 		dynamic *DynamicDomainMatcher
 		matcher DomainMatcher
 	}
-	reloaded := make([]reloadEntry, len(r.matchers))
-	for i, d := range r.matchers {
+	reloaded := make([]reloadEntry, len(matchers))
+	for i, d := range matchers {
 		m, err := factory.BuildMatcher(d.rules)
 		if err != nil {
 			errors.LogErrorInner(context.Background(), err, "failed to reload GeoSite data for domain matcher ", i)
@@ -52,13 +54,14 @@ func (r *DomainRegistry) Reload() error {
 		entry.dynamic.Reload(entry.matcher)
 	}
 	r.factory = factory
-	errors.LogInfo(context.Background(), "reloaded GeoSite data for ", len(r.matchers), " domain matcher(s)")
+	errors.LogInfo(context.Background(), "reloaded GeoSite data for ", len(matchers), " domain matcher(s)")
 	return nil
 }
 
 func newDomainRegistry() *DomainRegistry {
 	return &DomainRegistry{
-		factory: newDomainMatcherFactory(),
+		factory:  newDomainMatcherFactory(),
+		matchers: utils.NewWeakCacheList[DynamicDomainMatcher](),
 	}
 }
 

--- a/common/geodata/domain_registry.go
+++ b/common/geodata/domain_registry.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/utils"
+	"github.com/xtls/xray-core/common/uuid"
 )
 
 type DomainRegistry struct {
 	mu       sync.Mutex
 	factory  DomainMatcherFactory
-	matchers *utils.WeakCacheList[DynamicDomainMatcher]
+	matchers *utils.WeakCacheMap[uuid.UUID, DynamicDomainMatcher]
 }
 
 func (r *DomainRegistry) BuildDomainMatcher(rules []*DomainRule) (DomainMatcher, error) {
@@ -25,7 +26,7 @@ func (r *DomainRegistry) BuildDomainMatcher(rules []*DomainRule) (DomainMatcher,
 	}
 
 	d := NewDynamicDomainMatcher(rules, m)
-	r.matchers.Add(d)
+	r.matchers.Store(uuid.New(), d)
 	return d, nil
 }
 
@@ -33,7 +34,11 @@ func (r *DomainRegistry) Reload() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	matchers := r.matchers.Values()
+	var matchers []*DynamicDomainMatcher
+	r.matchers.Range(func(_ uuid.UUID, matcher *DynamicDomainMatcher) bool {
+		matchers = append(matchers, matcher)
+		return true
+	})
 	errors.LogInfo(context.Background(), "reloading GeoSite data for ", len(matchers), " domain matcher(s)")
 
 	factory := newDomainMatcherFactory()
@@ -61,7 +66,7 @@ func (r *DomainRegistry) Reload() error {
 func newDomainRegistry() *DomainRegistry {
 	return &DomainRegistry{
 		factory:  newDomainMatcherFactory(),
-		matchers: utils.NewWeakCacheList[DynamicDomainMatcher](),
+		matchers: utils.NewWeakCacheMap[uuid.UUID, DynamicDomainMatcher](),
 	}
 }
 

--- a/common/geodata/ip_registry.go
+++ b/common/geodata/ip_registry.go
@@ -7,25 +7,26 @@ import (
 
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/utils"
 )
 
 type IPRegistry struct {
-	mu           sync.Mutex
-	ipsetFactory *IPSetFactory
-	matchers     []*DynamicIPMatcher
+	mu       sync.Mutex
+	factory  *IPSetFactory
+	matchers *utils.WeakCacheList[DynamicIPMatcher]
 }
 
 func (r *IPRegistry) BuildIPMatcher(rules []*IPRule) (IPMatcher, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	m, err := buildOptimizedIPMatcher(r.ipsetFactory, rules)
+	m, err := buildOptimizedIPMatcher(r.factory, rules)
 	if err != nil {
 		return nil, err
 	}
 
 	d := NewDynamicIPMatcher(rules, m)
-	r.matchers = append(r.matchers, d)
+	r.matchers.Add(d)
 	return d, nil
 }
 
@@ -33,15 +34,16 @@ func (r *IPRegistry) Reload() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	errors.LogInfo(context.Background(), "reloading GeoIP data for ", len(r.matchers), " IP matcher(s)")
+	matchers := r.matchers.Values()
+	errors.LogInfo(context.Background(), "reloading GeoIP data for ", len(matchers), " IP matcher(s)")
 
 	factory := newIPSetFactory()
 	type reloadEntry struct {
 		dynamic *DynamicIPMatcher
 		matcher IPMatcher
 	}
-	reloaded := make([]reloadEntry, len(r.matchers))
-	for i, d := range r.matchers {
+	reloaded := make([]reloadEntry, len(matchers))
+	for i, d := range matchers {
 		m, err := buildOptimizedIPMatcher(factory, d.rules)
 		if err != nil {
 			errors.LogErrorInner(context.Background(), err, "failed to reload GeoIP data for IP matcher ", i)
@@ -52,14 +54,15 @@ func (r *IPRegistry) Reload() error {
 	for _, entry := range reloaded {
 		entry.dynamic.Reload(entry.matcher)
 	}
-	r.ipsetFactory = factory
-	errors.LogInfo(context.Background(), "reloaded GeoIP data for ", len(r.matchers), " IP matcher(s)")
+	r.factory = factory
+	errors.LogInfo(context.Background(), "reloaded GeoIP data for ", len(matchers), " IP matcher(s)")
 	return nil
 }
 
 func newIPRegistry() *IPRegistry {
 	return &IPRegistry{
-		ipsetFactory: newIPSetFactory(),
+		factory:  newIPSetFactory(),
+		matchers: utils.NewWeakCacheList[DynamicIPMatcher](),
 	}
 }
 

--- a/common/geodata/ip_registry.go
+++ b/common/geodata/ip_registry.go
@@ -8,12 +8,13 @@ import (
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/utils"
+	"github.com/xtls/xray-core/common/uuid"
 )
 
 type IPRegistry struct {
 	mu       sync.Mutex
 	factory  *IPSetFactory
-	matchers *utils.WeakCacheList[DynamicIPMatcher]
+	matchers *utils.WeakCacheMap[uuid.UUID, DynamicIPMatcher]
 }
 
 func (r *IPRegistry) BuildIPMatcher(rules []*IPRule) (IPMatcher, error) {
@@ -26,7 +27,7 @@ func (r *IPRegistry) BuildIPMatcher(rules []*IPRule) (IPMatcher, error) {
 	}
 
 	d := NewDynamicIPMatcher(rules, m)
-	r.matchers.Add(d)
+	r.matchers.Store(uuid.New(), d)
 	return d, nil
 }
 
@@ -34,7 +35,11 @@ func (r *IPRegistry) Reload() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	matchers := r.matchers.Values()
+	var matchers []*DynamicIPMatcher
+	r.matchers.Range(func(_ uuid.UUID, matcher *DynamicIPMatcher) bool {
+		matchers = append(matchers, matcher)
+		return true
+	})
 	errors.LogInfo(context.Background(), "reloading GeoIP data for ", len(matchers), " IP matcher(s)")
 
 	factory := newIPSetFactory()
@@ -62,7 +67,7 @@ func (r *IPRegistry) Reload() error {
 func newIPRegistry() *IPRegistry {
 	return &IPRegistry{
 		factory:  newIPSetFactory(),
-		matchers: utils.NewWeakCacheList[DynamicIPMatcher](),
+		matchers: utils.NewWeakCacheMap[uuid.UUID, DynamicIPMatcher](),
 	}
 }
 

--- a/common/geodata/rule_parser.go
+++ b/common/geodata/rule_parser.go
@@ -138,7 +138,7 @@ func ParseDomainRule(r string, defaultType Domain_Type) (*DomainRule, error) {
 	}
 
 	prefix := 0
-	for _, ext := range [...]string{"ext:", "ext-domain:"} {
+	for _, ext := range [...]string{"ext:", "ext-domain:", "ext-site:"} {
 		if strings.HasPrefix(r, ext) {
 			prefix = len(ext)
 			break
@@ -167,7 +167,7 @@ func ParseDomainRules(rules []string, defaultType Domain_Type) ([]*DomainRule, e
 		}
 
 		prefix := 0
-		for _, ext := range [...]string{"ext:", "ext-domain:"} {
+		for _, ext := range [...]string{"ext:", "ext-domain:", "ext-site:"} {
 			if strings.HasPrefix(r, ext) {
 				prefix = len(ext)
 				break

--- a/common/utils/weak_cache.go
+++ b/common/utils/weak_cache.go
@@ -1,8 +1,8 @@
 package utils
 
 import (
+	"maps"
 	"runtime"
-	"slices"
 	"sync"
 	"weak"
 )
@@ -45,51 +45,15 @@ func (c *WeakCacheMap[K, V]) Store(key K, value *V) {
 	}, struct{}{})
 }
 
-// WeakCacheList is a list that holds weak references to values.
-// Use for shared expensive objects and automatic cleanup when no longer used.
-// This object can be GC and no goroutine is used for cleanup.
-type WeakCacheList[V any] struct {
-	mu sync.Mutex
-	l  []weak.Pointer[V]
-}
-
-func NewWeakCacheList[V any]() *WeakCacheList[V] {
-	return new(WeakCacheList[V])
-}
-
-func (c *WeakCacheList[V]) Add(value *V) {
-	if value == nil {
-		return
-	}
-
+func (c *WeakCacheMap[K, V]) Range(f func(K, *V) bool) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	weakPtr := weak.Make(value)
-	c.l = append(c.l, weakPtr)
-	runtime.AddCleanup(value, func(struct{}) {
-		c.mu.Lock()
-		defer c.mu.Unlock()
-		c.l = slices.DeleteFunc(c.l, func(p weak.Pointer[V]) bool {
-			return p == weakPtr
-		})
-	}, struct{}{})
-}
-
-func (c *WeakCacheList[V]) Values() []*V {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	values := make([]*V, 0, len(c.l))
-	alive := make([]weak.Pointer[V], 0, len(c.l))
-	for _, p := range c.l {
-		v := p.Value()
-		if v == nil {
-			continue
+	snapshot := maps.Clone(c.m)
+	c.mu.Unlock()
+	for k, v := range snapshot {
+		if value := v.Value(); value != nil {
+			if !f(k, value) {
+				break
+			}
 		}
-		alive = append(alive, p)
-		values = append(values, v)
 	}
-	c.l = alive
-	return values
 }

--- a/common/utils/weak_cache.go
+++ b/common/utils/weak_cache.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"runtime"
+	"slices"
 	"sync"
 	"weak"
 )
@@ -42,4 +43,53 @@ func (c *WeakCacheMap[K, V]) Store(key K, value *V) {
 			delete(c.m, key)
 		}
 	}, struct{}{})
+}
+
+// WeakCacheList is a list that holds weak references to values.
+// Use for shared expensive objects and automatic cleanup when no longer used.
+// This object can be GC and no goroutine is used for cleanup.
+type WeakCacheList[V any] struct {
+	mu sync.Mutex
+	l  []weak.Pointer[V]
+}
+
+func NewWeakCacheList[V any]() *WeakCacheList[V] {
+	return new(WeakCacheList[V])
+}
+
+func (c *WeakCacheList[V]) Add(value *V) {
+	if value == nil {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	weakPtr := weak.Make(value)
+	c.l = append(c.l, weakPtr)
+	runtime.AddCleanup(value, func(struct{}) {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		c.l = slices.DeleteFunc(c.l, func(p weak.Pointer[V]) bool {
+			return p == weakPtr
+		})
+	}, struct{}{})
+}
+
+func (c *WeakCacheList[V]) Values() []*V {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	values := make([]*V, 0, len(c.l))
+	alive := make([]weak.Pointer[V], 0, len(c.l))
+	for _, p := range c.l {
+		v := p.Value()
+		if v == nil {
+			continue
+		}
+		alive = append(alive, p)
+		values = append(values, v)
+	}
+	c.l = alive
+	return values
 }


### PR DESCRIPTION
为了实现热重载 Registry 要持有 Matcher
因此 #6139 光清理 Factory 不够