### PR TITLE
Hysteria: support VLESS route auth IDs

### DIFF
--- a/proxy/hysteria/account/config.go
+++ b/proxy/hysteria/account/config.go
@@ -4,7 +4,9 @@ import (
 	"sync"
 
 	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/protocol"
+	"github.com/xtls/xray-core/common/uuid"
 
 	"google.golang.org/protobuf/proto"
 )
@@ -37,6 +39,32 @@ type Validator struct {
 	users  map[string]*protocol.MemoryUser
 
 	mutex sync.Mutex
+}
+
+func vlessRouteAuthKey(auth string) ([16]byte, bool) {
+	var key [16]byte
+	if len(auth) != 32 && len(auth) != 36 {
+		return key, false
+	}
+	id, err := uuid.ParseString(auth)
+	if err != nil {
+		return key, false
+	}
+	copy(key[:], id.Bytes())
+	key[6] = 0
+	key[7] = 0
+	return key, true
+}
+
+func VlessRouteFromAuth(auth string) net.Port {
+	if len(auth) != 32 && len(auth) != 36 {
+		return 0
+	}
+	id, err := uuid.ParseString(auth)
+	if err != nil {
+		return 0
+	}
+	return net.PortFromBytes(id.Bytes()[6:8])
 }
 
 func NewValidator() *Validator {
@@ -87,7 +115,21 @@ func (v *Validator) Get(auth string) *protocol.MemoryUser {
 	v.mutex.Lock()
 	defer v.mutex.Unlock()
 
-	return v.users[auth]
+	if user := v.users[auth]; user != nil {
+		return user
+	}
+
+	key, ok := vlessRouteAuthKey(auth)
+	if !ok {
+		return nil
+	}
+	for storedAuth, user := range v.users {
+		storedKey, ok := vlessRouteAuthKey(storedAuth)
+		if ok && storedKey == key {
+			return user
+		}
+	}
+	return nil
 }
 
 func (v *Validator) GetByEmail(email string) *protocol.MemoryUser {

--- a/proxy/hysteria/account/config_test.go
+++ b/proxy/hysteria/account/config_test.go
@@ -1,0 +1,28 @@
+package account
+
+import (
+	"testing"
+
+	"github.com/xtls/xray-core/common/protocol"
+)
+
+func TestValidatorGetAcceptsVlessRouteAuthVariant(t *testing.T) {
+	user := &protocol.MemoryUser{
+		Email:   "user@example.com",
+		Account: &MemoryAccount{Auth: "00000000-0000-1234-8000-000000000000"},
+	}
+	validator := NewValidator()
+	if err := validator.Add(user); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := validator.Get("00000000-0000-0001-8000-000000000000"); got != user {
+		t.Fatal("validator did not accept UUID auth variant with a different VLESS route")
+	}
+	if got := validator.Get("00000000-0000-0001-9000-000000000000"); got != nil {
+		t.Fatalf("validator accepted auth with non-route bytes changed: %v", got)
+	}
+	if got := validator.Get("password"); got != nil {
+		t.Fatalf("validator accepted unrelated password auth: %v", got)
+	}
+}

--- a/proxy/hysteria/server.go
+++ b/proxy/hysteria/server.go
@@ -82,19 +82,30 @@ func (s *Server) Process(ctx context.Context, network net.Network, conn stat.Con
 	inbound := session.InboundFromContext(ctx)
 	inbound.Name = "hysteria"
 	inbound.CanSpliceCopy = 3
+	iConn := stat.TryUnwrapStatsConn(conn)
 
 	var useremail string
 	var userlevel uint32
 	type User interface{ User() *protocol.MemoryUser }
-	if v, ok := conn.(User); ok {
+	type Auth interface{ Auth() string }
+	if v, ok := iConn.(User); ok {
 		inbound.User = v.User()
 		if inbound.User != nil {
 			useremail = inbound.User.Email
 			userlevel = inbound.User.Level
+			auth := ""
+			if v, ok := iConn.(Auth); ok {
+				auth = v.Auth()
+			}
+			if hysteriaAccount, ok := inbound.User.Account.(*account.MemoryAccount); ok {
+				if auth == "" {
+					auth = hysteriaAccount.Auth
+				}
+				inbound.VlessRoute = account.VlessRouteFromAuth(auth)
+			}
 		}
 	}
 
-	iConn := stat.TryUnwrapStatsConn(conn)
 	if _, ok := iConn.(*hysteria.InterUdpConn); ok {
 		r := io.Reader(conn)
 		b := make([]byte, MaxUDPSize)

--- a/proxy/hysteria/server_test.go
+++ b/proxy/hysteria/server_test.go
@@ -1,0 +1,147 @@
+package hysteria
+
+import (
+	"context"
+	"io"
+	stdnet "net"
+	"testing"
+	"time"
+
+	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/protocol"
+	"github.com/xtls/xray-core/common/session"
+	"github.com/xtls/xray-core/features/policy"
+	"github.com/xtls/xray-core/proxy/hysteria/account"
+)
+
+func TestVlessRouteFromAuth(t *testing.T) {
+	const routeID = net.Port(0x1234)
+
+	tests := []struct {
+		name string
+		auth string
+		want net.Port
+	}{
+		{
+			name: "hyphenated UUID",
+			auth: "00000000-0000-1234-8000-000000000000",
+			want: routeID,
+		},
+		{
+			name: "plain UUID",
+			auth: "00000000000012348000000000000000",
+			want: routeID,
+		},
+		{
+			name: "password auth",
+			auth: "password",
+			want: 0,
+		},
+		{
+			name: "invalid UUID",
+			auth: "00000000-0000-123k-8000-000000000000",
+			want: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := account.VlessRouteFromAuth(test.auth); got != test.want {
+				t.Fatalf("VlessRouteFromAuth(%q) = %d, want %d", test.auth, got, test.want)
+			}
+		})
+	}
+}
+
+type testPolicyManager struct{}
+
+func (*testPolicyManager) Type() interface{} {
+	return policy.ManagerType()
+}
+
+func (*testPolicyManager) Start() error {
+	return nil
+}
+
+func (*testPolicyManager) Close() error {
+	return nil
+}
+
+func (*testPolicyManager) ForLevel(uint32) policy.Session {
+	return policy.SessionDefault()
+}
+
+func (*testPolicyManager) ForSystem() policy.System {
+	return policy.System{}
+}
+
+type testUserConn struct {
+	user *protocol.MemoryUser
+	auth string
+}
+
+func (c *testUserConn) User() *protocol.MemoryUser {
+	return c.user
+}
+
+func (c *testUserConn) Auth() string {
+	return c.auth
+}
+
+func (*testUserConn) Read([]byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (*testUserConn) Write(b []byte) (int, error) {
+	return len(b), nil
+}
+
+func (*testUserConn) Close() error {
+	return nil
+}
+
+func (*testUserConn) LocalAddr() stdnet.Addr {
+	return &stdnet.TCPAddr{IP: stdnet.IPv4(127, 0, 0, 1), Port: 443}
+}
+
+func (*testUserConn) RemoteAddr() stdnet.Addr {
+	return &stdnet.TCPAddr{IP: stdnet.IPv4(127, 0, 0, 1), Port: 12345}
+}
+
+func (*testUserConn) SetDeadline(time.Time) error {
+	return nil
+}
+
+func (*testUserConn) SetReadDeadline(time.Time) error {
+	return nil
+}
+
+func (*testUserConn) SetWriteDeadline(time.Time) error {
+	return nil
+}
+
+func TestServerProcessSetsVlessRouteFromHysteriaAuth(t *testing.T) {
+	const serverAuth = "00000000-0000-1234-8000-000000000000"
+	const clientAuth = "00000000-0000-0001-8000-000000000000"
+
+	inbound := &session.Inbound{}
+	user := &protocol.MemoryUser{
+		Account: &account.MemoryAccount{Auth: serverAuth},
+		Level:   1,
+		Email:   "user@example.com",
+	}
+	server := &Server{
+		policyManager: &testPolicyManager{},
+	}
+
+	err := server.Process(session.ContextWithInbound(context.Background(), inbound), net.Network_TCP, &testUserConn{user: user, auth: clientAuth}, nil)
+	if err == nil {
+		t.Fatal("Process unexpectedly succeeded with an empty test connection")
+	}
+	if inbound.User != user {
+		t.Fatal("server did not use the authenticated Hysteria user from the connection")
+	}
+	if inbound.VlessRoute != 1 {
+		t.Fatalf("inbound.VlessRoute = %d, want %d", inbound.VlessRoute, net.Port(1))
+	}
+}

--- a/transport/internet/hysteria/conn.go
+++ b/transport/internet/hysteria/conn.go
@@ -21,10 +21,15 @@ type interConn struct {
 	mutex  sync.Mutex
 
 	user *protocol.MemoryUser
+	auth string
 }
 
 func (i *interConn) User() *protocol.MemoryUser {
 	return i.user
+}
+
+func (i *interConn) Auth() string {
+	return i.auth
 }
 
 func (i *interConn) Read(b []byte) (int, error) {
@@ -91,10 +96,15 @@ type InterUdpConn struct {
 	mutex sync.Mutex
 
 	user *protocol.MemoryUser
+	auth string
 }
 
 func (i *InterUdpConn) User() *protocol.MemoryUser {
 	return i.user
+}
+
+func (i *InterUdpConn) Auth() string {
+	return i.auth
 }
 
 func (i *InterUdpConn) SetLast() {

--- a/transport/internet/hysteria/hub.go
+++ b/transport/internet/hysteria/hub.go
@@ -35,6 +35,7 @@ type udpSessionManagerServer struct {
 	mutex          sync.RWMutex
 
 	user *protocol.MemoryUser
+	auth string
 }
 
 func (m *udpSessionManagerServer) close(udpConn *InterUdpConn) {
@@ -125,6 +126,7 @@ func (m *udpSessionManagerServer) feed(id uint32, d []byte) {
 			last: time.Now(),
 
 			user: m.user,
+			auth: m.auth,
 		}
 		udpConn.closeFunc = func() {
 			m.mutex.Lock()
@@ -151,9 +153,10 @@ type httpHandler struct {
 	validator   *account.Validator
 	masqHandler http.Handler
 
-	auth  bool
-	mutex sync.Mutex
-	user  *protocol.MemoryUser
+	auth      bool
+	mutex     sync.Mutex
+	user      *protocol.MemoryUser
+	authValue string
 }
 
 func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -183,6 +186,7 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if user != nil || ok {
 			h.auth = true
 			h.user = user
+			h.authValue = auth
 
 			switch h.quicParams.Congestion {
 			case "reno":
@@ -214,6 +218,7 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					udpIdleTimeout: time.Duration(h.config.UdpIdleTimeout) * time.Second,
 
 					user: h.user,
+					auth: h.authValue,
 				}
 				go udpSM.clean()
 				go udpSM.run()
@@ -247,6 +252,7 @@ func (h *httpHandler) StreamDispatcher(ft http3.FrameType, stream *quic.Stream, 
 			remote: h.conn.RemoteAddr(),
 
 			user: h.user,
+			auth: h.authValue,
 		})
 		return true, nil
 	default:


### PR DESCRIPTION
This mirrors VLESS UUID routing behavior for Hysteria users whose auth value is UUID-like. UUID bytes 6:8 are excluded from user lookup and are used to populate Inbound.VlessRoute, allowing routing rules to distinguish route IDs while keeping the rest of the auth UUID stable.\n\nTests cover auth lookup with route-byte variants and route extraction from the client auth value.