### PR TITLE
Socks5 Server: allow UDP source port changes for same client IP

### DIFF
--- a/proxy/socks/protocol.go
+++ b/proxy/socks/protocol.go
@@ -215,6 +215,9 @@ func (s *ServerSession) handshake5(nMethod byte, reader io.Reader, writer net.Co
 		} else {
 			expectedRemote.IP = request.Address.IP()
 		}
+		if request.Port != 0 {
+			expectedRemote.Port = int(request.Port)
+		}
 		tempUDPConn = NewTempUDPConn(udpHub, writer, expectedRemote)
 	}
 	if err := writeSocks5Response(writer, statusSuccess, responseAddress, responsePort); err != nil {

--- a/proxy/socks/protocol.go
+++ b/proxy/socks/protocol.go
@@ -214,7 +214,6 @@ func (s *ServerSession) handshake5(nMethod byte, reader io.Reader, writer net.Co
 			expectedRemote.IP = writer.RemoteAddr().(*net.TCPAddr).IP // unix?
 		} else {
 			expectedRemote.IP = request.Address.IP()
-			expectedRemote.Port = int(request.Port) // 0 is allowed
 		}
 		tempUDPConn = NewTempUDPConn(udpHub, writer, expectedRemote)
 	}

--- a/proxy/socks/temp_udp_listen.go
+++ b/proxy/socks/temp_udp_listen.go
@@ -37,9 +37,7 @@ func (c *TempUDPConn) Read(b []byte) (n int, err error) {
 		remote := remote.(*net.UDPAddr)
 		expected := c.ExpectedRemote.Load()
 		if remote.IP.Equal(expected.IP) {
-			if remote.Port != expected.Port {
-				c.ExpectedRemote.Store(remote)
-			}
+			c.ExpectedRemote.Store(remote)
 			c.Timer.Update()
 			return
 		}

--- a/proxy/socks/temp_udp_listen.go
+++ b/proxy/socks/temp_udp_listen.go
@@ -37,15 +37,11 @@ func (c *TempUDPConn) Read(b []byte) (n int, err error) {
 		remote := remote.(*net.UDPAddr)
 		expected := c.ExpectedRemote.Load()
 		if remote.IP.Equal(expected.IP) {
-			if remote.Port == expected.Port {
-				c.Timer.Update()
-				return
-			}
-			if expected.Port == 0 {
+			if remote.Port != expected.Port {
 				c.ExpectedRemote.Store(remote)
-				c.Timer.Update()
-				return
 			}
+			c.Timer.Update()
+			return
 		}
 	}
 }


### PR DESCRIPTION
After the changes in [XTLS/Xray-core#6149](https://github.com/XTLS/Xray-core/pull/6149),  Discord voice not working.
Allow SOCKS5 UDP ASSOCIATE clients to continue working when their UDP source port changes, which can happen with Discord/WebRTC traffic.

@Fangliding 