### PR TITLE
Routing: Exclude iOS from Darwin for `process`

### DIFF
--- a/common/net/find_process_darwin.go
+++ b/common/net/find_process_darwin.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin && !ios
 
 package net
 

--- a/common/net/find_process_darwin.s
+++ b/common/net/find_process_darwin.s
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin && !ios
 
 #include "textflag.h"
 

--- a/common/net/find_process_darwin_test.go
+++ b/common/net/find_process_darwin_test.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin && !ios
 
 package net
 

--- a/common/net/find_process_ios.go
+++ b/common/net/find_process_ios.go
@@ -1,0 +1,11 @@
+//go:build ios
+
+package net
+
+import (
+	"github.com/xtls/xray-core/common/errors"
+)
+
+func FindProcess(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (int, string, string, error) {
+	return 0, "", "", errors.New("process lookup is not supported on this platform")
+}


### PR DESCRIPTION
## Summary

- restrict the Darwin `libproc` process lookup implementation to macOS
- add an iOS fallback that reports process lookup as unsupported
- keep macOS process-based routing behavior unchanged

## Why

Go's `darwin` build constraint also matches `GOOS=ios`. As a result, the macOS implementation imported `proc_pidinfo`, `proc_pidfdinfo`, and `proc_pidpath` into iOS binaries even though these APIs are not exposed through the public iOS SDK. This can trigger App Store Guideline 2.5.1 validation or review failures.

## Validation

- `go test ./common/net -count=1`
- `CGO_ENABLED=0 go test ./common/net -count=1`
- `go test ./app/router ./proxy/tun -count=1`
- verified `GOOS=ios` selects `find_process_ios.go`
- verified the iOS archive contains no `proc_pid*` symbols while the macOS archive still does
