### PR TITLE
splithttp: avoid stale H2/H3 packet-up idle connections

### DIFF
--- a/transport/internet/splithttp/client.go
+++ b/transport/internet/splithttp/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"sync"
+	"time"
 
 	"github.com/apernet/quic-go/http3"
 	"github.com/xtls/xray-core/common"
@@ -34,6 +35,8 @@ type DefaultDialerClient struct {
 	client          *http.Client
 	closed          bool
 	httpVersion     string
+	packetUpMu      sync.Mutex
+	lastPacketUp    time.Time
 	// pool of net.Conn, created using dialUploadConn
 	uploadRawPool  *sync.Pool
 	dialUploadConn func(ctxInner context.Context) (net.Conn, error)
@@ -106,6 +109,7 @@ func (c *DefaultDialerClient) PostPacket(ctx context.Context, url string, sessio
 	c.transportConfig.FillPacketRequest(req, sessionId, seqStr, payload)
 
 	if c.httpVersion != "1.1" {
+		c.closeIdleConnectionsIfPacketUpStale(time.Now())
 		resp, err := c.client.Do(req)
 		if err != nil {
 			c.closed = true
@@ -175,6 +179,18 @@ func (c *DefaultDialerClient) PostPacket(ctx context.Context, url string, sessio
 	}
 
 	return nil
+}
+
+const packetUpIdleConnectionStaleDuration = 30 * time.Second
+
+func (c *DefaultDialerClient) closeIdleConnectionsIfPacketUpStale(now time.Time) {
+	c.packetUpMu.Lock()
+	defer c.packetUpMu.Unlock()
+
+	if !c.lastPacketUp.IsZero() && now.Sub(c.lastPacketUp) > packetUpIdleConnectionStaleDuration {
+		c.client.CloseIdleConnections()
+	}
+	c.lastPacketUp = now
 }
 
 // HTTP/1.1 and HTTP/2 will close itself, we only handle HTTP/3 here

--- a/transport/internet/splithttp/client_internal_test.go
+++ b/transport/internet/splithttp/client_internal_test.go
@@ -1,0 +1,143 @@
+package splithttp
+
+import (
+	"context"
+	"io"
+	stdnet "net"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/xtls/xray-core/common/buf"
+)
+
+type closeTrackingTransport struct {
+	mu                    sync.Mutex
+	closeIdleCalls        int
+	closeCallsAtRoundTrip []int
+}
+
+func (t *closeTrackingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Body != nil {
+		io.Copy(io.Discard, req.Body)
+		req.Body.Close()
+	}
+
+	t.mu.Lock()
+	t.closeCallsAtRoundTrip = append(t.closeCallsAtRoundTrip, t.closeIdleCalls)
+	t.mu.Unlock()
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Body:       io.NopCloser(strings.NewReader("")),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func (t *closeTrackingTransport) CloseIdleConnections() {
+	t.mu.Lock()
+	t.closeIdleCalls++
+	t.mu.Unlock()
+}
+
+func (t *closeTrackingTransport) CloseIdleCallCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.closeIdleCalls
+}
+
+func (t *closeTrackingTransport) CloseCallsAtRoundTrip(index int) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.closeCallsAtRoundTrip[index]
+}
+
+func TestDefaultDialerClientPostPacketDoesNotCloseIdleConnectionOnFirstH2Post(t *testing.T) {
+	transport := &closeTrackingTransport{}
+	client := &DefaultDialerClient{
+		transportConfig: &Config{},
+		client:          &http.Client{Transport: transport},
+		httpVersion:     "2",
+	}
+
+	if err := client.PostPacket(context.Background(), "http://example.com/upload", "session", "0", testPacketPayload()); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := transport.CloseIdleCallCount(); got != 0 {
+		t.Fatalf("expected first H2 packet-up POST not to close idle connections, got %d calls", got)
+	}
+	if got := transport.CloseCallsAtRoundTrip(0); got != 0 {
+		t.Fatalf("expected no idle close before first RoundTrip, got %d calls", got)
+	}
+	if client.lastPacketUp.IsZero() {
+		t.Fatal("expected lastPacketUp to be recorded")
+	}
+}
+
+func TestDefaultDialerClientPostPacketClosesIdleConnectionBeforeStaleH2Post(t *testing.T) {
+	transport := &closeTrackingTransport{}
+	client := &DefaultDialerClient{
+		transportConfig: &Config{},
+		client:          &http.Client{Transport: transport},
+		httpVersion:     "2",
+		lastPacketUp:    time.Now().Add(-packetUpIdleConnectionStaleDuration - time.Second),
+	}
+
+	if err := client.PostPacket(context.Background(), "http://example.com/upload", "session", "1", testPacketPayload()); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := transport.CloseIdleCallCount(); got != 1 {
+		t.Fatalf("expected stale H2 packet-up POST to close idle connections once, got %d calls", got)
+	}
+	if got := transport.CloseCallsAtRoundTrip(0); got != 1 {
+		t.Fatalf("expected idle connections to be closed before RoundTrip, got %d calls before RoundTrip", got)
+	}
+}
+
+func TestDefaultDialerClientPostPacketDoesNotCloseIdleConnectionForH1(t *testing.T) {
+	transport := &closeTrackingTransport{}
+	client := &DefaultDialerClient{
+		transportConfig: &Config{},
+		client:          &http.Client{Transport: transport},
+		httpVersion:     "1.1",
+		lastPacketUp:    time.Now().Add(-packetUpIdleConnectionStaleDuration - time.Second),
+		uploadRawPool:   &sync.Pool{},
+		dialUploadConn: func(context.Context) (stdnet.Conn, error) {
+			return &writeOnlyConn{}, nil
+		},
+	}
+
+	if err := client.PostPacket(context.Background(), "http://example.com/upload", "session", "2", testPacketPayload()); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := transport.CloseIdleCallCount(); got != 0 {
+		t.Fatalf("expected H1 packet-up POST not to close http.Client idle connections, got %d calls", got)
+	}
+}
+
+func testPacketPayload() buf.MultiBuffer {
+	return buf.MultiBuffer{buf.FromBytes([]byte("hello"))}
+}
+
+type writeOnlyConn struct{}
+
+func (c *writeOnlyConn) Read([]byte) (int, error)         { return 0, io.EOF }
+func (c *writeOnlyConn) Write(b []byte) (int, error)      { return len(b), nil }
+func (c *writeOnlyConn) Close() error                     { return nil }
+func (c *writeOnlyConn) LocalAddr() stdnet.Addr           { return testAddr("local") }
+func (c *writeOnlyConn) RemoteAddr() stdnet.Addr          { return testAddr("remote") }
+func (c *writeOnlyConn) SetDeadline(time.Time) error      { return nil }
+func (c *writeOnlyConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *writeOnlyConn) SetWriteDeadline(time.Time) error { return nil }
+
+type testAddr string
+
+func (a testAddr) Network() string { return string(a) }
+func (a testAddr) String() string  { return string(a) }


### PR DESCRIPTION
## Summary

- Avoid reusing long-idle XHTTP packet-up pooled connections for HTTP/2 and HTTP/3.
- Before a new H2/H3 packet-up POST, close idle connections when the previous packet-up POST started more than 30 seconds ago.
- Keep HTTP/1.1 behavior unchanged and do not retry request bodies after `Do` errors.

## Details

This only calls `http.Client.CloseIdleConnections()`, so active requests are not interrupted. The existing error path is preserved: if `Do` fails, the dialer client is marked closed and XMUX can remove it.

## Tests

- `go test -count=1 ./transport/internet/splithttp -run 'TestDefaultDialerClientPostPacket'`
