### PR TITLE
Skip REALITY non-443 warning for local inbounds

### DIFF
--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -173,7 +173,10 @@ func (c *InboundDetourConfig) Build() (*core.InboundHandlerConfig, error) {
 			return nil, err
 		}
 		receiverSettings.StreamSettings = ss
-		if strings.Contains(ss.SecurityType, "reality") && (receiverSettings.PortList == nil ||
+		realityOnLocalAddress := c.ListenOn != nil &&
+			((c.ListenOn.Family().IsIP() && c.ListenOn.IP().IsLoopback()) ||
+				(c.ListenOn.Family().IsDomain() && c.ListenOn.Domain() == "localhost"))
+		if strings.Contains(ss.SecurityType, "reality") && !realityOnLocalAddress && (receiverSettings.PortList == nil ||
 			len(receiverSettings.PortList.Ports()) != 1 || receiverSettings.PortList.Ports()[0] != 443) {
 			errors.LogWarning(context.Background(), `REALITY: Listening on non-443 ports may get your IP blocked by the GFW`)
 		}


### PR DESCRIPTION
Currently Xray warns when a REALITY inbound listens on a non-443 port, even if the inbound is bound only to loopback, such as `127.0.0.1:10000` or `localhost:10000`. In this setup the port is not exposed publicly and may be used behind a local L4/TLS frontend.

This change keeps the warning for public/non-local listeners, but skips it when the inbound listen address is loopback or `localhost`.