### PR TITLE
Proxyman: Fix shared inbound proxy ownership

### DIFF
--- a/app/proxyman/inbound/worker.go
+++ b/app/proxyman/inbound/worker.go
@@ -149,20 +149,10 @@ func (w *tcpWorker) Start() error {
 }
 
 func (w *tcpWorker) Close() error {
-	var errs []interface{}
-	if w.hub != nil {
-		if err := common.Close(w.hub); err != nil {
-			errs = append(errs, err)
-		}
-		if err := common.Close(w.proxy); err != nil {
-			errs = append(errs, err)
-		}
+	if w.hub == nil {
+		return nil
 	}
-	if len(errs) > 0 {
-		return errors.New("failed to close all resources").Base(errors.New(serial.Concat(errs...)))
-	}
-
-	return nil
+	return common.Close(w.hub)
 }
 
 func (w *tcpWorker) Port() net.Port {
@@ -448,10 +438,6 @@ func (w *udpWorker) Close() error {
 		}
 	}
 
-	if err := common.Close(w.proxy); err != nil {
-		errs = append(errs, err)
-	}
-
 	if len(errs) > 0 {
 		return errors.New("failed to close all resources").Base(errors.New(serial.Concat(errs...)))
 	}
@@ -535,20 +521,10 @@ func (w *dsWorker) Start() error {
 }
 
 func (w *dsWorker) Close() error {
-	var errs []interface{}
-	if w.hub != nil {
-		if err := common.Close(w.hub); err != nil {
-			errs = append(errs, err)
-		}
-		if err := common.Close(w.proxy); err != nil {
-			errs = append(errs, err)
-		}
+	if w.hub == nil {
+		return nil
 	}
-	if len(errs) > 0 {
-		return errors.New("failed to close all resources").Base(errors.New(serial.Concat(errs...)))
-	}
-
-	return nil
+	return common.Close(w.hub)
 }
 
 func IsLocal(ip net.IP) bool {


### PR DESCRIPTION
`AlwaysOnInboundHandler` creates a single inbound proxy and shares it with all TCP, UDP, and Unix workers created for that handler.

The worker shutdown paths currently close this shared proxy, while `AlwaysOnInboundHandler.Close` also closes it after closing the workers. As a result, the same proxy may be closed multiple times, with the exact number depending on the configured networks and port ranges.


## Motivation

Inbound proxy implementations are not required to support repeated or concurrent `Close` calls. Even when a particular implementation happens to tolerate repeated closure, the lifetime of one shared proxy should not depend on the number of workers created for an inbound.

This also establishes the ownership boundary needed for a future graceful shutdown path, where `AlwaysOnInboundHandler` can stop worker listeners independently, drain existing connections, and close the shared inbound proxy only after the drain completes.