### PR TITLE
HTTPUpgrade server: Keep accepting after transient errors as RAW does; Add handshake read deadline as WS does

### DIFF
--- a/transport/internet/httpupgrade/hub.go
+++ b/transport/internet/httpupgrade/hub.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/tls"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -44,11 +45,11 @@ func (s *server) Handle(conn net.Conn) {
 
 // upgrade execute a fake websocket upgrade process and return the available connection
 func (s *server) upgrade(conn net.Conn) (stat.Connection, error) {
-	// Don't let a connection that never finishes its handshake hold a
-	// goroutine and an fd forever. Same limit as the websocket listener's
-	// ReadHeaderTimeout.
+	// timeout and header limit are the same as websocket
 	conn.SetReadDeadline(time.Now().Add(time.Second * 4))
-	connReader := bufio.NewReader(conn)
+	defer conn.SetReadDeadline(time.Time{})
+	connReader := bufio.NewReader(io.LimitReader(conn, 12288))
+
 	req, err := http.ReadRequest(connReader)
 	if err != nil {
 		return nil, err
@@ -92,7 +93,6 @@ func (s *server) upgrade(conn net.Conn) (stat.Connection, error) {
 	}
 	remoteAddr = http_proto.ApplyTrustedXForwardedFor(req.Header, trustedXFF, remoteAddr)
 
-	conn.SetReadDeadline(time.Time{})
 	return stat.Connection(newConnection(conn, remoteAddr)), nil
 }
 
@@ -100,11 +100,6 @@ func (s *server) keepAccepting() {
 	for {
 		conn, err := s.innnerListener.Accept()
 		if err != nil {
-			// Exiting on a transient error such as EMFILE would leave the
-			// listening socket open but never accepted again: the backlog
-			// fills up and every new connection to this inbound times out
-			// until the process is restarted. Only stop when the listener
-			// is closed, like the TCP listener does.
 			errStr := err.Error()
 			if strings.Contains(errStr, "closed") {
 				break

--- a/transport/internet/httpupgrade/hub.go
+++ b/transport/internet/httpupgrade/hub.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/errors"
@@ -43,6 +44,10 @@ func (s *server) Handle(conn net.Conn) {
 
 // upgrade execute a fake websocket upgrade process and return the available connection
 func (s *server) upgrade(conn net.Conn) (stat.Connection, error) {
+	// Don't let a connection that never finishes its handshake hold a
+	// goroutine and an fd forever. Same limit as the websocket listener's
+	// ReadHeaderTimeout.
+	conn.SetReadDeadline(time.Now().Add(time.Second * 4))
 	connReader := bufio.NewReader(conn)
 	req, err := http.ReadRequest(connReader)
 	if err != nil {
@@ -87,6 +92,7 @@ func (s *server) upgrade(conn net.Conn) (stat.Connection, error) {
 	}
 	remoteAddr = http_proto.ApplyTrustedXForwardedFor(req.Header, trustedXFF, remoteAddr)
 
+	conn.SetReadDeadline(time.Time{})
 	return stat.Connection(newConnection(conn, remoteAddr)), nil
 }
 
@@ -94,7 +100,20 @@ func (s *server) keepAccepting() {
 	for {
 		conn, err := s.innnerListener.Accept()
 		if err != nil {
-			return
+			// Exiting on a transient error such as EMFILE would leave the
+			// listening socket open but never accepted again: the backlog
+			// fills up and every new connection to this inbound times out
+			// until the process is restarted. Only stop when the listener
+			// is closed, like the TCP listener does.
+			errStr := err.Error()
+			if strings.Contains(errStr, "closed") {
+				break
+			}
+			errors.LogWarningInner(context.Background(), err, "failed to accept raw connections")
+			if strings.Contains(errStr, "too many") {
+				time.Sleep(time.Millisecond * 500)
+			}
+			continue
 		}
 		go s.Handle(conn)
 	}


### PR DESCRIPTION
not ai

On a few busy servers behind a CDN we kept hitting a state where the httpupgrade inbound goes deaf: the process is fine, the port still shows LISTEN, but nothing gets accepted anymore and every new connection times out until xray is restarted. All other inbounds on the same instance keep working. Took a while to hunt down because nothing gets logged when it happens.

Two things in the httpupgrade hub cause it, and they feed each other:

1. `keepAccepting()` returns on any `Accept()` error. Under fd pressure `Accept()` returns "too many open files", the loop exits silently, and since the listening socket is still open the kernel keeps queueing SYNs into a backlog nobody drains. The port looks alive but every connection hangs. The tcp listener already handles this case (log, short sleep on EMFILE, continue), and ws is safe too since net/http's Serve retries temporary errors. httpupgrade is the only listener that gives up.

2. The upgrade handshake has no read deadline, so a connection that never sends a complete request holds a goroutine and an fd forever. On a public server that junk piles up and is exactly what builds the fd pressure for point 1.

This PR copies the tcp listener's accept loop behavior (only stop when the listener is closed) and puts a 4 second read deadline on the handshake, same value the ws listener uses for ReadHeaderTimeout. The deadline is cleared when the connection is handed over.

Seen in production on nodes proxying traffic through Cloudflare and nginx into this inbound, the port went deaf every day or two under load. `go test ./transport/internet/httpupgrade/` passes with the change.


This image is for some servers only with vless-hu-tls-cdn
<img width="2546" height="1080" alt="image" src="https://github.com/user-attachments/assets/8fe9bd61-9b3f-4b9a-bc3c-f8acea0397a7" />
