### PR TITLE
fix(finalmask/xmc): serverConn missing CloseWrite panics when layered under REALITY

### DIFF
--- a/transport/internet/finalmask/xmc/server.go
+++ b/transport/internet/finalmask/xmc/server.go
@@ -242,6 +242,29 @@ func (c *serverConn) Close() error {
 	return c.c.Close()
 }
 
+// closeWriter matches reality.CloseWriteConn's method set (net.Conn is
+// already satisfied above). *net.TCPConn / *net.UnixConn implement this.
+type closeWriter interface {
+	CloseWrite() error
+}
+
+// CloseWrite makes *serverConn satisfy reality.CloseWriteConn, which
+// transport/internet/reality's Server() hard type-asserts the wrapped conn
+// against (github.com/xtls/reality/tls.go: "underlying := raw.(CloseWriteConn)")
+// for its splice-to-real-destination fallback path when a connection past
+// this mask isn't a genuine REALITY client. Half-closing the raw TCP
+// connection is a socket-level operation below XMC's byte-stream cipher —
+// it doesn't need to go through the CFB8 encrypt/decrypt loop, so a direct
+// passthrough to the underlying conn is correct. Without this method,
+// finalmask.tcp:xmc layered under security:reality panics the whole
+// process on the very first connection (confirmed via local repro).
+func (c *serverConn) CloseWrite() error {
+	if cw, ok := c.c.(closeWriter); ok {
+		return cw.CloseWrite()
+	}
+	return c.c.Close()
+}
+
 func (c *serverConn) LocalAddr() net.Addr {
 	return c.c.LocalAddr()
 }


### PR DESCRIPTION
## Problem

Stacking `finalmask.tcp: [{"type": "xmc", ...}]` underneath `security: "reality"` on the same inbound panics the whole `xray` process on the very first connection:

```
panic: interface conversion: *xmc.serverConn is not reality.CloseWriteConn: missing method CloseWrite
```

Repro: any inbound with `network: "tcp"`, `security: "reality"`, and `streamSettings.finalmask.tcp` containing an `xmc` entry. The panic fires as soon as a client completes the XMC (Minecraft) handshake and REALITY's `Server()` runs.

## Root cause

`github.com/xtls/reality`'s `Server()` does a hard (non-`,ok`) type assertion on the wrapped connection:

```go
underlying := raw.(CloseWriteConn) // *net.TCPConn or *net.UnixConn
```

`CloseWriteConn` is `net.Conn` + `CloseWrite() error`, used for REALITY's splice-to-real-destination fallback when the peer isn't a genuine REALITY client (half-closing the real TCP connection without fully closing the read side).

`xmc.serverConn` (added in #6210) only implements the plain `net.Conn` methods, so the assertion panics as soon as any TCP-network inbound has both `finalmask.tcp` and `security: reality` configured.

## Fix

Add `CloseWrite()` to `*serverConn`, forwarding to the underlying raw `net.Conn` (typically `*net.TCPConn`) via a small local `closeWriter` interface, falling back to a full `Close()` if the underlying conn doesn't support it. Half-close is a socket-level operation below XMC's AES/CFB8 byte-stream cipher, so a direct passthrough is correct — it doesn't need to go through the encrypt/decrypt loop.

Client side (`transport/internet/reality`'s `UClient`) doesn't have an analogous type assertion, so no change needed there.

## Verification

Local repro before/after the fix, using this project's own `xray` binary built from this branch:

- **Before**: `vless` + `reality` + `finalmask.tcp: [xmc]` inbound — server panics and the process exits on the first connection.
- **After**: same config — REALITY handshake completes for real (`isHandshakeComplete: true`), VLESS+Vision correctly proxies to the actually-requested destination through the XMC-wrapped tunnel (confirmed real HTTP 200 + page content, not REALITY's disguise-site fallback), no panic, process stays up.
- Also re-confirmed `finalmask.tcp: [xmc]` + plain `security: tls` and `finalmask.tcp: [xmc]` with no security both continue to work unaffected (this bug is scoped specifically to the REALITY combination).

---

（中文说明）`finalmask.tcp` 叠加 `security: reality` 时，第一个连接就会让整个 xray 进程 panic：`reality.Server()` 对被 XMC 包装后的连接做了不带 `,ok` 的硬类型断言 `raw.(CloseWriteConn)`，要求实现 `CloseWrite()`，但 `xmc.serverConn` 只实现了普通 `net.Conn`。这个 PR 给 `serverConn` 补上 `CloseWrite()`，透传给底层原始连接——半关闭是 socket 层操作，不需要经过 XMC 的 CFB8 加解密，直接透传语义上是对的。本地起 vless+reality+finalmask.tcp:xmc 复现并验证：修复前必崩，修复后 REALITY 握手真实完成、VLESS+Vision 正确代理到真实目标，无 panic。同时确认 finalmask.tcp:xmc 单独用或叠加纯 TLS 不受影响，问题精确限定在叠加 REALITY 这个组合上。