### PR TITLE
Fix(stats): handle concurrent registration races

### DIFF
--- a/app/stats/stats.go
+++ b/app/stats/stats.go
@@ -40,7 +40,9 @@ func (m *Manager) RegisterCounter(name string) (stats.Counter, error) {
 	defer m.access.Unlock()
 
 	if _, found := m.counters[name]; found {
-		return nil, errors.New("Counter ", name, " already registered.")
+		return nil, errors.New(
+			"Counter ", name, " already registered.",
+		).Base(stats.ErrAlreadyRegistered)
 	}
 	errors.LogDebug(context.Background(), "create new counter ", name)
 	c := new(Counter)
@@ -89,7 +91,9 @@ func (m *Manager) RegisterOnlineMap(name string) (stats.OnlineMap, error) {
 	defer m.access.Unlock()
 
 	if _, found := m.onlineMaps[name]; found {
-		return nil, errors.New("OnlineMap ", name, " already registered.")
+		return nil, errors.New(
+			"OnlineMap ", name, " already registered.",
+		).Base(stats.ErrAlreadyRegistered)
 	}
 	errors.LogDebug(context.Background(), "create new OnlineMap ", name)
 	om := NewOnlineMap()
@@ -138,14 +142,19 @@ func (m *Manager) RegisterChannel(name string) (stats.Channel, error) {
 	defer m.access.Unlock()
 
 	if _, found := m.channels[name]; found {
-		return nil, errors.New("Channel ", name, " already registered.")
+		return nil, errors.New(
+			"Channel ", name, " already registered.",
+		).Base(stats.ErrAlreadyRegistered)
 	}
 	errors.LogDebug(context.Background(), "create new channel ", name)
 	c := NewChannel(&ChannelConfig{BufferSize: 64, Blocking: false})
-	m.channels[name] = c
 	if m.running {
-		return c, c.Start()
+		if err := c.Start(); err != nil {
+			return nil, err
+		}
 	}
+
+	m.channels[name] = c
 	return c, nil
 }
 

--- a/features/stats/stats.go
+++ b/features/stats/stats.go
@@ -8,6 +8,8 @@ import (
 	"github.com/xtls/xray-core/features"
 )
 
+var ErrAlreadyRegistered = errors.New("already registered")
+
 // Counter is the interface for stats counters.
 //
 // xray:api:stable
@@ -112,32 +114,68 @@ type Manager interface {
 
 // GetOrRegisterCounter tries to get the StatCounter first. If not exist, it then tries to create a new counter.
 func GetOrRegisterCounter(m Manager, name string) (Counter, error) {
-	counter := m.GetCounter(name)
-	if counter != nil {
-		return counter, nil
-	}
+	for {
+		counter := m.GetCounter(name)
+		if counter != nil {
+			return counter, nil
+		}
 
-	return m.RegisterCounter(name)
+		counter, err := m.RegisterCounter(name)
+		if err == nil {
+			return counter, nil
+		}
+
+		if !errors.AllEqual(ErrAlreadyRegistered, err) {
+			return counter, err
+		}
+
+		// Get here because another goroutine registered it between Get and Register.
+		// Let's retry.
+	}
 }
 
 // GetOrRegisterOnlineMap tries to get the OnlineMap first. If not exist, it then tries to create a new OnlineMap.
 func GetOrRegisterOnlineMap(m Manager, name string) (OnlineMap, error) {
-	onlineMap := m.GetOnlineMap(name)
-	if onlineMap != nil {
-		return onlineMap, nil
-	}
+	for {
+		onlineMap := m.GetOnlineMap(name)
+		if onlineMap != nil {
+			return onlineMap, nil
+		}
 
-	return m.RegisterOnlineMap(name)
+		onlineMap, err := m.RegisterOnlineMap(name)
+		if err == nil {
+			return onlineMap, nil
+		}
+
+		if !errors.AllEqual(ErrAlreadyRegistered, err) {
+			return onlineMap, err
+		}
+
+		// Get here because another goroutine registered it between Get and Register.
+		// Let's retry.
+	}
 }
 
 // GetOrRegisterChannel tries to get the StatChannel first. If not exist, it then tries to create a new channel.
 func GetOrRegisterChannel(m Manager, name string) (Channel, error) {
-	channel := m.GetChannel(name)
-	if channel != nil {
-		return channel, nil
-	}
+	for {
+		channel := m.GetChannel(name)
+		if channel != nil {
+			return channel, nil
+		}
 
-	return m.RegisterChannel(name)
+		channel, err := m.RegisterChannel(name)
+		if err == nil {
+			return channel, nil
+		}
+
+		if !errors.AllEqual(ErrAlreadyRegistered, err) {
+			return channel, err
+		}
+
+		// Get here because another goroutine registered it between Get and Register.
+		// Let's retry.
+	}
 }
 
 // ManagerType returns the type of Manager interface. Can be used to implement common.HasType.


### PR DESCRIPTION
## Issue

Fix concurrent registration races in the stats `GetOrRegister*` helpers.

Previously, multiple goroutines could observe that the same counter, online map,
or channel was missing and then attempt to register it concurrently. The losing
goroutine would receive an `already registered` error instead of returning the
object created by the winning goroutine.

## Solution

### Adopted

Retry the complete get-or-register sequence when registration fails with
`ErrAlreadyRegistered`.

### Alternative solution

The `Manager` interface is marked as stable, so this change keeps the existing
interface unchanged.

If changing the interface is acceptable, a cleaner solution would be to add an
atomic `Ensure*` or `GetOrRegister*` operation to `Manager` and implement the
lookup and creation under a single write lock. The retry approach used here
preserves compatibility with existing `Manager` implementations while fixing
the current race.