### PR TITLE
splithttp: bind sendThrough=origin to the real per-connection local IP

### DIFF
--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -373,11 +373,23 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 			Reader:         request.Body,
 			ResponseWriter: writer,
 		}
+		// Use the concrete local address this request actually arrived on,
+		// not the listener's wildcard address (e.g. "[::]" / "0.0.0.0"). Go's
+		// net/http stores the per-connection local address in the request
+		// context under LocalAddrContextKey. Without this, sendThrough "origin"
+		// (which derives the outbound gateway from inbound.Local) reads the
+		// wildcard and pins every connection's egress to a single address,
+		// breaking source-in-source-out on multi-IP hosts. Fall back to the
+		// listener address when the key is absent (e.g. HTTP/3).
+		localAddr := h.localAddr
+		if la, ok := request.Context().Value(http.LocalAddrContextKey).(net.Addr); ok && la != nil {
+			localAddr = la
+		}
 		conn := splitConn{
 			writer:     httpSC,
 			reader:     httpSC,
 			remoteAddr: remoteAddr,
-			localAddr:  h.localAddr,
+			localAddr:  localAddr,
 		}
 		if sessionId != "" { // if not stream-one
 			conn.reader = currentSession.uploadQueue

--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -373,14 +373,6 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 			Reader:         request.Body,
 			ResponseWriter: writer,
 		}
-		// Use the concrete local address this request actually arrived on,
-		// not the listener's wildcard address (e.g. "[::]" / "0.0.0.0"). Go's
-		// net/http stores the per-connection local address in the request
-		// context under LocalAddrContextKey. Without this, sendThrough "origin"
-		// (which derives the outbound gateway from inbound.Local) reads the
-		// wildcard and pins every connection's egress to a single address,
-		// breaking source-in-source-out on multi-IP hosts. Fall back to the
-		// listener address when the key is absent (e.g. HTTP/3).
 		localAddr := h.localAddr
 		if la, ok := request.Context().Value(http.LocalAddrContextKey).(net.Addr); ok && la != nil {
 			localAddr = la


### PR DESCRIPTION
### Problem

With `sendThrough: "origin"` (source-in-source-out), the outbound gateway is derived from `inbound.Local`, which is set from `conn.LocalAddr()` of the accepted connection (`app/proxyman/inbound/worker.go`).

For the **XHTTP (splithttp)** inbound, every accepted connection's `LocalAddr` is set to `h.localAddr`, which is the **listener** address (`l.listener.Addr()`). On a wildcard listener that is the unspecified address (`[::]` or `0.0.0.0`).

Consequences on a multi-IP host:

- `sendThrough: origin` reads the wildcard `[::]` for every connection, so all egress is bound to a single (often IPv6) source address regardless of which local IP the client actually connected to — source-in-source-out silently stops working.
- On hosts whose `[::]` has no route, the outbound fails entirely: the REALITY handshake and VLESS tunnel come up, but no data flows (`network is unreachable`).

TCP inbounds are unaffected because `worker.go` already uses the real `conn.LocalAddr()`; only XHTTP substitutes the listener address.

### Fix

Read the concrete per-connection local address from the request context via `http.LocalAddrContextKey`, which `net/http` populates with the address the client actually connected to. Fall back to the listener address when the key is absent (e.g. HTTP/3, where `net/http` does not set it), preserving current behavior there.

### Verification

Confirmed under HTTP/2 on a wildcard `[::]` listener that `request.Context().Value(http.LocalAddrContextKey)` returns the concrete IP the client connected to (different entry IP → different value), whereas `l.listener.Addr()` is always `[::]`.

End-to-end on a 5-IP host running `sendThrough: origin` + VLESS/REALITY/XHTTP: before the patch all egress bound `[::]` (broken on a host without IPv6 route); after the patch each entry IP egresses via the matching source IP (`.38→.38`, `.49→.49`, …), all reachable.
