### PR TITLE
TUN inbound: Avoid panic on nil RemoteAddr due to quickly closed connection

### DIFF
--- a/proxy/tun/handler.go
+++ b/proxy/tun/handler.go
@@ -147,7 +147,7 @@ func (t *Handler) HandleConnection(conn net.Conn, destination net.Destination) {
 	// due to gvisor weird behavior
 	remote := conn.RemoteAddr()
 	if remote == nil {
-		errors.LogInfo(t.ctx, "dropped quick close connection")
+		errors.LogInfo(t.ctx, "dropped quickly closed connection")
 		return
 	}
 	source := net.DestinationFromAddr(remote)

--- a/proxy/tun/handler.go
+++ b/proxy/tun/handler.go
@@ -143,7 +143,14 @@ func (t *Handler) HandleConnection(conn net.Conn, destination net.Destination) {
 	defer cancel()
 	ctx = c.ContextWithID(ctx, session.NewID())
 
-	source := net.DestinationFromAddr(conn.RemoteAddr())
+	// if the connection is already closed, conn.RemoteAddr() will be nil
+	// due to gvisor weird behavior
+	remote := conn.RemoteAddr()
+	if remote == nil {
+		errors.LogInfo(t.ctx, "dropped quick close connection")
+		return
+	}
+	source := net.DestinationFromAddr(remote)
 	inbound := session.Inbound{
 		Name:          "tun",
 		Tag:           t.tag,


### PR DESCRIPTION
#6364