### PR TITLE
TUN inbound: Add `desc` config for Windows ("Wintun" by default)

### DIFF
--- a/infra/conf/transport_security.go
+++ b/infra/conf/transport_security.go
@@ -113,8 +113,10 @@ func (c *REALITYConfig) Build() (proto.Message, error) {
 					config.MinClientVer[i] = byte(u)
 				}
 			}
+			errors.LogWarning(context.Background(), `REALITY: Changing "minClientVer" will increase the likelihood of your server's IP being blocked by the GFW`)
 		} else {
-			config.MinClientVer = []byte{26, 3, 27} // change it at your own risk: https://github.com/XTLS/Xray-core/pull/6181#issuecomment-4567373533
+			config.MinClientVer = []byte{26, 3, 27} // change it at your own risk: https://github.com/XTLS/Xray-core/commit/af7eb68028732a8ee3c0e5d6ab2b8a657bb2e770
+			errors.LogWarning(context.Background(), `REALITY: The default minimal client version is Xray-core v26.3.27, other clients may be refused to connect`)
 		}
 		if c.MaxClientVer != "" {
 			config.MaxClientVer = make([]byte, 3)
@@ -159,8 +161,10 @@ func (c *REALITYConfig) Build() (proto.Message, error) {
 		}
 
 		for _, sn := range config.ServerNames {
-			if strings.Contains(sn, "apple") || strings.Contains(sn, "icloud") {
-				errors.LogWarning(context.Background(), `REALITY: Choosing apple, icloud, etc. as the target may get your IP blocked by the GFW`)
+			sn = strings.ToLower(sn)
+			if strings.HasSuffix(sn, ".ru") || strings.HasSuffix(sn, ".ir") || strings.HasSuffix(sn, ".cn") ||
+				strings.Contains(sn, "apple") || strings.Contains(sn, "icloud") || strings.Contains(sn, "microsoft") {
+				errors.LogWarning(context.Background(), `REALITY: Choosing "`, sn, `" as the target will increase the likelihood of your server's IP being blocked by the GFW`)
 			}
 		}
 

--- a/infra/conf/tun.go
+++ b/infra/conf/tun.go
@@ -13,6 +13,7 @@ import (
 
 type TunConfig struct {
 	Name                   string   `json:"name"`
+	Desc                   string   `json:"desc"`
 	MTU                    uint32   `json:"mtu"`
 	Gateway                []string `json:"gateway"`
 	DNS                    []string `json:"dns"`
@@ -24,6 +25,7 @@ type TunConfig struct {
 func (v *TunConfig) Build() (proto.Message, error) {
 	config := &tun.Config{
 		Name:                   v.Name,
+		Desc:                   v.Desc,
 		MTU:                    v.MTU,
 		Gateway:                v.Gateway,
 		DNS:                    v.DNS,
@@ -43,6 +45,9 @@ func (v *TunConfig) Build() (proto.Message, error) {
 			return nil, err
 		}
 		config.Name = name
+	}
+	if config.Desc == "" {
+		config.Desc = "Wintun"
 	}
 	if config.MTU == 0 {
 		config.MTU = 1500

--- a/proxy/tun/README.md
+++ b/proxy/tun/README.md
@@ -32,11 +32,15 @@ Here is simple Xray config snippet to enable the inbound:
       "protocol": "tun",
       "settings": {
         "name": "xray0",
+        "desc": "Wintun",
         "MTU": 1492
       }
     }
   ],
 ```
+
+`desc` sets the Windows Wintun adapter tunnel type and defaults to `Wintun`.
+It is ignored on other platforms.
 
 ## SUPPORTED FEATURES
 

--- a/proxy/tun/README.md
+++ b/proxy/tun/README.md
@@ -31,9 +31,9 @@ Here is simple Xray config snippet to enable the inbound:
       "port": 0,
       "protocol": "tun",
       "settings": {
-        "name": "xray0",
+        "name": "utun10",
         "desc": "Wintun",
-        "MTU": 1492
+        "mtu": 1500
       }
     }
   ],

--- a/proxy/tun/config.pb.go
+++ b/proxy/tun/config.pb.go
@@ -7,11 +7,12 @@
 package tun
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -30,6 +31,7 @@ type Config struct {
 	UserLevel              uint32                 `protobuf:"varint,5,opt,name=user_level,json=userLevel,proto3" json:"user_level,omitempty"`
 	AutoSystemRoutingTable []string               `protobuf:"bytes,6,rep,name=auto_system_routing_table,json=autoSystemRoutingTable,proto3" json:"auto_system_routing_table,omitempty"`
 	AutoOutboundsInterface string                 `protobuf:"bytes,7,opt,name=auto_outbounds_interface,json=autoOutboundsInterface,proto3" json:"auto_outbounds_interface,omitempty"`
+	Desc                   string                 `protobuf:"bytes,8,opt,name=desc,proto3" json:"desc,omitempty"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
 }
@@ -113,11 +115,18 @@ func (x *Config) GetAutoOutboundsInterface() string {
 	return ""
 }
 
+func (x *Config) GetDesc() string {
+	if x != nil {
+		return x.Desc
+	}
+	return ""
+}
+
 var File_proxy_tun_config_proto protoreflect.FileDescriptor
 
 const file_proxy_tun_config_proto_rawDesc = "" +
 	"\n" +
-	"\x16proxy/tun/config.proto\x12\x0exray.proxy.tun\"\xee\x01\n" +
+	"\x16proxy/tun/config.proto\x12\x0exray.proxy.tun\"\x82\x02\n" +
 	"\x06Config\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n" +
 	"\x03MTU\x18\x02 \x01(\rR\x03MTU\x12\x18\n" +
@@ -126,7 +135,8 @@ const file_proxy_tun_config_proto_rawDesc = "" +
 	"\n" +
 	"user_level\x18\x05 \x01(\rR\tuserLevel\x129\n" +
 	"\x19auto_system_routing_table\x18\x06 \x03(\tR\x16autoSystemRoutingTable\x128\n" +
-	"\x18auto_outbounds_interface\x18\a \x01(\tR\x16autoOutboundsInterfaceBL\n" +
+	"\x18auto_outbounds_interface\x18\a \x01(\tR\x16autoOutboundsInterface\x12\x12\n" +
+	"\x04desc\x18\b \x01(\tR\x04descBL\n" +
 	"\x12com.xray.proxy.tunP\x01Z#github.com/xtls/xray-core/proxy/tun\xaa\x02\x0eXray.Proxy.Tunb\x06proto3"
 
 var (

--- a/proxy/tun/config.proto
+++ b/proxy/tun/config.proto
@@ -14,4 +14,5 @@ message Config {
   uint32 user_level = 5;
   repeated string auto_system_routing_table = 6;
   string auto_outbounds_interface = 7;
+  string desc = 8;
 }

--- a/proxy/tun/tun_windows.go
+++ b/proxy/tun/tun_windows.go
@@ -50,7 +50,7 @@ var _ GVisorDevice = (*WindowsTun)(nil)
 // interface with the same name exist, it tried to be reused.
 func NewTun(options *Config) (Tun, error) {
 	// instantiate wintun adapter
-	adapter, err := open(options.Name)
+	adapter, err := open(options.Name, options.Desc)
 	if err != nil {
 		return nil, err
 	}
@@ -73,12 +73,12 @@ func NewTun(options *Config) (Tun, error) {
 	return tun, nil
 }
 
-func open(name string) (*wintun.Adapter, error) {
+func open(name, desc string) (*wintun.Adapter, error) {
 	// generate a deterministic GUID from the adapter name
 	id := md5.Sum([]byte(name))
 	guid := (*windows.GUID)(unsafe.Pointer(&id[0]))
 	// try to create adapter anew
-	adapter, err := wintun.CreateAdapter(name, "Xray", guid)
+	adapter, err := wintun.CreateAdapter(name, desc, guid)
 	if err == nil {
 		return adapter, nil
 	}


### PR DESCRIPTION
https://github.com/XTLS/Xray-docs-next/pull/872#issuecomment-4936055488

Windows 手动配置 TUN Desc，默认值为 `Wintun` 即 `Wintun Tunnel`

``` jsonc

        {
            "tag": "tun", 
            "protocol": "tun", 
            "settings": {
                 // 添加配置
                "desc": "xxx",
                "mtu": 1500,
                ...
            }
        }

```

实际效果应为

``` bash 
(base) PS C:\Users\saruo\Desktop\tun_test> route print
===========================================================================
接口列表
124...........................xxx Tunnel
```