### PR TITLE
XHTTP server: Fix `scStreamUpServerSecs` when `xPaddingObfsMode` is true

### DIFF
--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -146,6 +146,7 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		writer.WriteHeader(http.StatusBadRequest)
 		return
 	}
+	obfsPaddingAccepted := h.config.XPaddingObfsMode && paddingValue != ""
 
 	sessionId, seqStr := h.config.ExtractMetaFromRequest(request, h.path)
 
@@ -215,8 +216,8 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 				writer.Header().Set("Cache-Control", "no-store")
 				writer.WriteHeader(http.StatusOK)
 				scStreamUpServerSecs := h.config.GetNormalizedScStreamUpServerSecs()
-				referrer := request.Header.Get("Referer")
-				if referrer != "" && scStreamUpServerSecs.To > 0 {
+				hasLegacyRefererCompatMarker := request.Header.Get("Referer") != ""
+				if (hasLegacyRefererCompatMarker || obfsPaddingAccepted) && scStreamUpServerSecs.To > 0 {
 					go func() {
 						for {
 							_, err := httpSC.Write(bytes.Repeat([]byte{'X'}, int(h.config.GetNormalizedXPaddingBytes().rand())))


### PR DESCRIPTION
### Motivation

`scStreamUpServerSecs` currently uses a non-empty `Referer` header as the compatibility marker for enabling stream-up response-body keepalive on the server side.

That made sense when the newer XHTTP request padding path always placed `x_padding` in `Referer`. However, `xPaddingObfsMode` now allows valid request padding to be placed elsewhere, such as a configured header, cookie, or query parameter.

With such configs, the request can pass xpadding validation but still have no `Referer` header. In that case, stream-up handling accepts the request, but the `scStreamUpServerSecs` keepalive goroutine is not started.

This makes the keepalive behavior accidentally depend on the old padding placement rather than on whether the request came from a compatible, validated newer xpadding path.

### Changes

This PR treats accepted obfs-mode xpadding as an additional stream-up keepalive compatibility marker.

Before:

- `Referer` present: stream-up server keepalive can start
- `Referer` absent: stream-up server keepalive does not start

After:

- `Referer` present: unchanged
- `xPaddingObfsMode` enabled and request padding accepted: stream-up server keepalive can start
- invalid/missing padding: unchanged; request is rejected before stream-up handling
- `scStreamUpServerSecs <= 0`: unchanged; keepalive remains disabled

No config, protobuf, mode-selection, padding-generation, or XMUX behavior is changed.

### Compatibility

This preserves the legacy/default behavior while fixing obfs xpadding configurations that intentionally do not use `Referer`.

Old clients without `Referer` and without accepted obfs padding still do not trigger the server response-body keepalive.

### Testing

- `go test ./transport/internet/splithttp`
- `go test ./...`