### PR TITLE
Add per-user bandwidth limits

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -182,6 +182,9 @@ func (d *DefaultDispatcher) getLink(ctx context.Context) (*transport.Link, *tran
 		if p.Stats.UserOnline {
 			trackOnlineIP(ctx, d.stats, user.Email, sessionInbound.Source.Address.String())
 		}
+
+		inboundLink.Writer = NewUserRateLimitWriter(ctx, user.Email, "uplink", user.SpeedLimitUpMbps, inboundLink.Writer)
+		outboundLink.Writer = NewUserRateLimitWriter(ctx, user.Email, "downlink", user.SpeedLimitDownMbps, outboundLink.Writer)
 	}
 
 	return inboundLink, outboundLink
@@ -216,6 +219,9 @@ func WrapLink(ctx context.Context, policyManager policy.Manager, statsManager st
 		if p.Stats.UserOnline {
 			trackOnlineIP(ctx, statsManager, user.Email, sessionInbound.Source.Address.String())
 		}
+
+		link.Reader = NewUserRateLimitReader(ctx, user.Email, "uplink", user.SpeedLimitUpMbps, link.Reader)
+		link.Writer = NewUserRateLimitWriter(ctx, user.Email, "downlink", user.SpeedLimitDownMbps, link.Writer)
 	}
 
 	return link

--- a/app/dispatcher/rate_limiter.go
+++ b/app/dispatcher/rate_limiter.go
@@ -1,0 +1,150 @@
+package dispatcher
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/xtls/xray-core/common"
+	"github.com/xtls/xray-core/common/buf"
+	"golang.org/x/time/rate"
+)
+
+const minRateLimitBurstBytes = 64 * 1024
+
+var userRateLimiters sync.Map
+
+type userRateLimitKey struct {
+	email     string
+	direction string
+	mbps      uint64
+}
+
+func getUserRateLimiter(email, direction string, mbps uint64) *rate.Limiter {
+	key := userRateLimitKey{
+		email:     email,
+		direction: direction,
+		mbps:      mbps,
+	}
+	if limiter, ok := userRateLimiters.Load(key); ok {
+		return limiter.(*rate.Limiter)
+	}
+
+	bytesPerSecond := mbps * 1000 * 1000 / 8
+	if bytesPerSecond == 0 {
+		bytesPerSecond = 1
+	}
+	burst := int(bytesPerSecond)
+	if burst < minRateLimitBurstBytes {
+		burst = minRateLimitBurstBytes
+	}
+
+	limiter := rate.NewLimiter(rate.Limit(bytesPerSecond), burst)
+	actual, _ := userRateLimiters.LoadOrStore(key, limiter)
+	return actual.(*rate.Limiter)
+}
+
+func waitRateLimit(ctx context.Context, limiter *rate.Limiter, bytes int) error {
+	if bytes <= 0 {
+		return nil
+	}
+	burst := limiter.Burst()
+	for bytes > 0 {
+		chunk := bytes
+		if chunk > burst {
+			chunk = burst
+		}
+		if err := limiter.WaitN(ctx, chunk); err != nil {
+			return err
+		}
+		bytes -= chunk
+	}
+	return nil
+}
+
+type UserRateLimitWriter struct {
+	ctx     context.Context
+	limiter *rate.Limiter
+	Writer  buf.Writer
+}
+
+func NewUserRateLimitWriter(ctx context.Context, email, direction string, mbps uint64, writer buf.Writer) buf.Writer {
+	if mbps == 0 || email == "" || writer == nil {
+		return writer
+	}
+	return &UserRateLimitWriter{
+		ctx:     ctx,
+		limiter: getUserRateLimiter(email, direction, mbps),
+		Writer:  writer,
+	}
+}
+
+func (w *UserRateLimitWriter) WriteMultiBuffer(mb buf.MultiBuffer) error {
+	if err := waitRateLimit(w.ctx, w.limiter, int(mb.Len())); err != nil {
+		buf.ReleaseMulti(mb)
+		return fmt.Errorf("user rate limit wait failed: %w", err)
+	}
+	return w.Writer.WriteMultiBuffer(mb)
+}
+
+func (w *UserRateLimitWriter) Close() error {
+	return common.Close(w.Writer)
+}
+
+func (w *UserRateLimitWriter) Interrupt() {
+	common.Interrupt(w.Writer)
+}
+
+type UserRateLimitReader struct {
+	ctx     context.Context
+	limiter *rate.Limiter
+	Reader  buf.Reader
+}
+
+func NewUserRateLimitReader(ctx context.Context, email, direction string, mbps uint64, reader buf.Reader) buf.Reader {
+	if mbps == 0 || email == "" || reader == nil {
+		return reader
+	}
+	return &UserRateLimitReader{
+		ctx:     ctx,
+		limiter: getUserRateLimiter(email, direction, mbps),
+		Reader:  reader,
+	}
+}
+
+func (r *UserRateLimitReader) ReadMultiBuffer() (buf.MultiBuffer, error) {
+	mb, err := r.Reader.ReadMultiBuffer()
+	if err != nil || mb.IsEmpty() {
+		return mb, err
+	}
+	if waitErr := waitRateLimit(r.ctx, r.limiter, int(mb.Len())); waitErr != nil {
+		buf.ReleaseMulti(mb)
+		return nil, fmt.Errorf("user rate limit wait failed: %w", waitErr)
+	}
+	return mb, nil
+}
+
+func (r *UserRateLimitReader) ReadMultiBufferTimeout(timeout time.Duration) (buf.MultiBuffer, error) {
+	timeoutReader, ok := r.Reader.(buf.TimeoutReader)
+	if !ok {
+		return r.ReadMultiBuffer()
+	}
+	mb, err := timeoutReader.ReadMultiBufferTimeout(timeout)
+	if err != nil || mb.IsEmpty() {
+		return mb, err
+	}
+	if waitErr := waitRateLimit(r.ctx, r.limiter, int(mb.Len())); waitErr != nil {
+		buf.ReleaseMulti(mb)
+		return nil, fmt.Errorf("user rate limit wait failed: %w", waitErr)
+	}
+	return mb, nil
+}
+
+func (r *UserRateLimitReader) Close() error {
+	return common.Close(r.Reader)
+}
+
+func (r *UserRateLimitReader) Interrupt() {
+	common.Interrupt(r.Reader)
+}

