### PR TITLE
Observatory: add reliable one-shot outbound probe batches and result notifications

### DIFF
--- a/app/observatory/burst/burstobserver.go
+++ b/app/observatory/burst/burstobserver.go
@@ -231,7 +231,6 @@ func (o *Observer) ProbeOutbounds(ctx context.Context, tags []string, maxConcurr
 	o.probeDone = done
 	o.probeAccess.Unlock()
 
-	publishUpdate := false
 	defer func() {
 		cancel()
 		o.probeAccess.Lock()
@@ -241,14 +240,9 @@ func (o *Observer) ProbeOutbounds(ctx context.Context, tags []string, maxConcurr
 		}
 		close(done)
 		o.probeAccess.Unlock()
-		if publishUpdate {
-			o.updates.NotifyObservationUpdate()
-		}
 	}()
 
-	err = o.hp.ProbeOutbounds(probeCtx, uniqueTags, maxConcurrency, samples)
-	publishUpdate = err == nil
-	return err
+	return o.hp.probeOutbounds(probeCtx, uniqueTags, maxConcurrency, samples)
 }
 
 func (o *Observer) createResult() []*observatory.OutboundStatus {
@@ -256,9 +250,6 @@ func (o *Observer) createResult() []*observatory.OutboundStatus {
 	o.hp.access.Lock()
 	defer o.hp.access.Unlock()
 	results := o.hp.Results
-	if o.hp.activeProbe != nil {
-		results = o.hp.activeProbe.results
-	}
 	for name, value := range results {
 		statistics := value.getStatistics()
 		status := observatory.OutboundStatus{

--- a/app/observatory/burst/burstobserver.go
+++ b/app/observatory/burst/burstobserver.go
@@ -27,7 +27,14 @@ type Observer struct {
 	finished *done.Instance
 
 	ohm outbound.Manager
+
+	probeAccess sync.Mutex
+	probeCancel context.CancelFunc
+	probeDone   chan struct{}
+	closed      bool
 }
+
+var _ extension.ObservatoryBatchProbe = (*Observer)(nil)
 
 func (o *Observer) GetObservation(ctx context.Context) (proto.Message, error) {
 	return &observatory.ObservationResult{Status: o.createResult()}, nil
@@ -50,6 +57,84 @@ func (o *Observer) ObservationProbeDeadline() time.Duration {
 
 func (o *Observer) Check(tag []string) {
 	o.hp.Check(tag)
+}
+
+// ProbeOutbounds runs a one-shot probe batch without starting another Xray
+// instance. Configure this observer without subject selectors when using it as
+// an embedder-controlled probe feature; scheduled and one-shot observation are
+// intentionally kept mutually exclusive so their result sets cannot race.
+func (o *Observer) ProbeOutbounds(ctx context.Context, tags []string, maxConcurrency, samples int) error {
+	if ctx == nil {
+		return errors.New("outbound probe context is nil")
+	}
+	if maxConcurrency <= 0 {
+		return errors.New("outbound probe concurrency must be positive")
+	}
+	if samples <= 0 {
+		return errors.New("outbound probe sample count must be positive")
+	}
+	if o.config != nil && len(o.config.SubjectSelector) != 0 {
+		return errors.New("one-shot outbound probing requires an observer without scheduled selectors")
+	}
+	if o.hp == nil {
+		return errors.New("outbound probe health checker is unavailable")
+	}
+	if o.ohm == nil {
+		return errors.New("outbound manager is unavailable")
+	}
+
+	uniqueTags := make([]string, 0, len(tags))
+	seen := make(map[string]struct{}, len(tags))
+	for _, tag := range tags {
+		if tag == "" {
+			return errors.New("outbound probe tag is empty")
+		}
+		if _, found := seen[tag]; found {
+			continue
+		}
+		if o.ohm.GetHandler(tag) == nil {
+			return errors.New("outbound probe handler not found: ", tag)
+		}
+		seen[tag] = struct{}{}
+		uniqueTags = append(uniqueTags, tag)
+	}
+
+	o.probeAccess.Lock()
+	if o.closed {
+		o.probeAccess.Unlock()
+		return errors.New("outbound observer is closed")
+	}
+	if o.probeDone != nil {
+		o.probeAccess.Unlock()
+		return errors.New("an outbound probe batch is already running")
+	}
+	probeCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	o.probeCancel = cancel
+	o.probeDone = done
+	o.probeAccess.Unlock()
+
+	publishUpdate := false
+	defer func() {
+		cancel()
+		o.probeAccess.Lock()
+		if o.probeDone == done {
+			o.probeCancel = nil
+			o.probeDone = nil
+		}
+		close(done)
+		o.probeAccess.Unlock()
+		// Publish only after the probe is no longer marked as running. An
+		// embedder may synchronously close the core from an update listener;
+		// notifying earlier would make Close wait for this same goroutine.
+		if publishUpdate {
+			o.updates.NotifyObservationUpdate()
+		}
+	}()
+
+	err := o.hp.ProbeOutbounds(probeCtx, uniqueTags, maxConcurrency, samples)
+	publishUpdate = err == nil
+	return err
 }
 
 func (o *Observer) createResult() []*observatory.OutboundStatus {
@@ -99,9 +184,24 @@ func (o *Observer) Start() error {
 }
 
 func (o *Observer) Close() error {
+	o.probeAccess.Lock()
+	o.closed = true
+	cancel := o.probeCancel
+	done := o.probeDone
+	o.probeAccess.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		<-done
+	}
+
 	if o.finished != nil {
 		o.hp.StopScheduler()
 		return o.finished.Close()
+	}
+	if o.hp != nil {
+		o.hp.cancelCtx()
 	}
 	return nil
 }

--- a/app/observatory/burst/burstobserver.go
+++ b/app/observatory/burst/burstobserver.go
@@ -3,6 +3,7 @@ package burst
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/xtls/xray-core/app/observatory"
 	"github.com/xtls/xray-core/common"
@@ -21,6 +22,7 @@ type Observer struct {
 
 	statusLock sync.Mutex
 	hp         *HealthPing
+	updates    extension.ObservatoryUpdateDispatcher
 
 	finished *done.Instance
 
@@ -29,6 +31,21 @@ type Observer struct {
 
 func (o *Observer) GetObservation(ctx context.Context) (proto.Message, error) {
 	return &observatory.ObservationResult{Status: o.createResult()}, nil
+}
+
+func (o *Observer) SubscribeObservationUpdates(listener func()) func() {
+	return o.updates.SubscribeObservationUpdates(listener)
+}
+
+func (o *Observer) ObservationProbeDeadline() time.Duration {
+	if o.hp == nil || o.hp.Settings == nil || o.hp.Settings.Timeout <= 0 {
+		return 0
+	}
+	deadline := o.hp.Settings.Timeout
+	if o.hp.Settings.Connectivity != "" {
+		deadline += o.hp.Settings.Timeout
+	}
+	return deadline
 }
 
 func (o *Observer) Check(tag []string) {
@@ -100,12 +117,14 @@ func New(ctx context.Context, config *Config) (*Observer, error) {
 		return nil, errors.New("Cannot get depended features").Base(err)
 	}
 	hp := NewHealthPing(ctx, dispatcher, config.PingConfig)
-	return &Observer{
+	observer := &Observer{
 		config: config,
 		ctx:    ctx,
 		ohm:    outboundManager,
 		hp:     hp,
-	}, nil
+	}
+	hp.onUpdate = observer.updates.NotifyObservationUpdate
+	return observer, nil
 }
 
 func init() {

--- a/app/observatory/burst/burstobserver.go
+++ b/app/observatory/burst/burstobserver.go
@@ -29,12 +29,11 @@ type Observer struct {
 
 	ohm outbound.Manager
 
-	probeAccess     sync.Mutex
-	probeCancel     context.CancelFunc
-	probeDone       chan struct{}
-	manualChecks    int
-	probePublishing bool
-	closed          bool
+	probeAccess  sync.Mutex
+	probeCancel  context.CancelFunc
+	probeDone    chan struct{}
+	manualChecks int
+	closed       bool
 }
 
 var _ extension.ObservatoryBatchProbe = (*Observer)(nil)
@@ -43,8 +42,8 @@ func (o *Observer) GetObservation(ctx context.Context) (proto.Message, error) {
 	return &observatory.ObservationResult{Status: o.createResult()}, nil
 }
 
-func (o *Observer) SubscribeObservationUpdates(listener func()) func() {
-	return o.updates.SubscribeObservationUpdates(listener)
+func (o *Observer) SubscribeObservationUpdates() (<-chan struct{}, func()) {
+	return o.updates.SubscribeObservationUpdates()
 }
 
 func (o *Observer) ObservationProbeDeadline() time.Duration {
@@ -60,7 +59,7 @@ func (o *Observer) ObservationProbeDeadline() time.Duration {
 
 func (o *Observer) Check(tag []string) {
 	o.probeAccess.Lock()
-	if o.closed || o.probeDone != nil || o.probePublishing {
+	if o.closed || o.probeDone != nil {
 		o.probeAccess.Unlock()
 		return
 	}
@@ -187,10 +186,6 @@ func (o *Observer) ProbeOutbounds(ctx context.Context, tags []string, maxConcurr
 		o.probeAccess.Unlock()
 		return errors.New("a manual outbound check is already running")
 	}
-	if o.probePublishing {
-		o.probeAccess.Unlock()
-		return errors.New("outbound probe results are being published")
-	}
 	probeCtx, cancel := context.WithCancel(ctx)
 	done := make(chan struct{})
 	o.probeCancel = cancel
@@ -206,20 +201,9 @@ func (o *Observer) ProbeOutbounds(ctx context.Context, tags []string, maxConcurr
 			o.probeDone = nil
 		}
 		close(done)
-		o.probePublishing = publishUpdate
 		o.probeAccess.Unlock()
-		// Publish only after the probe is no longer marked as running. An
-		// embedder may synchronously close the core from an update listener;
-		// notifying earlier would make Close wait for this same goroutine.
 		if publishUpdate {
-			func() {
-				defer func() {
-					o.probeAccess.Lock()
-					o.probePublishing = false
-					o.probeAccess.Unlock()
-				}()
-				o.updates.NotifyObservationUpdate()
-			}()
+			o.updates.NotifyObservationUpdate()
 		}
 	}()
 
@@ -287,14 +271,15 @@ func (o *Observer) Close() error {
 		<-done
 	}
 
+	var err error
 	if o.finished != nil {
 		o.hp.StopScheduler()
-		return o.finished.Close()
-	}
-	if o.hp != nil {
+		err = o.finished.Close()
+	} else if o.hp != nil {
 		o.hp.cancelCtx()
 	}
-	return nil
+	o.updates.Close()
+	return err
 }
 
 func New(ctx context.Context, config *Config) (*Observer, error) {

--- a/app/observatory/burst/burstobserver.go
+++ b/app/observatory/burst/burstobserver.go
@@ -2,6 +2,7 @@ package burst
 
 import (
 	"context"
+	"math"
 	"sync"
 	"time"
 
@@ -73,6 +74,93 @@ func (o *Observer) Check(tag []string) {
 	o.hp.Check(tag)
 }
 
+func validateBatchProbeParameters(maxConcurrency, samples int) error {
+	if maxConcurrency <= 0 {
+		return errors.New("outbound probe concurrency must be positive")
+	}
+	if samples <= 0 {
+		return errors.New("outbound probe sample count must be positive")
+	}
+	return nil
+}
+
+func normalizeBatchProbeTags(tags []string) ([]string, error) {
+	uniqueTags := make([]string, 0, len(tags))
+	seen := make(map[string]struct{}, len(tags))
+	for _, tag := range tags {
+		if tag == "" {
+			return nil, errors.New("outbound probe tag is empty")
+		}
+		if _, found := seen[tag]; found {
+			continue
+		}
+		seen[tag] = struct{}{}
+		uniqueTags = append(uniqueTags, tag)
+	}
+	return uniqueTags, nil
+}
+
+func (o *Observer) prepareBatchProbe(tags []string, maxConcurrency, samples int) ([]string, error) {
+	if err := validateBatchProbeParameters(maxConcurrency, samples); err != nil {
+		return nil, err
+	}
+	if o.config != nil && len(o.config.SubjectSelector) != 0 {
+		return nil, errors.New("one-shot outbound probing requires an observer without scheduled selectors")
+	}
+	if o.hp == nil {
+		return nil, errors.New("outbound probe health checker is unavailable")
+	}
+	if o.ohm == nil {
+		return nil, errors.New("outbound manager is unavailable")
+	}
+
+	uniqueTags, err := normalizeBatchProbeTags(tags)
+	if err != nil {
+		return nil, err
+	}
+	for _, tag := range uniqueTags {
+		if o.ohm.GetHandler(tag) == nil {
+			return nil, errors.New("outbound probe handler not found: ", tag)
+		}
+	}
+	return uniqueTags, nil
+}
+
+// ProbeOutboundsDeadline reports the configured worst-case batch probe budget.
+// Each worker owns a complete tag and samples it serially; failed samples may
+// also consume one direct-connectivity timeout before they can be classified.
+func (o *Observer) ProbeOutboundsDeadline(tags []string, maxConcurrency, samples int) (time.Duration, error) {
+	uniqueTags, err := o.prepareBatchProbe(tags, maxConcurrency, samples)
+	if err != nil {
+		return 0, err
+	}
+	if len(uniqueTags) == 0 {
+		return 0, nil
+	}
+	if o.hp.Settings == nil || o.hp.Settings.Timeout <= 0 {
+		return 0, errors.New("outbound probe timeout must be positive")
+	}
+
+	perSample := o.hp.Settings.Timeout
+	if o.hp.Settings.Connectivity != "" {
+		if perSample > time.Duration(math.MaxInt64)-perSample {
+			return 0, errors.New("outbound probe deadline exceeds time.Duration")
+		}
+		perSample += perSample
+	}
+	workers := min(maxConcurrency, len(uniqueTags))
+	waves := 1 + (len(uniqueTags)-1)/workers
+	steps := int64(waves)
+	if int64(samples) > math.MaxInt64/steps {
+		return 0, errors.New("outbound probe deadline exceeds time.Duration")
+	}
+	steps *= int64(samples)
+	if int64(perSample) > math.MaxInt64/steps {
+		return 0, errors.New("outbound probe deadline exceeds time.Duration")
+	}
+	return time.Duration(steps * int64(perSample)), nil
+}
+
 // ProbeOutbounds runs a one-shot probe batch without starting another Xray
 // instance. Configure this observer without subject selectors when using it as
 // an embedder-controlled probe feature; scheduled and one-shot observation are
@@ -81,36 +169,9 @@ func (o *Observer) ProbeOutbounds(ctx context.Context, tags []string, maxConcurr
 	if ctx == nil {
 		return errors.New("outbound probe context is nil")
 	}
-	if maxConcurrency <= 0 {
-		return errors.New("outbound probe concurrency must be positive")
-	}
-	if samples <= 0 {
-		return errors.New("outbound probe sample count must be positive")
-	}
-	if o.config != nil && len(o.config.SubjectSelector) != 0 {
-		return errors.New("one-shot outbound probing requires an observer without scheduled selectors")
-	}
-	if o.hp == nil {
-		return errors.New("outbound probe health checker is unavailable")
-	}
-	if o.ohm == nil {
-		return errors.New("outbound manager is unavailable")
-	}
-
-	uniqueTags := make([]string, 0, len(tags))
-	seen := make(map[string]struct{}, len(tags))
-	for _, tag := range tags {
-		if tag == "" {
-			return errors.New("outbound probe tag is empty")
-		}
-		if _, found := seen[tag]; found {
-			continue
-		}
-		if o.ohm.GetHandler(tag) == nil {
-			return errors.New("outbound probe handler not found: ", tag)
-		}
-		seen[tag] = struct{}{}
-		uniqueTags = append(uniqueTags, tag)
+	uniqueTags, err := o.prepareBatchProbe(tags, maxConcurrency, samples)
+	if err != nil {
+		return err
 	}
 
 	o.probeAccess.Lock()
@@ -162,7 +223,7 @@ func (o *Observer) ProbeOutbounds(ctx context.Context, tags []string, maxConcurr
 		}
 	}()
 
-	err := o.hp.ProbeOutbounds(probeCtx, uniqueTags, maxConcurrency, samples)
+	err = o.hp.ProbeOutbounds(probeCtx, uniqueTags, maxConcurrency, samples)
 	publishUpdate = err == nil
 	return err
 }

--- a/app/observatory/burst/burstobserver.go
+++ b/app/observatory/burst/burstobserver.go
@@ -28,10 +28,12 @@ type Observer struct {
 
 	ohm outbound.Manager
 
-	probeAccess sync.Mutex
-	probeCancel context.CancelFunc
-	probeDone   chan struct{}
-	closed      bool
+	probeAccess     sync.Mutex
+	probeCancel     context.CancelFunc
+	probeDone       chan struct{}
+	manualChecks    int
+	probePublishing bool
+	closed          bool
 }
 
 var _ extension.ObservatoryBatchProbe = (*Observer)(nil)
@@ -56,6 +58,18 @@ func (o *Observer) ObservationProbeDeadline() time.Duration {
 }
 
 func (o *Observer) Check(tag []string) {
+	o.probeAccess.Lock()
+	if o.closed || o.probeDone != nil || o.probePublishing {
+		o.probeAccess.Unlock()
+		return
+	}
+	o.manualChecks++
+	o.probeAccess.Unlock()
+	defer func() {
+		o.probeAccess.Lock()
+		o.manualChecks--
+		o.probeAccess.Unlock()
+	}()
 	o.hp.Check(tag)
 }
 
@@ -108,6 +122,14 @@ func (o *Observer) ProbeOutbounds(ctx context.Context, tags []string, maxConcurr
 		o.probeAccess.Unlock()
 		return errors.New("an outbound probe batch is already running")
 	}
+	if o.manualChecks != 0 {
+		o.probeAccess.Unlock()
+		return errors.New("a manual outbound check is already running")
+	}
+	if o.probePublishing {
+		o.probeAccess.Unlock()
+		return errors.New("outbound probe results are being published")
+	}
 	probeCtx, cancel := context.WithCancel(ctx)
 	done := make(chan struct{})
 	o.probeCancel = cancel
@@ -123,12 +145,20 @@ func (o *Observer) ProbeOutbounds(ctx context.Context, tags []string, maxConcurr
 			o.probeDone = nil
 		}
 		close(done)
+		o.probePublishing = publishUpdate
 		o.probeAccess.Unlock()
 		// Publish only after the probe is no longer marked as running. An
 		// embedder may synchronously close the core from an update listener;
 		// notifying earlier would make Close wait for this same goroutine.
 		if publishUpdate {
-			o.updates.NotifyObservationUpdate()
+			func() {
+				defer func() {
+					o.probeAccess.Lock()
+					o.probePublishing = false
+					o.probeAccess.Unlock()
+				}()
+				o.updates.NotifyObservationUpdate()
+			}()
 		}
 	}()
 

--- a/app/observatory/burst/burstobserver.go
+++ b/app/observatory/burst/burstobserver.go
@@ -38,6 +38,15 @@ type Observer struct {
 
 var _ extension.ObservatoryBatchProbe = (*Observer)(nil)
 
+const (
+	// These are defensive implementation limits, not tuning recommendations.
+	// Batch parameters come from embedders and directly control goroutine count,
+	// request count, and retained result memory.
+	maxBatchProbeWorkers              = 256
+	maxBatchProbeSamplesPerOutbound   = 1024
+	maxBatchProbeRetainedMeasurements = 1 << 20
+)
+
 func (o *Observer) GetObservation(ctx context.Context) (proto.Message, error) {
 	return &observatory.ObservationResult{Status: o.createResult()}, nil
 }
@@ -80,6 +89,23 @@ func validateBatchProbeParameters(maxConcurrency, samples int) error {
 	if samples <= 0 {
 		return errors.New("outbound probe sample count must be positive")
 	}
+	if samples > maxBatchProbeSamplesPerOutbound {
+		return errors.New("outbound probe sample count exceeds limit of ", maxBatchProbeSamplesPerOutbound)
+	}
+	return nil
+}
+
+func validateBatchProbeWork(tagCount, maxConcurrency, samples int) error {
+	if tagCount == 0 {
+		return nil
+	}
+	workers := min(maxConcurrency, tagCount)
+	if workers > maxBatchProbeWorkers {
+		return errors.New("outbound probe concurrency exceeds active-worker limit of ", maxBatchProbeWorkers)
+	}
+	if tagCount > maxBatchProbeRetainedMeasurements/samples {
+		return errors.New("outbound probe batch exceeds retained-measurement limit of ", maxBatchProbeRetainedMeasurements)
+	}
 	return nil
 }
 
@@ -117,12 +143,43 @@ func (o *Observer) prepareBatchProbe(tags []string, maxConcurrency, samples int)
 	if err != nil {
 		return nil, err
 	}
+	if err := validateBatchProbeWork(len(uniqueTags), maxConcurrency, samples); err != nil {
+		return nil, err
+	}
 	for _, tag := range uniqueTags {
 		if o.ohm.GetHandler(tag) == nil {
 			return nil, errors.New("outbound probe handler not found: ", tag)
 		}
 	}
 	return uniqueTags, nil
+}
+
+func batchProbeDeadline(settings *HealthPingSettings, tagCount, maxConcurrency, samples int) (time.Duration, error) {
+	if tagCount == 0 {
+		return 0, nil
+	}
+	if settings == nil || settings.Timeout <= 0 {
+		return 0, errors.New("outbound probe timeout must be positive")
+	}
+
+	perSample := settings.Timeout
+	if settings.Connectivity != "" {
+		if perSample > time.Duration(math.MaxInt64)-perSample {
+			return 0, errors.New("outbound probe deadline exceeds time.Duration")
+		}
+		perSample += perSample
+	}
+	workers := min(maxConcurrency, tagCount)
+	waves := 1 + (tagCount-1)/workers
+	steps := int64(waves)
+	if int64(samples) > math.MaxInt64/steps {
+		return 0, errors.New("outbound probe deadline exceeds time.Duration")
+	}
+	steps *= int64(samples)
+	if int64(perSample) > math.MaxInt64/steps {
+		return 0, errors.New("outbound probe deadline exceeds time.Duration")
+	}
+	return time.Duration(steps * int64(perSample)), nil
 }
 
 // ProbeOutboundsDeadline reports the configured worst-case batch probe budget.
@@ -136,28 +193,7 @@ func (o *Observer) ProbeOutboundsDeadline(tags []string, maxConcurrency, samples
 	if len(uniqueTags) == 0 {
 		return 0, nil
 	}
-	if o.hp.Settings == nil || o.hp.Settings.Timeout <= 0 {
-		return 0, errors.New("outbound probe timeout must be positive")
-	}
-
-	perSample := o.hp.Settings.Timeout
-	if o.hp.Settings.Connectivity != "" {
-		if perSample > time.Duration(math.MaxInt64)-perSample {
-			return 0, errors.New("outbound probe deadline exceeds time.Duration")
-		}
-		perSample += perSample
-	}
-	workers := min(maxConcurrency, len(uniqueTags))
-	waves := 1 + (len(uniqueTags)-1)/workers
-	steps := int64(waves)
-	if int64(samples) > math.MaxInt64/steps {
-		return 0, errors.New("outbound probe deadline exceeds time.Duration")
-	}
-	steps *= int64(samples)
-	if int64(perSample) > math.MaxInt64/steps {
-		return 0, errors.New("outbound probe deadline exceeds time.Duration")
-	}
-	return time.Duration(steps * int64(perSample)), nil
+	return batchProbeDeadline(o.hp.Settings, len(uniqueTags), maxConcurrency, samples)
 }
 
 // ProbeOutbounds runs a one-shot probe batch without starting another Xray
@@ -170,6 +206,9 @@ func (o *Observer) ProbeOutbounds(ctx context.Context, tags []string, maxConcurr
 	}
 	uniqueTags, err := o.prepareBatchProbe(tags, maxConcurrency, samples)
 	if err != nil {
+		return err
+	}
+	if _, err := batchProbeDeadline(o.hp.Settings, len(uniqueTags), maxConcurrency, samples); err != nil {
 		return err
 	}
 

--- a/app/observatory/burst/burstobserver.go
+++ b/app/observatory/burst/burstobserver.go
@@ -255,21 +255,26 @@ func (o *Observer) createResult() []*observatory.OutboundStatus {
 	var result []*observatory.OutboundStatus
 	o.hp.access.Lock()
 	defer o.hp.access.Unlock()
-	for name, value := range o.hp.Results {
+	results := o.hp.Results
+	if o.hp.activeProbe != nil {
+		results = o.hp.activeProbe.results
+	}
+	for name, value := range results {
+		statistics := value.getStatistics()
 		status := observatory.OutboundStatus{
-			Alive:           value.getStatistics().All != value.getStatistics().Fail,
-			Delay:           value.getStatistics().Average.Milliseconds(),
+			Alive:           statistics.All != statistics.Fail,
+			Delay:           statistics.Average.Milliseconds(),
 			LastErrorReason: "",
 			OutboundTag:     name,
 			LastSeenTime:    0,
 			LastTryTime:     0,
 			HealthPing: &observatory.HealthPingMeasurementResult{
-				All:       int64(value.getStatistics().All),
-				Fail:      int64(value.getStatistics().Fail),
-				Deviation: int64(value.getStatistics().Deviation),
-				Average:   int64(value.getStatistics().Average),
-				Max:       int64(value.getStatistics().Max),
-				Min:       int64(value.getStatistics().Min),
+				All:       int64(statistics.All),
+				Fail:      int64(statistics.Fail),
+				Deviation: int64(statistics.Deviation),
+				Average:   int64(statistics.Average),
+				Max:       int64(statistics.Max),
+				Min:       int64(statistics.Min),
 			},
 		}
 		result = append(result, &status)

--- a/app/observatory/burst/healthping.go
+++ b/app/observatory/burst/healthping.go
@@ -29,21 +29,14 @@ type HealthPing struct {
 	ctx           context.Context
 	cancelCtx     context.CancelFunc
 	cancelPending atomic.Pointer[context.CancelFunc]
-	batchAccess   sync.Mutex
 	dispatcher    routing.Dispatcher
 	access        sync.Mutex
 	ticker        *time.Ticker
 
-	Settings    *HealthPingSettings
-	Results     map[string]*HealthPingRTTS
-	activeProbe *batchProbeResults
-	onUpdate    func()
-	measure     func(context.Context, string) (time.Duration, error)
-}
-
-type batchProbeResults struct {
-	results map[string]*HealthPingRTTS
-	samples int
+	Settings *HealthPingSettings
+	Results  map[string]*HealthPingRTTS
+	onUpdate func()
+	measure  func(context.Context, string) (time.Duration, error)
 }
 
 // NewHealthPing creates a new HealthPing with settings
@@ -164,44 +157,21 @@ func (h *HealthPing) Check(tags []string) error {
 	return nil
 }
 
-// ProbeOutbounds performs a finite, cancellable probe batch. Every unique tag
-// is sampled the requested number of times, while the worker pool bounds the
-// total number of probes in flight. Completed samples are exposed through the
-// active observation view as they arrive. When the batch ends, that view remains
-// available even if the caller cancelled it or the underlying network failed;
-// the returned error tells the embedder that the result set is incomplete.
-func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcurrency, samples int) error {
-	if ctx == nil {
-		return errors.New("outbound probe context is nil")
-	}
-	if err := validateBatchProbeParameters(maxConcurrency, samples); err != nil {
-		return err
-	}
-
-	uniqueTags, err := normalizeBatchProbeTags(tags)
-	if err != nil {
-		return err
-	}
-	if err := validateBatchProbeWork(len(uniqueTags), maxConcurrency, samples); err != nil {
-		return err
-	}
+// probeOutbounds executes a finite batch prepared by Observer. The observer
+// owns validation and overlap exclusion; keeping those policy decisions at the
+// public API boundary leaves HealthPing responsible only for measurements and
+// result publication.
+func (h *HealthPing) probeOutbounds(ctx context.Context, tags []string, maxConcurrency, samples int) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 	if err := h.ctx.Err(); err != nil {
 		return err
 	}
-	if !h.batchAccess.TryLock() {
-		return errors.New("an outbound health probe batch is already running")
-	}
-	defer h.batchAccess.Unlock()
-	if len(uniqueTags) == 0 {
+	if len(tags) == 0 {
 		h.replaceResults(make(map[string]*HealthPingRTTS))
 		h.notifyUpdate()
 		return nil
-	}
-	if _, err := batchProbeDeadline(h.Settings, len(uniqueTags), maxConcurrency, samples); err != nil {
-		return err
 	}
 
 	// The caller controls the lifetime of a batch, but it does not own Xray's
@@ -214,12 +184,9 @@ func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcu
 		cancel()
 	}()
 
-	batchResults := h.beginProbeResults(samples, len(uniqueTags))
-	defer func() {
-		h.finishProbeResults(batchResults)
-	}()
+	h.replaceResults(make(map[string]*HealthPingRTTS, len(tags)))
 
-	workerCount := min(maxConcurrency, len(uniqueTags))
+	workerCount := min(maxConcurrency, len(tags))
 	tasks := make(chan string)
 	var networkUnavailable atomic.Bool
 	var workers sync.WaitGroup
@@ -253,7 +220,7 @@ func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcu
 						}
 						delay = rttFailed
 					}
-					h.putProbeResult(batchResults, tag, delay)
+					h.putProbeResult(tag, delay, samples)
 				}
 			}
 		}()
@@ -263,7 +230,7 @@ func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcu
 	go func() {
 		defer close(feedDone)
 		defer close(tasks)
-		for _, tag := range uniqueTags {
+		for _, tag := range tags {
 			select {
 			case tasks <- tag:
 			case <-runCtx.Done():
@@ -309,47 +276,18 @@ func (h *HealthPing) replaceResults(replacements map[string]*HealthPingRTTS) {
 	h.access.Unlock()
 }
 
-func (h *HealthPing) beginProbeResults(samples, capacity int) *batchProbeResults {
-	batch := &batchProbeResults{
-		results: make(map[string]*HealthPingRTTS, capacity),
-		samples: samples,
-	}
+func (h *HealthPing) putProbeResult(tag string, delay time.Duration, samples int) {
 	h.access.Lock()
-	h.activeProbe = batch
-	h.access.Unlock()
-	return batch
-}
-
-func (h *HealthPing) putProbeResult(batch *batchProbeResults, tag string, delay time.Duration) {
-	h.access.Lock()
-	if h.activeProbe != batch {
-		h.access.Unlock()
-		return
-	}
-	result := batch.results[tag]
+	result := h.Results[tag]
 	if result == nil {
-		// Unlike scheduler-owned samples, a completed one-shot batch is an
-		// immutable snapshot. Keep it valid until a later batch replaces it.
-		result = NewHealthPingResult(batch.samples, 0)
-		batch.results[tag] = result
+		// One-shot samples do not expire because the containing probe process is
+		// disposable and the completed snapshot is its final output.
+		result = NewHealthPingResult(samples, 0)
+		h.Results[tag] = result
 	}
 	result.Put(delay)
 	h.access.Unlock()
 	h.notifyUpdate()
-}
-
-func (h *HealthPing) finishProbeResults(batch *batchProbeResults) {
-	h.access.Lock()
-	if h.activeProbe != batch {
-		h.access.Unlock()
-		return
-	}
-	// A one-shot observer belongs to a disposable probe process. Preserve the
-	// measurements completed by this run regardless of how it ended; there is
-	// no earlier batch in the process whose results would be more relevant.
-	h.Results = batch.results
-	h.activeProbe = nil
-	h.access.Unlock()
 }
 
 func (h *HealthPing) notifyUpdate() {

--- a/app/observatory/burst/healthping.go
+++ b/app/observatory/burst/healthping.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/xtls/xray-core/common/dice"
 	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/features/extension"
 	"github.com/xtls/xray-core/features/routing"
 )
 
@@ -211,6 +212,7 @@ func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcu
 
 	workerCount := min(maxConcurrency, len(uniqueTags))
 	tasks := make(chan string)
+	var networkUnavailable atomic.Bool
 	var workers sync.WaitGroup
 	workers.Add(workerCount)
 	for range workerCount {
@@ -229,6 +231,9 @@ func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcu
 						}
 						if !connectivityOK {
 							errors.LogWarning(h.ctx, "network is down while probing ", tag)
+							networkUnavailable.Store(true)
+							cancel()
+							return
 						} else {
 							errors.LogWarning(h.ctx, fmt.Sprintf(
 								"error ping %s with %s: %s",
@@ -262,6 +267,12 @@ func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcu
 	<-feedDone
 	if err := ctx.Err(); err != nil {
 		return err
+	}
+	if err := h.ctx.Err(); err != nil {
+		return err
+	}
+	if networkUnavailable.Load() {
+		return extension.ErrObservatoryProbeNetworkUnavailable
 	}
 	if err := runCtx.Err(); err != nil {
 		return err

--- a/app/observatory/burst/healthping.go
+++ b/app/observatory/burst/healthping.go
@@ -42,9 +42,8 @@ type HealthPing struct {
 }
 
 type batchProbeResults struct {
-	results   map[string]*HealthPingRTTS
-	samples   int
-	published bool
+	results map[string]*HealthPingRTTS
+	samples int
 }
 
 // NewHealthPing creates a new HealthPing with settings
@@ -168,8 +167,9 @@ func (h *HealthPing) Check(tags []string) error {
 // ProbeOutbounds performs a finite, cancellable probe batch. Every unique tag
 // is sampled the requested number of times, while the worker pool bounds the
 // total number of probes in flight. Completed samples are exposed through the
-// active observation view as they arrive. The active view becomes the stable
-// snapshot only after full success; an aborted batch restores the previous one.
+// active observation view as they arrive. When the batch ends, that view remains
+// available even if the caller cancelled it or the underlying network failed;
+// the returned error tells the embedder that the result set is incomplete.
 func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcurrency, samples int) error {
 	if ctx == nil {
 		return errors.New("outbound probe context is nil")
@@ -215,9 +215,8 @@ func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcu
 	}()
 
 	batchResults := h.beginProbeResults(samples, len(uniqueTags))
-	commitResults := false
 	defer func() {
-		h.finishProbeResults(batchResults, commitResults)
+		h.finishProbeResults(batchResults)
 	}()
 
 	workerCount := min(maxConcurrency, len(uniqueTags))
@@ -287,7 +286,6 @@ func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcu
 	if err := runCtx.Err(); err != nil {
 		return err
 	}
-	commitResults = true
 	return nil
 }
 
@@ -336,28 +334,22 @@ func (h *HealthPing) putProbeResult(batch *batchProbeResults, tag string, delay 
 		batch.results[tag] = result
 	}
 	result.Put(delay)
-	batch.published = true
 	h.access.Unlock()
 	h.notifyUpdate()
 }
 
-func (h *HealthPing) finishProbeResults(batch *batchProbeResults, commit bool) {
+func (h *HealthPing) finishProbeResults(batch *batchProbeResults) {
 	h.access.Lock()
 	if h.activeProbe != batch {
 		h.access.Unlock()
 		return
 	}
-	if commit {
-		h.Results = batch.results
-	}
+	// A one-shot observer belongs to a disposable probe process. Preserve the
+	// measurements completed by this run regardless of how it ended; there is
+	// no earlier batch in the process whose results would be more relevant.
+	h.Results = batch.results
 	h.activeProbe = nil
-	published := batch.published
 	h.access.Unlock()
-	if !commit && published {
-		// A subscriber may already have rendered the progressive view. Signal
-		// that it should query again and reveal the previous stable snapshot.
-		h.notifyUpdate()
-	}
 }
 
 func (h *HealthPing) notifyUpdate() {

--- a/app/observatory/burst/healthping.go
+++ b/app/observatory/burst/healthping.go
@@ -165,24 +165,13 @@ func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcu
 	if ctx == nil {
 		return errors.New("outbound probe context is nil")
 	}
-	if maxConcurrency <= 0 {
-		return errors.New("outbound probe concurrency must be positive")
-	}
-	if samples <= 0 {
-		return errors.New("outbound probe sample count must be positive")
+	if err := validateBatchProbeParameters(maxConcurrency, samples); err != nil {
+		return err
 	}
 
-	uniqueTags := make([]string, 0, len(tags))
-	seen := make(map[string]struct{}, len(tags))
-	for _, tag := range tags {
-		if tag == "" {
-			return errors.New("outbound probe tag is empty")
-		}
-		if _, found := seen[tag]; found {
-			continue
-		}
-		seen[tag] = struct{}{}
-		uniqueTags = append(uniqueTags, tag)
+	uniqueTags, err := normalizeBatchProbeTags(tags)
+	if err != nil {
+		return err
 	}
 	if err := ctx.Err(); err != nil {
 		return err

--- a/app/observatory/burst/healthping.go
+++ b/app/observatory/burst/healthping.go
@@ -173,6 +173,9 @@ func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcu
 	if err != nil {
 		return err
 	}
+	if err := validateBatchProbeWork(len(uniqueTags), maxConcurrency, samples); err != nil {
+		return err
+	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -182,6 +185,9 @@ func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcu
 	if len(uniqueTags) == 0 {
 		h.replaceResults(make(map[string]*HealthPingRTTS))
 		return nil
+	}
+	if _, err := batchProbeDeadline(h.Settings, len(uniqueTags), maxConcurrency, samples); err != nil {
+		return err
 	}
 
 	// The caller controls the lifetime of a batch, but it does not own Xray's

--- a/app/observatory/burst/healthping.go
+++ b/app/observatory/burst/healthping.go
@@ -194,10 +194,12 @@ func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcu
 		cancel()
 	}()
 
-	validity := h.Settings.Interval * time.Duration(samples) * 2
 	batchResults := make(map[string]*HealthPingRTTS, len(uniqueTags))
 	for _, tag := range uniqueTags {
-		batchResults[tag] = NewHealthPingResult(samples, validity)
+		// Unlike scheduler-owned samples, a completed one-shot batch is an
+		// immutable snapshot. Keep it valid until the next batch replaces it so
+		// early tags cannot expire while later tags are still being measured.
+		batchResults[tag] = NewHealthPingResult(samples, 0)
 	}
 
 	workerCount := min(maxConcurrency, len(uniqueTags))

--- a/app/observatory/burst/healthping.go
+++ b/app/observatory/burst/healthping.go
@@ -34,6 +34,7 @@ type HealthPing struct {
 
 	Settings *HealthPingSettings
 	Results  map[string]*HealthPingRTTS
+	onUpdate func()
 }
 
 // NewHealthPing creates a new HealthPing with settings
@@ -233,7 +234,6 @@ func (h *HealthPing) doCheck(ctx context.Context, tags []string, duration time.D
 // PutResult put a ping rtt to results
 func (h *HealthPing) PutResult(tag string, rtt time.Duration) {
 	h.access.Lock()
-	defer h.access.Unlock()
 	if h.Results == nil {
 		h.Results = make(map[string]*HealthPingRTTS)
 	}
@@ -248,13 +248,17 @@ func (h *HealthPing) PutResult(tag string, rtt time.Duration) {
 		h.Results[tag] = r
 	}
 	r.Put(rtt)
+	h.access.Unlock()
+	if h.onUpdate != nil {
+		h.onUpdate()
+	}
 }
 
 // Cleanup removes results of removed handlers,
 // tags should be all valid tags of the Balancer now
 func (h *HealthPing) Cleanup(tags []string) {
 	h.access.Lock()
-	defer h.access.Unlock()
+	changed := false
 	for tag := range h.Results {
 		found := false
 		for _, v := range tags {
@@ -265,7 +269,12 @@ func (h *HealthPing) Cleanup(tags []string) {
 		}
 		if !found {
 			delete(h.Results, tag)
+			changed = true
 		}
+	}
+	h.access.Unlock()
+	if changed && h.onUpdate != nil {
+		h.onUpdate()
 	}
 }
 

--- a/app/observatory/burst/healthping.go
+++ b/app/observatory/burst/healthping.go
@@ -186,14 +186,20 @@ func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcu
 	if len(uniqueTags) == 0 {
 		return nil
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if err := h.ctx.Err(); err != nil {
 		return err
 	}
 
-	runCtx, cancel := context.WithCancel(ctx)
-	stopHealthPingCancellation := context.AfterFunc(h.ctx, cancel)
+	// The caller controls the lifetime of a batch, but it does not own Xray's
+	// instance context. Keep the health checker's context as the value-bearing
+	// parent required by tagged.Dialer and bridge caller cancellation into it.
+	runCtx, cancel := context.WithCancel(h.ctx)
+	stopCallerCancellation := context.AfterFunc(ctx, cancel)
 	defer func() {
-		stopHealthPingCancellation()
+		stopCallerCancellation()
 		cancel()
 	}()
 
@@ -254,6 +260,9 @@ func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcu
 
 	workers.Wait()
 	<-feedDone
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if err := runCtx.Err(); err != nil {
 		return err
 	}

--- a/app/observatory/burst/healthping.go
+++ b/app/observatory/burst/healthping.go
@@ -35,6 +35,7 @@ type HealthPing struct {
 	Settings *HealthPingSettings
 	Results  map[string]*HealthPingRTTS
 	onUpdate func()
+	measure  func(context.Context, string) (time.Duration, error)
 }
 
 // NewHealthPing creates a new HealthPing with settings
@@ -155,6 +156,131 @@ func (h *HealthPing) Check(tags []string) error {
 	return nil
 }
 
+// ProbeOutbounds performs a finite, cancellable probe batch. Every unique tag
+// is sampled the requested number of times, while the worker pool bounds the
+// total number of probes in flight. Results are built privately and published
+// as one snapshot, so observers never see a partially completed batch.
+func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcurrency, samples int) error {
+	if ctx == nil {
+		return errors.New("outbound probe context is nil")
+	}
+	if maxConcurrency <= 0 {
+		return errors.New("outbound probe concurrency must be positive")
+	}
+	if samples <= 0 {
+		return errors.New("outbound probe sample count must be positive")
+	}
+
+	uniqueTags := make([]string, 0, len(tags))
+	seen := make(map[string]struct{}, len(tags))
+	for _, tag := range tags {
+		if tag == "" {
+			return errors.New("outbound probe tag is empty")
+		}
+		if _, found := seen[tag]; found {
+			continue
+		}
+		seen[tag] = struct{}{}
+		uniqueTags = append(uniqueTags, tag)
+	}
+	if len(uniqueTags) == 0 {
+		return nil
+	}
+	if err := h.ctx.Err(); err != nil {
+		return err
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	stopHealthPingCancellation := context.AfterFunc(h.ctx, cancel)
+	defer func() {
+		stopHealthPingCancellation()
+		cancel()
+	}()
+
+	validity := h.Settings.Interval * time.Duration(samples) * 2
+	batchResults := make(map[string]*HealthPingRTTS, len(uniqueTags))
+	for _, tag := range uniqueTags {
+		batchResults[tag] = NewHealthPingResult(samples, validity)
+	}
+
+	workerCount := min(maxConcurrency, len(uniqueTags))
+	tasks := make(chan string)
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for tag := range tasks {
+				for range samples {
+					delay, err := h.measureOutbound(runCtx, tag)
+					if err != nil {
+						if runCtx.Err() != nil {
+							return
+						}
+						connectivityOK := h.checkConnectivity(runCtx)
+						if runCtx.Err() != nil {
+							return
+						}
+						if !connectivityOK {
+							errors.LogWarning(h.ctx, "network is down while probing ", tag)
+						} else {
+							errors.LogWarning(h.ctx, fmt.Sprintf(
+								"error ping %s with %s: %s",
+								h.Settings.Destination,
+								tag,
+								err,
+							))
+						}
+						delay = rttFailed
+					}
+					batchResults[tag].Put(delay)
+				}
+			}
+		}()
+	}
+
+	feedDone := make(chan struct{})
+	go func() {
+		defer close(feedDone)
+		defer close(tasks)
+		for _, tag := range uniqueTags {
+			select {
+			case tasks <- tag:
+			case <-runCtx.Done():
+				return
+			}
+		}
+	}()
+
+	workers.Wait()
+	<-feedDone
+	if err := runCtx.Err(); err != nil {
+		return err
+	}
+	h.replaceResults(batchResults)
+	return nil
+}
+
+func (h *HealthPing) measureOutbound(ctx context.Context, tag string) (time.Duration, error) {
+	if h.measure != nil {
+		return h.measure(ctx, tag)
+	}
+	client := newPingClient(
+		ctx,
+		h.dispatcher,
+		h.Settings.Destination,
+		h.Settings.Timeout,
+		tag,
+	)
+	return client.MeasureDelayContext(ctx, h.Settings.HttpMethod)
+}
+
+func (h *HealthPing) replaceResults(replacements map[string]*HealthPingRTTS) {
+	h.access.Lock()
+	h.Results = replacements
+	h.access.Unlock()
+}
+
 type rtt struct {
 	handler string
 	value   time.Duration
@@ -194,7 +320,7 @@ func (h *HealthPing) doCheck(ctx context.Context, tags []string, duration time.D
 					}
 					return
 				}
-				if !h.checkConnectivity() {
+				if !h.checkConnectivity(ctx) {
 					errors.LogWarning(h.ctx, "network is down")
 					ch <- &rtt{
 						handler: handler,
@@ -280,7 +406,7 @@ func (h *HealthPing) Cleanup(tags []string) {
 
 // checkConnectivity checks the network connectivity, it returns
 // true if network is good or "connectivity check url" not set
-func (h *HealthPing) checkConnectivity() bool {
+func (h *HealthPing) checkConnectivity(ctx context.Context) bool {
 	if h.Settings.Connectivity == "" {
 		return true
 	}
@@ -288,7 +414,7 @@ func (h *HealthPing) checkConnectivity() bool {
 		h.Settings.Connectivity,
 		h.Settings.Timeout,
 	)
-	if _, err := tester.MeasureDelay(h.Settings.HttpMethod); err != nil {
+	if _, err := tester.MeasureDelayContext(ctx, h.Settings.HttpMethod); err != nil {
 		return false
 	}
 	return true

--- a/app/observatory/burst/healthping.go
+++ b/app/observatory/burst/healthping.go
@@ -184,14 +184,15 @@ func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcu
 		seen[tag] = struct{}{}
 		uniqueTags = append(uniqueTags, tag)
 	}
-	if len(uniqueTags) == 0 {
-		return nil
-	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 	if err := h.ctx.Err(); err != nil {
 		return err
+	}
+	if len(uniqueTags) == 0 {
+		h.replaceResults(make(map[string]*HealthPingRTTS))
+		return nil
 	}
 
 	// The caller controls the lifetime of a batch, but it does not own Xray's

--- a/app/observatory/burst/healthping.go
+++ b/app/observatory/burst/healthping.go
@@ -29,14 +29,22 @@ type HealthPing struct {
 	ctx           context.Context
 	cancelCtx     context.CancelFunc
 	cancelPending atomic.Pointer[context.CancelFunc]
+	batchAccess   sync.Mutex
 	dispatcher    routing.Dispatcher
 	access        sync.Mutex
 	ticker        *time.Ticker
 
-	Settings *HealthPingSettings
-	Results  map[string]*HealthPingRTTS
-	onUpdate func()
-	measure  func(context.Context, string) (time.Duration, error)
+	Settings    *HealthPingSettings
+	Results     map[string]*HealthPingRTTS
+	activeProbe *batchProbeResults
+	onUpdate    func()
+	measure     func(context.Context, string) (time.Duration, error)
+}
+
+type batchProbeResults struct {
+	results   map[string]*HealthPingRTTS
+	samples   int
+	published bool
 }
 
 // NewHealthPing creates a new HealthPing with settings
@@ -159,8 +167,9 @@ func (h *HealthPing) Check(tags []string) error {
 
 // ProbeOutbounds performs a finite, cancellable probe batch. Every unique tag
 // is sampled the requested number of times, while the worker pool bounds the
-// total number of probes in flight. Results are built privately and published
-// as one snapshot, so observers never see a partially completed batch.
+// total number of probes in flight. Completed samples are exposed through the
+// active observation view as they arrive. The active view becomes the stable
+// snapshot only after full success; an aborted batch restores the previous one.
 func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcurrency, samples int) error {
 	if ctx == nil {
 		return errors.New("outbound probe context is nil")
@@ -182,8 +191,13 @@ func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcu
 	if err := h.ctx.Err(); err != nil {
 		return err
 	}
+	if !h.batchAccess.TryLock() {
+		return errors.New("an outbound health probe batch is already running")
+	}
+	defer h.batchAccess.Unlock()
 	if len(uniqueTags) == 0 {
 		h.replaceResults(make(map[string]*HealthPingRTTS))
+		h.notifyUpdate()
 		return nil
 	}
 	if _, err := batchProbeDeadline(h.Settings, len(uniqueTags), maxConcurrency, samples); err != nil {
@@ -200,13 +214,11 @@ func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcu
 		cancel()
 	}()
 
-	batchResults := make(map[string]*HealthPingRTTS, len(uniqueTags))
-	for _, tag := range uniqueTags {
-		// Unlike scheduler-owned samples, a completed one-shot batch is an
-		// immutable snapshot. Keep it valid until the next batch replaces it so
-		// early tags cannot expire while later tags are still being measured.
-		batchResults[tag] = NewHealthPingResult(samples, 0)
-	}
+	batchResults := h.beginProbeResults(samples, len(uniqueTags))
+	commitResults := false
+	defer func() {
+		h.finishProbeResults(batchResults, commitResults)
+	}()
 
 	workerCount := min(maxConcurrency, len(uniqueTags))
 	tasks := make(chan string)
@@ -242,7 +254,7 @@ func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcu
 						}
 						delay = rttFailed
 					}
-					batchResults[tag].Put(delay)
+					h.putProbeResult(batchResults, tag, delay)
 				}
 			}
 		}()
@@ -275,7 +287,7 @@ func (h *HealthPing) ProbeOutbounds(ctx context.Context, tags []string, maxConcu
 	if err := runCtx.Err(); err != nil {
 		return err
 	}
-	h.replaceResults(batchResults)
+	commitResults = true
 	return nil
 }
 
@@ -297,6 +309,61 @@ func (h *HealthPing) replaceResults(replacements map[string]*HealthPingRTTS) {
 	h.access.Lock()
 	h.Results = replacements
 	h.access.Unlock()
+}
+
+func (h *HealthPing) beginProbeResults(samples, capacity int) *batchProbeResults {
+	batch := &batchProbeResults{
+		results: make(map[string]*HealthPingRTTS, capacity),
+		samples: samples,
+	}
+	h.access.Lock()
+	h.activeProbe = batch
+	h.access.Unlock()
+	return batch
+}
+
+func (h *HealthPing) putProbeResult(batch *batchProbeResults, tag string, delay time.Duration) {
+	h.access.Lock()
+	if h.activeProbe != batch {
+		h.access.Unlock()
+		return
+	}
+	result := batch.results[tag]
+	if result == nil {
+		// Unlike scheduler-owned samples, a completed one-shot batch is an
+		// immutable snapshot. Keep it valid until a later batch replaces it.
+		result = NewHealthPingResult(batch.samples, 0)
+		batch.results[tag] = result
+	}
+	result.Put(delay)
+	batch.published = true
+	h.access.Unlock()
+	h.notifyUpdate()
+}
+
+func (h *HealthPing) finishProbeResults(batch *batchProbeResults, commit bool) {
+	h.access.Lock()
+	if h.activeProbe != batch {
+		h.access.Unlock()
+		return
+	}
+	if commit {
+		h.Results = batch.results
+	}
+	h.activeProbe = nil
+	published := batch.published
+	h.access.Unlock()
+	if !commit && published {
+		// A subscriber may already have rendered the progressive view. Signal
+		// that it should query again and reveal the previous stable snapshot.
+		h.notifyUpdate()
+	}
+}
+
+func (h *HealthPing) notifyUpdate() {
+	if h.onUpdate != nil {
+		h.onUpdate()
+	}
 }
 
 type rtt struct {
@@ -393,9 +460,7 @@ func (h *HealthPing) PutResult(tag string, rtt time.Duration) {
 	}
 	r.Put(rtt)
 	h.access.Unlock()
-	if h.onUpdate != nil {
-		h.onUpdate()
-	}
+	h.notifyUpdate()
 }
 
 // Cleanup removes results of removed handlers,
@@ -417,8 +482,8 @@ func (h *HealthPing) Cleanup(tags []string) {
 		}
 	}
 	h.access.Unlock()
-	if changed && h.onUpdate != nil {
-		h.onUpdate()
+	if changed {
+		h.notifyUpdate()
 	}
 }
 

--- a/app/observatory/burst/healthping_result.go
+++ b/app/observatory/burst/healthping_result.go
@@ -111,7 +111,10 @@ func (h *HealthPingRTTS) getStatistics() *HealthPingStats {
 		stats.Min = 0
 		return stats
 	}
-	stats.Average = time.Duration(int(sum) / cnt)
+	// time.Duration is int64 even on 32-bit targets. Keep the accumulated
+	// nanoseconds in that width: converting through int corrupts otherwise
+	// valid multi-second measurements on ARMv7 and other 32-bit platforms.
+	stats.Average = sum / time.Duration(cnt)
 	var std float64
 	if cnt < 2 {
 		// no enough data for standard deviation, we assume it's half of the average rtt

--- a/app/observatory/burst/healthping_result.go
+++ b/app/observatory/burst/healthping_result.go
@@ -31,7 +31,8 @@ type pingRTT struct {
 	value time.Duration
 }
 
-// NewHealthPingResult returns a *HealthPingResult with specified capacity
+// NewHealthPingResult returns a *HealthPingResult with specified capacity.
+// A non-positive validity keeps samples until the result itself is replaced.
 func NewHealthPingResult(cap int, validity time.Duration) *HealthPingRTTS {
 	return &HealthPingRTTS{cap: cap, validity: validity}
 }
@@ -86,9 +87,10 @@ func (h *HealthPingRTTS) getStatistics() *HealthPingStats {
 	sum := time.Duration(0)
 	cnt := 0
 	validRTTs := make([]time.Duration, 0)
+	now := time.Now()
 	for _, rtt := range h.rtts {
 		switch {
-		case rtt.value == rttUntested || time.Since(rtt.time) > h.validity:
+		case rtt.value == rttUntested || h.isOutdated(rtt, now):
 			continue
 		case rtt.value == rttFailed:
 			stats.Fail++
@@ -128,6 +130,9 @@ func (h *HealthPingRTTS) getStatistics() *HealthPingStats {
 }
 
 func (h *HealthPingRTTS) findOutdated(now time.Time) int {
+	if h.validity <= 0 {
+		return -1
+	}
 	for i := h.cap - 1; i < 2*h.cap; i++ {
 		// from oldest to latest
 		idx := h.calcIndex(i)
@@ -140,4 +145,8 @@ func (h *HealthPingRTTS) findOutdated(now time.Time) int {
 		}
 	}
 	return -1
+}
+
+func (h *HealthPingRTTS) isOutdated(rtt *pingRTT, now time.Time) bool {
+	return h.validity > 0 && now.Sub(rtt.time) > h.validity
 }

--- a/app/observatory/burst/healthping_result_test.go
+++ b/app/observatory/burst/healthping_result_test.go
@@ -115,3 +115,14 @@ func TestHealthPingResultsCanRemainUnexpired(t *testing.T) {
 		t.Fatalf("non-expiring statistics = %+v, want one successful 42ms sample", actual)
 	}
 }
+
+func TestHealthPingResultsAverageLargeDurations(t *testing.T) {
+	hr := burst.NewHealthPingResult(2, time.Hour)
+	hr.Put(1500 * time.Millisecond)
+	hr.Put(1500 * time.Millisecond)
+
+	actual := hr.Get()
+	if actual.Average != 1500*time.Millisecond {
+		t.Fatalf("average = %v, want 1.5s", actual.Average)
+	}
+}

--- a/app/observatory/burst/healthping_result_test.go
+++ b/app/observatory/burst/healthping_result_test.go
@@ -104,3 +104,14 @@ func TestHealthPingResultsIgnoreOutdated(t *testing.T) {
 		t.Errorf("expected: %v, actual: %v", expected, actual)
 	}
 }
+
+func TestHealthPingResultsCanRemainUnexpired(t *testing.T) {
+	hr := burst.NewHealthPingResult(1, 0)
+	hr.Put(42 * time.Millisecond)
+	time.Sleep(time.Millisecond)
+
+	actual := hr.Get()
+	if actual.All != 1 || actual.Fail != 0 || actual.Average != 42*time.Millisecond {
+		t.Fatalf("non-expiring statistics = %+v, want one successful 42ms sample", actual)
+	}
+}

--- a/app/observatory/burst/healthping_update_test.go
+++ b/app/observatory/burst/healthping_update_test.go
@@ -1,0 +1,31 @@
+package burst
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestHealthPingNotifiesAfterResultUpdate(t *testing.T) {
+	healthPing := NewHealthPing(context.Background(), nil, nil)
+	updates := 0
+	healthPing.onUpdate = func() { updates++ }
+
+	healthPing.PutResult("proxy-a", 42*time.Millisecond)
+
+	if updates != 1 {
+		t.Fatalf("updates = %d, want 1", updates)
+	}
+}
+
+func TestBurstObserverReportsConfiguredProbeDeadline(t *testing.T) {
+	observer := &Observer{hp: &HealthPing{Settings: &HealthPingSettings{Timeout: 30 * time.Second}}}
+	if got, want := observer.ObservationProbeDeadline(), 30*time.Second; got != want {
+		t.Fatalf("probe deadline = %v, want %v", got, want)
+	}
+
+	observer.hp.Settings.Connectivity = "https://example.com/generate_204"
+	if got, want := observer.ObservationProbeDeadline(), 60*time.Second; got != want {
+		t.Fatalf("probe deadline with connectivity check = %v, want %v", got, want)
+	}
+}

--- a/app/observatory/burst/one_shot_probe_test.go
+++ b/app/observatory/burst/one_shot_probe_test.go
@@ -14,6 +14,29 @@ import (
 	"github.com/xtls/xray-core/features/outbound"
 )
 
+func requireObservationUpdate(t *testing.T, updates <-chan struct{}) {
+	t.Helper()
+	select {
+	case _, open := <-updates:
+		if !open {
+			t.Fatal("observation update subscription closed unexpectedly")
+		}
+	default:
+		t.Fatal("observer did not publish a result update")
+	}
+}
+
+func requireNoObservationUpdate(t *testing.T, updates <-chan struct{}) {
+	t.Helper()
+	select {
+	case _, open := <-updates:
+		if open {
+			t.Fatal("observer published an unexpected result update")
+		}
+	default:
+	}
+}
+
 func TestOneShotProbeBoundsConcurrencyAndSamplesEveryTag(t *testing.T) {
 	healthPing := NewHealthPing(context.Background(), nil, nil)
 	tags := []string{"proxy-a", "proxy-b", "proxy-c"}
@@ -29,24 +52,10 @@ func TestOneShotProbeBoundsConcurrencyAndSamplesEveryTag(t *testing.T) {
 
 	var active atomic.Int32
 	var peak atomic.Int32
-	var updates atomic.Int32
-	var expectedSamples atomic.Int32
-	var incompletePublication atomic.Bool
 	var tagAccess sync.Mutex
 	activeTags := make(map[string]int)
 	concurrentSample := false
-	expectedSamples.Store(3)
-	unsubscribe := observer.SubscribeObservationUpdates(func() {
-		healthPing.access.Lock()
-		defer healthPing.access.Unlock()
-		for _, tag := range tags {
-			result := healthPing.Results[tag]
-			if result == nil || result.getStatistics().All != int(expectedSamples.Load()) {
-				incompletePublication.Store(true)
-			}
-		}
-		updates.Add(1)
-	})
+	updates, unsubscribe := observer.SubscribeObservationUpdates()
 	defer unsubscribe()
 	healthPing.measure = func(ctx context.Context, tag string) (time.Duration, error) {
 		current := active.Add(1)
@@ -87,12 +96,8 @@ func TestOneShotProbeBoundsConcurrencyAndSamplesEveryTag(t *testing.T) {
 	if concurrentSample {
 		t.Fatal("samples for the same outbound ran concurrently")
 	}
-	if got := updates.Load(); got != 1 {
-		t.Fatalf("result updates = %d, want one atomic publication", got)
-	}
-	if incompletePublication.Load() {
-		t.Fatal("observer was notified before the complete batch was published")
-	}
+	requireObservationUpdate(t, updates)
+	requireNoObservationUpdate(t, updates)
 
 	healthPing.access.Lock()
 	if _, found := healthPing.Results["stale"]; found {
@@ -113,13 +118,11 @@ func TestOneShotProbeBoundsConcurrencyAndSamplesEveryTag(t *testing.T) {
 	healthPing.access.Unlock()
 
 	// A later batch must replace, rather than accumulate with, prior samples.
-	expectedSamples.Store(1)
 	if err := observer.ProbeOutbounds(context.Background(), tags, 1, 1); err != nil {
 		t.Fatal(err)
 	}
-	if got := updates.Load(); got != 2 {
-		t.Fatalf("result updates after replacement = %d, want 2", got)
-	}
+	requireObservationUpdate(t, updates)
+	requireNoObservationUpdate(t, updates)
 	healthPing.access.Lock()
 	defer healthPing.access.Unlock()
 	for _, tag := range tags {
@@ -140,15 +143,14 @@ func TestOneShotProbePublishesEmptySnapshot(t *testing.T) {
 		ohm:    &probeTestManager{handlers: map[string]outbound.Handler{}},
 	}
 	defer observer.Close()
-	var updates atomic.Int32
-	observer.SubscribeObservationUpdates(func() { updates.Add(1) })
+	updates, unsubscribe := observer.SubscribeObservationUpdates()
+	defer unsubscribe()
 
 	if err := observer.ProbeOutbounds(context.Background(), nil, 1, 1); err != nil {
 		t.Fatal(err)
 	}
-	if got := updates.Load(); got != 1 {
-		t.Fatalf("result updates = %d, want one empty-snapshot publication", got)
-	}
+	requireObservationUpdate(t, updates)
+	requireNoObservationUpdate(t, updates)
 	healthPing.access.Lock()
 	defer healthPing.access.Unlock()
 	if len(healthPing.Results) != 0 {
@@ -231,16 +233,14 @@ func TestOneShotProbePreservesSnapshotWhenNetworkIsUnavailable(t *testing.T) {
 	}}
 	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
 	defer observer.Close()
-	var updates atomic.Int32
-	observer.SubscribeObservationUpdates(func() { updates.Add(1) })
+	updates, unsubscribe := observer.SubscribeObservationUpdates()
+	defer unsubscribe()
 
 	err := observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1)
 	if !stderrors.Is(err, extension.ErrObservatoryProbeNetworkUnavailable) {
 		t.Fatalf("probe error = %v, want network-unavailable error", err)
 	}
-	if got := updates.Load(); got != 0 {
-		t.Fatalf("result updates = %d, want none for an aborted batch", got)
-	}
+	requireNoObservationUpdate(t, updates)
 	healthPing.access.Lock()
 	defer healthPing.access.Unlock()
 	if healthPing.Results["previous"] != previous || len(healthPing.Results) != 1 {
@@ -248,7 +248,7 @@ func TestOneShotProbePreservesSnapshotWhenNetworkIsUnavailable(t *testing.T) {
 	}
 }
 
-func TestObserverUpdateListenerCanCloseAfterPublication(t *testing.T) {
+func TestObserverSubscriberCanCloseAfterPublication(t *testing.T) {
 	healthPing := NewHealthPing(context.Background(), nil, nil)
 	healthPing.measure = func(context.Context, string) (time.Duration, error) {
 		return 20 * time.Millisecond, nil
@@ -257,30 +257,18 @@ func TestObserverUpdateListenerCanCloseAfterPublication(t *testing.T) {
 		"proxy-a": &probeTestHandler{tag: "proxy-a"},
 	}}
 	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
-	listenerDone := make(chan error, 1)
-	observer.SubscribeObservationUpdates(func() {
-		listenerDone <- observer.Close()
-	})
+	updates, unsubscribe := observer.SubscribeObservationUpdates()
+	defer unsubscribe()
 
-	probeDone := make(chan error, 1)
-	go func() {
-		probeDone <- observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1)
-	}()
-	select {
-	case err := <-listenerDone:
-		if err != nil {
-			t.Fatal(err)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("update listener deadlocked while closing the observer")
+	if err := observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1); err != nil {
+		t.Fatal(err)
 	}
-	select {
-	case err := <-probeDone:
-		if err != nil {
-			t.Fatal(err)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("probe did not return after its update listener closed the observer")
+	requireObservationUpdate(t, updates)
+	if err := observer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, open := <-updates; open {
+		t.Fatal("observer close left the update subscription open")
 	}
 }
 
@@ -476,54 +464,8 @@ func TestObserverDropsManualCheckDuringBatch(t *testing.T) {
 	}
 }
 
-func TestObserverRejectsBatchDuringManualCheckPublication(t *testing.T) {
+func TestUnreadObservationUpdatesDoNotBlockProbeCompletion(t *testing.T) {
 	healthPing := NewHealthPing(context.Background(), nil, nil)
-	healthPing.Settings.Destination = "://invalid-probe-url"
-	manager := &probeTestManager{handlers: map[string]outbound.Handler{
-		"proxy-a": &probeTestHandler{tag: "proxy-a"},
-	}}
-	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
-	healthPing.onUpdate = observer.updates.NotifyObservationUpdate
-	defer observer.Close()
-
-	listenerStarted := make(chan struct{})
-	releaseListener := make(chan struct{})
-	var listenerOnce sync.Once
-	observer.SubscribeObservationUpdates(func() {
-		listenerOnce.Do(func() { close(listenerStarted) })
-		<-releaseListener
-	})
-	checkDone := make(chan struct{})
-	go func() {
-		observer.Check([]string{"manual"})
-		close(checkDone)
-	}()
-	<-listenerStarted
-
-	probeDone := make(chan error, 1)
-	go func() {
-		probeDone <- observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1)
-	}()
-	select {
-	case err := <-probeDone:
-		if err == nil || !strings.Contains(err.Error(), "manual outbound check") {
-			t.Fatalf("probe error = %v, want active-manual-check error", err)
-		}
-	case <-time.After(time.Second):
-		close(releaseListener)
-		t.Fatal("batch probe blocked behind a manual check")
-	}
-	close(releaseListener)
-	select {
-	case <-checkDone:
-	case <-time.After(time.Second):
-		t.Fatal("manual check did not finish after listener release")
-	}
-}
-
-func TestObserverRejectsReentrantWorkDuringBatchPublication(t *testing.T) {
-	healthPing := NewHealthPing(context.Background(), nil, nil)
-	healthPing.Settings.Destination = "://invalid-probe-url"
 	healthPing.measure = func(context.Context, string) (time.Duration, error) {
 		return 20 * time.Millisecond, nil
 	}
@@ -533,29 +475,18 @@ func TestObserverRejectsReentrantWorkDuringBatchPublication(t *testing.T) {
 	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
 	healthPing.onUpdate = observer.updates.NotifyObservationUpdate
 	defer observer.Close()
-
-	var updates atomic.Int32
-	nestedProbeError := make(chan error, 1)
-	observer.SubscribeObservationUpdates(func() {
-		if updates.Add(1) != 1 {
-			return
-		}
-		observer.Check([]string{"manual"})
-		nestedProbeError <- observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1)
-	})
+	updates, unsubscribe := observer.SubscribeObservationUpdates()
+	defer unsubscribe()
 
 	if err := observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1); err != nil {
 		t.Fatal(err)
 	}
-	if got := updates.Load(); got != 1 {
-		t.Fatalf("publication updates = %d, want exactly one", got)
+	if err := observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1); err != nil {
+		t.Fatal(err)
 	}
-	if err := <-nestedProbeError; err == nil || !strings.Contains(err.Error(), "being published") {
-		t.Fatalf("nested probe error = %v, want publication-in-progress error", err)
-	}
-	healthPing.access.Lock()
-	defer healthPing.access.Unlock()
-	if _, found := healthPing.Results["manual"]; found {
-		t.Fatal("reentrant manual check mutated the published batch")
-	}
+
+	// Both successful batches complete while the single-slot notification
+	// channel is deliberately left unread. Their signals are coalesced.
+	requireObservationUpdate(t, updates)
+	requireNoObservationUpdate(t, updates)
 }

--- a/app/observatory/burst/one_shot_probe_test.go
+++ b/app/observatory/burst/one_shot_probe_test.go
@@ -3,6 +3,7 @@ package burst
 import (
 	"context"
 	stderrors "errors"
+	"math"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -152,6 +153,45 @@ func TestOneShotProbePublishesEmptySnapshot(t *testing.T) {
 	defer healthPing.access.Unlock()
 	if len(healthPing.Results) != 0 {
 		t.Fatalf("empty batch retained %d stale results", len(healthPing.Results))
+	}
+}
+
+func TestObserverReportsBatchProbeDeadline(t *testing.T) {
+	tags := []string{"proxy-a", "proxy-b", "proxy-c", "proxy-d", "proxy-e"}
+	manager := &probeTestManager{handlers: make(map[string]outbound.Handler, len(tags))}
+	for _, tag := range tags {
+		manager.handlers[tag] = &probeTestHandler{tag: tag}
+	}
+	healthPing := NewHealthPing(context.Background(), nil, nil)
+	healthPing.Settings.Timeout = 2 * time.Second
+	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+	defer observer.Close()
+
+	withDuplicate := append(append([]string{}, tags...), "proxy-a")
+	if got, err := observer.ProbeOutboundsDeadline(withDuplicate, 2, 3); err != nil || got != 18*time.Second {
+		t.Fatalf("batch deadline = %v, %v; want 18s, nil", got, err)
+	}
+	healthPing.Settings.Connectivity = "https://example.com/generate_204"
+	if got, err := observer.ProbeOutboundsDeadline(withDuplicate, 2, 3); err != nil || got != 36*time.Second {
+		t.Fatalf("batch deadline with connectivity = %v, %v; want 36s, nil", got, err)
+	}
+	healthPing.Settings.Connectivity = ""
+	if got, err := observer.ProbeOutboundsDeadline(tags, 10, 3); err != nil || got != 6*time.Second {
+		t.Fatalf("single-wave batch deadline = %v, %v; want 6s, nil", got, err)
+	}
+	if got, err := observer.ProbeOutboundsDeadline(nil, 2, 3); err != nil || got != 0 {
+		t.Fatalf("empty batch deadline = %v, %v; want 0, nil", got, err)
+	}
+	if _, err := observer.ProbeOutboundsDeadline(tags, 0, 1); err == nil {
+		t.Fatal("zero concurrency did not return an error")
+	}
+	if _, err := observer.ProbeOutboundsDeadline(tags, 1, 0); err == nil {
+		t.Fatal("zero samples did not return an error")
+	}
+
+	healthPing.Settings.Timeout = time.Duration(math.MaxInt64/2 + 1)
+	if _, err := observer.ProbeOutboundsDeadline(tags[:2], 1, 1); err == nil {
+		t.Fatal("overflowing batch deadline did not return an error")
 	}
 }
 

--- a/app/observatory/burst/one_shot_probe_test.go
+++ b/app/observatory/burst/one_shot_probe_test.go
@@ -3,6 +3,7 @@ package burst
 import (
 	"context"
 	stderrors "errors"
+	"fmt"
 	"math"
 	"strings"
 	"sync"
@@ -194,6 +195,57 @@ func TestObserverReportsBatchProbeDeadline(t *testing.T) {
 	healthPing.Settings.Timeout = time.Duration(math.MaxInt64/2 + 1)
 	if _, err := observer.ProbeOutboundsDeadline(tags[:2], 1, 1); err == nil {
 		t.Fatal("overflowing batch deadline did not return an error")
+	}
+	var measures atomic.Int32
+	healthPing.measure = func(context.Context, string) (time.Duration, error) {
+		measures.Add(1)
+		return time.Millisecond, nil
+	}
+	if err := observer.ProbeOutbounds(context.Background(), tags[:2], 1, 1); err == nil {
+		t.Fatal("batch with an overflowing deadline started probing")
+	}
+	if got := measures.Load(); got != 0 {
+		t.Fatalf("overflowing batch started %d measurements, want none", got)
+	}
+}
+
+func TestObserverRejectsUnboundedBatchWork(t *testing.T) {
+	workerTags := make([]string, maxBatchProbeWorkers+1)
+	manager := &probeTestManager{handlers: make(map[string]outbound.Handler, len(workerTags))}
+	for i := range workerTags {
+		workerTags[i] = fmt.Sprintf("proxy-%d", i)
+		manager.handlers[workerTags[i]] = &probeTestHandler{tag: workerTags[i]}
+	}
+	healthPing := NewHealthPing(context.Background(), nil, nil)
+	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+	defer observer.Close()
+
+	if _, err := observer.ProbeOutboundsDeadline(
+		workerTags[:1],
+		1,
+		maxBatchProbeSamplesPerOutbound+1,
+	); err == nil || !strings.Contains(err.Error(), "sample count exceeds") {
+		t.Fatalf("sample limit error = %v", err)
+	}
+	if _, err := observer.ProbeOutboundsDeadline(
+		workerTags,
+		len(workerTags),
+		1,
+	); err == nil || !strings.Contains(err.Error(), "active-worker limit") {
+		t.Fatalf("worker limit error = %v", err)
+	}
+
+	retainedTags := make([]string, maxBatchProbeRetainedMeasurements/maxBatchProbeSamplesPerOutbound+1)
+	for i := range retainedTags {
+		retainedTags[i] = fmt.Sprintf("retained-%d", i)
+		manager.handlers[retainedTags[i]] = &probeTestHandler{tag: retainedTags[i]}
+	}
+	if _, err := observer.ProbeOutboundsDeadline(
+		retainedTags,
+		1,
+		maxBatchProbeSamplesPerOutbound,
+	); err == nil || !strings.Contains(err.Error(), "retained-measurement limit") {
+		t.Fatalf("retained measurement limit error = %v", err)
 	}
 }
 

--- a/app/observatory/burst/one_shot_probe_test.go
+++ b/app/observatory/burst/one_shot_probe_test.go
@@ -128,6 +128,33 @@ func TestOneShotProbeBoundsConcurrencyAndSamplesEveryTag(t *testing.T) {
 	}
 }
 
+func TestOneShotProbePublishesEmptySnapshot(t *testing.T) {
+	healthPing := NewHealthPing(context.Background(), nil, nil)
+	staleResult := NewHealthPingResult(1, time.Hour)
+	staleResult.Put(time.Second)
+	healthPing.Results = map[string]*HealthPingRTTS{"stale": staleResult}
+	observer := &Observer{
+		config: &Config{},
+		hp:     healthPing,
+		ohm:    &probeTestManager{handlers: map[string]outbound.Handler{}},
+	}
+	defer observer.Close()
+	var updates atomic.Int32
+	observer.SubscribeObservationUpdates(func() { updates.Add(1) })
+
+	if err := observer.ProbeOutbounds(context.Background(), nil, 1, 1); err != nil {
+		t.Fatal(err)
+	}
+	if got := updates.Load(); got != 1 {
+		t.Fatalf("result updates = %d, want one empty-snapshot publication", got)
+	}
+	healthPing.access.Lock()
+	defer healthPing.access.Unlock()
+	if len(healthPing.Results) != 0 {
+		t.Fatalf("empty batch retained %d stale results", len(healthPing.Results))
+	}
+}
+
 func TestOneShotProbeRecordsFailedSamples(t *testing.T) {
 	healthPing := NewHealthPing(context.Background(), nil, nil)
 	healthPing.measure = func(context.Context, string) (time.Duration, error) {

--- a/app/observatory/burst/one_shot_probe_test.go
+++ b/app/observatory/burst/one_shot_probe_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	coreobservatory "github.com/xtls/xray-core/app/observatory"
 	"github.com/xtls/xray-core/features/extension"
 	"github.com/xtls/xray-core/features/outbound"
 )
@@ -36,6 +37,35 @@ func requireNoObservationUpdate(t *testing.T, updates <-chan struct{}) {
 		}
 	default:
 	}
+}
+
+func waitForObservationUpdate(t *testing.T, updates <-chan struct{}) {
+	t.Helper()
+	select {
+	case _, open := <-updates:
+		if !open {
+			t.Fatal("observation update subscription closed unexpectedly")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for an observation update")
+	}
+}
+
+func observationStatuses(t *testing.T, observer *Observer) map[string]*coreobservatory.OutboundStatus {
+	t.Helper()
+	message, err := observer.GetObservation(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, ok := message.(*coreobservatory.ObservationResult)
+	if !ok {
+		t.Fatalf("observation type = %T, want *observatory.ObservationResult", message)
+	}
+	statuses := make(map[string]*coreobservatory.OutboundStatus, len(result.Status))
+	for _, status := range result.Status {
+		statuses[status.OutboundTag] = status
+	}
+	return statuses
 }
 
 func TestOneShotProbeBoundsConcurrencyAndSamplesEveryTag(t *testing.T) {
@@ -130,6 +160,74 @@ func TestOneShotProbeBoundsConcurrencyAndSamplesEveryTag(t *testing.T) {
 		if got := healthPing.Results[tag].getStatistics().All; got != 1 {
 			t.Fatalf("replacement samples for %q = %d, want 1", tag, got)
 		}
+	}
+}
+
+func TestOneShotProbePublishesProgressiveResults(t *testing.T) {
+	healthPing := NewHealthPing(context.Background(), nil, nil)
+	secondStarted := make(chan struct{})
+	releaseSecond := make(chan struct{})
+	healthPing.measure = func(ctx context.Context, tag string) (time.Duration, error) {
+		if tag == "proxy-a" {
+			return 20 * time.Millisecond, nil
+		}
+		close(secondStarted)
+		select {
+		case <-releaseSecond:
+			return 40 * time.Millisecond, nil
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		}
+	}
+	manager := &probeTestManager{handlers: map[string]outbound.Handler{
+		"proxy-a": &probeTestHandler{tag: "proxy-a"},
+		"proxy-b": &probeTestHandler{tag: "proxy-b"},
+	}}
+	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+	healthPing.onUpdate = observer.updates.NotifyObservationUpdate
+	defer observer.Close()
+	updates, unsubscribe := observer.SubscribeObservationUpdates()
+	defer unsubscribe()
+
+	probeDone := make(chan error, 1)
+	go func() {
+		probeDone <- observer.ProbeOutbounds(
+			context.Background(),
+			[]string{"proxy-a", "proxy-b"},
+			1,
+			1,
+		)
+	}()
+	<-secondStarted
+	waitForObservationUpdate(t, updates)
+
+	progress := observationStatuses(t, observer)
+	if len(progress) != 1 || progress["proxy-a"] == nil {
+		t.Fatalf("progressive statuses = %v, want only proxy-a", progress)
+	}
+	if got := progress["proxy-a"].Delay; got != 20 {
+		t.Fatalf("progressive proxy-a delay = %dms, want 20ms", got)
+	}
+	if got := progress["proxy-a"].HealthPing.All; got != 1 {
+		t.Fatalf("progressive proxy-a samples = %d, want 1", got)
+	}
+	select {
+	case err := <-probeDone:
+		t.Fatalf("probe completed before proxy-b was released: %v", err)
+	default:
+	}
+
+	close(releaseSecond)
+	if err := <-probeDone; err != nil {
+		t.Fatal(err)
+	}
+	waitForObservationUpdate(t, updates)
+	complete := observationStatuses(t, observer)
+	if len(complete) != 2 || complete["proxy-a"] == nil || complete["proxy-b"] == nil {
+		t.Fatalf("completed statuses = %v, want proxy-a and proxy-b", complete)
+	}
+	if got := complete["proxy-b"].Delay; got != 40 {
+		t.Fatalf("completed proxy-b delay = %dms, want 40ms", got)
 	}
 }
 
@@ -274,25 +372,59 @@ func TestOneShotProbeRecordsFailedSamples(t *testing.T) {
 func TestOneShotProbePreservesSnapshotWhenNetworkIsUnavailable(t *testing.T) {
 	healthPing := NewHealthPing(context.Background(), nil, nil)
 	healthPing.Settings.Connectivity = "://invalid-connectivity-url"
-	healthPing.measure = func(context.Context, string) (time.Duration, error) {
-		return 0, stderrors.New("unreachable")
+	secondStarted := make(chan struct{})
+	releaseSecond := make(chan struct{})
+	healthPing.measure = func(ctx context.Context, tag string) (time.Duration, error) {
+		if tag == "proxy-a" {
+			return 20 * time.Millisecond, nil
+		}
+		close(secondStarted)
+		select {
+		case <-releaseSecond:
+			return 0, stderrors.New("unreachable")
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		}
 	}
 	previous := NewHealthPingResult(1, time.Hour)
 	previous.Put(42 * time.Millisecond)
 	healthPing.Results = map[string]*HealthPingRTTS{"previous": previous}
 	manager := &probeTestManager{handlers: map[string]outbound.Handler{
 		"proxy-a": &probeTestHandler{tag: "proxy-a"},
+		"proxy-b": &probeTestHandler{tag: "proxy-b"},
 	}}
 	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+	healthPing.onUpdate = observer.updates.NotifyObservationUpdate
 	defer observer.Close()
 	updates, unsubscribe := observer.SubscribeObservationUpdates()
 	defer unsubscribe()
 
-	err := observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1)
+	probeDone := make(chan error, 1)
+	go func() {
+		probeDone <- observer.ProbeOutbounds(
+			context.Background(),
+			[]string{"proxy-a", "proxy-b"},
+			1,
+			1,
+		)
+	}()
+	<-secondStarted
+	waitForObservationUpdate(t, updates)
+	progress := observationStatuses(t, observer)
+	if len(progress) != 1 || progress["proxy-a"] == nil {
+		t.Fatalf("progressive statuses = %v, want only proxy-a", progress)
+	}
+
+	close(releaseSecond)
+	err := <-probeDone
 	if !stderrors.Is(err, extension.ErrObservatoryProbeNetworkUnavailable) {
 		t.Fatalf("probe error = %v, want network-unavailable error", err)
 	}
-	requireNoObservationUpdate(t, updates)
+	waitForObservationUpdate(t, updates)
+	rolledBack := observationStatuses(t, observer)
+	if len(rolledBack) != 1 || rolledBack["previous"] == nil {
+		t.Fatalf("rolled-back statuses = %v, want previous snapshot", rolledBack)
+	}
 	healthPing.access.Lock()
 	defer healthPing.access.Unlock()
 	if healthPing.Results["previous"] != previous || len(healthPing.Results) != 1 {
@@ -359,6 +491,53 @@ func TestOneShotProbeHonorsCancellation(t *testing.T) {
 	defer healthPing.access.Unlock()
 	if healthPing.Results["proxy-a"] != previous {
 		t.Fatal("cancelled probe replaced the previous complete result with a partial batch")
+	}
+}
+
+func TestOneShotProbeRollsBackProgressAfterCancellation(t *testing.T) {
+	healthPing := NewHealthPing(context.Background(), nil, nil)
+	previous := NewHealthPingResult(1, time.Hour)
+	previous.Put(42 * time.Millisecond)
+	healthPing.Results = map[string]*HealthPingRTTS{"previous": previous}
+	secondStarted := make(chan struct{})
+	healthPing.measure = func(ctx context.Context, tag string) (time.Duration, error) {
+		if tag == "proxy-a" {
+			return 20 * time.Millisecond, nil
+		}
+		close(secondStarted)
+		<-ctx.Done()
+		return 0, ctx.Err()
+	}
+	manager := &probeTestManager{handlers: map[string]outbound.Handler{
+		"proxy-a": &probeTestHandler{tag: "proxy-a"},
+		"proxy-b": &probeTestHandler{tag: "proxy-b"},
+	}}
+	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+	healthPing.onUpdate = observer.updates.NotifyObservationUpdate
+	defer observer.Close()
+	updates, unsubscribe := observer.SubscribeObservationUpdates()
+	defer unsubscribe()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	probeDone := make(chan error, 1)
+	go func() {
+		probeDone <- observer.ProbeOutbounds(ctx, []string{"proxy-a", "proxy-b"}, 1, 1)
+	}()
+	<-secondStarted
+	waitForObservationUpdate(t, updates)
+	progress := observationStatuses(t, observer)
+	if len(progress) != 1 || progress["proxy-a"] == nil {
+		t.Fatalf("progressive statuses = %v, want only proxy-a", progress)
+	}
+
+	cancel()
+	if err := <-probeDone; !stderrors.Is(err, context.Canceled) {
+		t.Fatalf("probe error = %v, want context cancellation", err)
+	}
+	waitForObservationUpdate(t, updates)
+	rolledBack := observationStatuses(t, observer)
+	if len(rolledBack) != 1 || rolledBack["previous"] == nil {
+		t.Fatalf("rolled-back statuses = %v, want previous snapshot", rolledBack)
 	}
 }
 

--- a/app/observatory/burst/one_shot_probe_test.go
+++ b/app/observatory/burst/one_shot_probe_test.go
@@ -396,3 +396,126 @@ func TestObserverRejectsOverlapAndCloseCancelsProbe(t *testing.T) {
 		t.Fatalf("closed observer error = %v", err)
 	}
 }
+
+func TestObserverDropsManualCheckDuringBatch(t *testing.T) {
+	healthPing := NewHealthPing(context.Background(), nil, nil)
+	healthPing.Settings.Destination = "://invalid-probe-url"
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startedOnce sync.Once
+	healthPing.measure = func(ctx context.Context, _ string) (time.Duration, error) {
+		startedOnce.Do(func() { close(started) })
+		select {
+		case <-release:
+			return 20 * time.Millisecond, nil
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		}
+	}
+	manager := &probeTestManager{handlers: map[string]outbound.Handler{
+		"proxy-a": &probeTestHandler{tag: "proxy-a"},
+	}}
+	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+	defer observer.Close()
+
+	probeDone := make(chan error, 1)
+	go func() {
+		probeDone <- observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1)
+	}()
+	<-started
+	observer.Check([]string{"manual"})
+	healthPing.access.Lock()
+	_, manualResult := healthPing.Results["manual"]
+	healthPing.access.Unlock()
+	if manualResult {
+		t.Fatal("manual check mutated results while a batch was running")
+	}
+	close(release)
+	if err := <-probeDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestObserverRejectsBatchDuringManualCheckPublication(t *testing.T) {
+	healthPing := NewHealthPing(context.Background(), nil, nil)
+	healthPing.Settings.Destination = "://invalid-probe-url"
+	manager := &probeTestManager{handlers: map[string]outbound.Handler{
+		"proxy-a": &probeTestHandler{tag: "proxy-a"},
+	}}
+	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+	healthPing.onUpdate = observer.updates.NotifyObservationUpdate
+	defer observer.Close()
+
+	listenerStarted := make(chan struct{})
+	releaseListener := make(chan struct{})
+	var listenerOnce sync.Once
+	observer.SubscribeObservationUpdates(func() {
+		listenerOnce.Do(func() { close(listenerStarted) })
+		<-releaseListener
+	})
+	checkDone := make(chan struct{})
+	go func() {
+		observer.Check([]string{"manual"})
+		close(checkDone)
+	}()
+	<-listenerStarted
+
+	probeDone := make(chan error, 1)
+	go func() {
+		probeDone <- observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1)
+	}()
+	select {
+	case err := <-probeDone:
+		if err == nil || !strings.Contains(err.Error(), "manual outbound check") {
+			t.Fatalf("probe error = %v, want active-manual-check error", err)
+		}
+	case <-time.After(time.Second):
+		close(releaseListener)
+		t.Fatal("batch probe blocked behind a manual check")
+	}
+	close(releaseListener)
+	select {
+	case <-checkDone:
+	case <-time.After(time.Second):
+		t.Fatal("manual check did not finish after listener release")
+	}
+}
+
+func TestObserverRejectsReentrantWorkDuringBatchPublication(t *testing.T) {
+	healthPing := NewHealthPing(context.Background(), nil, nil)
+	healthPing.Settings.Destination = "://invalid-probe-url"
+	healthPing.measure = func(context.Context, string) (time.Duration, error) {
+		return 20 * time.Millisecond, nil
+	}
+	manager := &probeTestManager{handlers: map[string]outbound.Handler{
+		"proxy-a": &probeTestHandler{tag: "proxy-a"},
+	}}
+	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+	healthPing.onUpdate = observer.updates.NotifyObservationUpdate
+	defer observer.Close()
+
+	var updates atomic.Int32
+	nestedProbeError := make(chan error, 1)
+	observer.SubscribeObservationUpdates(func() {
+		if updates.Add(1) != 1 {
+			return
+		}
+		observer.Check([]string{"manual"})
+		nestedProbeError <- observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1)
+	})
+
+	if err := observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1); err != nil {
+		t.Fatal(err)
+	}
+	if got := updates.Load(); got != 1 {
+		t.Fatalf("publication updates = %d, want exactly one", got)
+	}
+	if err := <-nestedProbeError; err == nil || !strings.Contains(err.Error(), "being published") {
+		t.Fatalf("nested probe error = %v, want publication-in-progress error", err)
+	}
+	healthPing.access.Lock()
+	defer healthPing.access.Unlock()
+	if _, found := healthPing.Results["manual"]; found {
+		t.Fatal("reentrant manual check mutated the published batch")
+	}
+}

--- a/app/observatory/burst/one_shot_probe_test.go
+++ b/app/observatory/burst/one_shot_probe_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/xtls/xray-core/features/extension"
 	"github.com/xtls/xray-core/features/outbound"
 )
 
@@ -146,6 +147,37 @@ func TestOneShotProbeRecordsFailedSamples(t *testing.T) {
 	stats := healthPing.Results["proxy-a"].getStatistics()
 	if stats.All != 2 || stats.Fail != 2 {
 		t.Fatalf("failed sample statistics = all %d, fail %d; want 2, 2", stats.All, stats.Fail)
+	}
+}
+
+func TestOneShotProbePreservesSnapshotWhenNetworkIsUnavailable(t *testing.T) {
+	healthPing := NewHealthPing(context.Background(), nil, nil)
+	healthPing.Settings.Connectivity = "://invalid-connectivity-url"
+	healthPing.measure = func(context.Context, string) (time.Duration, error) {
+		return 0, stderrors.New("unreachable")
+	}
+	previous := NewHealthPingResult(1, time.Hour)
+	previous.Put(42 * time.Millisecond)
+	healthPing.Results = map[string]*HealthPingRTTS{"previous": previous}
+	manager := &probeTestManager{handlers: map[string]outbound.Handler{
+		"proxy-a": &probeTestHandler{tag: "proxy-a"},
+	}}
+	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+	defer observer.Close()
+	var updates atomic.Int32
+	observer.SubscribeObservationUpdates(func() { updates.Add(1) })
+
+	err := observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1)
+	if !stderrors.Is(err, extension.ErrObservatoryProbeNetworkUnavailable) {
+		t.Fatalf("probe error = %v, want network-unavailable error", err)
+	}
+	if got := updates.Load(); got != 0 {
+		t.Fatalf("result updates = %d, want none for an aborted batch", got)
+	}
+	healthPing.access.Lock()
+	defer healthPing.access.Unlock()
+	if healthPing.Results["previous"] != previous || len(healthPing.Results) != 1 {
+		t.Fatal("network-unavailable batch replaced the previous complete snapshot")
 	}
 }
 

--- a/app/observatory/burst/one_shot_probe_test.go
+++ b/app/observatory/burst/one_shot_probe_test.go
@@ -68,6 +68,16 @@ func observationStatuses(t *testing.T, observer *Observer) map[string]*coreobser
 	return statuses
 }
 
+func newProbeTestObserver(healthPing *HealthPing, manager outbound.Manager) *Observer {
+	observer := &Observer{
+		config: &Config{},
+		hp:     healthPing,
+		ohm:    manager,
+	}
+	healthPing.onUpdate = observer.updates.NotifyObservationUpdate
+	return observer
+}
+
 func TestOneShotProbeBoundsConcurrencyAndSamplesEveryTag(t *testing.T) {
 	healthPing := NewHealthPing(context.Background(), nil, nil)
 	tags := []string{"proxy-a", "proxy-b", "proxy-c"}
@@ -75,11 +85,8 @@ func TestOneShotProbeBoundsConcurrencyAndSamplesEveryTag(t *testing.T) {
 	for _, tag := range tags {
 		manager.handlers[tag] = &probeTestHandler{tag: tag}
 	}
-	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+	observer := newProbeTestObserver(healthPing, manager)
 	defer observer.Close()
-	staleResult := NewHealthPingResult(1, time.Hour)
-	staleResult.Put(time.Second)
-	healthPing.Results = map[string]*HealthPingRTTS{"stale": staleResult}
 
 	var active atomic.Int32
 	var peak atomic.Int32
@@ -131,34 +138,14 @@ func TestOneShotProbeBoundsConcurrencyAndSamplesEveryTag(t *testing.T) {
 	requireNoObservationUpdate(t, updates)
 
 	healthPing.access.Lock()
-	if _, found := healthPing.Results["stale"]; found {
-		healthPing.access.Unlock()
-		t.Fatal("completed batch retained a result outside the requested tags")
-	}
+	defer healthPing.access.Unlock()
 	for _, tag := range tags {
 		result := healthPing.Results[tag]
 		if result == nil {
-			healthPing.access.Unlock()
 			t.Fatalf("missing result for %q", tag)
 		}
 		if got := result.getStatistics().All; got != 3 {
-			healthPing.access.Unlock()
 			t.Fatalf("samples for %q = %d, want 3", tag, got)
-		}
-	}
-	healthPing.access.Unlock()
-
-	// A later batch must replace, rather than accumulate with, prior samples.
-	if err := observer.ProbeOutbounds(context.Background(), tags, 1, 1); err != nil {
-		t.Fatal(err)
-	}
-	requireObservationUpdate(t, updates)
-	requireNoObservationUpdate(t, updates)
-	healthPing.access.Lock()
-	defer healthPing.access.Unlock()
-	for _, tag := range tags {
-		if got := healthPing.Results[tag].getStatistics().All; got != 1 {
-			t.Fatalf("replacement samples for %q = %d, want 1", tag, got)
 		}
 	}
 }
@@ -183,8 +170,7 @@ func TestOneShotProbePublishesProgressiveResults(t *testing.T) {
 		"proxy-a": &probeTestHandler{tag: "proxy-a"},
 		"proxy-b": &probeTestHandler{tag: "proxy-b"},
 	}}
-	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
-	healthPing.onUpdate = observer.updates.NotifyObservationUpdate
+	observer := newProbeTestObserver(healthPing, manager)
 	defer observer.Close()
 	updates, unsubscribe := observer.SubscribeObservationUpdates()
 	defer unsubscribe()
@@ -233,14 +219,10 @@ func TestOneShotProbePublishesProgressiveResults(t *testing.T) {
 
 func TestOneShotProbePublishesEmptySnapshot(t *testing.T) {
 	healthPing := NewHealthPing(context.Background(), nil, nil)
-	staleResult := NewHealthPingResult(1, time.Hour)
-	staleResult.Put(time.Second)
-	healthPing.Results = map[string]*HealthPingRTTS{"stale": staleResult}
-	observer := &Observer{
-		config: &Config{},
-		hp:     healthPing,
-		ohm:    &probeTestManager{handlers: map[string]outbound.Handler{}},
-	}
+	observer := newProbeTestObserver(
+		healthPing,
+		&probeTestManager{handlers: map[string]outbound.Handler{}},
+	)
 	defer observer.Close()
 	updates, unsubscribe := observer.SubscribeObservationUpdates()
 	defer unsubscribe()
@@ -265,7 +247,7 @@ func TestObserverReportsBatchProbeDeadline(t *testing.T) {
 	}
 	healthPing := NewHealthPing(context.Background(), nil, nil)
 	healthPing.Settings.Timeout = 2 * time.Second
-	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+	observer := newProbeTestObserver(healthPing, manager)
 	defer observer.Close()
 
 	withDuplicate := append(append([]string{}, tags...), "proxy-a")
@@ -315,7 +297,7 @@ func TestObserverRejectsUnboundedBatchWork(t *testing.T) {
 		manager.handlers[workerTags[i]] = &probeTestHandler{tag: workerTags[i]}
 	}
 	healthPing := NewHealthPing(context.Background(), nil, nil)
-	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+	observer := newProbeTestObserver(healthPing, manager)
 	defer observer.Close()
 
 	if _, err := observer.ProbeOutboundsDeadline(
@@ -355,7 +337,7 @@ func TestOneShotProbeRecordsFailedSamples(t *testing.T) {
 	manager := &probeTestManager{handlers: map[string]outbound.Handler{
 		"proxy-a": &probeTestHandler{tag: "proxy-a"},
 	}}
-	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+	observer := newProbeTestObserver(healthPing, manager)
 	defer observer.Close()
 
 	if err := observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 2); err != nil {
@@ -390,8 +372,7 @@ func TestOneShotProbeRetainsProgressWhenNetworkIsUnavailable(t *testing.T) {
 		"proxy-a": &probeTestHandler{tag: "proxy-a"},
 		"proxy-b": &probeTestHandler{tag: "proxy-b"},
 	}}
-	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
-	healthPing.onUpdate = observer.updates.NotifyObservationUpdate
+	observer := newProbeTestObserver(healthPing, manager)
 	defer observer.Close()
 	updates, unsubscribe := observer.SubscribeObservationUpdates()
 	defer unsubscribe()
@@ -436,7 +417,7 @@ func TestObserverSubscriberCanCloseAfterPublication(t *testing.T) {
 	manager := &probeTestManager{handlers: map[string]outbound.Handler{
 		"proxy-a": &probeTestHandler{tag: "proxy-a"},
 	}}
-	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+	observer := newProbeTestObserver(healthPing, manager)
 	updates, unsubscribe := observer.SubscribeObservationUpdates()
 	defer unsubscribe()
 
@@ -454,7 +435,6 @@ func TestObserverSubscriberCanCloseAfterPublication(t *testing.T) {
 
 func TestOneShotProbeHonorsCancellation(t *testing.T) {
 	healthPing := NewHealthPing(context.Background(), nil, nil)
-	defer healthPing.cancelCtx()
 	started := make(chan struct{})
 	var startedOnce sync.Once
 	healthPing.measure = func(ctx context.Context, _ string) (time.Duration, error) {
@@ -462,11 +442,17 @@ func TestOneShotProbeHonorsCancellation(t *testing.T) {
 		<-ctx.Done()
 		return 0, ctx.Err()
 	}
+	manager := &probeTestManager{handlers: map[string]outbound.Handler{
+		"proxy-a": &probeTestHandler{tag: "proxy-a"},
+		"proxy-b": &probeTestHandler{tag: "proxy-b"},
+	}}
+	observer := newProbeTestObserver(healthPing, manager)
+	defer observer.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		done <- healthPing.ProbeOutbounds(ctx, []string{"proxy-a", "proxy-b"}, 2, 2)
+		done <- observer.ProbeOutbounds(ctx, []string{"proxy-a", "proxy-b"}, 2, 2)
 	}()
 	<-started
 	cancel()
@@ -502,8 +488,7 @@ func TestOneShotProbeRetainsProgressAfterCancellation(t *testing.T) {
 		"proxy-a": &probeTestHandler{tag: "proxy-a"},
 		"proxy-b": &probeTestHandler{tag: "proxy-b"},
 	}}
-	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
-	healthPing.onUpdate = observer.updates.NotifyObservationUpdate
+	observer := newProbeTestObserver(healthPing, manager)
 	defer observer.Close()
 	updates, unsubscribe := observer.SubscribeObservationUpdates()
 	defer unsubscribe()
@@ -538,15 +523,19 @@ func TestOneShotProbeRetainsObserverContext(t *testing.T) {
 		nil,
 		nil,
 	)
-	defer healthPing.cancelCtx()
 	healthPing.measure = func(ctx context.Context, _ string) (time.Duration, error) {
 		if got := ctx.Value(observerContextKey{}); got != contextValue {
 			return 0, stderrors.New("observer context value is missing")
 		}
 		return 20 * time.Millisecond, nil
 	}
+	manager := &probeTestManager{handlers: map[string]outbound.Handler{
+		"proxy-a": &probeTestHandler{tag: "proxy-a"},
+	}}
+	observer := newProbeTestObserver(healthPing, manager)
+	defer observer.Close()
 
-	if err := healthPing.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1); err != nil {
+	if err := observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1); err != nil {
 		t.Fatal(err)
 	}
 	healthPing.access.Lock()
@@ -581,7 +570,7 @@ func TestObserverRejectsMissingAndScheduledOutbounds(t *testing.T) {
 	manager := &probeTestManager{handlers: map[string]outbound.Handler{
 		"proxy-a": &probeTestHandler{tag: "proxy-a"},
 	}}
-	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+	observer := newProbeTestObserver(healthPing, manager)
 	defer observer.Close()
 
 	if err := observer.ProbeOutbounds(context.Background(), []string{"proxy-a", "missing"}, 1, 1); err == nil || !strings.Contains(err.Error(), "not found") {
@@ -609,7 +598,7 @@ func TestObserverRejectsOverlapAndCloseCancelsProbe(t *testing.T) {
 	manager := &probeTestManager{handlers: map[string]outbound.Handler{
 		"proxy-a": &probeTestHandler{tag: "proxy-a"},
 	}}
-	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+	observer := newProbeTestObserver(healthPing, manager)
 
 	probeDone := make(chan error, 1)
 	go func() {
@@ -663,7 +652,7 @@ func TestObserverDropsManualCheckDuringBatch(t *testing.T) {
 	manager := &probeTestManager{handlers: map[string]outbound.Handler{
 		"proxy-a": &probeTestHandler{tag: "proxy-a"},
 	}}
-	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+	observer := newProbeTestObserver(healthPing, manager)
 	defer observer.Close()
 
 	probeDone := make(chan error, 1)
@@ -692,20 +681,16 @@ func TestUnreadObservationUpdatesDoNotBlockProbeCompletion(t *testing.T) {
 	manager := &probeTestManager{handlers: map[string]outbound.Handler{
 		"proxy-a": &probeTestHandler{tag: "proxy-a"},
 	}}
-	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
-	healthPing.onUpdate = observer.updates.NotifyObservationUpdate
+	observer := newProbeTestObserver(healthPing, manager)
 	defer observer.Close()
 	updates, unsubscribe := observer.SubscribeObservationUpdates()
 	defer unsubscribe()
 
-	if err := observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1); err != nil {
-		t.Fatal(err)
-	}
-	if err := observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1); err != nil {
+	if err := observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 2); err != nil {
 		t.Fatal(err)
 	}
 
-	// Both successful batches complete while the single-slot notification
+	// Both sample updates are published while the single-slot notification
 	// channel is deliberately left unread. Their signals are coalesced.
 	requireObservationUpdate(t, updates)
 	requireNoObservationUpdate(t, updates)

--- a/app/observatory/burst/one_shot_probe_test.go
+++ b/app/observatory/burst/one_shot_probe_test.go
@@ -1,0 +1,312 @@
+package burst
+
+import (
+	"context"
+	stderrors "errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/xtls/xray-core/features/outbound"
+)
+
+func TestOneShotProbeBoundsConcurrencyAndSamplesEveryTag(t *testing.T) {
+	healthPing := NewHealthPing(context.Background(), nil, nil)
+	tags := []string{"proxy-a", "proxy-b", "proxy-c"}
+	manager := &probeTestManager{handlers: map[string]outbound.Handler{}}
+	for _, tag := range tags {
+		manager.handlers[tag] = &probeTestHandler{tag: tag}
+	}
+	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+	defer observer.Close()
+	staleResult := NewHealthPingResult(1, time.Hour)
+	staleResult.Put(time.Second)
+	healthPing.Results = map[string]*HealthPingRTTS{"stale": staleResult}
+
+	var active atomic.Int32
+	var peak atomic.Int32
+	var updates atomic.Int32
+	var expectedSamples atomic.Int32
+	var incompletePublication atomic.Bool
+	var tagAccess sync.Mutex
+	activeTags := make(map[string]int)
+	concurrentSample := false
+	expectedSamples.Store(3)
+	unsubscribe := observer.SubscribeObservationUpdates(func() {
+		healthPing.access.Lock()
+		defer healthPing.access.Unlock()
+		for _, tag := range tags {
+			result := healthPing.Results[tag]
+			if result == nil || result.getStatistics().All != int(expectedSamples.Load()) {
+				incompletePublication.Store(true)
+			}
+		}
+		updates.Add(1)
+	})
+	defer unsubscribe()
+	healthPing.measure = func(ctx context.Context, tag string) (time.Duration, error) {
+		current := active.Add(1)
+		for {
+			previous := peak.Load()
+			if current <= previous || peak.CompareAndSwap(previous, current) {
+				break
+			}
+		}
+		tagAccess.Lock()
+		activeTags[tag]++
+		if activeTags[tag] > 1 {
+			concurrentSample = true
+		}
+		tagAccess.Unlock()
+		defer func() {
+			tagAccess.Lock()
+			activeTags[tag]--
+			tagAccess.Unlock()
+			active.Add(-1)
+		}()
+
+		select {
+		case <-time.After(10 * time.Millisecond):
+			return 20 * time.Millisecond, nil
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		}
+	}
+
+	probeTags := append(append([]string{}, tags...), "proxy-a")
+	if err := observer.ProbeOutbounds(context.Background(), probeTags, 2, 3); err != nil {
+		t.Fatal(err)
+	}
+	if got := peak.Load(); got != 2 {
+		t.Fatalf("peak probes = %d, want 2", got)
+	}
+	if concurrentSample {
+		t.Fatal("samples for the same outbound ran concurrently")
+	}
+	if got := updates.Load(); got != 1 {
+		t.Fatalf("result updates = %d, want one atomic publication", got)
+	}
+	if incompletePublication.Load() {
+		t.Fatal("observer was notified before the complete batch was published")
+	}
+
+	healthPing.access.Lock()
+	if _, found := healthPing.Results["stale"]; found {
+		healthPing.access.Unlock()
+		t.Fatal("completed batch retained a result outside the requested tags")
+	}
+	for _, tag := range tags {
+		result := healthPing.Results[tag]
+		if result == nil {
+			healthPing.access.Unlock()
+			t.Fatalf("missing result for %q", tag)
+		}
+		if got := result.getStatistics().All; got != 3 {
+			healthPing.access.Unlock()
+			t.Fatalf("samples for %q = %d, want 3", tag, got)
+		}
+	}
+	healthPing.access.Unlock()
+
+	// A later batch must replace, rather than accumulate with, prior samples.
+	expectedSamples.Store(1)
+	if err := observer.ProbeOutbounds(context.Background(), tags, 1, 1); err != nil {
+		t.Fatal(err)
+	}
+	if got := updates.Load(); got != 2 {
+		t.Fatalf("result updates after replacement = %d, want 2", got)
+	}
+	healthPing.access.Lock()
+	defer healthPing.access.Unlock()
+	for _, tag := range tags {
+		if got := healthPing.Results[tag].getStatistics().All; got != 1 {
+			t.Fatalf("replacement samples for %q = %d, want 1", tag, got)
+		}
+	}
+}
+
+func TestOneShotProbeRecordsFailedSamples(t *testing.T) {
+	healthPing := NewHealthPing(context.Background(), nil, nil)
+	healthPing.measure = func(context.Context, string) (time.Duration, error) {
+		return 0, stderrors.New("unreachable")
+	}
+	manager := &probeTestManager{handlers: map[string]outbound.Handler{
+		"proxy-a": &probeTestHandler{tag: "proxy-a"},
+	}}
+	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+	defer observer.Close()
+
+	if err := observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 2); err != nil {
+		t.Fatal(err)
+	}
+	healthPing.access.Lock()
+	defer healthPing.access.Unlock()
+	stats := healthPing.Results["proxy-a"].getStatistics()
+	if stats.All != 2 || stats.Fail != 2 {
+		t.Fatalf("failed sample statistics = all %d, fail %d; want 2, 2", stats.All, stats.Fail)
+	}
+}
+
+func TestObserverUpdateListenerCanCloseAfterPublication(t *testing.T) {
+	healthPing := NewHealthPing(context.Background(), nil, nil)
+	healthPing.measure = func(context.Context, string) (time.Duration, error) {
+		return 20 * time.Millisecond, nil
+	}
+	manager := &probeTestManager{handlers: map[string]outbound.Handler{
+		"proxy-a": &probeTestHandler{tag: "proxy-a"},
+	}}
+	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+	listenerDone := make(chan error, 1)
+	observer.SubscribeObservationUpdates(func() {
+		listenerDone <- observer.Close()
+	})
+
+	probeDone := make(chan error, 1)
+	go func() {
+		probeDone <- observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1)
+	}()
+	select {
+	case err := <-listenerDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("update listener deadlocked while closing the observer")
+	}
+	select {
+	case err := <-probeDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("probe did not return after its update listener closed the observer")
+	}
+}
+
+func TestOneShotProbeHonorsCancellation(t *testing.T) {
+	healthPing := NewHealthPing(context.Background(), nil, nil)
+	defer healthPing.cancelCtx()
+	previous := NewHealthPingResult(1, time.Hour)
+	previous.Put(42 * time.Millisecond)
+	healthPing.Results = map[string]*HealthPingRTTS{"proxy-a": previous}
+	started := make(chan struct{})
+	var startedOnce sync.Once
+	healthPing.measure = func(ctx context.Context, _ string) (time.Duration, error) {
+		startedOnce.Do(func() { close(started) })
+		<-ctx.Done()
+		return 0, ctx.Err()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- healthPing.ProbeOutbounds(ctx, []string{"proxy-a", "proxy-b"}, 2, 2)
+	}()
+	<-started
+	cancel()
+
+	select {
+	case err := <-done:
+		if !stderrors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v, want context cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancelled probe batch did not return")
+	}
+
+	healthPing.access.Lock()
+	defer healthPing.access.Unlock()
+	if healthPing.Results["proxy-a"] != previous {
+		t.Fatal("cancelled probe replaced the previous complete result with a partial batch")
+	}
+}
+
+type probeTestHandler struct {
+	outbound.Handler
+	tag string
+}
+
+func (h *probeTestHandler) Tag() string { return h.tag }
+
+type probeTestManager struct {
+	outbound.Manager
+	handlers map[string]outbound.Handler
+}
+
+func (m *probeTestManager) GetHandler(tag string) outbound.Handler { return m.handlers[tag] }
+
+func TestObserverRejectsMissingAndScheduledOutbounds(t *testing.T) {
+	healthPing := NewHealthPing(context.Background(), nil, nil)
+	var measures atomic.Int32
+	healthPing.measure = func(context.Context, string) (time.Duration, error) {
+		measures.Add(1)
+		return time.Millisecond, nil
+	}
+	manager := &probeTestManager{handlers: map[string]outbound.Handler{
+		"proxy-a": &probeTestHandler{tag: "proxy-a"},
+	}}
+	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+	defer observer.Close()
+
+	if err := observer.ProbeOutbounds(context.Background(), []string{"proxy-a", "missing"}, 1, 1); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("missing handler error = %v", err)
+	}
+	if got := measures.Load(); got != 0 {
+		t.Fatalf("started %d probes before validating every outbound tag", got)
+	}
+
+	observer.config.SubjectSelector = []string{"proxy"}
+	if err := observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1); err == nil || !strings.Contains(err.Error(), "scheduled selectors") {
+		t.Fatalf("scheduled observer error = %v", err)
+	}
+}
+
+func TestObserverRejectsOverlapAndCloseCancelsProbe(t *testing.T) {
+	healthPing := NewHealthPing(context.Background(), nil, nil)
+	started := make(chan struct{})
+	var startedOnce sync.Once
+	healthPing.measure = func(ctx context.Context, _ string) (time.Duration, error) {
+		startedOnce.Do(func() { close(started) })
+		<-ctx.Done()
+		return 0, ctx.Err()
+	}
+	manager := &probeTestManager{handlers: map[string]outbound.Handler{
+		"proxy-a": &probeTestHandler{tag: "proxy-a"},
+	}}
+	observer := &Observer{config: &Config{}, hp: healthPing, ohm: manager}
+
+	probeDone := make(chan error, 1)
+	go func() {
+		probeDone <- observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1)
+	}()
+	<-started
+
+	if err := observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1); err == nil || !strings.Contains(err.Error(), "already running") {
+		t.Fatalf("overlapping probe error = %v", err)
+	}
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- observer.Close() }()
+	select {
+	case err := <-probeDone:
+		if !stderrors.Is(err, context.Canceled) {
+			t.Fatalf("probe error after close = %v, want context cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("observer close did not cancel the probe")
+	}
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("observer close did not wait for probe shutdown")
+	}
+
+	if err := observer.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1); err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("closed observer error = %v", err)
+	}
+}

--- a/app/observatory/burst/one_shot_probe_test.go
+++ b/app/observatory/burst/one_shot_probe_test.go
@@ -223,6 +223,33 @@ func TestOneShotProbeHonorsCancellation(t *testing.T) {
 	}
 }
 
+func TestOneShotProbeRetainsObserverContext(t *testing.T) {
+	type observerContextKey struct{}
+	contextValue := new(int)
+	healthPing := NewHealthPing(
+		context.WithValue(context.Background(), observerContextKey{}, contextValue),
+		nil,
+		nil,
+	)
+	defer healthPing.cancelCtx()
+	healthPing.measure = func(ctx context.Context, _ string) (time.Duration, error) {
+		if got := ctx.Value(observerContextKey{}); got != contextValue {
+			return 0, stderrors.New("observer context value is missing")
+		}
+		return 20 * time.Millisecond, nil
+	}
+
+	if err := healthPing.ProbeOutbounds(context.Background(), []string{"proxy-a"}, 1, 1); err != nil {
+		t.Fatal(err)
+	}
+	healthPing.access.Lock()
+	defer healthPing.access.Unlock()
+	stats := healthPing.Results["proxy-a"].getStatistics()
+	if stats.All != 1 || stats.Fail != 0 {
+		t.Fatalf("probe statistics = all %d, fail %d; want 1, 0", stats.All, stats.Fail)
+	}
+}
+
 type probeTestHandler struct {
 	outbound.Handler
 	tag string

--- a/app/observatory/burst/one_shot_probe_test.go
+++ b/app/observatory/burst/one_shot_probe_test.go
@@ -369,7 +369,7 @@ func TestOneShotProbeRecordsFailedSamples(t *testing.T) {
 	}
 }
 
-func TestOneShotProbePreservesSnapshotWhenNetworkIsUnavailable(t *testing.T) {
+func TestOneShotProbeRetainsProgressWhenNetworkIsUnavailable(t *testing.T) {
 	healthPing := NewHealthPing(context.Background(), nil, nil)
 	healthPing.Settings.Connectivity = "://invalid-connectivity-url"
 	secondStarted := make(chan struct{})
@@ -386,9 +386,6 @@ func TestOneShotProbePreservesSnapshotWhenNetworkIsUnavailable(t *testing.T) {
 			return 0, ctx.Err()
 		}
 	}
-	previous := NewHealthPingResult(1, time.Hour)
-	previous.Put(42 * time.Millisecond)
-	healthPing.Results = map[string]*HealthPingRTTS{"previous": previous}
 	manager := &probeTestManager{handlers: map[string]outbound.Handler{
 		"proxy-a": &probeTestHandler{tag: "proxy-a"},
 		"proxy-b": &probeTestHandler{tag: "proxy-b"},
@@ -420,15 +417,14 @@ func TestOneShotProbePreservesSnapshotWhenNetworkIsUnavailable(t *testing.T) {
 	if !stderrors.Is(err, extension.ErrObservatoryProbeNetworkUnavailable) {
 		t.Fatalf("probe error = %v, want network-unavailable error", err)
 	}
-	waitForObservationUpdate(t, updates)
-	rolledBack := observationStatuses(t, observer)
-	if len(rolledBack) != 1 || rolledBack["previous"] == nil {
-		t.Fatalf("rolled-back statuses = %v, want previous snapshot", rolledBack)
+	partial := observationStatuses(t, observer)
+	if len(partial) != 1 || partial["proxy-a"] == nil {
+		t.Fatalf("partial statuses = %v, want completed proxy-a result", partial)
 	}
 	healthPing.access.Lock()
 	defer healthPing.access.Unlock()
-	if healthPing.Results["previous"] != previous || len(healthPing.Results) != 1 {
-		t.Fatal("network-unavailable batch replaced the previous complete snapshot")
+	if healthPing.Results["proxy-a"] == nil || len(healthPing.Results) != 1 {
+		t.Fatal("network-unavailable batch discarded its completed measurements")
 	}
 }
 
@@ -459,9 +455,6 @@ func TestObserverSubscriberCanCloseAfterPublication(t *testing.T) {
 func TestOneShotProbeHonorsCancellation(t *testing.T) {
 	healthPing := NewHealthPing(context.Background(), nil, nil)
 	defer healthPing.cancelCtx()
-	previous := NewHealthPingResult(1, time.Hour)
-	previous.Put(42 * time.Millisecond)
-	healthPing.Results = map[string]*HealthPingRTTS{"proxy-a": previous}
 	started := make(chan struct{})
 	var startedOnce sync.Once
 	healthPing.measure = func(ctx context.Context, _ string) (time.Duration, error) {
@@ -489,16 +482,13 @@ func TestOneShotProbeHonorsCancellation(t *testing.T) {
 
 	healthPing.access.Lock()
 	defer healthPing.access.Unlock()
-	if healthPing.Results["proxy-a"] != previous {
-		t.Fatal("cancelled probe replaced the previous complete result with a partial batch")
+	if len(healthPing.Results) != 0 {
+		t.Fatal("cancelled probe with no completed measurements exposed stale results")
 	}
 }
 
-func TestOneShotProbeRollsBackProgressAfterCancellation(t *testing.T) {
+func TestOneShotProbeRetainsProgressAfterCancellation(t *testing.T) {
 	healthPing := NewHealthPing(context.Background(), nil, nil)
-	previous := NewHealthPingResult(1, time.Hour)
-	previous.Put(42 * time.Millisecond)
-	healthPing.Results = map[string]*HealthPingRTTS{"previous": previous}
 	secondStarted := make(chan struct{})
 	healthPing.measure = func(ctx context.Context, tag string) (time.Duration, error) {
 		if tag == "proxy-a" {
@@ -534,10 +524,9 @@ func TestOneShotProbeRollsBackProgressAfterCancellation(t *testing.T) {
 	if err := <-probeDone; !stderrors.Is(err, context.Canceled) {
 		t.Fatalf("probe error = %v, want context cancellation", err)
 	}
-	waitForObservationUpdate(t, updates)
-	rolledBack := observationStatuses(t, observer)
-	if len(rolledBack) != 1 || rolledBack["previous"] == nil {
-		t.Fatalf("rolled-back statuses = %v, want previous snapshot", rolledBack)
+	partial := observationStatuses(t, observer)
+	if len(partial) != 1 || partial["proxy-a"] == nil {
+		t.Fatalf("partial statuses = %v, want completed proxy-a result", partial)
 	}
 }
 

--- a/app/observatory/burst/ping.go
+++ b/app/observatory/burst/ping.go
@@ -54,11 +54,17 @@ func newHTTPClient(ctxv context.Context, dispatcher routing.Dispatcher, handler 
 
 // MeasureDelay returns the delay time of the request to dest
 func (s *pingClient) MeasureDelay(httpMethod string) (time.Duration, error) {
+	return s.MeasureDelayContext(context.Background(), httpMethod)
+}
+
+// MeasureDelayContext returns the delay time of the request to dest and
+// cancels the request when ctx is done.
+func (s *pingClient) MeasureDelayContext(ctx context.Context, httpMethod string) (time.Duration, error) {
 	if s.httpClient == nil {
 		panic("pingClient not initialized")
 	}
 
-	req, err := http.NewRequest(httpMethod, s.destination, nil)
+	req, err := http.NewRequestWithContext(ctx, httpMethod, s.destination, nil)
 	if err != nil {
 		return rttFailed, err
 	}

--- a/app/observatory/burst/ping.go
+++ b/app/observatory/burst/ping.go
@@ -13,38 +13,46 @@ import (
 )
 
 type pingClient struct {
+	ctx         context.Context
 	destination string
-	httpClient  *http.Client
+	dispatcher  routing.Dispatcher
+	handler     string
+	timeout     time.Duration
+	direct      bool
 }
 
 func newPingClient(ctx context.Context, dispatcher routing.Dispatcher, destination string, timeout time.Duration, handler string) *pingClient {
 	return &pingClient{
+		ctx:         ctx,
 		destination: destination,
-		httpClient:  newHTTPClient(ctx, dispatcher, handler, timeout),
+		dispatcher:  dispatcher,
+		handler:     handler,
+		timeout:     timeout,
 	}
 }
 
 func newDirectPingClient(destination string, timeout time.Duration) *pingClient {
 	return &pingClient{
+		ctx:         context.Background(),
 		destination: destination,
-		httpClient:  &http.Client{Timeout: timeout},
+		timeout:     timeout,
+		direct:      true,
 	}
 }
 
-func newHTTPClient(ctxv context.Context, dispatcher routing.Dispatcher, handler string, timeout time.Duration) *http.Client {
+func newHTTPClient(ctx context.Context, dispatcher routing.Dispatcher, handler string) *http.Client {
 	tr := &http.Transport{
 		DisableKeepAlives: true,
-		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+		DialContext: func(_ context.Context, network, addr string) (net.Conn, error) {
 			dest, err := net.ParseDestination(network + ":" + addr)
 			if err != nil {
 				return nil, err
 			}
-			return tagged.Dialer(ctxv, dispatcher, dest, handler)
+			return tagged.Dialer(ctx, dispatcher, dest, handler)
 		},
 	}
 	return &http.Client{
 		Transport: tr,
-		Timeout:   timeout,
 		// don't follow redirect
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
@@ -54,34 +62,56 @@ func newHTTPClient(ctxv context.Context, dispatcher routing.Dispatcher, handler 
 
 // MeasureDelay returns the delay time of the request to dest
 func (s *pingClient) MeasureDelay(httpMethod string) (time.Duration, error) {
-	return s.MeasureDelayContext(context.Background(), httpMethod)
+	ctx := s.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return s.MeasureDelayContext(ctx, httpMethod)
 }
 
 // MeasureDelayContext returns the delay time of the request to dest and
 // cancels the request when ctx is done.
 func (s *pingClient) MeasureDelayContext(ctx context.Context, httpMethod string) (time.Duration, error) {
-	if s.httpClient == nil {
-		panic("pingClient not initialized")
+	if ctx == nil {
+		panic("pingClient context is nil")
+	}
+	var requestCtx context.Context
+	var cancel context.CancelFunc
+	if s.timeout > 0 {
+		requestCtx, cancel = context.WithTimeout(ctx, s.timeout)
+	} else {
+		requestCtx, cancel = context.WithCancel(ctx)
+	}
+	defer cancel()
+
+	var httpClient *http.Client
+	if s.direct {
+		httpClient = &http.Client{}
+	} else {
+		// net/http deliberately detaches the context passed to DialContext so a
+		// connection attempt may be reused by another request. Burst probes use
+		// one transport per request instead, allowing the captured Xray context
+		// to retain its instance value and end with this exact probe deadline.
+		httpClient = newHTTPClient(requestCtx, s.dispatcher, s.handler)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, httpMethod, s.destination, nil)
+	req, err := http.NewRequestWithContext(requestCtx, httpMethod, s.destination, nil)
 	if err != nil {
 		return rttFailed, err
 	}
 	utils.TryDefaultHeadersWith(req.Header, "nav")
 
 	start := time.Now()
-	resp, err := s.httpClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return rttFailed, err
 	}
+	defer resp.Body.Close()
 	if httpMethod == http.MethodGet {
 		_, err = io.Copy(io.Discard, resp.Body)
 		if err != nil {
 			return rttFailed, err
 		}
 	}
-	resp.Body.Close()
-
 	return time.Since(start), nil
 }

--- a/app/observatory/burst/ping_test.go
+++ b/app/observatory/burst/ping_test.go
@@ -1,0 +1,61 @@
+package burst
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	v2net "github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/features/routing"
+	"github.com/xtls/xray-core/transport/internet/tagged"
+)
+
+func TestPingClientDeadlineCancelsTaggedDial(t *testing.T) {
+	type pingContextKey struct{}
+	contextValue := new(int)
+	originalDialer := tagged.Dialer
+	defer func() { tagged.Dialer = originalDialer }()
+
+	dialStarted := make(chan struct{})
+	dialCanceled := make(chan struct{})
+	var startOnce sync.Once
+	var cancelOnce sync.Once
+	var retainedContextValue atomic.Bool
+	tagged.Dialer = func(ctx context.Context, _ routing.Dispatcher, _ v2net.Destination, _ string) (v2net.Conn, error) {
+		if ctx.Value(pingContextKey{}) == contextValue {
+			retainedContextValue.Store(true)
+		}
+		startOnce.Do(func() { close(dialStarted) })
+		<-ctx.Done()
+		cancelOnce.Do(func() { close(dialCanceled) })
+		return nil, ctx.Err()
+	}
+
+	client := newPingClient(
+		context.WithValue(context.Background(), pingContextKey{}, contextValue),
+		nil,
+		"http://probe.invalid/",
+		20*time.Millisecond,
+		"proxy-a",
+	)
+	if _, err := client.MeasureDelay(http.MethodHead); err == nil {
+		t.Fatal("probe unexpectedly succeeded")
+	}
+
+	select {
+	case <-dialStarted:
+	case <-time.After(time.Second):
+		t.Fatal("tagged dial did not start")
+	}
+	select {
+	case <-dialCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("probe deadline did not cancel the tagged dial")
+	}
+	if !retainedContextValue.Load() {
+		t.Fatal("tagged dial did not retain the observer context values")
+	}
+}

--- a/app/observatory/observer.go
+++ b/app/observatory/observer.go
@@ -31,6 +31,7 @@ type Observer struct {
 
 	statusLock sync.Mutex
 	status     []*OutboundStatus
+	updates    extension.ObservatoryUpdateDispatcher
 
 	finished *done.Instance
 
@@ -38,8 +39,38 @@ type Observer struct {
 	dispatcher routing.Dispatcher
 }
 
+const probeRequestTimeout = 5 * time.Second
+
 func (o *Observer) GetObservation(ctx context.Context) (proto.Message, error) {
-	return &ObservationResult{Status: o.status}, nil
+	o.statusLock.Lock()
+	defer o.statusLock.Unlock()
+	status := make([]*OutboundStatus, 0, len(o.status))
+	for _, item := range o.status {
+		status = append(status, proto.Clone(item).(*OutboundStatus))
+	}
+	return &ObservationResult{Status: status}, nil
+}
+
+func (o *Observer) SubscribeObservationUpdates(listener func()) func() {
+	return o.updates.SubscribeObservationUpdates(listener)
+}
+
+func (o *Observer) ObservationProbeDeadline() time.Duration {
+	if o.config == nil || o.config.EnableConcurrency {
+		return probeRequestTimeout
+	}
+
+	interval := 10 * time.Second
+	if o.config.ProbeInterval != 0 {
+		interval = time.Duration(o.config.ProbeInterval)
+	}
+	count := 1
+	if selector, ok := o.ohm.(outbound.HandlerSelector); ok {
+		if selected := selector.Select(o.config.SubjectSelector); len(selected) > 0 {
+			count = len(selected)
+		}
+	}
+	return time.Duration(count)*probeRequestTimeout + time.Duration(count-1)*interval
 }
 
 func (o *Observer) Type() interface{} {
@@ -114,10 +145,11 @@ func (o *Observer) background() {
 
 func (o *Observer) clearRemovedOutbounds(outbounds []string) {
 	o.statusLock.Lock()
-	defer o.statusLock.Unlock()
 	if len(o.status) == 0 {
+		o.statusLock.Unlock()
 		return
 	}
+	oldCount := len(o.status)
 	var pruned []*OutboundStatus
 	for _, status := range o.status {
 		if slices.Contains(outbounds, status.OutboundTag) {
@@ -125,6 +157,10 @@ func (o *Observer) clearRemovedOutbounds(outbounds []string) {
 		}
 	}
 	o.status = pruned
+	o.statusLock.Unlock()
+	if len(pruned) != oldCount {
+		o.updates.NotifyObservationUpdate()
+	}
 }
 
 func (o *Observer) probe(outbound string) ProbeResult {
@@ -155,7 +191,7 @@ func (o *Observer) probe(outbound string) ProbeResult {
 			}
 			return connection, nil
 		},
-		TLSHandshakeTimeout: time.Second * 5,
+		TLSHandshakeTimeout: probeRequestTimeout,
 	}
 	httpClient := &http.Client{
 		Transport: &httpTransport,
@@ -163,7 +199,7 @@ func (o *Observer) probe(outbound string) ProbeResult {
 			return http.ErrUseLastResponse
 		},
 		Jar:     nil,
-		Timeout: time.Second * 5,
+		Timeout: probeRequestTimeout,
 	}
 	var GETTime time.Duration
 	err := task.Run(o.ctx, func() error {
@@ -196,7 +232,6 @@ func (o *Observer) probe(outbound string) ProbeResult {
 
 func (o *Observer) updateStatusForResult(outbound string, result *ProbeResult) {
 	o.statusLock.Lock()
-	defer o.statusLock.Unlock()
 	var status *OutboundStatus
 	if location := o.findStatusLocationLockHolderOnly(outbound); location != -1 {
 		status = o.status[location]
@@ -216,6 +251,8 @@ func (o *Observer) updateStatusForResult(outbound string, result *ProbeResult) {
 		status.LastErrorReason = result.LastErrorReason
 		status.Delay = 99999999
 	}
+	o.statusLock.Unlock()
+	o.updates.NotifyObservationUpdate()
 }
 
 func (o *Observer) findStatusLocationLockHolderOnly(outbound string) int {

--- a/app/observatory/observer.go
+++ b/app/observatory/observer.go
@@ -51,8 +51,8 @@ func (o *Observer) GetObservation(ctx context.Context) (proto.Message, error) {
 	return &ObservationResult{Status: status}, nil
 }
 
-func (o *Observer) SubscribeObservationUpdates(listener func()) func() {
-	return o.updates.SubscribeObservationUpdates(listener)
+func (o *Observer) SubscribeObservationUpdates() (<-chan struct{}, func()) {
+	return o.updates.SubscribeObservationUpdates()
 }
 
 func (o *Observer) ObservationProbeDeadline() time.Duration {
@@ -86,6 +86,7 @@ func (o *Observer) Start() error {
 }
 
 func (o *Observer) Close() error {
+	o.updates.Close()
 	if o.finished != nil {
 		return o.finished.Close()
 	}

--- a/app/observatory/observer_test.go
+++ b/app/observatory/observer_test.go
@@ -1,6 +1,34 @@
 package observatory
 
-import "testing"
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestConcurrentObserverReportsInitialProbeDeadline(t *testing.T) {
+	observer := &Observer{config: &Config{EnableConcurrency: true}}
+	if got, want := observer.ObservationProbeDeadline(), 5*time.Second; got != want {
+		t.Fatalf("probe deadline = %v, want %v", got, want)
+	}
+}
+
+func TestObserverNotifiesAfterStatusUpdate(t *testing.T) {
+	observer := &Observer{}
+	updates := 0
+	observer.SubscribeObservationUpdates(func() {
+		updates++
+		if _, err := observer.GetObservation(context.Background()); err != nil {
+			t.Errorf("GetObservation returned an error: %v", err)
+		}
+	})
+
+	observer.updateStatusForResult("proxy-a", &ProbeResult{Alive: true, Delay: 42})
+
+	if updates != 1 {
+		t.Fatalf("updates = %d, want 1", updates)
+	}
+}
 
 func TestObserverUpdateStatusPrunesStaleOutbounds(t *testing.T) {
 	observer := &Observer{

--- a/app/observatory/observer_test.go
+++ b/app/observatory/observer_test.go
@@ -15,18 +15,18 @@ func TestConcurrentObserverReportsInitialProbeDeadline(t *testing.T) {
 
 func TestObserverNotifiesAfterStatusUpdate(t *testing.T) {
 	observer := &Observer{}
-	updates := 0
-	observer.SubscribeObservationUpdates(func() {
-		updates++
-		if _, err := observer.GetObservation(context.Background()); err != nil {
-			t.Errorf("GetObservation returned an error: %v", err)
-		}
-	})
+	updates, unsubscribe := observer.SubscribeObservationUpdates()
+	defer unsubscribe()
 
 	observer.updateStatusForResult("proxy-a", &ProbeResult{Alive: true, Delay: 42})
 
-	if updates != 1 {
-		t.Fatalf("updates = %d, want 1", updates)
+	select {
+	case <-updates:
+	default:
+		t.Fatal("observer did not publish a status update")
+	}
+	if _, err := observer.GetObservation(context.Background()); err != nil {
+		t.Errorf("GetObservation returned an error: %v", err)
 	}
 }
 

--- a/features/extension/observatory.go
+++ b/features/extension/observatory.go
@@ -12,8 +12,8 @@ import (
 
 // ErrObservatoryProbeNetworkUnavailable reports that a one-shot batch could
 // not distinguish outbound health because the underlying network was down.
-// Implementations must not publish an all-failed replacement snapshot for
-// this condition.
+// Implementations may retain measurements completed before this condition but
+// must not synthesize failed results for the unfinished outbounds.
 var ErrObservatoryProbeNetworkUnavailable = errors.New("underlying network is unavailable during observatory probe")
 
 type Observatory interface {
@@ -33,8 +33,9 @@ type BurstObservatory interface {
 // Implementations must honor ctx cancellation and must not exceed
 // maxConcurrency probes in flight. Implementations may expose progressive
 // results through GetObservation and ObservatoryUpdateNotifier while the call
-// is running. After a successful return, GetObservation must expose the entire
-// completed batch; an aborted batch must not remain as the stable snapshot.
+// is running. After any return, GetObservation must retain the samples completed
+// by that call. A nil error means the requested batch is complete; a non-nil
+// error means the exposed result set may be partial.
 type ObservatoryBatchProbe interface {
 	Observatory
 	// ProbeOutboundsDeadline returns the configured worst-case probe time

--- a/features/extension/observatory.go
+++ b/features/extension/observatory.go
@@ -2,12 +2,19 @@ package extension
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
 	"github.com/xtls/xray-core/features"
 	"google.golang.org/protobuf/proto"
 )
+
+// ErrObservatoryProbeNetworkUnavailable reports that a one-shot batch could
+// not distinguish outbound health because the underlying network was down.
+// Implementations must not publish an all-failed replacement snapshot for
+// this condition.
+var ErrObservatoryProbeNetworkUnavailable = errors.New("underlying network is unavailable during observatory probe")
 
 type Observatory interface {
 	features.Feature

--- a/features/extension/observatory.go
+++ b/features/extension/observatory.go
@@ -42,11 +42,12 @@ type ObservatoryBatchProbe interface {
 	ProbeOutbounds(ctx context.Context, tags []string, maxConcurrency, samples int) error
 }
 
-// ObservatoryUpdateNotifier publishes an event after an observatory result
-// changes. Consumers should query GetObservation or their routing strategy in
-// the callback instead of treating the event itself as a routing decision.
+// ObservatoryUpdateNotifier publishes a coalesced signal after an observatory
+// result changes. Consumers should query GetObservation or their routing
+// strategy after receiving the signal instead of treating it as a routing
+// decision itself.
 type ObservatoryUpdateNotifier interface {
-	SubscribeObservationUpdates(listener func()) (unsubscribe func())
+	SubscribeObservationUpdates() (updates <-chan struct{}, unsubscribe func())
 }
 
 // ObservatoryProbeDeadline reports the longest expected time before a
@@ -61,27 +62,35 @@ type ObservatoryProbeDeadline interface {
 type ObservatoryUpdateDispatcher struct {
 	access    sync.RWMutex
 	nextID    uint64
-	listeners map[uint64]func()
+	listeners map[uint64]chan struct{}
+	closed    bool
 }
 
-func (d *ObservatoryUpdateDispatcher) SubscribeObservationUpdates(listener func()) func() {
-	if listener == nil {
-		return func() {}
-	}
+func (d *ObservatoryUpdateDispatcher) SubscribeObservationUpdates() (<-chan struct{}, func()) {
 	d.access.Lock()
+	if d.closed {
+		updates := make(chan struct{})
+		close(updates)
+		d.access.Unlock()
+		return updates, func() {}
+	}
 	if d.listeners == nil {
-		d.listeners = make(map[uint64]func())
+		d.listeners = make(map[uint64]chan struct{})
 	}
 	id := d.nextID
 	d.nextID++
-	d.listeners[id] = listener
+	updates := make(chan struct{}, 1)
+	d.listeners[id] = updates
 	d.access.Unlock()
 
 	var once sync.Once
-	return func() {
+	return updates, func() {
 		once.Do(func() {
 			d.access.Lock()
-			delete(d.listeners, id)
+			if listener, found := d.listeners[id]; found {
+				delete(d.listeners, id)
+				close(listener)
+			}
 			d.access.Unlock()
 		})
 	}
@@ -89,15 +98,27 @@ func (d *ObservatoryUpdateDispatcher) SubscribeObservationUpdates(listener func(
 
 func (d *ObservatoryUpdateDispatcher) NotifyObservationUpdate() {
 	d.access.RLock()
-	listeners := make([]func(), 0, len(d.listeners))
 	for _, listener := range d.listeners {
-		listeners = append(listeners, listener)
+		select {
+		case listener <- struct{}{}:
+		default:
+		}
 	}
 	d.access.RUnlock()
+}
 
-	for _, listener := range listeners {
-		listener()
+func (d *ObservatoryUpdateDispatcher) Close() {
+	d.access.Lock()
+	if d.closed {
+		d.access.Unlock()
+		return
 	}
+	d.closed = true
+	for id, listener := range d.listeners {
+		delete(d.listeners, id)
+		close(listener)
+	}
+	d.access.Unlock()
 }
 
 func ObservatoryType() interface{} {

--- a/features/extension/observatory.go
+++ b/features/extension/observatory.go
@@ -35,6 +35,10 @@ type BurstObservatory interface {
 // must expose the completed batch as one result snapshot.
 type ObservatoryBatchProbe interface {
 	Observatory
+	// ProbeOutboundsDeadline returns the configured worst-case probe time
+	// budget for the requested batch. Callers may add platform-specific
+	// scheduling and cleanup grace when constructing an external deadline.
+	ProbeOutboundsDeadline(tags []string, maxConcurrency, samples int) (time.Duration, error)
 	ProbeOutbounds(ctx context.Context, tags []string, maxConcurrency, samples int) error
 }
 
@@ -45,10 +49,9 @@ type ObservatoryUpdateNotifier interface {
 	SubscribeObservationUpdates(listener func()) (unsubscribe func())
 }
 
-// ObservatoryProbeDeadline reports the longest expected time before the
-// initial probe cycle can publish an observation. Callers may use it to bound
-// temporary routing state without expiring that state before the observatory
-// has had a chance to produce a result.
+// ObservatoryProbeDeadline reports the longest expected time before a
+// scheduled observer's initial probe cycle can publish an observation. Batch
+// callers must use ObservatoryBatchProbe.ProbeOutboundsDeadline instead.
 type ObservatoryProbeDeadline interface {
 	ObservationProbeDeadline() time.Duration
 }

--- a/features/extension/observatory.go
+++ b/features/extension/observatory.go
@@ -2,6 +2,8 @@ package extension
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	"github.com/xtls/xray-core/features"
 	"google.golang.org/protobuf/proto"
@@ -16,6 +18,65 @@ type Observatory interface {
 type BurstObservatory interface {
 	Observatory
 	Check(tag []string)
+}
+
+// ObservatoryUpdateNotifier publishes an event after an observatory result
+// changes. Consumers should query GetObservation or their routing strategy in
+// the callback instead of treating the event itself as a routing decision.
+type ObservatoryUpdateNotifier interface {
+	SubscribeObservationUpdates(listener func()) (unsubscribe func())
+}
+
+// ObservatoryProbeDeadline reports the longest expected time before the
+// initial probe cycle can publish an observation. Callers may use it to bound
+// temporary routing state without expiring that state before the observatory
+// has had a chance to produce a result.
+type ObservatoryProbeDeadline interface {
+	ObservationProbeDeadline() time.Duration
+}
+
+// ObservatoryUpdateDispatcher provides instance-scoped update subscriptions
+// shared by observatory implementations.
+type ObservatoryUpdateDispatcher struct {
+	access    sync.RWMutex
+	nextID    uint64
+	listeners map[uint64]func()
+}
+
+func (d *ObservatoryUpdateDispatcher) SubscribeObservationUpdates(listener func()) func() {
+	if listener == nil {
+		return func() {}
+	}
+	d.access.Lock()
+	if d.listeners == nil {
+		d.listeners = make(map[uint64]func())
+	}
+	id := d.nextID
+	d.nextID++
+	d.listeners[id] = listener
+	d.access.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			d.access.Lock()
+			delete(d.listeners, id)
+			d.access.Unlock()
+		})
+	}
+}
+
+func (d *ObservatoryUpdateDispatcher) NotifyObservationUpdate() {
+	d.access.RLock()
+	listeners := make([]func(), 0, len(d.listeners))
+	for _, listener := range d.listeners {
+		listeners = append(listeners, listener)
+	}
+	d.access.RUnlock()
+
+	for _, listener := range listeners {
+		listener()
+	}
 }
 
 func ObservatoryType() interface{} {

--- a/features/extension/observatory.go
+++ b/features/extension/observatory.go
@@ -20,6 +20,17 @@ type BurstObservatory interface {
 	Check(tag []string)
 }
 
+// ObservatoryBatchProbe runs a finite set of outbound probes through one
+// already-created Xray instance. It is intended for embedders that need to
+// compare many outbounds without creating one core instance per outbound.
+// Implementations must honor ctx cancellation and must not exceed
+// maxConcurrency probes in flight. After a successful return, GetObservation
+// must expose the completed batch as one result snapshot.
+type ObservatoryBatchProbe interface {
+	Observatory
+	ProbeOutbounds(ctx context.Context, tags []string, maxConcurrency, samples int) error
+}
+
 // ObservatoryUpdateNotifier publishes an event after an observatory result
 // changes. Consumers should query GetObservation or their routing strategy in
 // the callback instead of treating the event itself as a routing decision.

--- a/features/extension/observatory.go
+++ b/features/extension/observatory.go
@@ -31,8 +31,10 @@ type BurstObservatory interface {
 // already-created Xray instance. It is intended for embedders that need to
 // compare many outbounds without creating one core instance per outbound.
 // Implementations must honor ctx cancellation and must not exceed
-// maxConcurrency probes in flight. After a successful return, GetObservation
-// must expose the completed batch as one result snapshot.
+// maxConcurrency probes in flight. Implementations may expose progressive
+// results through GetObservation and ObservatoryUpdateNotifier while the call
+// is running. After a successful return, GetObservation must expose the entire
+// completed batch; an aborted batch must not remain as the stable snapshot.
 type ObservatoryBatchProbe interface {
 	Observatory
 	// ProbeOutboundsDeadline returns the configured worst-case probe time

--- a/features/extension/observatory_test.go
+++ b/features/extension/observatory_test.go
@@ -4,14 +4,53 @@ import "testing"
 
 func TestObservatoryUpdateDispatcherSubscribeAndUnsubscribe(t *testing.T) {
 	var dispatcher ObservatoryUpdateDispatcher
-	updates := 0
-	unsubscribe := dispatcher.SubscribeObservationUpdates(func() { updates++ })
+	updates, unsubscribe := dispatcher.SubscribeObservationUpdates()
 
 	dispatcher.NotifyObservationUpdate()
+	select {
+	case <-updates:
+	default:
+		t.Fatal("subscriber did not receive an observation update")
+	}
+
 	unsubscribe()
+	if _, open := <-updates; open {
+		t.Fatal("unsubscribed update channel remained open")
+	}
+	dispatcher.NotifyObservationUpdate()
+}
+
+func TestObservatoryUpdateDispatcherCoalescesUnreadUpdates(t *testing.T) {
+	var dispatcher ObservatoryUpdateDispatcher
+	updates, unsubscribe := dispatcher.SubscribeObservationUpdates()
+	defer unsubscribe()
+
+	dispatcher.NotifyObservationUpdate()
 	dispatcher.NotifyObservationUpdate()
 
-	if updates != 1 {
-		t.Fatalf("updates = %d, want 1", updates)
+	select {
+	case <-updates:
+	default:
+		t.Fatal("subscriber did not receive the coalesced update")
+	}
+	select {
+	case <-updates:
+		t.Fatal("unread updates were not coalesced")
+	default:
+	}
+}
+
+func TestObservatoryUpdateDispatcherCloseReleasesSubscribers(t *testing.T) {
+	var dispatcher ObservatoryUpdateDispatcher
+	updates, _ := dispatcher.SubscribeObservationUpdates()
+
+	dispatcher.Close()
+	if _, open := <-updates; open {
+		t.Fatal("closed dispatcher left its update channel open")
+	}
+
+	lateUpdates, _ := dispatcher.SubscribeObservationUpdates()
+	if _, open := <-lateUpdates; open {
+		t.Fatal("subscription to a closed dispatcher returned an open channel")
 	}
 }

--- a/features/extension/observatory_test.go
+++ b/features/extension/observatory_test.go
@@ -1,0 +1,17 @@
+package extension
+
+import "testing"
+
+func TestObservatoryUpdateDispatcherSubscribeAndUnsubscribe(t *testing.T) {
+	var dispatcher ObservatoryUpdateDispatcher
+	updates := 0
+	unsubscribe := dispatcher.SubscribeObservationUpdates(func() { updates++ })
+
+	dispatcher.NotifyObservationUpdate()
+	unsubscribe()
+	dispatcher.NotifyObservationUpdate()
+
+	if updates != 1 {
+		t.Fatalf("updates = %d, want 1", updates)
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds an embedder-oriented Observatory API for running a finite, bounded batch of outbound probes through one already-created Xray instance.

It is intended for applications that need to measure many outbounds on demand but cannot afford to create one Xray process or core instance per outbound. A caller can provide the outbound tags, concurrency limit, and sample count, receive progressive result notifications, and retain the measurements completed by the current batch even if it is cancelled or interrupted.

The PR also adds Observatory result-update notifications and probe-deadline reporting. Besides supporting responsive one-shot probing, these APIs provide the coordination required by downstream cached-route warm-start implementations.

## Motivation

Applications commonly need to display the delay of many configured outbounds or evaluate policy-group candidates in one user-initiated operation.

Creating an independent Xray process for every outbound can provide isolation, but it is often impractical:

- Process and core startup are expensive.
- Each instance duplicates configuration, routing, DNS, transport, and runtime state.
- Memory and CPU usage grow with the number of outbounds.
- Mobile operating systems may limit or kill a large group of temporary processes.
- Startup and IPC overhead can dominate short delay measurements.
- Running multiple temporary cores in one process is undesirable and can corrupt the main core.

This feature provides a middle ground: one disposable Xray instance can contain all required outbounds and probe them concurrently with bounded resource usage. Embedders can therefore perform reliable bulk probing without requiring one process per outbound and without running multiple Xray cores in the same process.

## Public API

The following optional extension interfaces are added:

### `ObservatoryBatchProbe`

```go
type ObservatoryBatchProbe interface {
    Observatory

    ProbeOutboundsDeadline(
        tags []string,
        maxConcurrency int,
        samples int,
    ) (time.Duration, error)

    ProbeOutbounds(
        ctx context.Context,
        tags []string,
        maxConcurrency int,
        samples int,
    ) error
}
```

`ProbeOutbounds` runs a finite batch through the outbounds already registered in the current Xray instance.

The caller controls:

- Which outbound tags are tested.
- The maximum number of concurrent probe workers.
- The number of samples collected for each outbound.
- Cancellation through `context.Context`.

`ProbeOutboundsDeadline` reports the configured worst-case probe budget for the same parameters. This allows an embedding application to add only its own process-management grace period instead of relying on an arbitrary fixed timeout.

### `ObservatoryUpdateNotifier`

```go
type ObservatoryUpdateNotifier interface {
    SubscribeObservationUpdates() (
        updates <-chan struct{},
        unsubscribe func(),
    )
}
```

The notifier publishes a coalesced, non-blocking signal whenever observable results change.

The signal is deliberately not the result itself and is not a routing decision. After receiving it, a consumer queries `GetObservation` or reevaluates its balancer. This keeps delivery lightweight, prevents slow subscribers from blocking probe workers, and avoids exposing mutable internal state.

### `ObservatoryProbeDeadline`

```go
type ObservatoryProbeDeadline interface {
    ObservationProbeDeadline() time.Duration
}
```

This reports the longest expected time before a scheduled Observatory can publish its initial result. Batch callers use `ProbeOutboundsDeadline` instead.

The interface is implemented by both the regular Observatory and BurstObservatory.

## One-shot probing behavior

The BurstObservatory implementation now supports one-shot batches with the following behavior:

- One Xray instance probes all requested outbounds.
- Work is bounded by `maxConcurrency`.
- Samples for a given outbound are collected serially by its worker.
- Multiple outbounds can be measured concurrently.
- Duplicate tags are normalized.
- Empty tags, missing handlers, invalid concurrency, invalid sample counts, and excessive retained work are rejected before the batch begins.
- Only one batch may run on an observer at a time.
- A batch cannot overlap a manual `Check`.
- Closing the observer cancels and waits for the active batch.

A one-shot observer must be configured without scheduled subject selectors. Scheduled observation and one-shot probing are intentionally kept mutually exclusive so their result sets and lifecycles cannot race.

The current implementation also applies defensive limits to active workers, samples per outbound, and total retained measurements. These are safety limits for untrusted or erroneous embedder parameters, not recommended operating values.

## Progressive and partial results

One-shot probing does not wait for every outbound to finish before exposing useful information.

After each completed sample:

1. The current batch result is updated.
2. A coalesced notification is published.
3. The embedder may call `GetObservation`.
4. The user interface can immediately display the current average and availability information.

The batch begins with an empty result set. There is no previous batch snapshot: only measurements produced by the current invocation are exposed. Outbounds that have not produced a sample yet are absent.

Samples used by the one-shot batch are non-expiring because the intended lifecycle is:

1. Create one dedicated Xray instance.
2. Run one batch.
3. consume its final or partial snapshot;
4. discard the instance or containing process.

After `ProbeOutbounds` returns, `GetObservation` retains every sample completed by that invocation:

- A nil error means the requested batch completed.
- A non-nil error means the result may be partial.
- Cancellation preserves samples completed before cancellation.
- Core shutdown preserves already published samples.
- Network loss preserves completed measurements and does not mark all unfinished outbounds as dead.

This makes partial progress useful while avoiding misleading synthetic failures.

## Network-loss handling

A failed outbound and an unavailable underlying network are different conditions.

When an outbound probe fails and a connectivity check is configured, the implementation checks direct connectivity using the same cancellable instance context. If the underlying network is unavailable:

- The remaining batch is cancelled.
- Completed samples are retained.
- Unfinished outbounds are not synthesized as failed.
- `ErrObservatoryProbeNetworkUnavailable` is returned.

This allows an embedding application to report that the test was interrupted by network loss rather than incorrectly presenting every remaining proxy as unavailable.

Probe and connectivity dials honor cancellation at their individual deadlines, including tagged outbound dials. This prevents timed-out requests from remaining active after their result is no longer useful.

## Deadline calculation

Batch deadlines are derived from the actual probing parameters:

- Configured per-request timeout.
- Number of unique outbound tags.
- Maximum concurrency.
- Number of samples per outbound.
- Number of worker waves.
- An additional connectivity-check timeout where applicable.

Overflow and invalid values are rejected.

Scheduled Observatory deadlines are also exposed for regular and burst implementations. This gives downstream applications a configuration-aware safety boundary rather than forcing them to guess how long an initial observation should take.

## Warm-start support

The notification and scheduled-deadline additions are also required by downstream route warm-start implementations.

A mobile application may remember the last viable policy-group target for a particular network. After the underlying network changes, it can temporarily restore that target while the newly created core's Observatory performs its first fresh probe cycle.

A correct warm-start flow requires two pieces of information from Xray:

1. An event indicating that Observatory results actually changed.
2. A configuration-derived upper bound for the initial probe cycle.

`ObservatoryUpdateNotifier` allows the embedder to react when a real result changes instead of polling Observatory state every few hundred milliseconds. After a notification, the embedder reevaluates the balancer, stores the fresh viable target, and releases its temporary warm-route override.

`ObservatoryProbeDeadline` gives the embedder a sensible fallback deadline if no viable update is produced. For regular Observatory it accounts for concurrent or sequential probing. For BurstObservatory it reflects the configured health-ping timeout and optional connectivity check.

The update dispatcher is instance-scoped, supports multiple subscribers, coalesces unread notifications, and cannot be blocked by a slow consumer.

These APIs do not implement or persist a route cache inside Xray. Network identification and cache policy remain the embedding application's responsibility.

## Compatibility

- The existing `Observatory` and `BurstObservatory` interfaces retain their existing methods.
- Batch probing, notifications, and deadline reporting are exposed through optional extension interfaces.
- Existing embedders do not need to adopt the new APIs.
- Existing scheduled Observatory and BurstObservatory operation remains available.
- One-shot batch state is isolated from scheduled and manual probe state.
- `GetObservation` returns stable snapshots rather than exposing mutable internal result objects.
- No persistent cache or new configuration schema is introduced.

This PR is independent of [XTLS/Xray-core#6483](https://github.com/XTLS/Xray-core/pull/6483), whose reduced scope concerns instance-owned system dialer state.

## Downstream use

This work is intended as the Xray-core prerequisite for:

- [2dust/AndroidLibXrayLite#200](https://github.com/2dust/AndroidLibXrayLite/pull/200)
- [2dust/v2rayNG#5905](https://github.com/2dust/v2rayNG/pull/5905)

AndroidLibXrayLite wraps the batch API for mobile embedders. v2rayNG uses it in one focused disposable Android process containing one Xray instance, allowing multiple profiles and policy-group candidates to be probed concurrently without creating one process per outbound.

The same API can be used by other desktop, mobile, or embedded clients that need efficient bulk outbound measurements.

## Testing

The implementation includes coverage for:

- Bounded worker concurrency.
- Multiple samples per outbound.
- Parameter and outbound-tag validation.
- Batch deadline calculation and overflow handling.
- Progressive update delivery.
- Subscriber isolation and unsubscribe behavior.
- Stable observation snapshots.
- Empty batches.
- Cancellation and core shutdown.
- Partial-result retention.
- Underlying network loss.
- Per-probe deadline cancellation.
- Isolation from scheduled and manual probes.
- Non-expiring one-shot samples.
- Correct RTT statistics on 32-bit targets.

Focused Observatory and extension tests pass, including race-detector runs for the BurstObservatory and extension packages. A release-style Xray executable also builds successfully.