### PR TITLE
Observatory: Support per-outbound probeUrl override

### DIFF
--- a/app/observatory/burst/burstobserver.go
+++ b/app/observatory/burst/burstobserver.go
@@ -99,7 +99,7 @@ func New(ctx context.Context, config *Config) (*Observer, error) {
 	if err != nil {
 		return nil, errors.New("Cannot get depended features").Base(err)
 	}
-	hp := NewHealthPing(ctx, dispatcher, config.PingConfig)
+	hp := NewHealthPing(ctx, outboundManager, dispatcher, config.PingConfig)
 	return &Observer{
 		config: config,
 		ctx:    ctx,

--- a/app/observatory/burst/healthping.go
+++ b/app/observatory/burst/healthping.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/xtls/xray-core/common/dice"
 	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/features/outbound"
 	"github.com/xtls/xray-core/features/routing"
 )
 
@@ -28,6 +29,7 @@ type HealthPing struct {
 	ctx           context.Context
 	cancelCtx     context.CancelFunc
 	cancelPending atomic.Pointer[context.CancelFunc]
+	ohm           outbound.Manager
 	dispatcher    routing.Dispatcher
 	access        sync.Mutex
 	ticker        *time.Ticker
@@ -37,7 +39,7 @@ type HealthPing struct {
 }
 
 // NewHealthPing creates a new HealthPing with settings
-func NewHealthPing(ctx context.Context, dispatcher routing.Dispatcher, config *HealthPingConfig) *HealthPing {
+func NewHealthPing(ctx context.Context, ohm outbound.Manager, dispatcher routing.Dispatcher, config *HealthPingConfig) *HealthPing {
 	settings := &HealthPingSettings{}
 	if config != nil {
 
@@ -81,6 +83,7 @@ func NewHealthPing(ctx context.Context, dispatcher routing.Dispatcher, config *H
 	return &HealthPing{
 		ctx:        ctx,
 		cancelCtx:  cancel,
+		ohm:        ohm,
 		dispatcher: dispatcher,
 		Settings:   settings,
 		Results:    nil,
@@ -171,10 +174,18 @@ func (h *HealthPing) doCheck(ctx context.Context, tags []string, duration time.D
 	timers := make([]*time.Timer, 0, count)
 	for _, tag := range tags {
 		handler := tag
+		dest := h.Settings.Destination
+		if h.ohm != nil {
+			if ob := h.ohm.GetHandler(handler); ob != nil {
+				if p, ok := ob.(outbound.ProbeURLProvider); ok && p.ProbeURL() != "" {
+					dest = p.ProbeURL()
+				}
+			}
+		}
 		client := newPingClient(
 			h.ctx,
 			h.dispatcher,
-			h.Settings.Destination,
+			dest,
 			h.Settings.Timeout,
 			handler,
 		)

--- a/app/observatory/observer.go
+++ b/app/observatory/observer.go
@@ -127,7 +127,7 @@ func (o *Observer) clearRemovedOutbounds(outbounds []string) {
 	o.status = pruned
 }
 
-func (o *Observer) probe(outbound string) ProbeResult {
+func (o *Observer) probe(tag string) ProbeResult {
 	errorCollectorForRequest := newErrorCollector()
 
 	httpTransport := http.Transport{
@@ -143,7 +143,7 @@ func (o *Observer) probe(outbound string) ProbeResult {
 					return errors.New("cannot understand address").Base(err)
 				}
 				trackedCtx := session.TrackedConnectionError(o.ctx, errorCollectorForRequest)
-				conn, err := tagged.Dialer(trackedCtx, o.dispatcher, dest, outbound)
+				conn, err := tagged.Dialer(trackedCtx, o.dispatcher, dest, tag)
 				if err != nil {
 					return errors.New("cannot dial remote address ", dest).Base(err)
 				}
@@ -165,13 +165,19 @@ func (o *Observer) probe(outbound string) ProbeResult {
 		Jar:     nil,
 		Timeout: time.Second * 5,
 	}
+	probeURL := "https://www.google.com/generate_204"
+	if o.config.ProbeUrl != "" {
+		probeURL = o.config.ProbeUrl
+	}
+	if h := o.ohm.GetHandler(tag); h != nil {
+		if p, ok := h.(outbound.ProbeURLProvider); ok && p.ProbeURL() != "" {
+			probeURL = p.ProbeURL()
+		}
+	}
+
 	var GETTime time.Duration
 	err := task.Run(o.ctx, func() error {
 		startTime := time.Now()
-		probeURL := "https://www.google.com/generate_204"
-		if o.config.ProbeUrl != "" {
-			probeURL = o.config.ProbeUrl
-		}
 		req, _ := http.NewRequest(http.MethodGet, probeURL, nil)
 		utils.TryDefaultHeadersWith(req.Header, "nav")
 		response, err := httpClient.Do(req)
@@ -186,11 +192,11 @@ func (o *Observer) probe(outbound string) ProbeResult {
 		return nil
 	})
 	if err != nil {
-		errorMessage := "the outbound " + outbound + " is dead: GET request failed:" + err.Error() + "with outbound handler report underlying connection failed"
+		errorMessage := "the outbound " + tag + " is dead: GET request failed:" + err.Error() + "with outbound handler report underlying connection failed"
 		errors.LogInfoInner(o.ctx, errorCollectorForRequest.UnderlyingError(), errorMessage)
 		return ProbeResult{Alive: false, LastErrorReason: errorMessage}
 	}
-	errors.LogInfo(o.ctx, "the outbound ", outbound, " is alive:", GETTime.Seconds())
+	errors.LogInfo(o.ctx, "the outbound ", tag, " is alive:", GETTime.Seconds())
 	return ProbeResult{Alive: true, Delay: GETTime.Milliseconds()}
 }
 

--- a/app/proxyman/outbound/handler.go
+++ b/app/proxyman/outbound/handler.go
@@ -69,6 +69,7 @@ type Handler struct {
 	udp443          string
 	uplinkCounter   stats.Counter
 	downlinkCounter stats.Counter
+	probeURL        string
 }
 
 // NewHandler creates a new Handler based on the given configuration.
@@ -80,6 +81,7 @@ func NewHandler(ctx context.Context, config *core.OutboundHandlerConfig) (outbou
 		outboundManager: v.GetFeature(outbound.ManagerType()).(outbound.Manager),
 		uplinkCounter:   uplinkCounter,
 		downlinkCounter: downlinkCounter,
+		probeURL:        config.ProbeUrl,
 	}
 
 	if config.SenderSettings != nil {
@@ -175,6 +177,11 @@ func NewHandler(ctx context.Context, config *core.OutboundHandlerConfig) (outbou
 // Tag implements outbound.Handler.
 func (h *Handler) Tag() string {
 	return h.tag
+}
+
+// ProbeURL implements outbound.ProbeURLProvider.
+func (h *Handler) ProbeURL() string {
+	return h.probeURL
 }
 
 // Dispatch implements proxy.Outbound.Dispatch.

--- a/core/config.pb.go
+++ b/core/config.pb.go
@@ -178,7 +178,10 @@ type OutboundHandlerConfig struct {
 	// If not zero, this outbound will be expired in seconds. Not used for now.
 	Expire int64 `protobuf:"varint,4,opt,name=expire,proto3" json:"expire,omitempty"`
 	// Comment of this outbound handler. Not used for now.
-	Comment       string `protobuf:"bytes,5,opt,name=comment,proto3" json:"comment,omitempty"`
+	Comment string `protobuf:"bytes,5,opt,name=comment,proto3" json:"comment,omitempty"`
+	// URL used by observatories to health-check this outbound.
+	// Overrides the observatory's global probe URL / destination for this outbound only.
+	ProbeUrl      string `protobuf:"bytes,6,opt,name=probe_url,json=probeUrl,proto3" json:"probe_url,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -248,6 +251,13 @@ func (x *OutboundHandlerConfig) GetComment() string {
 	return ""
 }
 
+func (x *OutboundHandlerConfig) GetProbeUrl() string {
+	if x != nil {
+		return x.ProbeUrl
+	}
+	return ""
+}
+
 var File_core_config_proto protoreflect.FileDescriptor
 
 const file_core_config_proto_rawDesc = "" +
@@ -261,13 +271,14 @@ const file_core_config_proto_rawDesc = "" +
 	"\x14InboundHandlerConfig\x12\x10\n" +
 	"\x03tag\x18\x01 \x01(\tR\x03tag\x12M\n" +
 	"\x11receiver_settings\x18\x02 \x01(\v2 .xray.common.serial.TypedMessageR\x10receiverSettings\x12G\n" +
-	"\x0eproxy_settings\x18\x03 \x01(\v2 .xray.common.serial.TypedMessageR\rproxySettings\"\xef\x01\n" +
+	"\x0eproxy_settings\x18\x03 \x01(\v2 .xray.common.serial.TypedMessageR\rproxySettings\"\x8c\x02\n" +
 	"\x15OutboundHandlerConfig\x12\x10\n" +
 	"\x03tag\x18\x01 \x01(\tR\x03tag\x12I\n" +
 	"\x0fsender_settings\x18\x02 \x01(\v2 .xray.common.serial.TypedMessageR\x0esenderSettings\x12G\n" +
 	"\x0eproxy_settings\x18\x03 \x01(\v2 .xray.common.serial.TypedMessageR\rproxySettings\x12\x16\n" +
 	"\x06expire\x18\x04 \x01(\x03R\x06expire\x12\x18\n" +
-	"\acomment\x18\x05 \x01(\tR\acommentB=\n" +
+	"\acomment\x18\x05 \x01(\tR\acomment\x12\x1b\n" +
+	"\tprobe_url\x18\x06 \x01(\tR\bprobeUrlB=\n" +
 	"\rcom.xray.coreP\x01Z\x1egithub.com/xtls/xray-core/core\xaa\x02\tXray.Coreb\x06proto3"
 
 var (

--- a/core/config.proto
+++ b/core/config.proto
@@ -54,4 +54,7 @@ message OutboundHandlerConfig {
   int64 expire = 4;
   // Comment of this outbound handler. Not used for now.
   string comment = 5;
+  // URL used by observatories to health-check this outbound.
+  // Overrides the observatory's global probe URL / destination for this outbound only.
+  string probe_url = 6;
 }

--- a/features/outbound/outbound.go
+++ b/features/outbound/outbound.go
@@ -24,6 +24,13 @@ type HandlerSelector interface {
 	Select([]string) []string
 }
 
+// ProbeURLProvider is an optional interface for outbound handlers that have a
+// per-outbound health-check URL. Observatories use it to override their global
+// probe URL / destination for the specific outbound.
+type ProbeURLProvider interface {
+	ProbeURL() string
+}
+
 // Manager is a feature that manages outbound.Handlers.
 //
 // xray:api:stable

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -218,6 +218,7 @@ type OutboundDetourConfig struct {
 	ProxySettings  *ProxyConfig     `json:"proxySettings"`
 	MuxSettings    *MuxConfig       `json:"mux"`
 	TargetStrategy string           `json:"targetStrategy"`
+	ProbeURL       string           `json:"probeUrl,omitempty"`
 }
 
 func (c *OutboundDetourConfig) checkChainProxyConfig() error {
@@ -332,6 +333,7 @@ func (c *OutboundDetourConfig) Build() (*core.OutboundHandlerConfig, error) {
 		SenderSettings: serial.ToTypedMessage(senderSettings),
 		Tag:            c.Tag,
 		ProxySettings:  serial.ToTypedMessage(ts),
+		ProbeUrl:       c.ProbeURL,
 	}, nil
 }
 

--- a/infra/conf/xray_test.go
+++ b/infra/conf/xray_test.go
@@ -356,3 +356,29 @@ func TestConfig_Override(t *testing.T) {
 		})
 	}
 }
+
+func TestOutboundDetourConfig_ProbeURL(t *testing.T) {
+	c := &OutboundDetourConfig{}
+	common.Must(json.Unmarshal([]byte(`{
+		"protocol": "freedom",
+		"tag": "node-a",
+		"probeUrl": "https://node-a.internal/client/ping"
+	}`), c))
+
+	handler, err := c.Build()
+	common.Must(err)
+
+	if handler.ProbeUrl != "https://node-a.internal/client/ping" {
+		t.Errorf("OutboundHandlerConfig.ProbeUrl = %q, want %q", handler.ProbeUrl, "https://node-a.internal/client/ping")
+	}
+
+	// Round-trip through the wire format: a stale generated descriptor would
+	// silently drop the field here even though direct struct access above works.
+	wire, err := proto.Marshal(handler)
+	common.Must(err)
+	roundTripped := &core.OutboundHandlerConfig{}
+	common.Must(proto.Unmarshal(wire, roundTripped))
+	if roundTripped.ProbeUrl != handler.ProbeUrl {
+		t.Errorf("ProbeUrl did not survive proto wire round-trip: got %q, want %q", roundTripped.ProbeUrl, handler.ProbeUrl)
+	}
+}

--- a/testing/scenarios/observatory_test.go
+++ b/testing/scenarios/observatory_test.go
@@ -1,0 +1,180 @@
+package scenarios
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/xtls/xray-core/app/commander"
+	"github.com/xtls/xray-core/app/dispatcher"
+	"github.com/xtls/xray-core/app/observatory"
+	obscmd "github.com/xtls/xray-core/app/observatory/command"
+	"github.com/xtls/xray-core/app/proxyman"
+	"github.com/xtls/xray-core/common"
+	"github.com/xtls/xray-core/common/serial"
+	core "github.com/xtls/xray-core/core"
+	"github.com/xtls/xray-core/proxy/freedom"
+	v2httptest "github.com/xtls/xray-core/testing/servers/http"
+	"github.com/xtls/xray-core/testing/servers/tcp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// TestObservatoryPerOutboundProbeURL exercises the per-outbound ProbeUrl
+// override (config.proto field 6 / observer.go): two outbounds each expose
+// their own "self" health-check endpoint, and the plain (non-burst)
+// Observatory must probe each outbound against its own URL instead of the
+// Observatory-level global one.
+func TestObservatoryPerOutboundProbeURL(t *testing.T) {
+	var hitsA, hitsB atomic.Int32
+
+	portA := tcp.PickPort()
+	mockA := &v2httptest.Server{
+		Port: portA,
+		PathHandler: map[string]http.HandlerFunc{
+			"/ping-a": func(w http.ResponseWriter, r *http.Request) {
+				hitsA.Add(1)
+				w.WriteHeader(http.StatusNoContent)
+			},
+		},
+	}
+	_, err := mockA.Start()
+	common.Must(err)
+	defer mockA.Close()
+
+	portB := tcp.PickPort()
+	mockB := &v2httptest.Server{
+		Port: portB,
+		PathHandler: map[string]http.HandlerFunc{
+			"/ping-b": func(w http.ResponseWriter, r *http.Request) {
+				hitsB.Add(1)
+				w.WriteHeader(http.StatusNoContent)
+			},
+		},
+	}
+	_, err = mockB.Start()
+	common.Must(err)
+
+	cmdPort := tcp.PickPort()
+
+	config := &core.Config{
+		App: []*serial.TypedMessage{
+			// Dispatcher/inbound/outbound managers must be registered before
+			// Observatory: Observer.New() resolves its outbound.Manager and
+			// routing.Dispatcher dependencies via RequireFeatures, which only
+			// resolves synchronously if they're already present — otherwise
+			// the deferred callback fires after New() has already returned,
+			// silently leaving the Observer's manager/dispatcher nil. This
+			// matches the ordering infra/conf.Config.Build() always uses in
+			// real JSON-driven configs.
+			serial.ToTypedMessage(&dispatcher.Config{}),
+			serial.ToTypedMessage(&proxyman.InboundConfig{}),
+			serial.ToTypedMessage(&proxyman.OutboundConfig{}),
+			serial.ToTypedMessage(&observatory.Config{
+				SubjectSelector: []string{"node-"},
+				// Deliberately unroutable: if the per-outbound override were
+				// ignored, both outbounds would be probed against this and
+				// (wrongly) reported dead instead of using their own URL.
+				ProbeUrl:          "http://127.0.0.1:1/should-never-be-hit",
+				ProbeInterval:     int64(2 * time.Second),
+				EnableConcurrency: true,
+			}),
+			serial.ToTypedMessage(&commander.Config{
+				Tag:    "api",
+				Listen: fmt.Sprintf("127.0.0.1:%d", cmdPort),
+				Service: []*serial.TypedMessage{
+					serial.ToTypedMessage(&obscmd.Config{}),
+				},
+			}),
+		},
+		Outbound: []*core.OutboundHandlerConfig{
+			{
+				Tag:           "node-a",
+				ProxySettings: serial.ToTypedMessage(&freedom.Config{FinalRules: []*freedom.FinalRuleConfig{{Action: freedom.RuleAction_Allow}}}),
+				ProbeUrl:      fmt.Sprintf("http://127.0.0.1:%d/ping-a", portA),
+			},
+			{
+				Tag:           "node-b",
+				ProxySettings: serial.ToTypedMessage(&freedom.Config{FinalRules: []*freedom.FinalRuleConfig{{Action: freedom.RuleAction_Allow}}}),
+				ProbeUrl:      fmt.Sprintf("http://127.0.0.1:%d/ping-b", portB),
+			},
+		},
+	}
+
+	servers, err := InitializeServerConfigs(config)
+	common.Must(err)
+	defer CloseAllServers(servers)
+
+	cmdConn, err := grpc.Dial(fmt.Sprintf("127.0.0.1:%d", cmdPort), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+	common.Must(err)
+	defer cmdConn.Close()
+	obsClient := obscmd.NewObservatoryServiceClient(cmdConn)
+
+	statusByTag := func() map[string]*observatory.OutboundStatus {
+		resp, err := obsClient.GetOutboundStatus(context.Background(), &obscmd.GetOutboundStatusRequest{})
+		common.Must(err)
+		m := make(map[string]*observatory.OutboundStatus)
+		for _, s := range resp.Status.Status {
+			m[s.OutboundTag] = s
+		}
+		return m
+	}
+
+	// Wait for at least one probe cycle (interval is 2s).
+	deadline := time.Now().Add(15 * time.Second)
+	var status map[string]*observatory.OutboundStatus
+	for time.Now().Before(deadline) {
+		status = statusByTag()
+		if status["node-a"] != nil && status["node-b"] != nil && status["node-a"].Alive && status["node-b"].Alive {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	if status["node-a"] == nil || !status["node-a"].Alive {
+		reason := ""
+		if status["node-a"] != nil {
+			reason = status["node-a"].LastErrorReason
+		}
+		t.Fatalf("node-a expected alive via its own probeUrl, got status %+v, reason: %s", status["node-a"], reason)
+	}
+	if status["node-b"] == nil || !status["node-b"].Alive {
+		reason := ""
+		if status["node-b"] != nil {
+			reason = status["node-b"].LastErrorReason
+		}
+		t.Fatalf("node-b expected alive via its own probeUrl, got status %+v, reason: %s", status["node-b"], reason)
+	}
+	if hitsA.Load() == 0 {
+		t.Error("expected node-a's own probe endpoint (/ping-a) to receive at least one request")
+	}
+	if hitsB.Load() == 0 {
+		t.Error("expected node-b's own probe endpoint (/ping-b) to receive at least one request")
+	}
+
+	// Break node-a's own endpoint only; node-b must stay alive, proving the
+	// two outbounds are health-checked independently rather than off one
+	// shared URL.
+	mockA.Close()
+
+	deadline = time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		status = statusByTag()
+		if status["node-a"] != nil && !status["node-a"].Alive {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	if status["node-a"] == nil || status["node-a"].Alive {
+		t.Errorf("expected node-a to be marked dead after its own probe endpoint stopped, got %+v", status["node-a"])
+	}
+	if status["node-b"] == nil || !status["node-b"].Alive {
+		t.Errorf("expected node-b to remain alive while only node-a's endpoint was down, got %+v", status["node-b"])
+	}
+
+	mockB.Close()
+}


### PR DESCRIPTION
### Summary
- Observatory and BurstObservatory probe every selected outbound against one shared `probeUrl`/`destination`. That works for a generic internet-reachability check, but not for a node pool behind a `leastPing` balancer, where you want each outbound checked against itself (e.g. a `/ping` endpoint the node serves), not a third-party URL
- a single shared probe URL is also a single point of failure: if it goes down or gets rate-limited, every outbound in the pool is reported dead at once, regardless of the outbounds' actual state
- adds an optional `probeUrl` field on the outbound handler config (`outbounds[].probeUrl` in JSON). If set, Observatory/BurstObservatory use it instead of their own global probe URL for that one outbound; if unset, behavior is unchanged
- outbound handlers optionally implement a new `outbound.ProbeURLProvider` interface (`ProbeURL() string`) to expose the override, so this doesn't touch the `outbound.Handler`/`outbound.Manager` interfaces

Closes the same need as #4962 (per-group `probeUrl`/`probeInterval`), which was closed because turning `ObservatoryObject` into an array would break existing configs. Attaching `probeUrl` to the outbound instead is purely additive - no existing config's behavior changes.

### Example
```json
"outbounds": [
  { "tag": "node-nl", "protocol": "vless", "probeUrl": "https://node-nl.example/ping", "settings": {} },
  { "tag": "node-kz", "protocol": "vless", "probeUrl": "https://node-kz.example/ping", "settings": {} }
]
```

### Tests
- `go test ./app/observatory/... ./app/proxyman/outbound/... ./infra/conf/...`
- added `TestOutboundDetourConfig_ProbeURL` (`infra/conf/xray_test.go`): json -> `OutboundHandlerConfig` -> protobuf marshal/unmarshal round trip
- added `TestObservatoryPerOutboundProbeURL` (`testing/scenarios/observatory_test.go`): spins up a real xray instance with two outbounds and two local mock ping endpoints via the gRPC `ObservatoryService`, confirms each outbound is probed on its own URL and gets marked dead independently when only its own endpoint goes down
- `go build ./...`, `go vet ./...` clean