### PR TITLE
XHTTP: add opt-in downlink keepalive (scStreamDownServerSecs)

### DIFF
--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -209,36 +209,37 @@ func (c *HttpUpgradeConfig) Build() (proto.Message, error) {
 }
 
 type SplitHTTPConfig struct {
-	Host                 string            `json:"host"`
-	Path                 string            `json:"path"`
-	Mode                 string            `json:"mode"`
-	Headers              map[string]string `json:"headers"`
-	XPaddingBytes        Int32Range        `json:"xPaddingBytes"`
-	XPaddingObfsMode     bool              `json:"xPaddingObfsMode"`
-	XPaddingKey          string            `json:"xPaddingKey"`
-	XPaddingHeader       string            `json:"xPaddingHeader"`
-	XPaddingPlacement    string            `json:"xPaddingPlacement"`
-	XPaddingMethod       string            `json:"xPaddingMethod"`
-	UplinkHTTPMethod     string            `json:"uplinkHTTPMethod"`
-	SessionIDPlacement   string            `json:"sessionIDPlacement"`
-	SessionIDKey         string            `json:"sessionIDKey"`
-	SessionIDTable       string            `json:"sessionIDTable"`
-	SessionIDLength      Int32Range        `json:"sessionIDLength"`
-	SeqPlacement         string            `json:"seqPlacement"`
-	SeqKey               string            `json:"seqKey"`
-	UplinkDataPlacement  string            `json:"uplinkDataPlacement"`
-	UplinkDataKey        string            `json:"uplinkDataKey"`
-	UplinkChunkSize      Int32Range        `json:"uplinkChunkSize"`
-	NoGRPCHeader         bool              `json:"noGRPCHeader"`
-	NoSSEHeader          bool              `json:"noSSEHeader"`
-	ScMaxEachPostBytes   Int32Range        `json:"scMaxEachPostBytes"`
-	ScMinPostsIntervalMs Int32Range        `json:"scMinPostsIntervalMs"`
-	ScMaxBufferedPosts   int64             `json:"scMaxBufferedPosts"`
-	ScStreamUpServerSecs Int32Range        `json:"scStreamUpServerSecs"`
-	ServerMaxHeaderBytes int32             `json:"serverMaxHeaderBytes"`
-	Xmux                 XmuxConfig        `json:"xmux"`
-	DownloadSettings     *StreamConfig     `json:"downloadSettings"`
-	Extra                json.RawMessage   `json:"extra"`
+	Host                   string            `json:"host"`
+	Path                   string            `json:"path"`
+	Mode                   string            `json:"mode"`
+	Headers                map[string]string `json:"headers"`
+	XPaddingBytes          Int32Range        `json:"xPaddingBytes"`
+	XPaddingObfsMode       bool              `json:"xPaddingObfsMode"`
+	XPaddingKey            string            `json:"xPaddingKey"`
+	XPaddingHeader         string            `json:"xPaddingHeader"`
+	XPaddingPlacement      string            `json:"xPaddingPlacement"`
+	XPaddingMethod         string            `json:"xPaddingMethod"`
+	UplinkHTTPMethod       string            `json:"uplinkHTTPMethod"`
+	SessionIDPlacement     string            `json:"sessionIDPlacement"`
+	SessionIDKey           string            `json:"sessionIDKey"`
+	SessionIDTable         string            `json:"sessionIDTable"`
+	SessionIDLength        Int32Range        `json:"sessionIDLength"`
+	SeqPlacement           string            `json:"seqPlacement"`
+	SeqKey                 string            `json:"seqKey"`
+	UplinkDataPlacement    string            `json:"uplinkDataPlacement"`
+	UplinkDataKey          string            `json:"uplinkDataKey"`
+	UplinkChunkSize        Int32Range        `json:"uplinkChunkSize"`
+	NoGRPCHeader           bool              `json:"noGRPCHeader"`
+	NoSSEHeader            bool              `json:"noSSEHeader"`
+	ScMaxEachPostBytes     Int32Range        `json:"scMaxEachPostBytes"`
+	ScMinPostsIntervalMs   Int32Range        `json:"scMinPostsIntervalMs"`
+	ScMaxBufferedPosts     int64             `json:"scMaxBufferedPosts"`
+	ScStreamUpServerSecs   Int32Range        `json:"scStreamUpServerSecs"`
+	ScStreamDownServerSecs Int32Range        `json:"scStreamDownServerSecs"`
+	ServerMaxHeaderBytes   int32             `json:"serverMaxHeaderBytes"`
+	Xmux                   XmuxConfig        `json:"xmux"`
+	DownloadSettings       *StreamConfig     `json:"downloadSettings"`
+	Extra                  json.RawMessage   `json:"extra"`
 }
 
 type XmuxConfig struct {
@@ -413,33 +414,34 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 	}
 
 	config := &splithttp.Config{
-		Host:                 c.Host,
-		Path:                 c.Path,
-		Mode:                 c.Mode,
-		Headers:              c.Headers,
-		XPaddingBytes:        newRangeConfig(c.XPaddingBytes),
-		XPaddingObfsMode:     c.XPaddingObfsMode,
-		XPaddingKey:          c.XPaddingKey,
-		XPaddingHeader:       c.XPaddingHeader,
-		XPaddingPlacement:    c.XPaddingPlacement,
-		XPaddingMethod:       c.XPaddingMethod,
-		UplinkHTTPMethod:     c.UplinkHTTPMethod,
-		SessionIDPlacement:   c.SessionIDPlacement,
-		SeqPlacement:         c.SeqPlacement,
-		SessionIDKey:         c.SessionIDKey,
-		SeqKey:               c.SeqKey,
-		UplinkDataPlacement:  c.UplinkDataPlacement,
-		UplinkDataKey:        c.UplinkDataKey,
-		UplinkChunkSize:      newRangeConfig(c.UplinkChunkSize),
-		NoGRPCHeader:         c.NoGRPCHeader,
-		NoSSEHeader:          c.NoSSEHeader,
-		ScMaxEachPostBytes:   newRangeConfig(c.ScMaxEachPostBytes),
-		ScMinPostsIntervalMs: newRangeConfig(c.ScMinPostsIntervalMs),
-		ScMaxBufferedPosts:   c.ScMaxBufferedPosts,
-		ScStreamUpServerSecs: newRangeConfig(c.ScStreamUpServerSecs),
-		ServerMaxHeaderBytes: c.ServerMaxHeaderBytes,
-		SessionIDTable:       c.SessionIDTable,
-		SessionIDLength:      newRangeConfig(c.SessionIDLength),
+		Host:                   c.Host,
+		Path:                   c.Path,
+		Mode:                   c.Mode,
+		Headers:                c.Headers,
+		XPaddingBytes:          newRangeConfig(c.XPaddingBytes),
+		XPaddingObfsMode:       c.XPaddingObfsMode,
+		XPaddingKey:            c.XPaddingKey,
+		XPaddingHeader:         c.XPaddingHeader,
+		XPaddingPlacement:      c.XPaddingPlacement,
+		XPaddingMethod:         c.XPaddingMethod,
+		UplinkHTTPMethod:       c.UplinkHTTPMethod,
+		SessionIDPlacement:     c.SessionIDPlacement,
+		SeqPlacement:           c.SeqPlacement,
+		SessionIDKey:           c.SessionIDKey,
+		SeqKey:                 c.SeqKey,
+		UplinkDataPlacement:    c.UplinkDataPlacement,
+		UplinkDataKey:          c.UplinkDataKey,
+		UplinkChunkSize:        newRangeConfig(c.UplinkChunkSize),
+		NoGRPCHeader:           c.NoGRPCHeader,
+		NoSSEHeader:            c.NoSSEHeader,
+		ScMaxEachPostBytes:     newRangeConfig(c.ScMaxEachPostBytes),
+		ScMinPostsIntervalMs:   newRangeConfig(c.ScMinPostsIntervalMs),
+		ScMaxBufferedPosts:     c.ScMaxBufferedPosts,
+		ScStreamUpServerSecs:   newRangeConfig(c.ScStreamUpServerSecs),
+		ScStreamDownServerSecs: newRangeConfig(c.ScStreamDownServerSecs),
+		ServerMaxHeaderBytes:   c.ServerMaxHeaderBytes,
+		SessionIDTable:         c.SessionIDTable,
+		SessionIDLength:        newRangeConfig(c.SessionIDLength),
 		Xmux: &splithttp.XmuxConfig{
 			MaxConcurrency:   newRangeConfig(c.Xmux.MaxConcurrency),
 			MaxConnections:   newRangeConfig(c.Xmux.MaxConnections),

--- a/transport/internet/splithttp/client.go
+++ b/transport/internet/splithttp/client.go
@@ -90,7 +90,11 @@ func (c *DefaultDialerClient) OpenStream(ctx context.Context, url string, sessio
 			wrc.Close()
 			return
 		}
-		wrc.(*WaitReadCloser).Set(resp.Body)
+		var respReader io.ReadCloser = resp.Body
+		if c.transportConfig.DownlinkKeepAliveEnabled() {
+			respReader = newDownlinkReader(resp.Body)
+		}
+		wrc.(*WaitReadCloser).Set(respReader)
 	}()
 
 	<-gotConn.Wait()

--- a/transport/internet/splithttp/config.go
+++ b/transport/internet/splithttp/config.go
@@ -174,6 +174,13 @@ func (c *Config) GetNormalizedScStreamUpServerSecs() *RangeConfig {
 	return c.ScStreamUpServerSecs
 }
 
+// DownlinkKeepAliveEnabled reports whether the opt-in downlink wrapping format
+// (and its keepalive) is enabled. When disabled (the default), the download
+// stream is a raw byte stream, byte-for-byte identical to previous versions.
+func (c *Config) DownlinkKeepAliveEnabled() bool {
+	return c.ScStreamDownServerSecs != nil && c.ScStreamDownServerSecs.To > 0
+}
+
 func (c *Config) GetNormalizedUplinkChunkSize() *RangeConfig {
 	if c.UplinkChunkSize == nil || c.UplinkChunkSize.To == 0 {
 		switch c.UplinkDataPlacement {

--- a/transport/internet/splithttp/config.pb.go
+++ b/transport/internet/splithttp/config.pb.go
@@ -159,38 +159,39 @@ func (x *XmuxConfig) GetHKeepAlivePeriod() int64 {
 }
 
 type Config struct {
-	state                protoimpl.MessageState `protogen:"open.v1"`
-	Host                 string                 `protobuf:"bytes,1,opt,name=host,proto3" json:"host,omitempty"`
-	Path                 string                 `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
-	Mode                 string                 `protobuf:"bytes,3,opt,name=mode,proto3" json:"mode,omitempty"`
-	Headers              map[string]string      `protobuf:"bytes,4,rep,name=headers,proto3" json:"headers,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	XPaddingBytes        *RangeConfig           `protobuf:"bytes,5,opt,name=xPaddingBytes,proto3" json:"xPaddingBytes,omitempty"`
-	NoGRPCHeader         bool                   `protobuf:"varint,6,opt,name=noGRPCHeader,proto3" json:"noGRPCHeader,omitempty"`
-	NoSSEHeader          bool                   `protobuf:"varint,7,opt,name=noSSEHeader,proto3" json:"noSSEHeader,omitempty"`
-	ScMaxEachPostBytes   *RangeConfig           `protobuf:"bytes,8,opt,name=scMaxEachPostBytes,proto3" json:"scMaxEachPostBytes,omitempty"`
-	ScMinPostsIntervalMs *RangeConfig           `protobuf:"bytes,9,opt,name=scMinPostsIntervalMs,proto3" json:"scMinPostsIntervalMs,omitempty"`
-	ScMaxBufferedPosts   int64                  `protobuf:"varint,10,opt,name=scMaxBufferedPosts,proto3" json:"scMaxBufferedPosts,omitempty"`
-	ScStreamUpServerSecs *RangeConfig           `protobuf:"bytes,11,opt,name=scStreamUpServerSecs,proto3" json:"scStreamUpServerSecs,omitempty"`
-	Xmux                 *XmuxConfig            `protobuf:"bytes,12,opt,name=xmux,proto3" json:"xmux,omitempty"`
-	DownloadSettings     *internet.StreamConfig `protobuf:"bytes,13,opt,name=downloadSettings,proto3" json:"downloadSettings,omitempty"`
-	XPaddingObfsMode     bool                   `protobuf:"varint,14,opt,name=xPaddingObfsMode,proto3" json:"xPaddingObfsMode,omitempty"`
-	XPaddingKey          string                 `protobuf:"bytes,15,opt,name=xPaddingKey,proto3" json:"xPaddingKey,omitempty"`
-	XPaddingHeader       string                 `protobuf:"bytes,16,opt,name=xPaddingHeader,proto3" json:"xPaddingHeader,omitempty"`
-	XPaddingPlacement    string                 `protobuf:"bytes,17,opt,name=xPaddingPlacement,proto3" json:"xPaddingPlacement,omitempty"`
-	XPaddingMethod       string                 `protobuf:"bytes,18,opt,name=xPaddingMethod,proto3" json:"xPaddingMethod,omitempty"`
-	UplinkHTTPMethod     string                 `protobuf:"bytes,19,opt,name=uplinkHTTPMethod,proto3" json:"uplinkHTTPMethod,omitempty"`
-	SessionIDPlacement   string                 `protobuf:"bytes,20,opt,name=sessionIDPlacement,proto3" json:"sessionIDPlacement,omitempty"`
-	SessionIDKey         string                 `protobuf:"bytes,21,opt,name=sessionIDKey,proto3" json:"sessionIDKey,omitempty"`
-	SeqPlacement         string                 `protobuf:"bytes,22,opt,name=seqPlacement,proto3" json:"seqPlacement,omitempty"`
-	SeqKey               string                 `protobuf:"bytes,23,opt,name=seqKey,proto3" json:"seqKey,omitempty"`
-	UplinkDataPlacement  string                 `protobuf:"bytes,24,opt,name=uplinkDataPlacement,proto3" json:"uplinkDataPlacement,omitempty"`
-	UplinkDataKey        string                 `protobuf:"bytes,25,opt,name=uplinkDataKey,proto3" json:"uplinkDataKey,omitempty"`
-	UplinkChunkSize      *RangeConfig           `protobuf:"bytes,26,opt,name=uplinkChunkSize,proto3" json:"uplinkChunkSize,omitempty"`
-	ServerMaxHeaderBytes int32                  `protobuf:"varint,27,opt,name=serverMaxHeaderBytes,proto3" json:"serverMaxHeaderBytes,omitempty"`
-	SessionIDTable       string                 `protobuf:"bytes,28,opt,name=sessionIDTable,proto3" json:"sessionIDTable,omitempty"`
-	SessionIDLength      *RangeConfig           `protobuf:"bytes,29,opt,name=sessionIDLength,proto3" json:"sessionIDLength,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	state                  protoimpl.MessageState `protogen:"open.v1"`
+	Host                   string                 `protobuf:"bytes,1,opt,name=host,proto3" json:"host,omitempty"`
+	Path                   string                 `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
+	Mode                   string                 `protobuf:"bytes,3,opt,name=mode,proto3" json:"mode,omitempty"`
+	Headers                map[string]string      `protobuf:"bytes,4,rep,name=headers,proto3" json:"headers,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	XPaddingBytes          *RangeConfig           `protobuf:"bytes,5,opt,name=xPaddingBytes,proto3" json:"xPaddingBytes,omitempty"`
+	NoGRPCHeader           bool                   `protobuf:"varint,6,opt,name=noGRPCHeader,proto3" json:"noGRPCHeader,omitempty"`
+	NoSSEHeader            bool                   `protobuf:"varint,7,opt,name=noSSEHeader,proto3" json:"noSSEHeader,omitempty"`
+	ScMaxEachPostBytes     *RangeConfig           `protobuf:"bytes,8,opt,name=scMaxEachPostBytes,proto3" json:"scMaxEachPostBytes,omitempty"`
+	ScMinPostsIntervalMs   *RangeConfig           `protobuf:"bytes,9,opt,name=scMinPostsIntervalMs,proto3" json:"scMinPostsIntervalMs,omitempty"`
+	ScMaxBufferedPosts     int64                  `protobuf:"varint,10,opt,name=scMaxBufferedPosts,proto3" json:"scMaxBufferedPosts,omitempty"`
+	ScStreamUpServerSecs   *RangeConfig           `protobuf:"bytes,11,opt,name=scStreamUpServerSecs,proto3" json:"scStreamUpServerSecs,omitempty"`
+	Xmux                   *XmuxConfig            `protobuf:"bytes,12,opt,name=xmux,proto3" json:"xmux,omitempty"`
+	DownloadSettings       *internet.StreamConfig `protobuf:"bytes,13,opt,name=downloadSettings,proto3" json:"downloadSettings,omitempty"`
+	XPaddingObfsMode       bool                   `protobuf:"varint,14,opt,name=xPaddingObfsMode,proto3" json:"xPaddingObfsMode,omitempty"`
+	XPaddingKey            string                 `protobuf:"bytes,15,opt,name=xPaddingKey,proto3" json:"xPaddingKey,omitempty"`
+	XPaddingHeader         string                 `protobuf:"bytes,16,opt,name=xPaddingHeader,proto3" json:"xPaddingHeader,omitempty"`
+	XPaddingPlacement      string                 `protobuf:"bytes,17,opt,name=xPaddingPlacement,proto3" json:"xPaddingPlacement,omitempty"`
+	XPaddingMethod         string                 `protobuf:"bytes,18,opt,name=xPaddingMethod,proto3" json:"xPaddingMethod,omitempty"`
+	UplinkHTTPMethod       string                 `protobuf:"bytes,19,opt,name=uplinkHTTPMethod,proto3" json:"uplinkHTTPMethod,omitempty"`
+	SessionIDPlacement     string                 `protobuf:"bytes,20,opt,name=sessionIDPlacement,proto3" json:"sessionIDPlacement,omitempty"`
+	SessionIDKey           string                 `protobuf:"bytes,21,opt,name=sessionIDKey,proto3" json:"sessionIDKey,omitempty"`
+	SeqPlacement           string                 `protobuf:"bytes,22,opt,name=seqPlacement,proto3" json:"seqPlacement,omitempty"`
+	SeqKey                 string                 `protobuf:"bytes,23,opt,name=seqKey,proto3" json:"seqKey,omitempty"`
+	UplinkDataPlacement    string                 `protobuf:"bytes,24,opt,name=uplinkDataPlacement,proto3" json:"uplinkDataPlacement,omitempty"`
+	UplinkDataKey          string                 `protobuf:"bytes,25,opt,name=uplinkDataKey,proto3" json:"uplinkDataKey,omitempty"`
+	UplinkChunkSize        *RangeConfig           `protobuf:"bytes,26,opt,name=uplinkChunkSize,proto3" json:"uplinkChunkSize,omitempty"`
+	ServerMaxHeaderBytes   int32                  `protobuf:"varint,27,opt,name=serverMaxHeaderBytes,proto3" json:"serverMaxHeaderBytes,omitempty"`
+	SessionIDTable         string                 `protobuf:"bytes,28,opt,name=sessionIDTable,proto3" json:"sessionIDTable,omitempty"`
+	SessionIDLength        *RangeConfig           `protobuf:"bytes,29,opt,name=sessionIDLength,proto3" json:"sessionIDLength,omitempty"`
+	ScStreamDownServerSecs *RangeConfig           `protobuf:"bytes,30,opt,name=scStreamDownServerSecs,proto3" json:"scStreamDownServerSecs,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *Config) Reset() {
@@ -426,6 +427,13 @@ func (x *Config) GetSessionIDLength() *RangeConfig {
 	return nil
 }
 
+func (x *Config) GetScStreamDownServerSecs() *RangeConfig {
+	if x != nil {
+		return x.ScStreamDownServerSecs
+	}
+	return nil
+}
+
 var File_transport_internet_splithttp_config_proto protoreflect.FileDescriptor
 
 const file_transport_internet_splithttp_config_proto_rawDesc = "" +
@@ -441,7 +449,7 @@ const file_transport_internet_splithttp_config_proto_rawDesc = "" +
 	"\x0ecMaxReuseTimes\x18\x03 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x0ecMaxReuseTimes\x12Z\n" +
 	"\x10hMaxRequestTimes\x18\x04 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x10hMaxRequestTimes\x12Z\n" +
 	"\x10hMaxReusableSecs\x18\x05 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x10hMaxReusableSecs\x12*\n" +
-	"\x10hKeepAlivePeriod\x18\x06 \x01(\x03R\x10hKeepAlivePeriod\"\xcc\f\n" +
+	"\x10hKeepAlivePeriod\x18\x06 \x01(\x03R\x10hKeepAlivePeriod\"\xb4\r\n" +
 	"\x06Config\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
 	"\x04path\x18\x02 \x01(\tR\x04path\x12\x12\n" +
@@ -472,7 +480,8 @@ const file_transport_internet_splithttp_config_proto_rawDesc = "" +
 	"\x0fuplinkChunkSize\x18\x1a \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x0fuplinkChunkSize\x122\n" +
 	"\x14serverMaxHeaderBytes\x18\x1b \x01(\x05R\x14serverMaxHeaderBytes\x12&\n" +
 	"\x0esessionIDTable\x18\x1c \x01(\tR\x0esessionIDTable\x12X\n" +
-	"\x0fsessionIDLength\x18\x1d \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x0fsessionIDLength\x1a:\n" +
+	"\x0fsessionIDLength\x18\x1d \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x0fsessionIDLength\x12f\n" +
+	"\x16scStreamDownServerSecs\x18\x1e \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x16scStreamDownServerSecs\x1a:\n" +
 	"\fHeadersEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x85\x01\n" +
@@ -513,11 +522,12 @@ var file_transport_internet_splithttp_config_proto_depIdxs = []int32{
 	4,  // 11: xray.transport.internet.splithttp.Config.downloadSettings:type_name -> xray.transport.internet.StreamConfig
 	0,  // 12: xray.transport.internet.splithttp.Config.uplinkChunkSize:type_name -> xray.transport.internet.splithttp.RangeConfig
 	0,  // 13: xray.transport.internet.splithttp.Config.sessionIDLength:type_name -> xray.transport.internet.splithttp.RangeConfig
-	14, // [14:14] is the sub-list for method output_type
-	14, // [14:14] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	0,  // 14: xray.transport.internet.splithttp.Config.scStreamDownServerSecs:type_name -> xray.transport.internet.splithttp.RangeConfig
+	15, // [15:15] is the sub-list for method output_type
+	15, // [15:15] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_transport_internet_splithttp_config_proto_init() }

--- a/transport/internet/splithttp/config.proto
+++ b/transport/internet/splithttp/config.proto
@@ -52,4 +52,5 @@ message Config {
   int32 serverMaxHeaderBytes = 27;
   string sessionIDTable = 28;
   RangeConfig sessionIDLength = 29;
+  RangeConfig scStreamDownServerSecs = 30;
 }

--- a/transport/internet/splithttp/downlink.go
+++ b/transport/internet/splithttp/downlink.go
@@ -1,0 +1,158 @@
+package splithttp
+
+import (
+	"encoding/binary"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/xtls/xray-core/common/errors"
+)
+
+// Downlink wrapping format (opt-in, enabled by scStreamDownServerSecs).
+//
+// When enabled, the server wraps the XHTTP server->client ("download") byte
+// stream into a minimal length-prefixed frame format, and the client unwraps
+// it. This gives the download stream an in-band keepalive, so an idle download
+// response is not cut off by buffering / inactivity-timeout intermediaries
+// (e.g. CDNs that only hold an idle HTTP response open for a limited time).
+// See XTLS/Xray-core#4846.
+//
+// Every frame is:
+//
+//	+--------+-----------------+==========================+
+//	| type   | length (uint16) | payload (length bytes)   |
+//	| 1 byte | big-endian      |                          |
+//	+--------+-----------------+==========================+
+//
+// Only two frame types are defined for now; the remaining type space is
+// reserved for future downlink-wrapping features discussed in #4846
+// (e.g. multi-path aggregation, retransmission/ACK).
+const (
+	downlinkFrameData      byte = 0 // payload is proxied downlink data
+	downlinkFrameKeepAlive byte = 1 // payload is padding, discarded by the client
+)
+
+const (
+	downlinkFrameHeaderLen  = 3      // type(1) + length(2)
+	downlinkMaxFramePayload = 0xFFFF // uint16 length ceiling
+)
+
+// downlinkWriter wraps the raw server->client writer with the downlink frame
+// format. It serialises data frames (written by the proxy via Write) with
+// keepalive frames (written by a background goroutine via keepAlive) so the two
+// never interleave mid-frame on the wire.
+type downlinkWriter struct {
+	sync.Mutex
+	w         io.WriteCloser
+	lastWrite time.Time // guarded by the mutex
+}
+
+func newDownlinkWriter(w io.WriteCloser) *downlinkWriter {
+	return &downlinkWriter{w: w, lastWrite: time.Now()}
+}
+
+// Close closes the underlying writer. The keepalive goroutine stops on the next
+// write error, or earlier via the request context / stream-done signals.
+func (dw *downlinkWriter) Close() error {
+	return dw.w.Close()
+}
+
+func (dw *downlinkWriter) Write(b []byte) (int, error) {
+	if len(b) == 0 {
+		return 0, nil
+	}
+	dw.Lock()
+	defer dw.Unlock()
+	written := 0
+	for len(b) > 0 {
+		n := len(b)
+		if n > downlinkMaxFramePayload {
+			n = downlinkMaxFramePayload
+		}
+		if err := dw.writeFrameLocked(downlinkFrameData, b[:n]); err != nil {
+			return written, err
+		}
+		b = b[n:]
+		written += n
+	}
+	dw.lastWrite = time.Now()
+	return written, nil
+}
+
+// keepAlive writes a keepalive frame if no data has been written for at least
+// idle. It is a no-op (nil error) while the downlink is active, and returns a
+// non-nil error once the underlying writer is closed (stop the loop).
+func (dw *downlinkWriter) keepAlive(idle time.Duration, payload []byte) error {
+	dw.Lock()
+	defer dw.Unlock()
+	if time.Since(dw.lastWrite) < idle {
+		return nil
+	}
+	if err := dw.writeFrameLocked(downlinkFrameKeepAlive, payload); err != nil {
+		return err
+	}
+	dw.lastWrite = time.Now()
+	return nil
+}
+
+// writeFrameLocked writes one frame in a single underlying Write so that the
+// header and payload are flushed together. The caller must hold the mutex.
+func (dw *downlinkWriter) writeFrameLocked(typ byte, payload []byte) error {
+	frame := make([]byte, downlinkFrameHeaderLen+len(payload))
+	frame[0] = typ
+	binary.BigEndian.PutUint16(frame[1:downlinkFrameHeaderLen], uint16(len(payload)))
+	copy(frame[downlinkFrameHeaderLen:], payload)
+	_, err := dw.w.Write(frame)
+	return err
+}
+
+// downlinkReader unwraps the downlink frame format on the client side. It
+// yields the payload of data frames to the caller and silently discards
+// keepalive frames. It is not safe for concurrent use, matching the single
+// read-pump usage of the raw response body it replaces.
+type downlinkReader struct {
+	r         io.ReadCloser
+	hdr       [downlinkFrameHeaderLen]byte
+	remaining int // unread bytes of the current data frame
+}
+
+func newDownlinkReader(r io.ReadCloser) *downlinkReader {
+	return &downlinkReader{r: r}
+}
+
+func (dr *downlinkReader) Read(p []byte) (int, error) {
+	for {
+		if dr.remaining > 0 {
+			n := len(p)
+			if n > dr.remaining {
+				n = dr.remaining
+			}
+			m, err := dr.r.Read(p[:n])
+			dr.remaining -= m
+			return m, err
+		}
+		// At a frame boundary. io.EOF here is a clean end of stream;
+		// a partial header is a truncated stream (io.ErrUnexpectedEOF).
+		if _, err := io.ReadFull(dr.r, dr.hdr[:]); err != nil {
+			return 0, err
+		}
+		length := int(binary.BigEndian.Uint16(dr.hdr[1:downlinkFrameHeaderLen]))
+		switch dr.hdr[0] {
+		case downlinkFrameData:
+			dr.remaining = length
+		case downlinkFrameKeepAlive:
+			if length > 0 {
+				if _, err := io.CopyN(io.Discard, dr.r, int64(length)); err != nil {
+					return 0, err
+				}
+			}
+		default:
+			return 0, errors.New("unexpected downlink frame type: ", dr.hdr[0])
+		}
+	}
+}
+
+func (dr *downlinkReader) Close() error {
+	return dr.r.Close()
+}

--- a/transport/internet/splithttp/downlink_test.go
+++ b/transport/internet/splithttp/downlink_test.go
@@ -1,0 +1,117 @@
+package splithttp
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+type testWriteCloser struct{ io.Writer }
+
+func (testWriteCloser) Close() error { return nil }
+
+// TestDownlinkRoundTrip checks that the client-side reader reproduces exactly
+// the bytes the server wrote, with keepalive frames (of various sizes) sprinkled
+// in between and a single write large enough to span multiple data frames.
+func TestDownlinkRoundTrip(t *testing.T) {
+	var wire bytes.Buffer
+	dw := newDownlinkWriter(testWriteCloser{&wire})
+
+	big := bytes.Repeat([]byte("A"), 3*downlinkMaxFramePayload+123) // spans 4 data frames
+	writes := [][]byte{
+		[]byte("hello world"),
+		big,
+		{}, // empty write must not emit a frame
+		[]byte("tail"),
+	}
+
+	var want []byte
+	for i, w := range writes {
+		if _, err := dw.Write(w); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+		want = append(want, w...)
+		// idle==0 forces the keepalive to be emitted every time.
+		if err := dw.keepAlive(0, []byte("keepalive-padding")); err != nil {
+			t.Fatalf("keepalive %d: %v", i, err)
+		}
+	}
+	if err := dw.keepAlive(0, nil); err != nil { // zero-length keepalive
+		t.Fatal(err)
+	}
+
+	dr := newDownlinkReader(io.NopCloser(bytes.NewReader(wire.Bytes())))
+	got, err := io.ReadAll(dr)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("round-trip mismatch: got %d bytes, want %d bytes", len(got), len(want))
+	}
+}
+
+// TestDownlinkReaderByteAtATime exercises frame reassembly across arbitrary read
+// boundaries by reading a single byte at a time.
+func TestDownlinkReaderByteAtATime(t *testing.T) {
+	var wire bytes.Buffer
+	dw := newDownlinkWriter(testWriteCloser{&wire})
+	if err := dw.keepAlive(0, []byte("pad")); err != nil {
+		t.Fatal(err)
+	}
+	payload := bytes.Repeat([]byte("xyz"), 5000)
+	if _, err := dw.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := dw.keepAlive(0, []byte("pad2")); err != nil {
+		t.Fatal(err)
+	}
+
+	dr := newDownlinkReader(io.NopCloser(bytes.NewReader(wire.Bytes())))
+	var got []byte
+	one := make([]byte, 1)
+	for {
+		n, err := dr.Read(one)
+		got = append(got, one[:n]...)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("byte-at-a-time mismatch: got %d want %d", len(got), len(payload))
+	}
+}
+
+// TestDownlinkReaderUnknownFrame ensures the reader rejects unknown frame types
+// instead of silently corrupting the stream.
+func TestDownlinkReaderUnknownFrame(t *testing.T) {
+	wire := []byte{0x7f, 0x00, 0x01, 0x00} // type=0x7f, len=1, payload=0x00
+	dr := newDownlinkReader(io.NopCloser(bytes.NewReader(wire)))
+	if _, err := dr.Read(make([]byte, 16)); err == nil {
+		t.Fatal("expected error for unknown frame type, got nil")
+	}
+}
+
+// TestDownlinkReaderCleanEOF ensures EOF exactly at a frame boundary surfaces as
+// a clean io.EOF.
+func TestDownlinkReaderCleanEOF(t *testing.T) {
+	var wire bytes.Buffer
+	dw := newDownlinkWriter(testWriteCloser{&wire})
+	if _, err := dw.Write([]byte("done")); err != nil {
+		t.Fatal(err)
+	}
+	dr := newDownlinkReader(io.NopCloser(bytes.NewReader(wire.Bytes())))
+	buf := make([]byte, 4)
+	n, err := dr.Read(buf)
+	if err != nil && err != io.EOF {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if string(buf[:n]) != "done" {
+		t.Fatalf("got %q, want %q", buf[:n], "done")
+	}
+	if _, err := dr.Read(buf); err != io.EOF {
+		t.Fatalf("expected io.EOF at boundary, got %v", err)
+	}
+}

--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -383,6 +383,28 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 			conn.reader = currentSession.uploadQueue
 		}
 
+		if h.config.DownlinkKeepAliveEnabled() {
+			dw := newDownlinkWriter(httpSC)
+			conn.writer = dw
+			scStreamDownServerSecs := h.config.ScStreamDownServerSecs
+			go func() {
+				for {
+					interval := time.Duration(max(1, scStreamDownServerSecs.rand())) * time.Second
+					select {
+					case <-request.Context().Done():
+						return
+					case <-httpSC.Wait():
+						return
+					case <-time.After(interval):
+					}
+					padding := bytes.Repeat([]byte{'X'}, int(h.config.GetNormalizedXPaddingBytes().rand()))
+					if err := dw.keepAlive(interval, padding); err != nil {
+						return
+					}
+				}
+			}()
+		}
+
 		h.ln.addConn(stat.Connection(&conn))
 
 		// "A ResponseWriter may not be used after [Handler.ServeHTTP] has returned."


### PR DESCRIPTION
Refs #4846.

## Motivation

XHTTP's server→client ("download") leg is a single long-lived HTTP response whose body is a **raw** byte stream. Many CDNs / reverse proxies keep an **idle** streaming response open only for a limited time and then cut it (Cloudflare's documented limit is 100s; some edges are much shorter). Traffic that sends a request and then waits quietly for a delayed or server-pushed response — interactive apps, long-poll, anything that idles between messages — gets its download stream torn down during the quiet window; the session then looks dead and the app times out. Continuous/bulk traffic never idles long enough to trip it, which is why this only bites some workloads.

There is no server→client keepalive in any XHTTP mode today:

- the download branch in `hub.go` writes response headers, flushes once, then blocks on `select{ctx.Done()/Wait()}`; bytes flow only on real proxied data;
- `scStreamUpServerSecs` writes padding into the **uplink POST's** response — a different stream, discarded by the client — so it can't keep the download alive;
- the client reads the download as a raw stream (`resp.Body`), so injecting keepalive bytes into it would corrupt the tunnel;
- the edge→origin hop is frequently HTTP/1.1, so there's no byte-less HTTP/2 frame to lean on — a keepalive has to be **real bytes** the client can identify and strip.

This is exactly the prerequisite named in #4846:

> Once there's a custom downlink wrapping format, HTTP downlink can stay alive, won't be cut off by CDN's 100s inactivity.

This PR adds that minimal wrapping format and uses it for keepalive. It is intentionally scoped to keepalive; the broader #4846 goals (multi-path downlink aggregation, retransmission, ACK/connection-migration) are **out of scope** and the frame `type` space is left open for them.

## What it does

A new opt-in `xhttpSettings` field **`scStreamDownServerSecs`** (RangeConfig, mirroring `scStreamUpServerSecs`):

- **Unset / `To == 0` (default): OFF.** The download stays a raw byte stream, **byte-for-byte identical** to current releases. Zero behavior change.
- **Set on both ends:** the server wraps the download body in a minimal length-prefixed frame format and emits a keepalive frame whenever the download has been idle for the (randomised) interval; the client strips the framing. The value is the server keepalive interval in seconds (a range → jitter); choose it below the intermediary's idle-cut threshold. Like `mode` / padding, it must match on both ends.

### Wire format (download body, when enabled)

```
+--------+-----------------+==========================+
| type   | length (uint16) | payload (length bytes)   |
| 1 byte | big-endian      |                          |
+--------+-----------------+==========================+
  type 0x00 DATA       payload = proxied downlink bytes
  type 0x01 KEEPALIVE  payload = padding, discarded by the client
```

Only the response **body** is framed; HTTP status / headers are unchanged. The keepalive is **idle-gated** — an active download carries zero keepalive overhead — and the goroutine mirrors the existing `scStreamUpServerSecs` goroutine idiom, exiting promptly on request-context cancel / stream close.

## Changes

- `transport/internet/splithttp/downlink.go` (new): frame constants, `downlinkWriter` (server encode + idle-gated keepalive), `downlinkReader` (client decode / strip). Plus `downlink_test.go` (round-trip, >64KB chunking, byte-at-a-time reassembly, unknown-type rejection, clean EOF).
- `hub.go`: in the download branch, when enabled, wrap `conn.writer` and start the keepalive goroutine.
- `client.go`: wrap the `!uploadOnly` download `resp.Body` (one site covers packet-up, stream-up and stream-one downlinks).
- `config.proto` / `config.pb.go`, `config.go` (`DownlinkKeepAliveEnabled()`), `infra/conf/transport_internet.go` (JSON field).

(The larger line counts in `config.pb.go` and `transport_internet.go` are gofmt re-aligning the struct-tag column because the new field name is longer than the alignment width — no logic there.)

## Back-compat

OFF by default and gated on `ScStreamDownServerSecs != nil && To > 0`, so both proto- and JSON-built configs default to OFF and are unchanged. Enabling requires setting the field on **both** ends (documented). Browser-dialer downlink uses a separate read path and is out of scope (don't enable it there).

## Evidence

Measured against a real caching CDN edge that force-buffers and **idle-cuts the XHTTP download at ~30s** (edge→origin was plain HTTP/1.1, so the keepalive frames are visible on the wire). One request whose response is deliberately delayed 40s (download idle 40s), 5 concurrent tunnels, classified by whether the post-idle response arrived:

| path | keepalive | 40s-idle response |
|------|-----------|-------------------|
| direct (no CDN) | off | **3/3 arrive** (t≈40s) |
| via the CDN edge | off | **0/5 arrive — cut at t≈30s** |
| via the CDN edge | **on** | **5/5 arrive** (t≈40s) |

Direct proves the origin / xray never cuts an idle download; via-edge-OFF reproduces the CDN idle-cut (stock behavior); via-edge-ON fixes it. A short (3s) request survives in all cases, confirming framing doesn't disturb normal traffic.

Wire capture on the edge→origin hop during the 40s idle (plain HTTP, so the keepalive frames are in cleartext) — origin→edge packets:

```
t+0s   len=107,197   request setup + response headers
t+5s   len=13        keepalive
t+7s   len=12        keepalive
t+9s   len=13        keepalive
t+7s   len=15        keepalive
t+5s   len=11        keepalive
t+7s   len=14        keepalive
t+5s   len=151       the delayed response (arrives at t≈40s)
```

Six keepalive frames at 5–10s (the configured randomised interval) held the edge's ~30s idle timer off; the response then arrived intact.

## Notes for review

- The format is deliberately minimal and forward-compatible via the `type` byte; happy to align the wire format with your broader "multi-path downlink" / packet-down plans for #4846 (SEQ / ACK / retransmission frame types), or to change naming / placement — this PR only intends to land the keepalive primitive that #4846 identifies as the first payoff of a downlink wrapping format.
- `downlinkWriter.Write` currently allocates + copies each frame to emit header and payload in one write; a small buffer pool is an easy follow-up if the throughput of the enabled path matters.