### PR TITLE
TLS client: Support more `cipherSuites` for "unsafe" (golang) `fingerprint` for anti-NIN

### DIFF
--- a/transport/internet/tls/config.go
+++ b/transport/internet/tls/config.go
@@ -450,9 +450,13 @@ func (c *Config) GetTLSConfig(opts ...Option) *tls.Config {
 		for _, s := range tls.CipherSuites() {
 			id[s.Name] = s.ID
 		}
+		for _, s := range tls.InsecureCipherSuites() {
+			id[s.Name] = s.ID
+		}
 		for n := range strings.SplitSeq(c.CipherSuites, ":") {
-			if id[n] != 0 {
-				config.CipherSuites = append(config.CipherSuites, id[n])
+			n = strings.TrimSpace(n)
+			if v, ok := id[n]; ok {
+				config.CipherSuites = append(config.CipherSuites, v)
 			}
 		}
 	}

--- a/transport/internet/tls/tls.go
+++ b/transport/internet/tls/tls.go
@@ -147,6 +147,11 @@ func GeneraticUClient(c net.Conn, config *tls.Config) *utls.UConn {
 }
 
 func copyConfig(c *tls.Config) *utls.Config {
+	curvePreferences := make([]utls.CurveID, 0, len(c.CurvePreferences))
+	for _, curve := range c.CurvePreferences {
+		curvePreferences = append(curvePreferences, utls.CurveID(curve))
+	}
+
 	config := &utls.Config{
 		Rand:                           c.Rand,
 		RootCAs:                        c.RootCAs,
@@ -156,6 +161,10 @@ func copyConfig(c *tls.Config) *utls.Config {
 		KeyLogWriter:                   c.KeyLogWriter,
 		EncryptedClientHelloConfigList: c.EncryptedClientHelloConfigList,
 		NextProtos:                     c.NextProtos,
+		CipherSuites:                   c.CipherSuites,
+		MinVersion:                     c.MinVersion,
+		MaxVersion:                     c.MaxVersion,
+		CurvePreferences:               curvePreferences,
 	}
 	return config
 }

--- a/transport/internet/tls/tls.go
+++ b/transport/internet/tls/tls.go
@@ -147,11 +147,6 @@ func GeneraticUClient(c net.Conn, config *tls.Config) *utls.UConn {
 }
 
 func copyConfig(c *tls.Config) *utls.Config {
-	curvePreferences := make([]utls.CurveID, 0, len(c.CurvePreferences))
-	for _, curve := range c.CurvePreferences {
-		curvePreferences = append(curvePreferences, utls.CurveID(curve))
-	}
-
 	config := &utls.Config{
 		Rand:                           c.Rand,
 		RootCAs:                        c.RootCAs,
@@ -161,10 +156,6 @@ func copyConfig(c *tls.Config) *utls.Config {
 		KeyLogWriter:                   c.KeyLogWriter,
 		EncryptedClientHelloConfigList: c.EncryptedClientHelloConfigList,
 		NextProtos:                     c.NextProtos,
-		CipherSuites:                   c.CipherSuites,
-		MinVersion:                     c.MinVersion,
-		MaxVersion:                     c.MaxVersion,
-		CurvePreferences:               curvePreferences,
 	}
 	return config
 }


### PR DESCRIPTION
Weirdly, if you use python-tls-fingerprint, you can bypass dpi even on the most restrictive ISPs in Iran.
and for now to imitate python-tls-fingerprint, you just need to imitate it's cipherSuites (of course, the fragment also needs to be set up correctly so that cipherSuites is read by GFW but not SNI)

but even python-3.14.6-default-tls uses some cipherSuites that are listed in go-crypto/tls-InsecureCipherSuites.
so to imitate python-tls-fingerprint, you need to be able to use "InsecureCipherSuites" as well.

~The word "InsecureCipherSuites" is a bit confusing. actually, they are not insecure, they are just obsolete and generally not recommended.~

///
to be more precise, they only allowed python-tls-cipherSuites, which means the first 13 cipher should be almost identical to the first 13 in python-cipherSuites (with a few exceptions), for example the 13th-cipher must be "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 (0xc027)", otherwise dpi cannot be bypassed.

also, utls does not have python-fingerprint and none of the other fingerprints, even the old ones, have this feature, so we have to use tls with custom-cipherSuites.