### PR TITLE
XHTTP server: Refactor upload_queue.go

### DIFF
--- a/transport/internet/splithttp/upload_queue.go
+++ b/transport/internet/splithttp/upload_queue.go
@@ -43,6 +43,9 @@ func (h *uploadQueue) Push(p Packet) error {
 	}
 	select {
 	case h.pushedPackets <- p: // no panic
+		if h.closed.Done() {
+			return errors.New("packet queue closed")
+		}
 		return nil
 	case <-h.closed.Wait():
 		return errors.New("packet queue closed")

--- a/transport/internet/splithttp/upload_queue.go
+++ b/transport/internet/splithttp/upload_queue.go
@@ -38,8 +38,7 @@ func NewUploadQueue(maxPackets int) *uploadQueue {
 }
 
 func (h *uploadQueue) Push(p Packet) error {
-	if p.Reader != nil && !h.reader.CompareAndSwap(nil, p.Reader) {
-		p.Reader.Close()
+	if h.reader.Load() != nil || (p.Reader != nil && !h.reader.CompareAndSwap(nil, p.Reader)) {
 		return errors.New("h.reader already exists")
 	}
 	select {
@@ -55,16 +54,7 @@ func (h *uploadQueue) Close() error {
 	if reader := h.reader.Load(); reader != nil {
 		return reader.Close()
 	}
-	for {
-		select {
-		case p := <-h.pushedPackets:
-			if p.Reader != nil { // unlikely
-				p.Reader.Close()
-			}
-		default:
-			return nil
-		}
-	}
+	return nil
 }
 
 func (h *uploadQueue) Read(b []byte) (int, error) {

--- a/transport/internet/splithttp/upload_queue.go
+++ b/transport/internet/splithttp/upload_queue.go
@@ -6,10 +6,11 @@ package splithttp
 import (
 	"container/heap"
 	"io"
-	"runtime"
 	"sync"
+	"sync/atomic"
 
 	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/common/signal/done"
 )
 
 type Packet struct {
@@ -25,8 +26,9 @@ type uploadQueue struct {
 	writeCloseMutex sync.Mutex
 	heap            uploadHeap
 	nextSeq         uint64
-	closed          bool
 	maxPackets      int
+	closeOnce       atomic.Bool
+	closed          *done.Instance
 }
 
 func NewUploadQueue(maxPackets int) *uploadQueue {
@@ -34,51 +36,53 @@ func NewUploadQueue(maxPackets int) *uploadQueue {
 		pushedPackets: make(chan Packet, maxPackets),
 		heap:          uploadHeap{},
 		nextSeq:       0,
-		closed:        false,
+		closed:        done.New(),
 		maxPackets:    maxPackets,
 	}
 }
 
 func (h *uploadQueue) Push(p Packet) error {
 	h.writeCloseMutex.Lock()
+	defer h.writeCloseMutex.Unlock()
 
-	if h.closed {
-		h.writeCloseMutex.Unlock() // Modified
+	if h.closed.Done() {
 		return errors.New("packet queue closed")
 	}
 	if h.nomore {
-		h.writeCloseMutex.Unlock() // Modified
 		return errors.New("h.reader already exists")
 	}
 	if p.Reader != nil {
 		h.nomore = true
 	}
-	h.writeCloseMutex.Unlock() // Modified: Release lock before blocking on channel write
-
-	h.pushedPackets <- p
-	return nil
+	select {
+	case h.pushedPackets <- p:
+		return nil
+	case <-h.closed.Wait():
+		return errors.New("packet queue closed")
+	}
 }
 
 func (h *uploadQueue) Close() error {
+	if !h.closeOnce.CompareAndSwap(false, true) {
+		return nil
+	}
+	// must be called outside of lock to release Push() functions which might holding the lock
+	h.closed.Close()
 	h.writeCloseMutex.Lock()
 	defer h.writeCloseMutex.Unlock()
 
-	if !h.closed {
-		h.closed = true
-		runtime.Gosched() // hope Read() gets the packet
-	f:
-		for {
-			select {
-			case p := <-h.pushedPackets:
-				if p.Reader != nil {
-					h.reader = p.Reader
-				}
-			default:
-				break f
+	for shouldContinue := true; shouldContinue; {
+		select {
+		case p := <-h.pushedPackets:
+			if p.Reader != nil {
+				h.reader = p.Reader
 			}
+		default:
+			shouldContinue = false
 		}
-		close(h.pushedPackets)
 	}
+	close(h.pushedPackets)
+
 	if h.reader != nil {
 		return h.reader.Close()
 	}
@@ -90,7 +94,7 @@ func (h *uploadQueue) Read(b []byte) (int, error) {
 		return h.reader.Read(b)
 	}
 
-	if h.closed {
+	if h.closed.Done() {
 		return 0, io.EOF
 	}
 

--- a/transport/internet/splithttp/upload_queue.go
+++ b/transport/internet/splithttp/upload_queue.go
@@ -6,7 +6,6 @@ package splithttp
 import (
 	"container/heap"
 	"io"
-	"sync"
 	"sync/atomic"
 
 	"github.com/xtls/xray-core/common/errors"
@@ -14,21 +13,18 @@ import (
 )
 
 type Packet struct {
-	Reader  io.ReadCloser
+	Reader  *httpServerConn
 	Payload []byte
 	Seq     uint64
 }
 
 type uploadQueue struct {
-	reader          io.ReadCloser
-	nomore          bool
-	pushedPackets   chan Packet
-	writeCloseMutex sync.Mutex
-	heap            uploadHeap
-	nextSeq         uint64
-	maxPackets      int
-	closeOnce       atomic.Bool
-	closed          *done.Instance
+	reader        atomic.Pointer[httpServerConn]
+	pushedPackets chan Packet
+	heap          uploadHeap
+	nextSeq       uint64
+	maxPackets    int
+	closed        *done.Instance
 }
 
 func NewUploadQueue(maxPackets int) *uploadQueue {
@@ -42,20 +38,12 @@ func NewUploadQueue(maxPackets int) *uploadQueue {
 }
 
 func (h *uploadQueue) Push(p Packet) error {
-	h.writeCloseMutex.Lock()
-	defer h.writeCloseMutex.Unlock()
-
-	if h.closed.Done() {
-		return errors.New("packet queue closed")
-	}
-	if h.nomore {
+	if p.Reader != nil && !h.reader.CompareAndSwap(nil, p.Reader) {
+		p.Reader.Close()
 		return errors.New("h.reader already exists")
 	}
-	if p.Reader != nil {
-		h.nomore = true
-	}
 	select {
-	case h.pushedPackets <- p:
+	case h.pushedPackets <- p: // no panic
 		return nil
 	case <-h.closed.Wait():
 		return errors.New("packet queue closed")
@@ -63,35 +51,25 @@ func (h *uploadQueue) Push(p Packet) error {
 }
 
 func (h *uploadQueue) Close() error {
-	if !h.closeOnce.CompareAndSwap(false, true) {
-		return nil
-	}
-	// must be called outside of lock to release Push() functions which might holding the lock
 	h.closed.Close()
-	h.writeCloseMutex.Lock()
-	defer h.writeCloseMutex.Unlock()
-
-	for shouldContinue := true; shouldContinue; {
+	if reader := h.reader.Load(); reader != nil {
+		return reader.Close()
+	}
+	for {
 		select {
 		case p := <-h.pushedPackets:
-			if p.Reader != nil {
-				h.reader = p.Reader
+			if p.Reader != nil { // unlikely
+				p.Reader.Close()
 			}
 		default:
-			shouldContinue = false
+			return nil
 		}
 	}
-	close(h.pushedPackets)
-
-	if h.reader != nil {
-		return h.reader.Close()
-	}
-	return nil
 }
 
 func (h *uploadQueue) Read(b []byte) (int, error) {
-	if h.reader != nil {
-		return h.reader.Read(b)
+	if reader := h.reader.Load(); reader != nil {
+		return (*reader).Read(b)
 	}
 
 	if h.closed.Done() {
@@ -99,15 +77,15 @@ func (h *uploadQueue) Read(b []byte) (int, error) {
 	}
 
 	if len(h.heap) == 0 {
-		packet, more := <-h.pushedPackets
-		if !more {
+		select {
+		case p := <-h.pushedPackets:
+			if p.Reader != nil {
+				return p.Reader.Read(b)
+			}
+			heap.Push(&h.heap, p)
+		case <-h.closed.Wait():
 			return 0, io.EOF
 		}
-		if packet.Reader != nil {
-			h.reader = packet.Reader
-			return h.reader.Read(b)
-		}
-		heap.Push(&h.heap, packet)
 	}
 
 	for len(h.heap) > 0 {
@@ -138,11 +116,12 @@ func (h *uploadQueue) Read(b []byte) (int, error) {
 				return 0, errors.New("packet queue is too large")
 			}
 			heap.Push(&h.heap, packet)
-			packet2, more := <-h.pushedPackets
-			if !more {
+			select {
+			case p := <-h.pushedPackets:
+				heap.Push(&h.heap, p)
+			case <-h.closed.Wait():
 				return 0, io.EOF
 			}
-			heap.Push(&h.heap, packet2)
 		}
 	}
 

--- a/transport/internet/splithttp/upload_queue.go
+++ b/transport/internet/splithttp/upload_queue.go
@@ -41,17 +41,20 @@ func NewUploadQueue(maxPackets int) *uploadQueue {
 
 func (h *uploadQueue) Push(p Packet) error {
 	h.writeCloseMutex.Lock()
-	defer h.writeCloseMutex.Unlock()
 
 	if h.closed {
+		h.writeCloseMutex.Unlock() // Modified
 		return errors.New("packet queue closed")
 	}
 	if h.nomore {
+		h.writeCloseMutex.Unlock() // Modified
 		return errors.New("h.reader already exists")
 	}
 	if p.Reader != nil {
 		h.nomore = true
 	}
+	h.writeCloseMutex.Unlock() // Modified: Release lock before blocking on channel write
+
 	h.pushedPackets <- p
 	return nil
 }

--- a/transport/internet/splithttp/upload_queue.go
+++ b/transport/internet/splithttp/upload_queue.go
@@ -69,7 +69,7 @@ func (h *uploadQueue) Close() error {
 
 func (h *uploadQueue) Read(b []byte) (int, error) {
 	if reader := h.reader.Load(); reader != nil {
-		return (*reader).Read(b)
+		return reader.Read(b)
 	}
 
 	if h.closed.Done() {


### PR DESCRIPTION
In `splithttp.uploadQueue.Push`, the function locks `writeCloseMutex` and defers `Unlock`. 
However, if `pushedPackets` channel becomes full (e.g., due to a slow read or connection close), writing to the channel blocks indefinitely while still holding the mutex lock. This causes all subsequent `Push` and `Close` calls to hang forever on `writeCloseMutex.Lock()`.
This PR releases `writeCloseMutex` right before sending to `pushedPackets` to prevent the deadlock.
