### PR TITLE
REALITY server: Refine warnings in parsing configuration

### DIFF
--- a/infra/conf/transport_security.go
+++ b/infra/conf/transport_security.go
@@ -1,6 +1,7 @@
 package conf
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -158,10 +159,10 @@ func (c *REALITYConfig) Build() (proto.Message, error) {
 		}
 
 		for _, sn := range config.ServerNames {
-			host := strings.ToLower(sn)
-			if strings.HasSuffix(host, ".ru") || strings.HasSuffix(host, ".ir") || strings.HasSuffix(host, ".cn") ||
-				strings.Contains(host, "apple") || strings.Contains(host, "icloud") || strings.Contains(host, "microsoft") {
-				return nil, errors.New(`REALITY: "`, sn, `" must not be used as the target: such domains get the server's IP blocked, choose a proper dest`)
+			sn = strings.ToLower(sn)
+			if strings.HasSuffix(sn, ".ru") || strings.HasSuffix(sn, ".ir") || strings.HasSuffix(sn, ".cn") ||
+				strings.Contains(sn, "apple") || strings.Contains(sn, "icloud") || strings.Contains(sn, "microsoft") {
+				errors.LogWarning(context.Background(), `REALITY: Choosing "`, sn, `" as the target may get your server's IP blocked by the GFW`)
 			}
 		}
 

--- a/infra/conf/transport_security.go
+++ b/infra/conf/transport_security.go
@@ -113,8 +113,10 @@ func (c *REALITYConfig) Build() (proto.Message, error) {
 					config.MinClientVer[i] = byte(u)
 				}
 			}
+			errors.LogWarning(context.Background(), `REALITY: Changing "minClientVer" will increase the likelihood of your server's IP being blocked by the GFW`)
 		} else {
-			config.MinClientVer = []byte{26, 3, 27} // change it at your own risk: https://github.com/XTLS/Xray-core/pull/6181#issuecomment-4567373533
+			config.MinClientVer = []byte{26, 3, 27} // change it at your own risk: https://github.com/XTLS/Xray-core/commit/af7eb68028732a8ee3c0e5d6ab2b8a657bb2e770
+			errors.LogWarning(context.Background(), `REALITY: The default minimal client version is Xray-core v26.3.27, other clients may be refused to connect`)
 		}
 		if c.MaxClientVer != "" {
 			config.MaxClientVer = make([]byte, 3)
@@ -162,7 +164,7 @@ func (c *REALITYConfig) Build() (proto.Message, error) {
 			sn = strings.ToLower(sn)
 			if strings.HasSuffix(sn, ".ru") || strings.HasSuffix(sn, ".ir") || strings.HasSuffix(sn, ".cn") ||
 				strings.Contains(sn, "apple") || strings.Contains(sn, "icloud") || strings.Contains(sn, "microsoft") {
-				errors.LogWarning(context.Background(), `REALITY: Choosing "`, sn, `" as the target may get your server's IP blocked by the GFW`)
+				errors.LogWarning(context.Background(), `REALITY: Choosing "`, sn, `" as the target will increase the likelihood of your server's IP being blocked by the GFW`)
 			}
 		}
 

--- a/infra/conf/transport_security.go
+++ b/infra/conf/transport_security.go
@@ -1,7 +1,6 @@
 package conf
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -159,8 +158,10 @@ func (c *REALITYConfig) Build() (proto.Message, error) {
 		}
 
 		for _, sn := range config.ServerNames {
-			if strings.Contains(sn, "apple") || strings.Contains(sn, "icloud") {
-				errors.LogWarning(context.Background(), `REALITY: Choosing apple, icloud, etc. as the target may get your IP blocked by the GFW`)
+			host := strings.ToLower(sn)
+			if strings.HasSuffix(host, ".ru") || strings.HasSuffix(host, ".ir") || strings.HasSuffix(host, ".cn") ||
+				strings.Contains(host, "apple") || strings.Contains(host, "icloud") || strings.Contains(host, "microsoft") {
+				return nil, errors.New(`REALITY: "`, sn, `" must not be used as the target: such domains get the server's IP blocked, choose a proper dest`)
 			}
 		}
 


### PR DESCRIPTION
`*.ru`, `*.ir`, `*.cn` and `apple`/`icloud`/`microsoft` domains are increasingly abused as REALITY targets. The server IP never matches the domain's real IPs, so national DPI systems (GFW in China, TSPU/RKN in Russia, filtering in Iran) detect the mismatch and block such server IPs in bulk within days. Xray now rejects these targets at config load, so a node fails fast instead of silently getting its IP blocked.
