### PR TITLE
fix: VisionWriter/VisionReader lack a working Close(), breaking forced disconnect

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -200,6 +200,23 @@ func NewVisionReader(reader buf.Reader, trafficState *TrafficState, isUplink boo
 	}
 }
 
+// Close closes the underlying real connection. VisionReader anonymously
+// embeds the buf.Reader *interface* (only ReadMultiBuffer), not any concrete
+// reader, so Go's method promotion never gives it a working Close/Interrupt
+// even when the wrapped reader supports one - common.Close/common.Interrupt
+// on a bare *VisionReader used to be a silent no-op. Since VisionReader
+// already holds the real net.Conn for exactly this connection (used above
+// for the splice-detection/TLS-unwrap path), forwarding to it here gives any
+// caller that force-closes a dispatched Link (e.g. v2node's LinkManager
+// kicking a banned/expired/device-limit-exceeded user's in-flight Vision
+// session) a real way to sever the socket instead of doing nothing. The
+// generic inbound worker already closes this same conn unconditionally once
+// Process() returns, so this is an idempotent no-op double-close on the
+// normal teardown path and only matters for the forced-close case.
+func (w *VisionReader) Close() error {
+	return w.conn.Close()
+}
+
 func (w *VisionReader) ReadMultiBuffer() (buf.MultiBuffer, error) {
 	buffer, err := w.Reader.ReadMultiBuffer()
 	if buffer.IsEmpty() {
@@ -317,6 +334,14 @@ func NewVisionWriter(writer buf.Writer, trafficState *TrafficState, isUplink boo
 		ob:                ob,
 		testseed:          testseed,
 	}
+}
+
+// Close closes the underlying real connection - see the matching comment on
+// VisionReader.Close for why this is needed (VisionWriter has the identical
+// embed-an-interface-not-a-concrete-type problem, so it never got a working
+// Close either).
+func (w *VisionWriter) Close() error {
+	return w.conn.Close()
 }
 
 func (w *VisionWriter) WriteMultiBuffer(mb buf.MultiBuffer) error {


### PR DESCRIPTION
## Summary

`VisionWriter`/`VisionReader` (`proxy/proxy.go`) anonymously embed the `buf.Writer`/`buf.Reader` **interface** type, not any concrete writer/reader. Go's method promotion is based on the embedded field's static declared type, so neither struct ever gets a real `Close()`/`Interrupt()` — `common.Close()`/`common.Interrupt()` silently no-op on a bare `*VisionWriter` or `*VisionReader`, even though both already hold the real `net.Conn` for this exact connection (used a few lines above for the splice-detection / TLS input-unwrap path).

## Impact

Any caller that tracks a dispatched `transport.Link` and later needs to force-close it via the documented generic mechanism (`common.Close`/`common.Interrupt`) silently fails to do anything when the flow is Vision. Concretely: a panel-driven "kick this user now" (ban/expire/device-limit-exceeded) feature that registers the inbound `transport.Link`'s `Writer`/`Reader` and later calls `common.Close`/`common.Interrupt` on them expects an already-open connection to actually terminate. With Vision it doesn't — both calls fail their type assertions, and the connection keeps proxying traffic until the client disconnects on its own or the outbound policy's `ConnectionIdle` timeout fires (which never fires while traffic keeps flowing, so in practice: never, for an active session).

## Fix

Give `VisionWriter`/`VisionReader` a `Close()` that closes the real `net.Conn` they already hold a reference to. Reader and writer for the same session share the same underlying connection, so closing either side is enough to tear down the whole thing. This is safe on the normal teardown path too: the generic inbound worker (`app/proxyman/inbound/worker.go`) already closes this same `conn` unconditionally once `Process()` returns, so the added `Close()` is just an idempotent extra call there — it only changes behavior for the previously-broken forced-close-from-outside case.

## Testing

- `go build ./...`
- `go vet ./...`
- Existing `proxy/vless/encoding` test suite passes unchanged
- Added a standalone unit test constructing a `VisionWriter`/`VisionReader` around a fake `net.Conn` and confirming `Close()` reaches it (not included in this diff since it lives in a private fork's test layout — happy to add an equivalent test in this repo's own style if useful)