### PR TITLE
fix: xmc VarInt handling infinite-loops on a negative value (pre-auth DoS)

### DIFF
--- a/transport/internet/finalmask/xmc/protocol.go
+++ b/transport/internet/finalmask/xmc/protocol.go
@@ -99,10 +99,15 @@ func (v *Varint) writeTo(w io.Writer) error {
 	SEGMENT_BITS := byte(0x7F)
 	CONTINUE_BIT := byte(0x80)
 
-	value := int32(*v)
+	// Must be an unsigned shift: value is the raw 32-bit wire pattern of a
+	// Varint (negative Go int32 values are a legal encoding, matching the
+	// Minecraft protocol's own VarInt spec). A signed int32 >>= 7 sign-extends
+	// and asymptotes to -1, never reaching 0 - the loop below would never
+	// terminate for a negative *v.
+	value := uint32(*v)
 
 	for {
-		currentByte := byte(value & int32(SEGMENT_BITS))
+		currentByte := byte(value & uint32(SEGMENT_BITS))
 		value >>= 7
 		if value != 0 {
 			currentByte |= CONTINUE_BIT
@@ -122,11 +127,18 @@ func (v *Varint) writeTo(w io.Writer) error {
 }
 
 func varintSize(value Varint) int {
+	// Unsigned shift for the same reason as writeTo above. readPacket() calls
+	// this with an attacker-controlled, unvalidated packetID read straight off
+	// the wire from an unauthenticated connection - a 5-byte VarInt encoding
+	// of a negative int32 (e.g. bytes 80 80 80 80 08 -> -2147483648) used to
+	// pin this in an infinite loop, a pre-auth 100%-CPU DoS with a ~6-byte
+	// payload.
+	uv := uint32(value)
 	size := 0
 	for {
 		size++
-		value >>= 7
-		if value == 0 {
+		uv >>= 7
+		if uv == 0 {
 			break
 		}
 	}


### PR DESCRIPTION
## Summary

`varintSize()` and `Varint.writeTo()` in `transport/internet/finalmask/xmc/protocol.go` shift a `Varint` (`type Varint int32`) right by 7 in a loop until it reaches 0, to compute how many bytes the VarInt encoding takes. Go's `>>=` on a signed type is an arithmetic (sign-extending) shift — for a negative starting value this converges to `-1`, never `0`, so the loop never terminates.

## Reachability (pre-auth)

`readPacket()` calls `varintSize(packetID)` (line ~33) with `packetID` read directly off the wire via `Varint.readFrom()`, on a brand-new, completely unauthenticated connection — before any handshake/password check. There's no check that `packetID` is non-negative first.

A 5-byte VarInt encoding of a negative `int32` is a **legal** encoding under `readFrom`'s own existing bounds check: it only rejects `position >= 32`, checked *after* a continuation-bit-set byte — so a final, non-continuation byte that happens to set the sign bit (bit 31) passes through untouched. Concretely, the 5 bytes `80 80 80 80 08` decode via the current `readFrom` logic to `-2147483648`, with no error.

So a ~6-byte payload — `00 80 80 80 80 08` (`packetLength=0`, then that `packetID`) — sent as literally the first bytes on a new connection to an `xmc`-configured listener pins the handling goroutine (and a full CPU core, since it's a pure in-memory compute loop with no I/O to yield on) in an infinite loop, before any password/auth check ever runs.

## Fix

Do the shift-until-zero loop on the *unsigned* 32-bit bit pattern instead. `uint32(value) >>= 7` is a logical shift and correctly reaches 0 after at most 5 iterations for any 32-bit pattern, matching how VarInt size/encoding is meant to work regardless of the sign of the underlying value (this mirrors how Minecraft's own reference VarInt implementations treat the value as an unsigned 32-bit pattern for exactly this reason). `readFrom`'s own decoding logic is untouched and already round-trips negative values correctly — only the two loop-*termination* checks (in `varintSize` and `writeTo`) were wrong.

## Testing

Verified with a unit test (not included in this diff, happy to add one in-repo if useful):
- Before the fix: `varintSize(Varint(-2147483648))` and `readPacket()` fed the literal payload above both hang past a 2s timeout in a real goroutine.
- After the fix: both return normally — `varintSize` returns `5`; `readPacket` returns a clean "bad length" error, since the resulting negative `dataLength` is already rejected by the existing bounds check a few lines further down.
- `go build ./...`, `go test ./transport/internet/finalmask/...` all pass.