### PR TITLE
Stats: Track online users per inbound tag

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -180,7 +180,7 @@ func (d *DefaultDispatcher) getLink(ctx context.Context) (*transport.Link, *tran
 		}
 
 		if p.Stats.UserOnline {
-			trackOnlineIP(ctx, d.stats, user.Email, sessionInbound.Source.Address.String())
+			trackOnlineIP(ctx, d.stats, sessionInbound.Tag, user.Email, sessionInbound.Source.Address.String())
 		}
 	}
 
@@ -214,16 +214,19 @@ func WrapLink(ctx context.Context, policyManager policy.Manager, statsManager st
 			}
 		}
 		if p.Stats.UserOnline {
-			trackOnlineIP(ctx, statsManager, user.Email, sessionInbound.Source.Address.String())
+			trackOnlineIP(ctx, statsManager, sessionInbound.Tag, user.Email, sessionInbound.Source.Address.String())
 		}
 	}
 
 	return link
 }
 
-func trackOnlineIP(ctx context.Context, sm stats.Manager, email, ip string) {
-	name := "user>>>" + email + ">>>online"
-	if om, _ := sm.GetOrRegisterOnlineMap(name); om != nil {
+func trackOnlineIP(ctx context.Context, sm stats.Manager, inboundTag, email, ip string) {
+	if om, _ := sm.GetOrRegisterOnlineMap("user>>>" + email + ">>>online"); om != nil {
+		om.AddIP(ip)
+		context.AfterFunc(ctx, func() { om.RemoveIP(ip) })
+	}
+	if om, _ := sm.GetOrRegisterOnlineMap("inbound>>>" + inboundTag + ">>>user>>>" + email + ">>>online"); om != nil {
 		om.AddIP(ip)
 		context.AfterFunc(ctx, func() { om.RemoveIP(ip) })
 	}

--- a/app/stats/command/command.go
+++ b/app/stats/command/command.go
@@ -180,6 +180,16 @@ func (s *statsServer) QueryStats(ctx context.Context, request *QueryStatsRequest
 		return true
 	})
 
+	s.stats.VisitOnlineMaps(func(name string, om feature_stats.OnlineMap) bool {
+		if strings.Contains(name, request.Pattern) {
+			response.Stat = append(response.Stat, &Stat{
+				Name:  name,
+				Value: int64(om.Count()),
+			})
+		}
+		return true
+	})
+
 	return response, nil
 }
 


### PR DESCRIPTION
Online users are tracked per-user globally (`user>>>{email}>>>online`) but there's no way to see which inbound they came from. Adding a per-inbound key (`inbound>>>{tag}>>>user>>>{email}>>>online`) alongside the existing global one and wiring VisitOnlineMaps into QueryStats makes both queryable.

```bash
go test ./app/dispatcher ./app/stats/command -count=1