--- a/app/dispatcher/rate_limiter.go
+++ b/app/dispatcher/rate_limiter.go
@@ -12,6 +12,7 @@ import (
 )
 
 const minRateLimitBurstBytes = 64 * 1024
+const maxRateLimitBurstBytes = 64 * 1024
 
 var userRateLimiters sync.Map
 
@@ -38,6 +39,9 @@ func getUserRateLimiter(email, direction string, mbps uint64) *rate.Limiter {
 	burst := int(bytesPerSecond)
 	if burst < minRateLimitBurstBytes {
 		burst = minRateLimitBurstBytes
+	}
+	if burst > maxRateLimitBurstBytes {
+		burst = maxRateLimitBurstBytes
 	}
 
 	limiter := rate.NewLimiter(rate.Limit(bytesPerSecond), burst)

--- a/common/protocol/user.go
+++ b/common/protocol/user.go
@@ -1,6 +1,8 @@
 package protocol
 
 import (
+	"encoding/json"
+
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/serial"
 )
@@ -23,15 +25,39 @@ func (u *User) GetTypedAccount() (Account, error) {
 	return nil, errors.New("Unknown account type: ", u.Account.Type)
 }
 
+func (u *User) UnmarshalJSON(data []byte) error {
+	type userJSON User
+	aux := struct {
+		*userJSON
+		SpeedLimitUpMbpsCamel   *uint64 `json:"speedLimitUpMbps"`
+		SpeedLimitDownMbpsCamel *uint64 `json:"speedLimitDownMbps"`
+	}{
+		userJSON: (*userJSON)(u),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if aux.SpeedLimitUpMbpsCamel != nil {
+		u.SpeedLimitUpMbps = *aux.SpeedLimitUpMbpsCamel
+	}
+	if aux.SpeedLimitDownMbpsCamel != nil {
+		u.SpeedLimitDownMbps = *aux.SpeedLimitDownMbpsCamel
+	}
+	return nil
+}
+
 func (u *User) ToMemoryUser() (*MemoryUser, error) {
 	account, err := u.GetTypedAccount()
 	if err != nil {
 		return nil, err
 	}
 	return &MemoryUser{
-		Account: account,
-		Email:   u.Email,
-		Level:   u.Level,
+		Account:            account,
+		Email:              u.Email,
+		Level:              u.Level,
+		SpeedLimitUpMbps:   u.SpeedLimitUpMbps,
+		SpeedLimitDownMbps: u.SpeedLimitDownMbps,
 	}, nil
 }
 
@@ -40,9 +66,11 @@ func ToProtoUser(mu *MemoryUser) *User {
 		return nil
 	}
 	return &User{
-		Account: serial.ToTypedMessage(mu.Account.ToProto()),
-		Email:   mu.Email,
-		Level:   mu.Level,
+		Account:            serial.ToTypedMessage(mu.Account.ToProto()),
+		Email:              mu.Email,
+		Level:              mu.Level,
+		SpeedLimitUpMbps:   mu.SpeedLimitUpMbps,
+		SpeedLimitDownMbps: mu.SpeedLimitDownMbps,
 	}
 }
 
@@ -52,4 +80,9 @@ type MemoryUser struct {
 	Account Account
 	Email   string
 	Level   uint32
+
+	// SpeedLimitUpMbps and SpeedLimitDownMbps are optional per-user limits.
+	// Zero means unlimited.
+	SpeedLimitUpMbps   uint64
+	SpeedLimitDownMbps uint64
 }

--- a/common/protocol/user.pb.go
+++ b/common/protocol/user.pb.go
@@ -29,9 +29,12 @@ type User struct {
 	Email string                 `protobuf:"bytes,2,opt,name=email,proto3" json:"email,omitempty"`
 	// Protocol specific account information. Must be the account proto in one of
 	// the proxies.
-	Account       *serial.TypedMessage `protobuf:"bytes,3,opt,name=account,proto3" json:"account,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Account *serial.TypedMessage `protobuf:"bytes,3,opt,name=account,proto3" json:"account,omitempty"`
+	// Optional per-user bandwidth limits in megabits per second.
+	SpeedLimitUpMbps   uint64 `protobuf:"varint,4,opt,name=speed_limit_up_mbps,json=speedLimitUpMbps,proto3" json:"speed_limit_up_mbps,omitempty"`
+	SpeedLimitDownMbps uint64 `protobuf:"varint,5,opt,name=speed_limit_down_mbps,json=speedLimitDownMbps,proto3" json:"speed_limit_down_mbps,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *User) Reset() {
@@ -85,15 +88,31 @@ func (x *User) GetAccount() *serial.TypedMessage {
 	return nil
 }
 
+func (x *User) GetSpeedLimitUpMbps() uint64 {
+	if x != nil {
+		return x.SpeedLimitUpMbps
+	}
+	return 0
+}
+
+func (x *User) GetSpeedLimitDownMbps() uint64 {
+	if x != nil {
+		return x.SpeedLimitDownMbps
+	}
+	return 0
+}
+
 var File_common_protocol_user_proto protoreflect.FileDescriptor
 
 const file_common_protocol_user_proto_rawDesc = "" +
 	"\n" +
-	"\x1acommon/protocol/user.proto\x12\x14xray.common.protocol\x1a!common/serial/typed_message.proto\"n\n" +
+	"\x1acommon/protocol/user.proto\x12\x14xray.common.protocol\x1a!common/serial/typed_message.proto\"\xd0\x01\n" +
 	"\x04User\x12\x14\n" +
 	"\x05level\x18\x01 \x01(\rR\x05level\x12\x14\n" +
 	"\x05email\x18\x02 \x01(\tR\x05email\x12:\n" +
-	"\aaccount\x18\x03 \x01(\v2 .xray.common.serial.TypedMessageR\aaccountB^\n" +
+	"\aaccount\x18\x03 \x01(\v2 .xray.common.serial.TypedMessageR\aaccount\x12-\n" +
+	"\x13speed_limit_up_mbps\x18\x04 \x01(\x04R\x10speedLimitUpMbps\x121\n" +
+	"\x15speed_limit_down_mbps\x18\x05 \x01(\x04R\x12speedLimitDownMbpsB^\n" +
 	"\x18com.xray.common.protocolP\x01Z)github.com/xtls/xray-core/common/protocol\xaa\x02\x14Xray.Common.Protocolb\x06proto3"
 
 var (

--- a/common/protocol/user.proto
+++ b/common/protocol/user.proto
@@ -16,4 +16,8 @@ message User {
   // Protocol specific account information. Must be the account proto in one of
   // the proxies.
   xray.common.serial.TypedMessage account = 3;
+
+  // Optional per-user bandwidth limits in megabits per second.
+  uint64 speed_limit_up_mbps = 4;
+  uint64 speed_limit_down_mbps = 5;
 }

--- a/common/protocol/user_test.go
+++ b/common/protocol/user_test.go
@@ -1,0 +1,61 @@
+package protocol_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/xtls/xray-core/common/protocol"
+	"github.com/xtls/xray-core/common/serial"
+	"github.com/xtls/xray-core/proxy/shadowsocks"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestUserSpeedLimitsProtoRoundTrip(t *testing.T) {
+	user := &protocol.User{
+		Level: 1,
+		Email: "limited@example.com",
+		Account: serial.ToTypedMessage(&shadowsocks.Account{
+			Password:   "password",
+			CipherType: shadowsocks.CipherType_CHACHA20_POLY1305,
+		}),
+		SpeedLimitUpMbps:   50,
+		SpeedLimitDownMbps: 75,
+	}
+
+	payload, err := proto.Marshal(user)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	decoded := new(protocol.User)
+	if err := proto.Unmarshal(payload, decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	if decoded.SpeedLimitUpMbps != user.SpeedLimitUpMbps {
+		t.Fatalf("uplink speed limit mismatch: got %d want %d", decoded.SpeedLimitUpMbps, user.SpeedLimitUpMbps)
+	}
+	if decoded.SpeedLimitDownMbps != user.SpeedLimitDownMbps {
+		t.Fatalf("downlink speed limit mismatch: got %d want %d", decoded.SpeedLimitDownMbps, user.SpeedLimitDownMbps)
+	}
+}
+
+func TestUserSpeedLimitsJSONCamelCase(t *testing.T) {
+	raw := []byte(`{
+		"email": "limited@example.com",
+		"speedLimitUpMbps": 50,
+		"speedLimitDownMbps": 75
+	}`)
+
+	user := new(protocol.User)
+	if err := json.Unmarshal(raw, user); err != nil {
+		t.Fatal(err)
+	}
+
+	if user.SpeedLimitUpMbps != 50 {
+		t.Fatalf("uplink speed limit mismatch: got %d want 50", user.SpeedLimitUpMbps)
+	}
+	if user.SpeedLimitDownMbps != 75 {
+		t.Fatalf("downlink speed limit mismatch: got %d want 75", user.SpeedLimitDownMbps)
+	}
+}

--- a/infra/conf/shadowsocks.go
+++ b/infra/conf/shadowsocks.go
@@ -30,12 +30,16 @@ func cipherFromString(c string) shadowsocks.CipherType {
 }
 
 type ShadowsocksUserConfig struct {
-	Cipher   string   `json:"method"`
-	Password string   `json:"password"`
-	Level    byte     `json:"level"`
-	Email    string   `json:"email"`
-	Address  *Address `json:"address"`
-	Port     uint16   `json:"port"`
+	Cipher                  string   `json:"method"`
+	Password                string   `json:"password"`
+	Level                   byte     `json:"level"`
+	Email                   string   `json:"email"`
+	Address                 *Address `json:"address"`
+	Port                    uint16   `json:"port"`
+	SpeedLimitUpMbps        uint64   `json:"speedLimitUpMbps"`
+	SpeedLimitDownMbps      uint64   `json:"speedLimitDownMbps"`
+	SpeedLimitUpMbpsSnake   uint64   `json:"speed_limit_up_mbps"`
+	SpeedLimitDownMbpsSnake uint64   `json:"speed_limit_down_mbps"`
 }
 
 type ShadowsocksServerConfig struct {
@@ -79,9 +83,11 @@ func (v *ShadowsocksServerConfig) Build() (proto.Message, error) {
 					return errors.New("unsupported cipher method: ", user.Cipher)
 				}
 				config.Users[idx] = &protocol.User{
-					Email:   user.Email,
-					Level:   uint32(user.Level),
-					Account: serial.ToTypedMessage(account),
+					Email:              user.Email,
+					Level:              uint32(user.Level),
+					SpeedLimitUpMbps:   firstNonZero(user.SpeedLimitUpMbps, user.SpeedLimitUpMbpsSnake),
+					SpeedLimitDownMbps: firstNonZero(user.SpeedLimitDownMbps, user.SpeedLimitDownMbpsSnake),
+					Account:            serial.ToTypedMessage(account),
 				}
 				return nil
 			}
@@ -143,9 +149,11 @@ func buildShadowsocks2022(v *ShadowsocksServerConfig) (proto.Message, error) {
 				Key: user.Password,
 			}
 			config.Users[idx] = &protocol.User{
-				Email:   user.Email,
-				Level:   uint32(user.Level),
-				Account: serial.ToTypedMessage(account),
+				Email:              user.Email,
+				Level:              uint32(user.Level),
+				SpeedLimitUpMbps:   firstNonZero(user.SpeedLimitUpMbps, user.SpeedLimitUpMbpsSnake),
+				SpeedLimitDownMbps: firstNonZero(user.SpeedLimitDownMbps, user.SpeedLimitDownMbpsSnake),
+				Account:            serial.ToTypedMessage(account),
 			}
 			return nil
 		}

--- a/infra/conf/speed_limit.go
+++ b/infra/conf/speed_limit.go
@@ -1,0 +1,10 @@
+package conf
+
+func firstNonZero(values ...uint64) uint64 {
+	for _, value := range values {
+		if value != 0 {
+			return value
+		}
+	}
+	return 0
+}

--- a/infra/conf/speed_limit_test.go
+++ b/infra/conf/speed_limit_test.go
@@ -1,0 +1,94 @@
+package conf
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/xtls/xray-core/common/protocol"
+	"github.com/xtls/xray-core/proxy/shadowsocks"
+	"github.com/xtls/xray-core/proxy/trojan"
+)
+
+func TestTrojanServerConfigBuildKeepsUserSpeedLimits(t *testing.T) {
+	raw := []byte(`{
+		"clients": [{
+			"password": "password",
+			"email": "limited@example.com",
+			"speedLimitUpMbps": 50,
+			"speedLimitDownMbps": 75
+		}]
+	}`)
+
+	cfg := new(TrojanServerConfig)
+	if err := json.Unmarshal(raw, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	msg, err := cfg.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	built := msg.(*trojan.ServerConfig)
+	assertUserSpeedLimits(t, built.Users[0], 50, 75)
+}
+
+func TestShadowsocksServerConfigBuildKeepsUserSpeedLimits(t *testing.T) {
+	raw := []byte(`{
+		"clients": [{
+			"method": "chacha20-ietf-poly1305",
+			"password": "password",
+			"email": "limited@example.com",
+			"speedLimitUpMbps": 50,
+			"speedLimitDownMbps": 75
+		}]
+	}`)
+
+	cfg := new(ShadowsocksServerConfig)
+	if err := json.Unmarshal(raw, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	msg, err := cfg.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	built := msg.(*shadowsocks.ServerConfig)
+	assertUserSpeedLimits(t, built.Users[0], 50, 75)
+}
+
+func TestSpeedLimitSnakeCaseFallback(t *testing.T) {
+	raw := []byte(`{
+		"clients": [{
+			"password": "password",
+			"email": "limited@example.com",
+			"speed_limit_up_mbps": 25,
+			"speed_limit_down_mbps": 35
+		}]
+	}`)
+
+	cfg := new(TrojanServerConfig)
+	if err := json.Unmarshal(raw, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	msg, err := cfg.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	built := msg.(*trojan.ServerConfig)
+	assertUserSpeedLimits(t, built.Users[0], 25, 35)
+}
+
+func assertUserSpeedLimits(t *testing.T, user *protocol.User, wantUp, wantDown uint64) {
+	t.Helper()
+
+	if user.SpeedLimitUpMbps != wantUp {
+		t.Fatalf("uplink speed limit mismatch: got %d want %d", user.SpeedLimitUpMbps, wantUp)
+	}
+	if user.SpeedLimitDownMbps != wantDown {
+		t.Fatalf("downlink speed limit mismatch: got %d want %d", user.SpeedLimitDownMbps, wantDown)
+	}
+}

--- a/infra/conf/trojan.go
+++ b/infra/conf/trojan.go
@@ -104,10 +104,14 @@ type TrojanInboundFallback struct {
 
 // TrojanUserConfig is user configuration
 type TrojanUserConfig struct {
-	Password string `json:"password"`
-	Level    byte   `json:"level"`
-	Email    string `json:"email"`
-	Flow     string `json:"flow"`
+	Password                string `json:"password"`
+	Level                   byte   `json:"level"`
+	Email                   string `json:"email"`
+	Flow                    string `json:"flow"`
+	SpeedLimitUpMbps        uint64 `json:"speedLimitUpMbps"`
+	SpeedLimitDownMbps      uint64 `json:"speedLimitDownMbps"`
+	SpeedLimitUpMbpsSnake   uint64 `json:"speed_limit_up_mbps"`
+	SpeedLimitDownMbpsSnake uint64 `json:"speed_limit_down_mbps"`
 }
 
 // TrojanServerConfig is Inbound configuration
@@ -136,8 +140,10 @@ func (c *TrojanServerConfig) Build() (proto.Message, error) {
 		}
 
 		config.Users[idx] = &protocol.User{
-			Level: uint32(rawUser.Level),
-			Email: rawUser.Email,
+			Level:              uint32(rawUser.Level),
+			Email:              rawUser.Email,
+			SpeedLimitUpMbps:   firstNonZero(rawUser.SpeedLimitUpMbps, rawUser.SpeedLimitUpMbpsSnake),
+			SpeedLimitDownMbps: firstNonZero(rawUser.SpeedLimitDownMbps, rawUser.SpeedLimitDownMbpsSnake),
 			Account: serial.ToTypedMessage(&trojan.Account{
 				Password: rawUser.Password,
 			}),


### PR DESCRIPTION
## Summary

This PR adds optional per-user bandwidth limits to `protocol.User` and applies them in the dispatcher.

New optional user fields:

- `speed_limit_up_mbps` / `speedLimitUpMbps`
- `speed_limit_down_mbps` / `speedLimitDownMbps`

A value of `0` keeps the current unlimited behavior.

## Behavior

- Limits are applied per user email and per direction (`uplink` / `downlink`).
- Concurrent connections for the same user share the same limiter, so the configured value is a per-user aggregate limit rather than a per-connection limit.
- Different users in the same inbound get separate limiters.
- Existing configs are unaffected because the new fields default to zero.

## Implementation notes

- The fields are added to `common/protocol/user.proto` and propagated to `MemoryUser`.
- Dispatcher writers/readers are wrapped with a token-bucket limiter only when the corresponding user limit is non-zero.
- `UnmarshalJSON` accepts camelCase keys as used by JSON config/frontends while keeping the generated protobuf snake_case JSON tags intact.
- `common/protocol/user.pb.go` was regenerated with `protoc 33.5`, `protoc-gen-go v1.36.11`, and `protoc-gen-go-grpc v1.6.0`.

## Tests

- `go test ./common/protocol ./app/dispatcher`
- `go build -o <temp> ./main`