### PR TITLE
finalmask/fragment: implement CloseWrite to satisfy reality.CloseWriteConn (#6509)

### DIFF
--- a/transport/internet/finalmask/fragment/conn.go
+++ b/transport/internet/finalmask/fragment/conn.go
@@ -43,6 +43,17 @@ func (c *fragmentConn) Splice() bool {
 	return true
 }
 
+type closeWriteConn interface {
+	CloseWrite() error
+}
+
+func (c *fragmentConn) CloseWrite() error {
+	if raw, ok := c.Conn.(closeWriteConn); ok {
+		return raw.CloseWrite()
+	}
+	return net.ErrClosed
+}
+
 // lengthForSegment returns the length range (min, max) for the given segment index (0-based).
 // Clamps to the last entry when the index exceeds the list length.
 func (c *fragmentConn) lengthForSegment(segIdx int) (int64, int64) {


### PR DESCRIPTION
Fixes #6509.

## Root cause
Since #6331 reversed the finalmask TCP mask wrapping order (`slices.Backward`), `fragmentConn` is the outermost wrapper for `{fragment, sudoku}` configs. The external `github.com/xtls/reality` library performs a hard type assertion on the connection handed to `reality.Server`:

```go
// github.com/xtls/reality/tls.go:186
underlying := raw.(CloseWriteConn) // *net.TCPConn or *net.UnixConn
```

`fragmentConn` does not implement `CloseWrite()`, so any REALITY server inbound combined with `finalmask` containing `fragment` panics on every client connection:

```
panic: interface conversion: *fragment.fragmentConn is not reality.CloseWriteConn: missing method CloseWrite
```

`sudoku.wrappedConn` already implements `CloseWrite()` (delegating to the underlying conn), which is why the panic only surfaced after #6331 made `fragment` the outer wrapper.

## Fix
Add `CloseWrite()` to `fragmentConn`, mirroring `sudoku/conn_tcp.go`:

```go
type closeWriteConn interface {
	CloseWrite() error
}

func (c *fragmentConn) CloseWrite() error {
	if raw, ok := c.Conn.(closeWriteConn); ok {
		return raw.CloseWrite()
	}
	return net.ErrClosed
}
```

Additive and non-breaking (+11 lines). Does not touch the wrapping order or the UDP path introduced by #6331.

## Verification
Deployed to a production bridge and tested end-to-end (VLESS + XHTTP + REALITY + finalmask fragment+sudoku):
- Live client traffic: stable, 0 restarts, 0 panics over several minutes.
- Explicit handshake test against a dedicated finalmask+REALITY inbound: HTTP 301/302 through the tunnel, 0 server panics.
- Stock build (without this patch) with the identical config crash-loops on the first client connection.
