### PR TITLE
Sockopt: Add sendProxyProtocol for TCP outbounds

### DIFF
--- a/infra/conf/freedom_test.go
+++ b/infra/conf/freedom_test.go
@@ -1,6 +1,7 @@
 package conf_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/xtls/xray-core/common/geodata"
@@ -10,6 +11,23 @@ import (
 	"github.com/xtls/xray-core/proxy/freedom"
 	"github.com/xtls/xray-core/transport/internet"
 )
+
+func TestFreedomOutboundRejectsSockoptSendProxyProtocol(t *testing.T) {
+	config := &OutboundDetourConfig{
+		Protocol: "freedom",
+		StreamSetting: &StreamConfig{
+			SocketSettings: &SocketConfig{SendProxyProtocol: 1},
+		},
+	}
+
+	_, err := config.Build()
+	if err == nil {
+		t.Fatal("expected config error")
+	}
+	if !strings.Contains(err.Error(), "sockopt.sendProxyProtocol is not supported for freedom outbound") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
 
 func TestFreedomConfig(t *testing.T) {
 	creator := func() Buildable {

--- a/infra/conf/transport_sockopt.go
+++ b/infra/conf/transport_sockopt.go
@@ -47,6 +47,7 @@ type SocketConfig struct {
 	TFO                   interface{}            `json:"tcpFastOpen"`
 	TProxy                string                 `json:"tproxy"`
 	AcceptProxyProtocol   bool                   `json:"acceptProxyProtocol"`
+	SendProxyProtocol     uint32                 `json:"sendProxyProtocol"`
 	DomainStrategy        string                 `json:"domainStrategy"`
 	DialerProxy           string                 `json:"dialerProxy"`
 	TCPKeepAliveInterval  int32                  `json:"tcpKeepAliveInterval"`
@@ -134,6 +135,10 @@ func (c *SocketConfig) Build() (*internet.SocketConfig, error) {
 		customSockopts = append(customSockopts, customSockopt)
 	}
 
+	if c.SendProxyProtocol > 2 {
+		return nil, errors.New("invalid PROXY protocol version, sendProxyProtocol only accepts 0, 1, 2")
+	}
+
 	addressPortStrategy := internet.AddressPortStrategy_None
 	switch strings.ToLower(c.AddressPortStrategy) {
 	case "none", "":
@@ -168,6 +173,7 @@ func (c *SocketConfig) Build() (*internet.SocketConfig, error) {
 		Tproxy:               tproxy,
 		DomainStrategy:       dStrategy,
 		AcceptProxyProtocol:  c.AcceptProxyProtocol,
+		SendProxyProtocol:    c.SendProxyProtocol,
 		DialerProxy:          c.DialerProxy,
 		TcpKeepAliveInterval: c.TCPKeepAliveInterval,
 		TcpKeepAliveIdle:     c.TCPKeepAliveIdle,

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -358,6 +358,9 @@ func (c *OutboundDetourConfig) Build() (*core.OutboundHandlerConfig, error) {
 	if err != nil {
 		return nil, errors.New("failed to load outbound detour config for protocol ", c.Protocol).Base(err)
 	}
+	if _, isFreedom := rawConfig.(*FreedomConfig); isFreedom && c.StreamSetting != nil && c.StreamSetting.SocketSettings != nil && c.StreamSetting.SocketSettings.SendProxyProtocol > 0 {
+		return nil, errors.New("sockopt.sendProxyProtocol is not supported for freedom outbound; use freedom settings.proxyProtocol")
+	}
 	if err := validateOutboundTransportSecurity(rawConfig, senderSettings); err != nil {
 		return nil, err
 	}

--- a/proxy/freedom/freedom.go
+++ b/proxy/freedom/freedom.go
@@ -8,7 +8,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pires/go-proxyproto"
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/buf"
 	"github.com/xtls/xray-core/common/crypto"
@@ -365,13 +364,9 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 		return nil
 	}
 	if h.config.ProxyProtocol > 0 && h.config.ProxyProtocol <= 2 {
-		version := byte(h.config.ProxyProtocol)
-		srcAddr := inbound.Source.RawNetAddr()
-		dstAddr := conn.RemoteAddr()
-		header := proxyproto.HeaderProxyFromAddrs(version, srcAddr, dstAddr)
-		if _, err = header.WriteTo(conn); err != nil {
+		if err := internet.WriteProxyProtocolHeader(conn, h.config.ProxyProtocol, inbound.Source.RawNetAddr(), conn.RemoteAddr()); err != nil {
 			conn.Close()
-			return errors.New("failed to set PROXY protocol v", version).Base(err)
+			return err
 		}
 	}
 	defer conn.Close()

--- a/transport/internet/config.pb.go
+++ b/transport/internet/config.pb.go
@@ -731,6 +731,7 @@ type SocketConfig struct {
 	// option. This option is for UDP only.
 	ReceiveOriginalDestAddress bool                 `protobuf:"varint,4,opt,name=receive_original_dest_address,json=receiveOriginalDestAddress,proto3" json:"receive_original_dest_address,omitempty"`
 	AcceptProxyProtocol        bool                 `protobuf:"varint,7,opt,name=accept_proxy_protocol,json=acceptProxyProtocol,proto3" json:"accept_proxy_protocol,omitempty"`
+	SendProxyProtocol          uint32               `protobuf:"varint,24,opt,name=send_proxy_protocol,json=sendProxyProtocol,proto3" json:"send_proxy_protocol,omitempty"`
 	DomainStrategy             DomainStrategy       `protobuf:"varint,8,opt,name=domain_strategy,json=domainStrategy,proto3,enum=xray.transport.internet.DomainStrategy" json:"domain_strategy,omitempty"`
 	DialerProxy                string               `protobuf:"bytes,9,opt,name=dialer_proxy,json=dialerProxy,proto3" json:"dialer_proxy,omitempty"`
 	TcpKeepAliveInterval       int32                `protobuf:"varint,10,opt,name=tcp_keep_alive_interval,json=tcpKeepAliveInterval,proto3" json:"tcp_keep_alive_interval,omitempty"`
@@ -814,6 +815,13 @@ func (x *SocketConfig) GetAcceptProxyProtocol() bool {
 		return x.AcceptProxyProtocol
 	}
 	return false
+}
+
+func (x *SocketConfig) GetSendProxyProtocol() uint32 {
+	if x != nil {
+		return x.SendProxyProtocol
+	}
+	return 0
 }
 
 func (x *SocketConfig) GetDomainStrategy() DomainStrategy {
@@ -1050,13 +1058,14 @@ const file_transport_internet_config_proto_rawDesc = "" +
 	"\x05level\x18\x03 \x01(\tR\x05level\x12\x10\n" +
 	"\x03opt\x18\x04 \x01(\tR\x03opt\x12\x14\n" +
 	"\x05value\x18\x05 \x01(\tR\x05value\x12\x12\n" +
-	"\x04type\x18\x06 \x01(\tR\x04type\"\xc9\b\n" +
+	"\x04type\x18\x06 \x01(\tR\x04type\"\xf9\b\n" +
 	"\fSocketConfig\x12\x12\n" +
 	"\x04mark\x18\x01 \x01(\x05R\x04mark\x12\x10\n" +
 	"\x03tfo\x18\x02 \x01(\x05R\x03tfo\x12H\n" +
 	"\x06tproxy\x18\x03 \x01(\x0e20.xray.transport.internet.SocketConfig.TProxyModeR\x06tproxy\x12A\n" +
 	"\x1dreceive_original_dest_address\x18\x04 \x01(\bR\x1areceiveOriginalDestAddress\x122\n" +
-	"\x15accept_proxy_protocol\x18\a \x01(\bR\x13acceptProxyProtocol\x12P\n" +
+	"\x15accept_proxy_protocol\x18\a \x01(\bR\x13acceptProxyProtocol\x12.\n" +
+	"\x13send_proxy_protocol\x18\x18 \x01(\rR\x11sendProxyProtocol\x12P\n" +
 	"\x0fdomain_strategy\x18\b \x01(\x0e2'.xray.transport.internet.DomainStrategyR\x0edomainStrategy\x12!\n" +
 	"\fdialer_proxy\x18\t \x01(\tR\vdialerProxy\x125\n" +
 	"\x17tcp_keep_alive_interval\x18\n" +

--- a/transport/internet/config.proto
+++ b/transport/internet/config.proto
@@ -126,6 +126,8 @@ message SocketConfig {
 
   bool accept_proxy_protocol = 7;
 
+  uint32 send_proxy_protocol = 24;
+
   DomainStrategy domain_strategy = 8;
 
   string dialer_proxy = 9;
@@ -133,9 +135,9 @@ message SocketConfig {
   int32 tcp_keep_alive_interval = 10;
 
   int32 tcp_keep_alive_idle = 11;
-  
+
   string tcp_congestion = 12;
-  
+
   string interface = 13;
 
   bool v6only = 14;

--- a/transport/internet/grpc/dial.go
+++ b/transport/internet/grpc/dial.go
@@ -135,6 +135,11 @@ func getGrpcClient(ctx context.Context, dest net.Destination, streamSettings *in
 					c = newConn
 				}
 
+				if err := internet.WriteOutboundProxyProtocol(gctx, c, sockopt); err != nil {
+					c.Close()
+					return nil, err
+				}
+
 				if tlsConfig != nil {
 					config := tlsConfig.GetTLSConfig(tls.WithDestination(dest))
 					if fingerprint := tls.GetFingerprint(tlsConfig.Fingerprint); fingerprint != nil {

--- a/transport/internet/httpupgrade/dialer.go
+++ b/transport/internet/httpupgrade/dialer.go
@@ -61,6 +61,11 @@ func dialhttpUpgrade(ctx context.Context, dest net.Destination, streamSettings *
 		pconn = newConn
 	}
 
+	if err := internet.WriteOutboundProxyProtocol(ctx, pconn, streamSettings.SocketSettings); err != nil {
+		pconn.Close()
+		return nil, err
+	}
+
 	var conn net.Conn
 	var requestURL url.URL
 	tConfig := tls.ConfigFromStreamSettings(streamSettings)

--- a/transport/internet/proxyprotocol_outbound.go
+++ b/transport/internet/proxyprotocol_outbound.go
@@ -1,0 +1,32 @@
+package internet
+
+import (
+	"context"
+	"io"
+
+	"github.com/pires/go-proxyproto"
+	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/session"
+)
+
+func WriteProxyProtocolHeader(writer io.Writer, version uint32, srcAddr, dstAddr net.Addr) error {
+	header := proxyproto.HeaderProxyFromAddrs(byte(version), srcAddr, dstAddr)
+	if _, err := header.WriteTo(writer); err != nil {
+		return errors.New("failed to set PROXY protocol v", version).Base(err)
+	}
+	return nil
+}
+
+func WriteOutboundProxyProtocol(ctx context.Context, conn net.Conn, sockopt *SocketConfig) error {
+	if sockopt == nil || sockopt.SendProxyProtocol == 0 {
+		return nil
+	}
+
+	inbound := session.InboundFromContext(ctx)
+	if inbound == nil || !inbound.Source.IsValid() || !inbound.Local.IsValid() {
+		return nil
+	}
+
+	return WriteProxyProtocolHeader(conn, sockopt.SendProxyProtocol, inbound.Source.RawNetAddr(), inbound.Local.RawNetAddr())
+}

--- a/transport/internet/proxyprotocol_outbound_test.go
+++ b/transport/internet/proxyprotocol_outbound_test.go
@@ -1,0 +1,75 @@
+package internet_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/xtls/xray-core/common"
+	xnet "github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/session"
+	. "github.com/xtls/xray-core/transport/internet"
+)
+
+type recordingConn struct {
+	bytes.Buffer
+}
+
+func (c *recordingConn) Read(_ []byte) (int, error)       { return 0, io.EOF }
+func (c *recordingConn) Close() error                     { return nil }
+func (c *recordingConn) LocalAddr() xnet.Addr             { return nil }
+func (c *recordingConn) RemoteAddr() xnet.Addr            { return nil }
+func (c *recordingConn) SetDeadline(time.Time) error      { return nil }
+func (c *recordingConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *recordingConn) SetWriteDeadline(time.Time) error { return nil }
+
+func TestWriteOutboundProxyProtocolV1(t *testing.T) {
+	conn := &recordingConn{}
+	ctx := session.ContextWithInbound(context.Background(), &session.Inbound{
+		Source: xnet.TCPDestination(xnet.ParseAddress("1.2.3.4"), 1234),
+		Local:  xnet.TCPDestination(xnet.ParseAddress("5.6.7.8"), 443),
+	})
+
+	common.Must(WriteOutboundProxyProtocol(ctx, conn, &SocketConfig{SendProxyProtocol: 1}))
+
+	const expected = "PROXY TCP4 1.2.3.4 5.6.7.8 1234 443\r\n"
+	if got := conn.String(); got != expected {
+		t.Fatal("unexpected proxy protocol header: ", got)
+	}
+}
+
+func TestWriteOutboundProxyProtocolV2(t *testing.T) {
+	conn := &recordingConn{}
+	ctx := session.ContextWithInbound(context.Background(), &session.Inbound{
+		Source: xnet.TCPDestination(xnet.ParseAddress("1.2.3.4"), 1234),
+		Local:  xnet.TCPDestination(xnet.ParseAddress("5.6.7.8"), 443),
+	})
+
+	common.Must(WriteOutboundProxyProtocol(ctx, conn, &SocketConfig{SendProxyProtocol: 2}))
+
+	expected := []byte{
+		0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A,
+		0x21,
+		0x11,
+		0x00, 0x0C,
+		0x01, 0x02, 0x03, 0x04,
+		0x05, 0x06, 0x07, 0x08,
+		0x04, 0xD2,
+		0x01, 0xBB,
+	}
+	if got := conn.Bytes(); !bytes.Equal(got, expected) {
+		t.Fatalf("unexpected proxy protocol v2 header:\n  got: %x\n  want: %x", got, expected)
+	}
+}
+
+func TestWriteOutboundProxyProtocolWithoutInbound(t *testing.T) {
+	conn := &recordingConn{}
+
+	common.Must(WriteOutboundProxyProtocol(context.Background(), conn, &SocketConfig{SendProxyProtocol: 1}))
+
+	if got := conn.Len(); got != 0 {
+		t.Fatal("expected no bytes to be written, got ", got)
+	}
+}

--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -132,6 +132,11 @@ func createHTTPClient(dest net.Destination, streamSettings *internet.MemoryStrea
 			conn = newConn
 		}
 
+		if err := internet.WriteOutboundProxyProtocol(ctxInner, conn, streamSettings.SocketSettings); err != nil {
+			conn.Close()
+			return nil, err
+		}
+
 		if realityConfig != nil {
 			return reality.UClient(conn, realityConfig, ctxInner, dest)
 		}

--- a/transport/internet/tcp/dialer.go
+++ b/transport/internet/tcp/dialer.go
@@ -33,6 +33,11 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 		conn = newConn
 	}
 
+	if err := internet.WriteOutboundProxyProtocol(ctx, conn, streamSettings.SocketSettings); err != nil {
+		conn.Close()
+		return nil, err
+	}
+
 	if config := tls.ConfigFromStreamSettings(streamSettings); config != nil {
 		mitmServerName := session.MitmServerNameFromContext(ctx)
 		mitmAlpn11 := session.MitmAlpn11FromContext(ctx)

--- a/transport/internet/websocket/dialer.go
+++ b/transport/internet/websocket/dialer.go
@@ -62,6 +62,11 @@ func dialWebSocket(ctx context.Context, dest net.Destination, streamSettings *in
 				conn = newConn
 			}
 
+			if err := internet.WriteOutboundProxyProtocol(ctx, conn, streamSettings.SocketSettings); err != nil {
+				conn.Close()
+				return nil, err
+			}
+
 			return conn, err
 		},
 		ReadBufferSize:   4 * 1024,
@@ -92,6 +97,11 @@ func dialWebSocket(ctx context.Context, dest net.Destination, streamSettings *in
 						return nil, errors.New("mask err").Base(err)
 					}
 					pconn = newConn
+				}
+
+				if err := internet.WriteOutboundProxyProtocol(ctx, pconn, streamSettings.SocketSettings); err != nil {
+					pconn.Close()
+					return nil, err
 				}
 
 				// TLS and apply the handshake


### PR DESCRIPTION
When you chain proxies (inbound → outbound → upstream), the real client IP is lost after the first hop. Every intermediary and the final backend only see the previous node's IP. IP-based logging becomes useless after the first hop — every node in the chain logs the previous node's IP instead of the real client.

acceptProxyProtocol (receiving PROXY headers from upstream) has existed since v1.0.0. sendProxyProtocol (writing them downstream) was never implemented at the transport layer. Freedom added its own proxy protocol support in [3a99520](https://github.com/XTLS/Xray-core/commit/3a995203), but only for direct TCP — VLESS, VMess, Trojan and other protocols were left out.

This adds sockopt.sendProxyProtocol (0|1|2), which writes a HAProxy PROXY protocol v1 or v2 header on every outbound TCP connection, at the transport layer (after dial, before TLS), regardless of the proxy protocol.

Config:

```json
"streamSettings": {
  "sockopt": {
    "sendProxyProtocol": 1
  }
}
```
All five TCP dialers (tcp, ws, grpc, httpupgrade, splithttp) write the header. Freedom outbound blocks the sockopt field and redirects to its own settings.proxyProtocol instead. Freedom's implementation was deduplicated — it now calls the same WriteProxyProtocolHeader as the dialers, removing the go-proxyproto import from freedom.go.

```bash
go test ./transport/internet -run TestWriteOutboundProxyProtocol -count=1
go test ./infra/conf -run TestFreedomOutboundRejects -count=1
```

Running on a [remnanode](https://github.com/remnawave/node) (VLESS+TCP+REALITY, sendProxyProtocol:2) with real users for a month — stable. Client IP visible in the [remnawave panel](https://github.com/remnawave/panel) where only node IP was visible before.