### PR TITLE
docs: remove Hey from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,6 @@
   - [v2rayN](https://github.com/2dust/v2rayN)
   - [GenyConnect](https://github.com/genyleap/GenyConnect)
   - [OneXray](https://github.com/OneXray/OneXray)
-- HarmonyOS
-  - [Hey](https://github.com/popsiclelmlm/Hey)
 
 ## Others that support VLESS, XTLS, REALITY, XUDP, PLUX...
 


### PR DESCRIPTION
Remove the HarmonyOS section and the Hey entry from README.

The Hey client is temporarily unavailable due to technical issues.