### PR TITLE
TLS client: Pinning CA must have `serverName` (or higher-priority `verifyPeerCertByName` or outbound's `address`) for `pinnedPeerCertSha256`

### DIFF
--- a/transport/internet/grpc/dial.go
+++ b/transport/internet/grpc/dial.go
@@ -136,10 +136,7 @@ func getGrpcClient(ctx context.Context, dest net.Destination, streamSettings *in
 				}
 
 				if tlsConfig != nil {
-					config := tlsConfig.GetTLSConfig()
-					if config.ServerName == "" && address.Family().IsDomain() {
-						config.ServerName = address.Domain()
-					}
+					config := tlsConfig.GetTLSConfig(tls.WithDestination(dest))
 					if fingerprint := tls.GetFingerprint(tlsConfig.Fingerprint); fingerprint != nil {
 						return tls.UClient(c, config, fingerprint), nil
 					} else { // Fallback to normal gRPC TLS

--- a/transport/internet/hysteria/dialer.go
+++ b/transport/internet/hysteria/dialer.go
@@ -345,7 +345,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 			c = &client{
 				dest:           dest,
 				config:         streamSettings.ProtocolSettings.(*Config),
-				tlsConfig:      tlsConfig.GetTLSConfig(),
+				tlsConfig:      tlsConfig.GetTLSConfig(tls.WithDestination(dest)),
 				socketConfig:   streamSettings.SocketSettings,
 				udpmaskManager: streamSettings.UdpmaskManager,
 				quicParams:     streamSettings.QuicParams,

--- a/transport/internet/tls/config.go
+++ b/transport/internet/tls/config.go
@@ -331,6 +331,9 @@ func (r *RandCarrier) verifyPeerCert(rawCerts [][]byte, verifiedChains [][]*x509
 	}
 
 	if verifyResult == foundCA { // if found CA, we need to verify here
+		if len(r.Config.ServerName) == 0 {
+			return errors.New("Pinning CA needs a valid ServerName")
+		}
 		opts := x509.VerifyOptions{
 			Roots:         CAs,
 			CurrentTime:   time.Now(),


### PR DESCRIPTION
修正一下验证逻辑