### PR TITLE
Fix cross-instance system dialer state corruption

### DIFF
--- a/app/observatory/burst/burstobserver.go
+++ b/app/observatory/burst/burstobserver.go
@@ -3,6 +3,7 @@ package burst
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/xtls/xray-core/app/observatory"
 	"github.com/xtls/xray-core/common"
@@ -21,6 +22,7 @@ type Observer struct {
 
 	statusLock sync.Mutex
 	hp         *HealthPing
+	updates    extension.ObservatoryUpdateDispatcher
 
 	finished *done.Instance
 
@@ -29,6 +31,21 @@ type Observer struct {
 
 func (o *Observer) GetObservation(ctx context.Context) (proto.Message, error) {
 	return &observatory.ObservationResult{Status: o.createResult()}, nil
+}
+
+func (o *Observer) SubscribeObservationUpdates(listener func()) func() {
+	return o.updates.SubscribeObservationUpdates(listener)
+}
+
+func (o *Observer) ObservationProbeDeadline() time.Duration {
+	if o.hp == nil || o.hp.Settings == nil || o.hp.Settings.Timeout <= 0 {
+		return 0
+	}
+	deadline := o.hp.Settings.Timeout
+	if o.hp.Settings.Connectivity != "" {
+		deadline += o.hp.Settings.Timeout
+	}
+	return deadline
 }
 
 func (o *Observer) Check(tag []string) {
@@ -100,12 +117,14 @@ func New(ctx context.Context, config *Config) (*Observer, error) {
 		return nil, errors.New("Cannot get depended features").Base(err)
 	}
 	hp := NewHealthPing(ctx, dispatcher, config.PingConfig)
-	return &Observer{
+	observer := &Observer{
 		config: config,
 		ctx:    ctx,
 		ohm:    outboundManager,
 		hp:     hp,
-	}, nil
+	}
+	hp.onUpdate = observer.updates.NotifyObservationUpdate
+	return observer, nil
 }
 
 func init() {

--- a/app/observatory/burst/healthping.go
+++ b/app/observatory/burst/healthping.go
@@ -34,6 +34,7 @@ type HealthPing struct {
 
 	Settings *HealthPingSettings
 	Results  map[string]*HealthPingRTTS
+	onUpdate func()
 }
 
 // NewHealthPing creates a new HealthPing with settings
@@ -233,7 +234,6 @@ func (h *HealthPing) doCheck(ctx context.Context, tags []string, duration time.D
 // PutResult put a ping rtt to results
 func (h *HealthPing) PutResult(tag string, rtt time.Duration) {
 	h.access.Lock()
-	defer h.access.Unlock()
 	if h.Results == nil {
 		h.Results = make(map[string]*HealthPingRTTS)
 	}
@@ -248,13 +248,17 @@ func (h *HealthPing) PutResult(tag string, rtt time.Duration) {
 		h.Results[tag] = r
 	}
 	r.Put(rtt)
+	h.access.Unlock()
+	if h.onUpdate != nil {
+		h.onUpdate()
+	}
 }
 
 // Cleanup removes results of removed handlers,
 // tags should be all valid tags of the Balancer now
 func (h *HealthPing) Cleanup(tags []string) {
 	h.access.Lock()
-	defer h.access.Unlock()
+	changed := false
 	for tag := range h.Results {
 		found := false
 		for _, v := range tags {
@@ -265,7 +269,12 @@ func (h *HealthPing) Cleanup(tags []string) {
 		}
 		if !found {
 			delete(h.Results, tag)
+			changed = true
 		}
+	}
+	h.access.Unlock()
+	if changed && h.onUpdate != nil {
+		h.onUpdate()
 	}
 }
 

--- a/app/observatory/burst/healthping_update_test.go
+++ b/app/observatory/burst/healthping_update_test.go
@@ -1,0 +1,31 @@
+package burst
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestHealthPingNotifiesAfterResultUpdate(t *testing.T) {
+	healthPing := NewHealthPing(context.Background(), nil, nil)
+	updates := 0
+	healthPing.onUpdate = func() { updates++ }
+
+	healthPing.PutResult("proxy-a", 42*time.Millisecond)
+
+	if updates != 1 {
+		t.Fatalf("updates = %d, want 1", updates)
+	}
+}
+
+func TestBurstObserverReportsConfiguredProbeDeadline(t *testing.T) {
+	observer := &Observer{hp: &HealthPing{Settings: &HealthPingSettings{Timeout: 30 * time.Second}}}
+	if got, want := observer.ObservationProbeDeadline(), 30*time.Second; got != want {
+		t.Fatalf("probe deadline = %v, want %v", got, want)
+	}
+
+	observer.hp.Settings.Connectivity = "https://example.com/generate_204"
+	if got, want := observer.ObservationProbeDeadline(), 60*time.Second; got != want {
+		t.Fatalf("probe deadline with connectivity check = %v, want %v", got, want)
+	}
+}

--- a/app/observatory/observer.go
+++ b/app/observatory/observer.go
@@ -31,6 +31,7 @@ type Observer struct {
 
 	statusLock sync.Mutex
 	status     []*OutboundStatus
+	updates    extension.ObservatoryUpdateDispatcher
 
 	finished *done.Instance
 
@@ -38,8 +39,38 @@ type Observer struct {
 	dispatcher routing.Dispatcher
 }
 
+const probeRequestTimeout = 5 * time.Second
+
 func (o *Observer) GetObservation(ctx context.Context) (proto.Message, error) {
-	return &ObservationResult{Status: o.status}, nil
+	o.statusLock.Lock()
+	defer o.statusLock.Unlock()
+	status := make([]*OutboundStatus, 0, len(o.status))
+	for _, item := range o.status {
+		status = append(status, proto.Clone(item).(*OutboundStatus))
+	}
+	return &ObservationResult{Status: status}, nil
+}
+
+func (o *Observer) SubscribeObservationUpdates(listener func()) func() {
+	return o.updates.SubscribeObservationUpdates(listener)
+}
+
+func (o *Observer) ObservationProbeDeadline() time.Duration {
+	if o.config == nil || o.config.EnableConcurrency {
+		return probeRequestTimeout
+	}
+
+	interval := 10 * time.Second
+	if o.config.ProbeInterval != 0 {
+		interval = time.Duration(o.config.ProbeInterval)
+	}
+	count := 1
+	if selector, ok := o.ohm.(outbound.HandlerSelector); ok {
+		if selected := selector.Select(o.config.SubjectSelector); len(selected) > 0 {
+			count = len(selected)
+		}
+	}
+	return time.Duration(count)*probeRequestTimeout + time.Duration(count-1)*interval
 }
 
 func (o *Observer) Type() interface{} {
@@ -114,10 +145,11 @@ func (o *Observer) background() {
 
 func (o *Observer) clearRemovedOutbounds(outbounds []string) {
 	o.statusLock.Lock()
-	defer o.statusLock.Unlock()
 	if len(o.status) == 0 {
+		o.statusLock.Unlock()
 		return
 	}
+	oldCount := len(o.status)
 	var pruned []*OutboundStatus
 	for _, status := range o.status {
 		if slices.Contains(outbounds, status.OutboundTag) {
@@ -125,6 +157,10 @@ func (o *Observer) clearRemovedOutbounds(outbounds []string) {
 		}
 	}
 	o.status = pruned
+	o.statusLock.Unlock()
+	if len(pruned) != oldCount {
+		o.updates.NotifyObservationUpdate()
+	}
 }
 
 func (o *Observer) probe(outbound string) ProbeResult {
@@ -155,7 +191,7 @@ func (o *Observer) probe(outbound string) ProbeResult {
 			}
 			return connection, nil
 		},
-		TLSHandshakeTimeout: time.Second * 5,
+		TLSHandshakeTimeout: probeRequestTimeout,
 	}
 	httpClient := &http.Client{
 		Transport: &httpTransport,
@@ -163,7 +199,7 @@ func (o *Observer) probe(outbound string) ProbeResult {
 			return http.ErrUseLastResponse
 		},
 		Jar:     nil,
-		Timeout: time.Second * 5,
+		Timeout: probeRequestTimeout,
 	}
 	var GETTime time.Duration
 	err := task.Run(o.ctx, func() error {
@@ -196,7 +232,6 @@ func (o *Observer) probe(outbound string) ProbeResult {
 
 func (o *Observer) updateStatusForResult(outbound string, result *ProbeResult) {
 	o.statusLock.Lock()
-	defer o.statusLock.Unlock()
 	var status *OutboundStatus
 	if location := o.findStatusLocationLockHolderOnly(outbound); location != -1 {
 		status = o.status[location]
@@ -216,6 +251,8 @@ func (o *Observer) updateStatusForResult(outbound string, result *ProbeResult) {
 		status.LastErrorReason = result.LastErrorReason
 		status.Delay = 99999999
 	}
+	o.statusLock.Unlock()
+	o.updates.NotifyObservationUpdate()
 }
 
 func (o *Observer) findStatusLocationLockHolderOnly(outbound string) int {

--- a/app/observatory/observer_test.go
+++ b/app/observatory/observer_test.go
@@ -1,6 +1,34 @@
 package observatory
 
-import "testing"
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestConcurrentObserverReportsInitialProbeDeadline(t *testing.T) {
+	observer := &Observer{config: &Config{EnableConcurrency: true}}
+	if got, want := observer.ObservationProbeDeadline(), 5*time.Second; got != want {
+		t.Fatalf("probe deadline = %v, want %v", got, want)
+	}
+}
+
+func TestObserverNotifiesAfterStatusUpdate(t *testing.T) {
+	observer := &Observer{}
+	updates := 0
+	observer.SubscribeObservationUpdates(func() {
+		updates++
+		if _, err := observer.GetObservation(context.Background()); err != nil {
+			t.Errorf("GetObservation returned an error: %v", err)
+		}
+	})
+
+	observer.updateStatusForResult("proxy-a", &ProbeResult{Alive: true, Delay: 42})
+
+	if updates != 1 {
+		t.Fatalf("updates = %d, want 1", updates)
+	}
+}
 
 func TestObserverUpdateStatusPrunesStaleOutbounds(t *testing.T) {
 	observer := &Observer{

--- a/app/proxyman/outbound/handler.go
+++ b/app/proxyman/outbound/handler.go
@@ -187,7 +187,7 @@ func (h *Handler) Dispatch(ctx context.Context, link *transport.Link) {
 		if ob.Target.Network == net.Network_UDP && ob.OriginalTarget.Address != nil {
 			strategy = strategy.GetDynamicStrategy(ob.OriginalTarget.Address.Family())
 		}
-		ips, err := internet.LookupForIP(ob.Target.Address.Domain(), strategy, nil)
+		ips, err := internet.LookupForIPWithContext(ctx, ob.Target.Address.Domain(), strategy, nil)
 		if err != nil {
 			errors.LogInfoInner(ctx, err, "failed to resolve ip for target ", ob.Target.Address.Domain())
 			if h.senderSettings.TargetStrategy.ForceIP() {

--- a/core/context.go
+++ b/core/context.go
@@ -2,6 +2,10 @@ package core
 
 import (
 	"context"
+
+	"github.com/xtls/xray-core/features/dns"
+	"github.com/xtls/xray-core/features/outbound"
+	"github.com/xtls/xray-core/transport/internet"
 )
 
 // XrayKey is the key type of Instance in Context, exported for test.
@@ -40,6 +44,17 @@ func toContext(ctx context.Context, v *Instance) context.Context {
 	if FromContext(ctx) != v {
 		ctx = context.WithValue(ctx, xrayKey, v)
 	}
+	ctx = internet.ContextWithSystemDialerDependenciesProvider(ctx, func() (dns.Client, outbound.Manager) {
+		var dnsClient dns.Client
+		if feature := v.GetFeature(dns.ClientType()); feature != nil {
+			dnsClient, _ = feature.(dns.Client)
+		}
+		var outboundManager outbound.Manager
+		if feature := v.GetFeature(outbound.ManagerType()); feature != nil {
+			outboundManager, _ = feature.(outbound.Manager)
+		}
+		return dnsClient, outboundManager
+	})
 	return ctx
 }
 

--- a/core/system_dialer_context_test.go
+++ b/core/system_dialer_context_test.go
@@ -68,3 +68,28 @@ func TestSystemDialerDependenciesAreInstanceScoped(t *testing.T) {
 		t.Fatal("closed test instance DNS client unexpectedly remained usable")
 	}
 }
+
+func TestCoreInitializesLegacySystemDialerFallback(t *testing.T) {
+	internet.InitSystemDialer(nil, nil)
+	t.Cleanup(func() {
+		internet.InitSystemDialer(nil, nil)
+	})
+
+	instance, err := New(&Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := instance.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	ips, err := internet.LookupForIP("localhost", internet.DomainStrategy_USE_IP, nil)
+	if err != nil {
+		t.Fatalf("legacy system dialer lookup was not initialized by core construction: %v", err)
+	}
+	if len(ips) == 0 {
+		t.Fatal("legacy system dialer lookup returned no addresses")
+	}
+}

--- a/core/system_dialer_context_test.go
+++ b/core/system_dialer_context_test.go
@@ -1,0 +1,70 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	xnet "github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/features/dns"
+	"github.com/xtls/xray-core/transport/internet"
+)
+
+type instanceDNSClient struct {
+	ip     xnet.IP
+	closed bool
+}
+
+func (*instanceDNSClient) Type() interface{} {
+	return dns.ClientType()
+}
+
+func (*instanceDNSClient) Start() error {
+	return nil
+}
+
+func (c *instanceDNSClient) Close() error {
+	c.closed = true
+	return nil
+}
+
+func (c *instanceDNSClient) LookupIP(string, dns.IPOption) ([]xnet.IP, uint32, error) {
+	if c.closed {
+		return nil, 0, errors.New("DNS client is closed")
+	}
+	return []xnet.IP{c.ip}, dns.DefaultTTL, nil
+}
+
+func TestSystemDialerDependenciesAreInstanceScoped(t *testing.T) {
+	mainDNS := &instanceDNSClient{ip: xnet.ParseIP("192.0.2.1")}
+	testDNS := &instanceDNSClient{ip: xnet.ParseIP("192.0.2.2")}
+	mainInstance := &Instance{}
+	testInstance := &Instance{}
+
+	// Core features retain contexts while the instance is still under
+	// construction, before its DNS client and outbound manager are registered.
+	mainContext := toContext(context.Background(), mainInstance)
+	testContext := toContext(context.Background(), testInstance)
+	if err := mainInstance.AddFeature(mainDNS); err != nil {
+		t.Fatal(err)
+	}
+	if err := testInstance.AddFeature(testDNS); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := testDNS.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	ips, err := internet.LookupForIPWithContext(mainContext, "example.com", internet.DomainStrategy_USE_IP, nil)
+	if err != nil {
+		t.Fatalf("main instance lookup failed after test instance closed: %v", err)
+	}
+	if got, want := ips[0].String(), mainDNS.ip.String(); got != want {
+		t.Fatalf("main instance used the wrong DNS client: got %s, want %s", got, want)
+	}
+
+	if _, err := internet.LookupForIPWithContext(testContext, "example.com", internet.DomainStrategy_USE_IP, nil); err == nil {
+		t.Fatal("closed test instance DNS client unexpectedly remained usable")
+	}
+}

--- a/core/xray.go
+++ b/core/xray.go
@@ -17,7 +17,6 @@ import (
 	"github.com/xtls/xray-core/features/policy"
 	"github.com/xtls/xray-core/features/routing"
 	"github.com/xtls/xray-core/features/stats"
-	"github.com/xtls/xray-core/transport/internet"
 )
 
 // Server is an instance of Xray. At any time, there must be at most one Server instance running.
@@ -227,13 +226,7 @@ func initInstanceWithConfig(config *Config, server *Instance) (bool, error) {
 		}
 	}
 
-	internet.InitSystemDialer(
-		server.GetFeature(dns.ClientType()).(dns.Client),
-		func() outbound.Manager {
-			obm, _ := server.GetFeature(outbound.ManagerType()).(outbound.Manager)
-			return obm
-		}(),
-	)
+	server.ctx = toContext(server.ctx, server)
 
 	server.resolveLock.Lock()
 	if server.pendingResolutions != nil {

--- a/core/xray.go
+++ b/core/xray.go
@@ -17,6 +17,7 @@ import (
 	"github.com/xtls/xray-core/features/policy"
 	"github.com/xtls/xray-core/features/routing"
 	"github.com/xtls/xray-core/features/stats"
+	"github.com/xtls/xray-core/transport/internet"
 )
 
 // Server is an instance of Xray. At any time, there must be at most one Server instance running.
@@ -227,6 +228,13 @@ func initInstanceWithConfig(config *Config, server *Instance) (bool, error) {
 	}
 
 	server.ctx = toContext(server.ctx, server)
+	internet.InitSystemDialer(
+		server.GetFeature(dns.ClientType()).(dns.Client),
+		func() outbound.Manager {
+			obm, _ := server.GetFeature(outbound.ManagerType()).(outbound.Manager)
+			return obm
+		}(),
+	)
 
 	server.resolveLock.Lock()
 	if server.pendingResolutions != nil {

--- a/features/extension/observatory.go
+++ b/features/extension/observatory.go
@@ -2,6 +2,8 @@ package extension
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	"github.com/xtls/xray-core/features"
 	"google.golang.org/protobuf/proto"
@@ -16,6 +18,65 @@ type Observatory interface {
 type BurstObservatory interface {
 	Observatory
 	Check(tag []string)
+}
+
+// ObservatoryUpdateNotifier publishes an event after an observatory result
+// changes. Consumers should query GetObservation or their routing strategy in
+// the callback instead of treating the event itself as a routing decision.
+type ObservatoryUpdateNotifier interface {
+	SubscribeObservationUpdates(listener func()) (unsubscribe func())
+}
+
+// ObservatoryProbeDeadline reports the longest expected time before the
+// initial probe cycle can publish an observation. Callers may use it to bound
+// temporary routing state without expiring that state before the observatory
+// has had a chance to produce a result.
+type ObservatoryProbeDeadline interface {
+	ObservationProbeDeadline() time.Duration
+}
+
+// ObservatoryUpdateDispatcher provides instance-scoped update subscriptions
+// shared by observatory implementations.
+type ObservatoryUpdateDispatcher struct {
+	access    sync.RWMutex
+	nextID    uint64
+	listeners map[uint64]func()
+}
+
+func (d *ObservatoryUpdateDispatcher) SubscribeObservationUpdates(listener func()) func() {
+	if listener == nil {
+		return func() {}
+	}
+	d.access.Lock()
+	if d.listeners == nil {
+		d.listeners = make(map[uint64]func())
+	}
+	id := d.nextID
+	d.nextID++
+	d.listeners[id] = listener
+	d.access.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			d.access.Lock()
+			delete(d.listeners, id)
+			d.access.Unlock()
+		})
+	}
+}
+
+func (d *ObservatoryUpdateDispatcher) NotifyObservationUpdate() {
+	d.access.RLock()
+	listeners := make([]func(), 0, len(d.listeners))
+	for _, listener := range d.listeners {
+		listeners = append(listeners, listener)
+	}
+	d.access.RUnlock()
+
+	for _, listener := range listeners {
+		listener()
+	}
 }
 
 func ObservatoryType() interface{} {

--- a/features/extension/observatory_test.go
+++ b/features/extension/observatory_test.go
@@ -1,0 +1,17 @@
+package extension
+
+import "testing"
+
+func TestObservatoryUpdateDispatcherSubscribeAndUnsubscribe(t *testing.T) {
+	var dispatcher ObservatoryUpdateDispatcher
+	updates := 0
+	unsubscribe := dispatcher.SubscribeObservationUpdates(func() { updates++ })
+
+	dispatcher.NotifyObservationUpdate()
+	unsubscribe()
+	dispatcher.NotifyObservationUpdate()
+
+	if updates != 1 {
+		t.Fatalf("updates = %d, want 1", updates)
+	}
+}

--- a/proxy/freedom/freedom.go
+++ b/proxy/freedom/freedom.go
@@ -292,7 +292,7 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 			if destination.Network == net.Network_UDP && origTargetAddr != nil && outGateway == nil {
 				strategy = strategy.GetDynamicStrategy(origTargetAddr.Family())
 			}
-			ips, err := internet.LookupForIP(dialDest.Address.Domain(), strategy, outGateway)
+			ips, err := internet.LookupForIPWithContext(ctx, dialDest.Address.Domain(), strategy, outGateway)
 			if err != nil {
 				errors.LogInfoInner(ctx, err, "failed to get IP address for domain ", dialDest.Address.Domain())
 				if h.config.DomainStrategy.ForceIP() || h.shouldResolveDomainBeforeFinalRules(dialDest, defaultRule) {
@@ -408,7 +408,7 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 				writer = buf.NewWriter(conn)
 			}
 		} else {
-			writer = NewPacketWriter(conn, h, defaultRule, UDPOverride, destination)
+			writer = NewPacketWriter(ctx, conn, h, defaultRule, UDPOverride, destination)
 			if h.config.Noises != nil {
 				errors.LogDebug(ctx, "NOISE", h.config.Noises)
 				writer = &NoisePacketWriter{
@@ -537,7 +537,7 @@ func (r *PacketReader) ReadMultiBuffer() (buf.MultiBuffer, error) {
 }
 
 // DialDest means the dial target used in the dialer when creating conn
-func NewPacketWriter(conn net.Conn, h *Handler, defaultRule *FinalRule, UDPOverride net.Destination, DialDest net.Destination) buf.Writer {
+func NewPacketWriter(ctx context.Context, conn net.Conn, h *Handler, defaultRule *FinalRule, UDPOverride net.Destination, DialDest net.Destination) buf.Writer {
 	iConn := conn
 	statConn, ok := iConn.(*stat.CounterConnection)
 	if ok {
@@ -555,6 +555,7 @@ func NewPacketWriter(conn net.Conn, h *Handler, defaultRule *FinalRule, UDPOverr
 			resolvedUDPAddr.Store(DialDest.Address.Domain(), net.DestinationFromAddr(conn.RemoteAddr()).Address)
 		}
 		return &PacketWriter{
+			ctx:               ctx,
 			PacketConnWrapper: c,
 			Counter:           counter,
 			Handler:           h,
@@ -569,6 +570,7 @@ func NewPacketWriter(conn net.Conn, h *Handler, defaultRule *FinalRule, UDPOverr
 }
 
 type PacketWriter struct {
+	ctx context.Context
 	*internet.PacketConnWrapper
 	stats.Counter
 	*Handler
@@ -605,7 +607,7 @@ func (w *PacketWriter) WriteMultiBuffer(mb buf.MultiBuffer) error {
 				} else {
 					ShouldUseSystemResolver := true
 					if w.Handler.config.DomainStrategy.HasStrategy() {
-						ips, err := internet.LookupForIP(b.UDP.Address.Domain(), w.Handler.config.DomainStrategy, w.LocalAddr)
+						ips, err := internet.LookupForIPWithContext(w.ctx, b.UDP.Address.Domain(), w.Handler.config.DomainStrategy, w.LocalAddr)
 						if err != nil {
 							// drop packet if resolve failed when forceIP
 							if w.Handler.config.DomainStrategy.ForceIP() {

--- a/transport/internet/dialer.go
+++ b/transport/internet/dialer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/dice"
@@ -80,11 +81,57 @@ func DestIpAddress() net.IP {
 }
 
 var (
-	dnsClient dns.Client
-	obm       outbound.Manager
+	defaultSystemDialerDependencies     systemDialerDependencies
+	defaultSystemDialerDependenciesLock sync.RWMutex
 )
 
-func LookupForIP(domain string, strategy DomainStrategy, localAddr net.Address) ([]net.IP, error) {
+type systemDialerDependencies struct {
+	dnsClient       dns.Client
+	outboundManager outbound.Manager
+}
+
+type systemDialerDependenciesContextKey struct{}
+
+type systemDialerDependenciesProvider func() systemDialerDependencies
+
+// ContextWithSystemDialerDependencies binds instance-owned dialer dependencies
+// to ctx. It is an internal API used by core to keep concurrent instances from
+// overwriting each other's DNS client and outbound manager.
+func ContextWithSystemDialerDependencies(ctx context.Context, dc dns.Client, om outbound.Manager) context.Context {
+	return context.WithValue(ctx, systemDialerDependenciesContextKey{}, systemDialerDependencies{
+		dnsClient:       dc,
+		outboundManager: om,
+	})
+}
+
+// ContextWithSystemDialerDependenciesProvider binds a lazy dependency provider
+// to ctx. It is an internal API used while a core instance is still being built.
+func ContextWithSystemDialerDependenciesProvider(ctx context.Context, provider func() (dns.Client, outbound.Manager)) context.Context {
+	return context.WithValue(ctx, systemDialerDependenciesContextKey{}, systemDialerDependenciesProvider(func() systemDialerDependencies {
+		dc, om := provider()
+		return systemDialerDependencies{dnsClient: dc, outboundManager: om}
+	}))
+}
+
+func systemDialerDependenciesFromContext(ctx context.Context) systemDialerDependencies {
+	if ctx != nil {
+		switch dependencies := ctx.Value(systemDialerDependenciesContextKey{}).(type) {
+		case systemDialerDependencies:
+			return dependencies
+		case systemDialerDependenciesProvider:
+			return dependencies()
+		}
+	}
+
+	defaultSystemDialerDependenciesLock.RLock()
+	defer defaultSystemDialerDependenciesLock.RUnlock()
+	return defaultSystemDialerDependencies
+}
+
+// LookupForIPWithContext resolves a domain with the DNS client owned by the
+// Xray instance in ctx.
+func LookupForIPWithContext(ctx context.Context, domain string, strategy DomainStrategy, localAddr net.Address) ([]net.IP, error) {
+	dnsClient := systemDialerDependenciesFromContext(ctx).dnsClient
 	if dnsClient == nil {
 		return nil, errors.New("DNS client not initialized").AtError()
 	}
@@ -106,6 +153,12 @@ func LookupForIP(domain string, strategy DomainStrategy, localAddr net.Address) 
 		return nil, dns.ErrEmptyResponse
 	}
 	return ips, err
+}
+
+// LookupForIP resolves a domain with the process-wide fallback DNS client.
+// Instance code should use LookupForIPWithContext instead.
+func LookupForIP(domain string, strategy DomainStrategy, localAddr net.Address) ([]net.IP, error) {
+	return LookupForIPWithContext(context.Background(), domain, strategy, localAddr)
 }
 
 func redirect(ctx context.Context, dst net.Destination, obt string, h outbound.Handler) net.Conn {
@@ -253,7 +306,7 @@ func DialSystem(ctx context.Context, dest net.Destination, sockopt *SocketConfig
 		if outboundName == "freedom" && dest.Network == net.Network_UDP && origTargetAddr != nil && src == nil {
 			finalStrategy = finalStrategy.GetDynamicStrategy(origTargetAddr.Family())
 		}
-		ips, err := LookupForIP(dest.Address.Domain(), finalStrategy, src)
+		ips, err := LookupForIPWithContext(ctx, dest.Address.Domain(), finalStrategy, src)
 		if err != nil {
 			errors.LogErrorInner(ctx, err, "failed to resolve ip")
 			if sockopt.DomainStrategy.ForceIP() {
@@ -268,6 +321,7 @@ func DialSystem(ctx context.Context, dest net.Destination, sockopt *SocketConfig
 	}
 
 	if len(sockopt.DialerProxy) > 0 {
+		obm := systemDialerDependenciesFromContext(ctx).outboundManager
 		if obm == nil {
 			return nil, errors.New("there is no outbound manager for dialerProxy").AtError()
 		}
@@ -282,6 +336,10 @@ func DialSystem(ctx context.Context, dest net.Destination, sockopt *SocketConfig
 }
 
 func InitSystemDialer(dc dns.Client, om outbound.Manager) {
-	dnsClient = dc
-	obm = om
+	defaultSystemDialerDependenciesLock.Lock()
+	defaultSystemDialerDependencies = systemDialerDependencies{
+		dnsClient:       dc,
+		outboundManager: om,
+	}
+	defaultSystemDialerDependenciesLock.Unlock()
 }


### PR DESCRIPTION
## Summary

This PR fixes process-global system-dialer state that can be corrupted when an embedding application creates multiple Xray core instances in the same process.

The scope has been deliberately reduced from the original version of this PR. All Observatory update-notification and probe-deadline changes have been removed. The ongoing Observatory work, including APIs intended for outbound probing by third-party embedders, will be presented separately.

This PR now addresses only the cross-instance DNS client and outbound-manager corruption.

## Problem

Some embedding applications currently create more than one `core.Instance` in the same process.

For example, v2rayNG may have:

1. A long-lived core carrying VPN traffic.
2. One or more short-lived cores performing outbound-delay or policy-group tests.

Before this change, construction of every core called `InitSystemDialer`, replacing package-level references to the DNS client and outbound manager.

A temporary test core could therefore overwrite the system-dialer dependencies belonging to the live core. After that temporary core was closed, the live core could continue trying to resolve domains through a closed DNS client or use an outbound manager belonging to the wrong instance.

This can produce partial and inconsistent failures:

- proxied or direct connections may stop working;
- some destinations may continue working while others fail;
- a newly created test core may still pass its own connection tests;
- restarting the live core restores normal operation.

## Root cause

The system dialer stored its DNS client and outbound manager in process-global variables even though those dependencies belong to a particular `core.Instance`.

Internal operations using those globals included:

- system-dialer DNS resolution;
- `dialerProxy` outbound-manager lookup;
- freedom outbound domain resolution;
- freedom UDP packet-writer resolution; and
- proxyman outbound target resolution.

Creating another core replaced the globals for every instance in the process.

## Changes

- Attach a lazy system-dialer dependency provider to each core instance context.
- Add `LookupForIPWithContext` for instance-aware DNS resolution.
- Resolve `dialerProxy` through the outbound manager associated with the current context.
- Propagate instance context through freedom, proxyman, system-dialer, and freedom UDP resolution paths.
- Synchronize the process-wide compatibility fallback.
- Preserve `InitSystemDialer` and `LookupForIP` for callers without an instance context.
- Continue initializing that compatibility fallback during ordinary core construction.
- Add regression coverage demonstrating that closing a temporary instance does not corrupt lookups performed by another instance.
- Add regression coverage for legacy fallback initialization through `core.New`.

## Working principle

Instance-owned internal paths now obtain their DNS client and outbound manager from the current Xray context.

The context contains a lazy provider rather than eagerly captured feature references because contexts are created while an instance may still be under construction. The provider resolves the current DNS client and outbound manager from that specific instance when they are needed.

Starting another core may still update the process-wide compatibility fallback, but it no longer changes the dependencies used by context-aware paths belonging to an existing instance.

Legacy callers without an instance context continue to use the synchronized process-wide fallback.

## Scope and compatibility

- No configuration schema changes.
- Existing `InitSystemDialer` and `LookupForIP` APIs remain available.
- Ordinary single-instance behavior is unchanged.
- This PR does not attempt to define broader lifecycle guarantees for running multiple complete Xray servers in one process.
- It narrowly prevents instance-owned internal dialer paths from being redirected to dependencies belonging to another in-process instance.

## Validation

The affected packages pass:

```text
go test -count=1 \
  ./core \
  ./transport/internet \
  ./app/proxyman/outbound \
  ./proxy/freedom
```