### PR TITLE
fix(mux): align online tracking with session lifecycle

### DIFF
--- a/app/dispatcher/online_test.go
+++ b/app/dispatcher/online_test.go
@@ -1,0 +1,43 @@
+package dispatcher
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	appstats "github.com/xtls/xray-core/app/stats"
+)
+
+func TestTrackOnlineIPRetainsDirectSessionSemantics(t *testing.T) {
+	manager, err := appstats.NewManager(context.Background(), &appstats.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	trackOnlineIP(ctx, manager, "user@example.com", "198.51.100.20")
+
+	online := manager.GetOnlineMap("user>>>user@example.com>>>online")
+	if online == nil || online.Count() != 1 {
+		t.Fatal("direct session did not acquire an online IP reference")
+	}
+	var lastSeen int64
+	online.ForEach(func(ip string, timestamp int64) bool {
+		if ip != "198.51.100.20" {
+			t.Fatalf("unexpected online IP: %s", ip)
+		}
+		lastSeen = timestamp
+		return true
+	})
+	if lastSeen == 0 {
+		t.Fatal("direct session did not record acquisition time")
+	}
+
+	cancel()
+	deadline := time.Now().Add(time.Second)
+	for online.Count() != 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("direct session online IP was not released after context cancellation")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}

--- a/common/mux/server.go
+++ b/common/mux/server.go
@@ -227,10 +227,13 @@ func (w *ServerWorker) handleStatusNew(ctx context.Context, meta *FrameMetadata,
 			errors.LogInfoInner(ctx, err, "XUDP hit ", meta.GlobalID)
 		}
 		if mb != nil {
-			ctx = session.ContextWithTimeoutOnly(ctx, true)
+			ctx = session.ContextWithTimeoutOnly(context.WithoutCancel(ctx), true)
+			ctx, cancel := context.WithCancel(ctx)
+			lifecycle := &xudpLifecycle{cancel: cancel}
 			// Actually, it won't return an error in Xray-core's implementations.
 			link, err := w.dispatcher.Dispatch(ctx, meta.Target)
 			if err != nil {
+				lifecycle.Close()
 				XUDPManager.Lock()
 				delete(XUDPManager.Map, x.GlobalID)
 				XUDPManager.Unlock()
@@ -242,6 +245,7 @@ func (w *ServerWorker) handleStatusNew(ctx context.Context, meta *FrameMetadata,
 				input:  link.Reader,
 				output: link.Writer,
 			}
+			x.setLifecycle(lifecycle)
 			errors.LogInfoInner(ctx, err, "XUDP new ", meta.GlobalID)
 		}
 		x.Mux = &Session{
@@ -261,8 +265,10 @@ func (w *ServerWorker) handleStatusNew(ctx context.Context, meta *FrameMetadata,
 		return nil
 	}
 
+	ctx, cancel := context.WithCancel(ctx)
 	link, err := w.dispatcher.Dispatch(ctx, meta.Target)
 	if err != nil {
+		cancel()
 		if meta.Option.Has(OptionData) {
 			buf.Copy(NewStreamReader(reader), buf.Discard)
 		}
@@ -272,6 +278,7 @@ func (w *ServerWorker) handleStatusNew(ctx context.Context, meta *FrameMetadata,
 		input:        link.Reader,
 		output:       link.Writer,
 		parent:       w.sessionManager,
+		cancel:       cancel,
 		ID:           meta.SessionID,
 		transferType: protocol.TransferTypeStream,
 	}

--- a/common/mux/server_test.go
+++ b/common/mux/server_test.go
@@ -2,17 +2,34 @@ package mux_test
 
 import (
 	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	appstats "github.com/xtls/xray-core/app/stats"
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/buf"
 	"github.com/xtls/xray-core/common/mux"
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/session"
+	commonxudp "github.com/xtls/xray-core/common/xudp"
 	"github.com/xtls/xray-core/features/routing"
 	"github.com/xtls/xray-core/transport"
 	"github.com/xtls/xray-core/transport/pipe"
 )
+
+func waitForCondition(t *testing.T, timeout time.Duration, description string, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for !condition() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", description)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
 
 func newLinkPair() (*transport.Link, *transport.Link) {
 	opt := pipe.WithoutSizeLimit()
@@ -121,4 +138,415 @@ func TestRegressionOutboundLeak(t *testing.T) {
 	if outbounds[0].Target.Address != nil {
 		t.Error("outbound target got leaked: ", outbounds[0].Target.String())
 	}
+}
+
+func TestLogicalSessionReleasesOnlineIPWhileCarrierRemainsOpen(t *testing.T) {
+	const sourceIP = "198.51.100.10"
+
+	online := appstats.NewOnlineMap()
+	websiteUplink, websiteDownlink := newLinkPair()
+	t.Cleanup(func() {
+		common.Close(websiteUplink.Reader)
+		common.Close(websiteUplink.Writer)
+	})
+
+	dispatcher := TestDispatcher{
+		OnDispatch: func(ctx context.Context, dest net.Destination) (*transport.Link, error) {
+			online.AddIP(sourceIP)
+			context.AfterFunc(ctx, func() { online.RemoveIP(sourceIP) })
+			return websiteDownlink, nil
+		},
+	}
+
+	carrierCtx, cancelCarrier := context.WithCancel(context.Background())
+	t.Cleanup(cancelCarrier)
+	muxServerUplink, muxServerDownlink := newLinkPair()
+	server, err := mux.NewServerWorker(carrierCtx, &dispatcher, muxServerUplink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { common.Close(server) })
+
+	client, err := mux.NewClientWorker(*muxServerDownlink, mux.ClientStrategy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { common.Close(client) })
+
+	clientCtx := session.ContextWithOutbounds(context.Background(), []*session.Outbound{{
+		Target: net.TCPDestination(net.DomainAddress("www.example.com"), 80),
+	}})
+	muxClientUplink, muxClientDownlink := newLinkPair()
+	if !client.Dispatch(clientCtx, muxClientUplink) {
+		t.Fatal("failed to dispatch logical Mux session")
+	}
+
+	waitForCondition(t, time.Second, "online IP acquisition", func() bool {
+		return online.Count() == 1
+	})
+
+	if err := common.Close(muxClientDownlink.Writer); err != nil {
+		t.Fatal(err)
+	}
+	waitForCondition(t, time.Second, "logical Mux session close", func() bool {
+		return server.ActiveConnections() == 0
+	})
+	if server.Closed() {
+		t.Fatal("Mux carrier closed before online lifecycle assertion")
+	}
+
+	waitForCondition(t, 200*time.Millisecond, "online IP release while Mux carrier remains open", func() bool {
+		return online.Count() == 0
+	})
+}
+
+func TestMuxCarrierWithoutLogicalSessionDoesNotTrackOnlineIP(t *testing.T) {
+	var dispatches atomic.Int32
+	dispatcher := TestDispatcher{
+		OnDispatch: func(ctx context.Context, dest net.Destination) (*transport.Link, error) {
+			dispatches.Add(1)
+			return nil, errors.New("unexpected logical dispatch")
+		},
+	}
+
+	carrierCtx, cancelCarrier := context.WithCancel(context.Background())
+	t.Cleanup(cancelCarrier)
+	muxServerUplink, _ := newLinkPair()
+	server, err := mux.NewServerWorker(carrierCtx, &dispatcher, muxServerUplink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { common.Close(server) })
+
+	time.Sleep(20 * time.Millisecond)
+	if dispatches.Load() != 0 {
+		t.Fatalf("Mux control carrier triggered %d logical dispatches", dispatches.Load())
+	}
+}
+
+func TestOnlineIPRemainsUntilLastLogicalSessionCloses(t *testing.T) {
+	const sourceIP = "198.51.100.13"
+
+	online := appstats.NewOnlineMap()
+	var websitesMu sync.Mutex
+	var websites []*transport.Link
+	dispatcher := TestDispatcher{
+		OnDispatch: func(ctx context.Context, dest net.Destination) (*transport.Link, error) {
+			online.AddIP(sourceIP)
+			context.AfterFunc(ctx, func() { online.RemoveIP(sourceIP) })
+			websiteUplink, websiteDownlink := newLinkPair()
+			websitesMu.Lock()
+			websites = append(websites, websiteUplink)
+			websitesMu.Unlock()
+			return websiteDownlink, nil
+		},
+	}
+	t.Cleanup(func() {
+		websitesMu.Lock()
+		defer websitesMu.Unlock()
+		for _, website := range websites {
+			common.Close(website.Reader)
+			common.Close(website.Writer)
+		}
+	})
+
+	carrierCtx, cancelCarrier := context.WithCancel(context.Background())
+	t.Cleanup(cancelCarrier)
+	muxServerUplink, muxServerDownlink := newLinkPair()
+	server, err := mux.NewServerWorker(carrierCtx, &dispatcher, muxServerUplink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { common.Close(server) })
+	client, err := mux.NewClientWorker(*muxServerDownlink, mux.ClientStrategy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { common.Close(client) })
+
+	openSession := func(domain string) *transport.Link {
+		t.Helper()
+		clientCtx := session.ContextWithOutbounds(context.Background(), []*session.Outbound{{
+			Target: net.TCPDestination(net.DomainAddress(domain), 80),
+		}})
+		uplink, downlink := newLinkPair()
+		if !client.Dispatch(clientCtx, uplink) {
+			t.Fatal("failed to dispatch logical Mux session")
+		}
+		if err := downlink.Writer.WriteMultiBuffer(buf.MultiBuffer{buf.FromBytes([]byte("request"))}); err != nil {
+			t.Fatal(err)
+		}
+		return downlink
+	}
+	first := openSession("one.example.com")
+	second := openSession("two.example.com")
+
+	waitForCondition(t, time.Second, "two online logical sessions", func() bool {
+		return server.ActiveConnections() == 2 && online.Count() == 1
+	})
+	if err := common.Close(first.Writer); err != nil {
+		t.Fatal(err)
+	}
+	waitForCondition(t, time.Second, "first logical session close", func() bool {
+		return server.ActiveConnections() == 1
+	})
+	if online.Count() != 1 {
+		t.Fatal("online IP was removed while another logical session remained active")
+	}
+	if err := common.Close(second.Writer); err != nil {
+		t.Fatal(err)
+	}
+	waitForCondition(t, time.Second, "final logical session release", func() bool {
+		return server.ActiveConnections() == 0 && online.Count() == 0
+	})
+}
+
+func TestFailedLogicalDispatchReleasesOnlineIP(t *testing.T) {
+	const sourceIP = "198.51.100.12"
+
+	online := appstats.NewOnlineMap()
+	acquired := make(chan struct{})
+	dispatcher := TestDispatcher{
+		OnDispatch: func(ctx context.Context, dest net.Destination) (*transport.Link, error) {
+			online.AddIP(sourceIP)
+			context.AfterFunc(ctx, func() { online.RemoveIP(sourceIP) })
+			close(acquired)
+			return nil, errors.New("expected dispatch failure")
+		},
+	}
+
+	carrierCtx, cancelCarrier := context.WithCancel(context.Background())
+	t.Cleanup(cancelCarrier)
+	muxServerUplink, muxServerDownlink := newLinkPair()
+	server, err := mux.NewServerWorker(carrierCtx, &dispatcher, muxServerUplink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { common.Close(server) })
+
+	client, err := mux.NewClientWorker(*muxServerDownlink, mux.ClientStrategy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { common.Close(client) })
+
+	clientCtx := session.ContextWithOutbounds(context.Background(), []*session.Outbound{{
+		Target: net.TCPDestination(net.DomainAddress("www.example.com"), 80),
+	}})
+	muxClientUplink, muxClientDownlink := newLinkPair()
+	if !client.Dispatch(clientCtx, muxClientUplink) {
+		t.Fatal("failed to create logical Mux session")
+	}
+	if err := muxClientDownlink.Writer.WriteMultiBuffer(buf.MultiBuffer{buf.FromBytes([]byte("request"))}); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for failed dispatch")
+	}
+	waitForCondition(t, 200*time.Millisecond, "online IP release after failed dispatch", func() bool {
+		return online.Count() == 0
+	})
+}
+
+func TestFailedXUDPDispatchReleasesOnlineIP(t *testing.T) {
+	const sourceIP = "198.51.100.14"
+
+	online := appstats.NewOnlineMap()
+	acquired := make(chan struct{})
+	dispatcher := TestDispatcher{
+		OnDispatch: func(ctx context.Context, dest net.Destination) (*transport.Link, error) {
+			online.AddIP(sourceIP)
+			context.AfterFunc(ctx, func() { online.RemoveIP(sourceIP) })
+			close(acquired)
+			return nil, errors.New("expected XUDP dispatch failure")
+		},
+	}
+
+	carrierCtx, cancelCarrier := context.WithCancel(context.Background())
+	t.Cleanup(cancelCarrier)
+	muxServerUplink, muxServerDownlink := newLinkPair()
+	server, err := mux.NewServerWorker(carrierCtx, &dispatcher, muxServerUplink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { common.Close(server) })
+	client, err := mux.NewClientWorker(*muxServerDownlink, mux.ClientStrategy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { common.Close(client) })
+
+	clientCtx := context.WithValue(context.Background(), "cone", true)
+	clientCtx = session.ContextWithInbound(clientCtx, &session.Inbound{
+		Name:   "socks",
+		Source: net.UDPDestination(net.ParseAddress(sourceIP), 12345),
+	})
+	target := net.UDPDestination(net.DomainAddress("dns.example.com"), 53)
+	clientCtx = session.ContextWithOutbounds(clientCtx, []*session.Outbound{{Target: target}})
+	globalID := commonxudp.GetGlobalID(clientCtx)
+
+	muxClientUplink, muxClientDownlink := newLinkPair()
+	if !client.Dispatch(clientCtx, muxClientUplink) {
+		t.Fatal("failed to create XUDP Mux session")
+	}
+	packet := buf.FromBytes([]byte("query"))
+	packet.UDP = &target
+	if err := muxClientDownlink.Writer.WriteMultiBuffer(buf.MultiBuffer{packet}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for failed XUDP dispatch")
+	}
+	waitForCondition(t, 200*time.Millisecond, "online IP release after failed XUDP dispatch", func() bool {
+		return online.Count() == 0
+	})
+	mux.XUDPManager.Lock()
+	_, retained := mux.XUDPManager.Map[globalID]
+	mux.XUDPManager.Unlock()
+	if retained {
+		t.Fatal("failed XUDP dispatch retained a global flow entry")
+	}
+}
+
+func TestXUDPReleasesOnlineIPWhenReusableFlowEnds(t *testing.T) {
+	const sourceIP = "198.51.100.11"
+
+	online := appstats.NewOnlineMap()
+	var dispatches atomic.Int32
+	websiteUplink, websiteDownlink := newLinkPair()
+	t.Cleanup(func() {
+		common.Close(websiteUplink.Reader)
+		common.Close(websiteUplink.Writer)
+	})
+
+	dispatcher := TestDispatcher{
+		OnDispatch: func(ctx context.Context, dest net.Destination) (*transport.Link, error) {
+			dispatches.Add(1)
+			online.AddIP(sourceIP)
+			context.AfterFunc(ctx, func() { online.RemoveIP(sourceIP) })
+			return websiteDownlink, nil
+		},
+	}
+
+	carrierCtx, cancelCarrier := context.WithCancel(context.Background())
+	t.Cleanup(cancelCarrier)
+	muxServerUplink, muxServerDownlink := newLinkPair()
+	server, err := mux.NewServerWorker(carrierCtx, &dispatcher, muxServerUplink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { common.Close(server) })
+
+	client, err := mux.NewClientWorker(*muxServerDownlink, mux.ClientStrategy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { common.Close(client) })
+
+	clientCtx := context.WithValue(context.Background(), "cone", true)
+	clientCtx = session.ContextWithInbound(clientCtx, &session.Inbound{
+		Name:   "socks",
+		Source: net.UDPDestination(net.ParseAddress(sourceIP), 12345),
+	})
+	target := net.UDPDestination(net.DomainAddress("dns.example.com"), 53)
+	clientCtx = session.ContextWithOutbounds(clientCtx, []*session.Outbound{{
+		Target: target,
+	}})
+	globalID := commonxudp.GetGlobalID(clientCtx)
+	if globalID == [8]byte{} {
+		t.Fatal("expected non-empty XUDP global ID")
+	}
+	var registeredXUDP *mux.XUDP
+	t.Cleanup(func() {
+		mux.XUDPManager.Lock()
+		if registeredXUDP != nil {
+			delete(mux.XUDPManager.Map, registeredXUDP.GlobalID)
+		}
+		mux.XUDPManager.Unlock()
+		if registeredXUDP != nil {
+			registeredXUDP.Interrupt()
+		}
+	})
+
+	muxClientUplink, muxClientDownlink := newLinkPair()
+	if !client.Dispatch(clientCtx, muxClientUplink) {
+		t.Fatal("failed to dispatch XUDP Mux session")
+	}
+	packet := buf.FromBytes([]byte("ping"))
+	packet.UDP = &target
+	if err := muxClientDownlink.Writer.WriteMultiBuffer(buf.MultiBuffer{packet}); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForCondition(t, time.Second, "XUDP online IP acquisition", func() bool {
+		return online.Count() == 1
+	})
+	waitForCondition(t, time.Second, "XUDP flow registration", func() bool {
+		mux.XUDPManager.Lock()
+		defer mux.XUDPManager.Unlock()
+		for _, x := range mux.XUDPManager.Map {
+			registeredXUDP = x
+			return true
+		}
+		return false
+	})
+
+	if err := common.Close(muxClientDownlink.Writer); err != nil {
+		t.Fatal(err)
+	}
+	waitForCondition(t, time.Second, "carrier-local XUDP session close", func() bool {
+		return server.ActiveConnections() == 0
+	})
+	if online.Count() != 1 {
+		t.Fatal("XUDP online reference was released before reusable flow ended")
+	}
+	if server.Closed() {
+		t.Fatal("Mux carrier closed before XUDP lifecycle assertion")
+	}
+	if dispatches.Load() != 1 {
+		t.Fatalf("unexpected initial XUDP dispatch count: %d", dispatches.Load())
+	}
+
+	reboundUplink, reboundDownlink := newLinkPair()
+	if !client.Dispatch(clientCtx, reboundUplink) {
+		t.Fatal("failed to rebind XUDP flow to another logical Mux session")
+	}
+	reboundPacket := buf.FromBytes([]byte("pong"))
+	reboundPacket.UDP = &target
+	if err := reboundDownlink.Writer.WriteMultiBuffer(buf.MultiBuffer{reboundPacket}); err != nil {
+		t.Fatal(err)
+	}
+	waitForCondition(t, time.Second, "XUDP flow rebind", func() bool {
+		return server.ActiveConnections() == 1
+	})
+	if dispatches.Load() != 1 {
+		t.Fatalf("XUDP rebind created a second dispatched flow: %d", dispatches.Load())
+	}
+	if online.Count() != 1 {
+		t.Fatalf("XUDP rebind changed online reference count: %d", online.Count())
+	}
+	if err := common.Close(reboundDownlink.Writer); err != nil {
+		t.Fatal(err)
+	}
+	waitForCondition(t, time.Second, "rebound XUDP session close", func() bool {
+		return server.ActiveConnections() == 0
+	})
+
+	mux.XUDPManager.Lock()
+	x := registeredXUDP
+	delete(mux.XUDPManager.Map, registeredXUDP.GlobalID)
+	mux.XUDPManager.Unlock()
+	if x == nil {
+		t.Fatal("XUDP flow disappeared before permanent interruption")
+	}
+	x.Interrupt()
+
+	waitForCondition(t, 200*time.Millisecond, "online IP release after XUDP flow interruption", func() bool {
+		return online.Count() == 0
+	})
 }

--- a/common/mux/session.go
+++ b/common/mux/session.go
@@ -158,6 +158,7 @@ type Session struct {
 	input        buf.Reader
 	output       buf.Writer
 	parent       *SessionManager
+	cancel       context.CancelFunc
 	ID           uint16
 	transferType protocol.TransferType
 	closed       bool
@@ -176,6 +177,9 @@ func (s *Session) Close(locked bool) error {
 		return nil
 	}
 	s.closed = true
+	if s.cancel != nil {
+		s.cancel()
+	}
 	if s.done != nil {
 		s.done.Close()
 	}
@@ -216,13 +220,40 @@ const (
 )
 
 type XUDP struct {
-	GlobalID [8]byte
-	Status   uint64
-	Expire   time.Time
-	Mux      *Session
+	GlobalID        [8]byte
+	Status          uint64
+	Expire          time.Time
+	Mux             *Session
+	lifecycleAccess sync.Mutex
+	lifecycle       *xudpLifecycle
+}
+
+type xudpLifecycle struct {
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (l *xudpLifecycle) Close() {
+	if l != nil {
+		l.once.Do(l.cancel)
+	}
+}
+
+func (x *XUDP) setLifecycle(lifecycle *xudpLifecycle) {
+	x.lifecycleAccess.Lock()
+	x.lifecycle = lifecycle
+	x.lifecycleAccess.Unlock()
+}
+
+func (x *XUDP) closeLifecycle() {
+	x.lifecycleAccess.Lock()
+	lifecycle := x.lifecycle
+	x.lifecycleAccess.Unlock()
+	lifecycle.Close()
 }
 
 func (x *XUDP) Interrupt() {
+	x.closeLifecycle()
 	common.Interrupt(x.Mux.input)
 	common.Close(x.Mux.output)
 }

--- a/common/mux/session_lifecycle_test.go
+++ b/common/mux/session_lifecycle_test.go
@@ -1,0 +1,55 @@
+package mux
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func waitForContextCancellation(t *testing.T, ctx context.Context) {
+	t.Helper()
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for session-owned context cancellation")
+	}
+}
+
+func TestSessionCloseCancelsOwnedContext(t *testing.T) {
+	manager := NewSessionManager()
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Session{
+		parent: manager,
+		cancel: cancel,
+		ID:     1,
+	}
+	if !manager.Add(s) {
+		t.Fatal("failed to add session")
+	}
+
+	if err := s.Close(false); err != nil {
+		t.Fatal(err)
+	}
+	waitForContextCancellation(t, ctx)
+	if err := s.Close(false); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSessionManagerCloseCancelsOwnedContexts(t *testing.T) {
+	manager := NewSessionManager()
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Session{
+		parent: manager,
+		cancel: cancel,
+		ID:     1,
+	}
+	if !manager.Add(s) {
+		t.Fatal("failed to add session")
+	}
+
+	if err := manager.Close(); err != nil {
+		t.Fatal(err)
+	}
+	waitForContextCancellation(t, ctx)
+}


### PR DESCRIPTION
<img width="392" height="148" alt="telegram-cloud-photo-size-4-5962909144257859007-x" src="https://github.com/user-attachments/assets/a0d5bceb-9f03-403e-8372-69fe7c9f10d1" />
