### PR TITLE
feat(mux): add 'drop' option for xudpProxyUDP443 to prevent IP leak in TUN mode

### DIFF
--- a/app/proxyman/outbound/handler.go
+++ b/app/proxyman/outbound/handler.go
@@ -6,6 +6,7 @@ import (
 	goerrors "errors"
 	"io"
 	"math/big"
+	"time"
 
 	"github.com/xtls/xray-core/common/dice"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/xtls/xray-core/common/net/cnc"
 	"github.com/xtls/xray-core/common/serial"
 	"github.com/xtls/xray-core/common/session"
+	"github.com/xtls/xray-core/common/signal"
 	"github.com/xtls/xray-core/core"
 	"github.com/xtls/xray-core/features/outbound"
 	"github.com/xtls/xray-core/features/policy"
@@ -222,6 +224,19 @@ func (h *Handler) Dispatch(ctx context.Context, link *transport.Link) {
 			switch h.udp443 {
 			case "reject":
 				test(errors.New("XUDP rejected UDP/443 traffic").AtInfo())
+				return
+			case "drop":
+				errors.LogInfo(ctx, "XUDP dropped UDP/443 traffic")
+				ctx, cancel := context.WithCancel(ctx)
+				timer := signal.CancelAfterInactivity(ctx, func() {
+					cancel()
+				}, time.Duration(30+dice.Roll(61))*time.Second)
+				go func() {
+					buf.Copy(link.Reader, buf.Discard, buf.UpdateActivity(timer))
+					<-ctx.Done()
+					common.Interrupt(link.Writer)
+					common.Interrupt(link.Reader)
+				}()
 				return
 			case "skip":
 				goto out

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -110,7 +110,7 @@ func (m *MuxConfig) Build() (*proxyman.MultiplexingConfig, error) {
 	switch m.XudpProxyUDP443 {
 	case "":
 		m.XudpProxyUDP443 = "reject"
-	case "reject", "allow", "skip":
+	case "reject", "allow", "skip", "drop":
 	default:
 		return nil, errors.New(`unknown "xudpProxyUDP443": `, m.XudpProxyUDP443)
 	}


### PR DESCRIPTION
### What does this PR do?
Adds a new `"drop"` option to `xudpProxyUDP443` in the Mux configuration to silently consume UDP 443 (QUIC) packets instead of abruptly rejecting them.

### Why is this needed? (The Bug)
Currently, when `xudpProxyUDP443` is set to `"reject"`, the outbound handler abruptly returns an error and interrupts the reader/writer. 
In VPN / TUN environments (e.g. Windows/Android TUN mode clients), when the OS network stack receives a sudden connection rejection or ICMP port unreachable for UDP, it assumes the TUN interface is broken for that destination. The OS then performs an automatic fallback to the physical network interface (e.g., Wi-Fi / Cellular). 

This OS-level behavior bypasses the proxy entirely, causing the user's real IP address (e.g. in Iran or China) to be leaked for blocked QUIC traffic.

### How does this fix it?
By setting `"xudpProxyUDP443": "drop"`, the UDP traffic is silently consumed and discarded (similar to the `blackhole` proxy mechanism) using `buf.Discard` with an inactivity timeout. 
Because the connection is dropped silently rather than rejected, the OS does not trigger a network fallback. Instead, the browser's QUIC connection simply times out, forcing it to gracefully fall back to TCP 443 (HTTPS), which is then safely routed through the proxy tunnel without any IP leaks.

### Changes:
- `infra/conf/xray.go`: Added `"drop"` to the valid switch cases for `xudpProxyUDP443`.
- `app/proxyman/outbound/handler.go`: Added the `"drop"` case which copies the `link.Reader` to `buf.Discard` using `signal.CancelAfterInactivity` to prevent goroutine leaks.