### PR TITLE
TUN inbound: Refine `gateway` and `autoSystemRoutingTable` on Linux

### DIFF
--- a/proxy/tun/README.md
+++ b/proxy/tun/README.md
@@ -14,11 +14,11 @@ Plainly enabling it in the config probably will result nothing, or lock your rou
 
 ## DETAILS
 
-Current implementation does not contain options to configure network level addresses, routing or rules.
-Enabling the feature will result only tun interface up, and that's it. \
-This is explicit decision, significantly simplifying implementation, and allowing any number of custom configurations, consumers could come up with. Network interface is OS level entity, and OS is what should manage it. \
-Working configuration, is tun enabled in Xray config with specific name (e.g. xray0), and OS level configuration to manage "xray0" interface, applying routing and rules on interface up.
-This way consistency of system level routing and rules is ensured from single place of responsibility - the OS itself. \
+By default, enabling the feature will only bring the tun interface up. \
+When configured explicitly, Windows and Linux can also apply interface addresses from `gateway` and on-link routes from `autoSystemRoutingTable`.
+Linux does not configure system DNS from the `dns` field; system DNS remains managed by the OS or distribution-specific network services. \
+For more advanced routing policies or rules, OS level configuration can still manage the named interface (e.g. xray0) when it appears.
+This keeps complex system level routing and rules in a single place of responsibility - the OS itself. \
 Examples of how to achieve this on a simple Linux system (Ubuntu with systemd-networkd) can be found at the end of this README.
 
 Due to this inbound not actually being a proxy, the configuration ignore required listen and port options, and never listen on any port. \

--- a/proxy/tun/tun_linux.go
+++ b/proxy/tun/tun_linux.go
@@ -26,9 +26,10 @@ type LinuxTun struct {
 	options *Config
 	ownsTun bool
 
-	systemRoutes     []netlink.Route
-	routeMonitorStop chan struct{}
-	routeMonitorOnce sync.Once
+	interfaceAddresses []netlink.Addr
+	systemRoutes       []netlink.Route
+	routeMonitorStop   chan struct{}
+	routeMonitorOnce   sync.Once
 }
 
 // LinuxTun implements Tun
@@ -172,7 +173,14 @@ func (t *LinuxTun) Start() error {
 		return err
 	}
 
+	if err := t.setInterfaceAddresses(); err != nil {
+		_ = netlink.LinkSetDown(t.tunLink)
+		return err
+	}
+
 	if err := t.setSystemRoutes(); err != nil {
+		_ = t.unsetInterfaceAddresses()
+		_ = netlink.LinkSetDown(t.tunLink)
 		return err
 	}
 
@@ -193,6 +201,7 @@ func (t *LinuxTun) Close() error {
 	})
 
 	_ = t.unsetSystemRoutes()
+	_ = t.unsetInterfaceAddresses()
 
 	if t.ownsTun {
 		_ = netlink.LinkSetDown(t.tunLink)
@@ -221,6 +230,37 @@ func (t *LinuxTun) newEndpoint() (stack.LinkEndpoint, error) {
 
 func setinterface(network, address string, fd uintptr, iface *net.Interface) error {
 	return unix.BindToDevice(int(fd), iface.Name)
+}
+
+func (t *LinuxTun) setInterfaceAddresses() error {
+	if len(t.options.Gateway) == 0 {
+		return nil
+	}
+	for _, address := range t.options.Gateway {
+		addr, err := netlink.ParseAddr(address)
+		if err != nil {
+			_ = t.unsetInterfaceAddresses()
+			return errors.New("invalid interface address ", address).Base(err)
+		}
+		if err := netlink.AddrAdd(t.tunLink, addr); err != nil {
+			_ = t.unsetInterfaceAddresses()
+			return errors.New("failed to add interface address ", address).Base(err)
+		}
+		t.interfaceAddresses = append(t.interfaceAddresses, *addr)
+	}
+	return nil
+}
+
+func (t *LinuxTun) unsetInterfaceAddresses() error {
+	var errs []error
+	for i := len(t.interfaceAddresses) - 1; i >= 0; i-- {
+		address := t.interfaceAddresses[i]
+		if err := netlink.AddrDel(t.tunLink, &address); err != nil {
+			errs = append(errs, errors.New("failed to delete interface address").Base(err))
+		}
+	}
+	t.interfaceAddresses = nil
+	return errors.Combine(errs...)
 }
 
 func (t *LinuxTun) setSystemRoutes() error {

--- a/proxy/tun/tun_linux.go
+++ b/proxy/tun/tun_linux.go
@@ -256,7 +256,7 @@ func (t *LinuxTun) unsetInterfaceAddresses() error {
 	for i := len(t.interfaceAddresses) - 1; i >= 0; i-- {
 		address := t.interfaceAddresses[i]
 		if err := netlink.AddrDel(t.tunLink, &address); err != nil {
-			errs = append(errs, errors.New("failed to delete interface address").Base(err))
+			errs = append(errs, errors.New("failed to delete interface address ", address.String()).Base(err))
 		}
 	}
 	t.interfaceAddresses = nil


### PR DESCRIPTION
补充 Linux TUN 对 `gateway` 和 `autoSystemRoutingTable` 的支持。

这里给 Linux TUN 设置 IP，不是因为 gVisor/Xray 的 TUN 包收发在协议层必须依赖这个地址。Linux 上只把 TUN link up，再添加 dev route，在一些场景下也可以工作。设置 IP 的主要目的，是让 Xray-core 可以完整接管“创建 TUN 接口、配置接口地址、配置系统路由、关闭时清理”的生命周期。

在这个配置里，`gateway` 更准确地理解为 TUN 接口地址，例如 `198.18.0.1/15` 或 `fc00::1/64`。把它写到 TUN 设备后，系统状态会更明确：`ip addr show <tun>` 能看到接口地址，`autoSystemRoutingTable` 添加的路由也可以直接指向这个 TUN link。这里不会派生隐藏的下一跳地址，也不会把 route 写成 `via 198.18.0.2` 之类的形式；路由仍然是 on-link route，只绑定到对应的 `LinkIndex`。

这样做还有两个实际收益：

1. 和 Windows 语义对齐。Windows 侧已经把 `gateway` 作为 TUN 接口地址写入，Linux 补齐后，同一份 TUN inbound 配置在 Windows/Linux 上语义一致。
2. 客户端不再需要额外维护一套 `ip addr add` 的 wrapper 逻辑。对于直接使用官方 Xray 二进制的桌面客户端，这可以减少应用层对系统路由的重复处理。

这次改动的边界比较明确：Linux 不接管系统 DNS，不修改 `resolv.conf`、systemd-resolved 或 NetworkManager；route 不设置 `Gw`，也不调整 metric；如果 TUN 是外部 fd 传入的，`ownsTun == false` 时不会修改外部接口。关闭时只清理本次由 Xray 添加的地址和路由。

AI Coding by GPT-5.5 Extra High
Tested on Linux
