### PR TITLE
Add lazy selector mode to BurstObservatory

### DIFF
--- a/app/observatory/burst/burstobserver.go
+++ b/app/observatory/burst/burstobserver.go
@@ -68,14 +68,19 @@ func (o *Observer) Type() interface{} {
 func (o *Observer) Start() error {
 	if o.config != nil && len(o.config.SubjectSelector) != 0 {
 		o.finished = done.New()
-		o.hp.StartScheduler(func() ([]string, error) {
+		o.hp.StartScheduler(func() ([][]string, error) {
 			hs, ok := o.ohm.(outbound.HandlerSelector)
 			if !ok {
 				return nil, errors.New("outbound.Manager is not a HandlerSelector")
 			}
 
-			outbounds := hs.Select(o.config.SubjectSelector)
-			return outbounds, nil
+			groups := make([][]string, 0, len(o.config.SubjectSelector))
+			for _, selector := range o.config.SubjectSelector {
+				if tags := hs.Select([]string{selector}); len(tags) > 0 {
+					groups = append(groups, tags)
+				}
+			}
+			return groups, nil
 		})
 	}
 	return nil
@@ -99,7 +104,7 @@ func New(ctx context.Context, config *Config) (*Observer, error) {
 	if err != nil {
 		return nil, errors.New("Cannot get depended features").Base(err)
 	}
-	hp := NewHealthPing(ctx, dispatcher, config.PingConfig)
+	hp := NewHealthPing(ctx, dispatcher, config.PingConfig, config.SelectorMode)
 	return &Observer{
 		config: config,
 		ctx:    ctx,

--- a/app/observatory/burst/config.pb.go
+++ b/app/observatory/burst/config.pb.go
@@ -24,10 +24,16 @@ const (
 type Config struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// @Document The selectors for outbound under observation
-	SubjectSelector []string          `protobuf:"bytes,2,rep,name=subject_selector,json=subjectSelector,proto3" json:"subject_selector,omitempty"`
-	PingConfig      *HealthPingConfig `protobuf:"bytes,3,opt,name=ping_config,json=pingConfig,proto3" json:"ping_config,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	SubjectSelector []string `protobuf:"bytes,2,rep,name=subject_selector,json=subjectSelector,proto3" json:"subject_selector,omitempty"`
+	// @Document Controls how subject_selector entries are checked when there
+	// is more than one. Empty/"all" (default): every matching tag is checked
+	// together. "lazy": entries are treated as an ordered fallback chain, and
+	// an entry's group of tags is only checked once at least one check in a
+	// preceding entry's group failed.
+	SelectorMode  string            `protobuf:"bytes,3,opt,name=selector_mode,json=selectorMode,proto3" json:"selector_mode,omitempty"`
+	PingConfig    *HealthPingConfig `protobuf:"bytes,4,opt,name=ping_config,json=pingConfig,proto3" json:"ping_config,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Config) Reset() {
@@ -65,6 +71,13 @@ func (x *Config) GetSubjectSelector() []string {
 		return x.SubjectSelector
 	}
 	return nil
+}
+
+func (x *Config) GetSelectorMode() string {
+	if x != nil {
+		return x.SelectorMode
+	}
+	return ""
 }
 
 func (x *Config) GetPingConfig() *HealthPingConfig {
@@ -169,10 +182,11 @@ var File_app_observatory_burst_config_proto protoreflect.FileDescriptor
 
 const file_app_observatory_burst_config_proto_rawDesc = "" +
 	"\n" +
-	"\"app/observatory/burst/config.proto\x12\x1fxray.core.app.observatory.burst\"\x87\x01\n" +
+	"\"app/observatory/burst/config.proto\x12\x1fxray.core.app.observatory.burst\"\xac\x01\n" +
 	"\x06Config\x12)\n" +
-	"\x10subject_selector\x18\x02 \x03(\tR\x0fsubjectSelector\x12R\n" +
-	"\vping_config\x18\x03 \x01(\v21.xray.core.app.observatory.burst.HealthPingConfigR\n" +
+	"\x10subject_selector\x18\x02 \x03(\tR\x0fsubjectSelector\x12#\n" +
+	"\rselector_mode\x18\x03 \x01(\tR\fselectorMode\x12R\n" +
+	"\vping_config\x18\x04 \x01(\v21.xray.core.app.observatory.burst.HealthPingConfigR\n" +
 	"pingConfig\"\xd4\x01\n" +
 	"\x10HealthPingConfig\x12 \n" +
 	"\vdestination\x18\x01 \x01(\tR\vdestination\x12\"\n" +

--- a/app/observatory/burst/config.proto
+++ b/app/observatory/burst/config.proto
@@ -11,7 +11,15 @@ message Config {
   */
   repeated string subject_selector = 2;
 
-  HealthPingConfig ping_config = 3;
+  /* @Document Controls how subject_selector entries are checked when there
+  is more than one. Empty/"all" (default): every matching tag is checked
+  together. "lazy": entries are treated as an ordered fallback chain, and
+  an entry's group of tags is only checked once at least one check in a
+  preceding entry's group failed.
+  */
+  string selector_mode = 3;
+
+  HealthPingConfig ping_config = 4;
 }
 
 message HealthPingConfig {

--- a/app/observatory/burst/healthping.go
+++ b/app/observatory/burst/healthping.go
@@ -3,6 +3,7 @@ package burst
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -21,7 +22,13 @@ type HealthPingSettings struct {
 	SamplingCount int           `json:"sampling"`
 	Timeout       time.Duration `json:"timeout"`
 	HttpMethod    string        `json:"httpMethod"`
+	SelectorMode  string        `json:"selectorMode"`
 }
+
+// SelectorModeLazy makes StartScheduler treat each group as an ordered
+// fallback chain: a group is only checked if at least one check in a
+// preceding group failed.
+const SelectorModeLazy = "lazy"
 
 // HealthPing is the health checker for balancers
 type HealthPing struct {
@@ -36,11 +43,12 @@ type HealthPing struct {
 	Results  map[string]*HealthPingRTTS
 }
 
-// NewHealthPing creates a new HealthPing with settings
-func NewHealthPing(ctx context.Context, dispatcher routing.Dispatcher, config *HealthPingConfig) *HealthPing {
+// NewHealthPing creates a new HealthPing with settings. selectorMode
+// controls how groups passed to StartScheduler are checked, see
+// SelectorModeLazy.
+func NewHealthPing(ctx context.Context, dispatcher routing.Dispatcher, config *HealthPingConfig, selectorMode string) *HealthPing {
 	settings := &HealthPingSettings{}
 	if config != nil {
-
 		var httpMethod string
 		if config.HttpMethod == "" {
 			httpMethod = "HEAD"
@@ -77,6 +85,7 @@ func NewHealthPing(ctx context.Context, dispatcher routing.Dispatcher, config *H
 		// a larger timeout could possibly makes checks run longer
 		settings.Timeout = 5 * time.Second
 	}
+	settings.SelectorMode = selectorMode
 	ctx, cancel := context.WithCancel(ctx)
 	return &HealthPing{
 		ctx:        ctx,
@@ -87,8 +96,9 @@ func NewHealthPing(ctx context.Context, dispatcher routing.Dispatcher, config *H
 	}
 }
 
-// StartScheduler implements the HealthChecker
-func (h *HealthPing) StartScheduler(selector func() ([]string, error)) {
+// StartScheduler implements the HealthChecker. The selector returns tags
+// grouped by their subjectSelector entry, in the same order as configured.
+func (h *HealthPing) StartScheduler(selector func() ([][]string, error)) {
 	if h.ticker != nil {
 		return
 	}
@@ -98,18 +108,18 @@ func (h *HealthPing) StartScheduler(selector func() ([]string, error)) {
 
 	// init run to get a fast check result
 	go func() {
-		tags, err := selector()
+		groups, err := selector()
 		if err != nil {
 			errors.LogWarning(h.ctx, "error select outbounds for initial health check: ", err)
 			return
 		}
-		h.Check(tags)
+		h.checkGroups(h.ctx, groups, 0, 1)
 	}()
 
 	go func() {
 		for {
 			go func() {
-				tags, err := selector()
+				groups, err := selector()
 				if err != nil {
 					errors.LogWarning(h.ctx, "error select outbounds for scheduled health check: ", err)
 					return
@@ -120,9 +130,9 @@ func (h *HealthPing) StartScheduler(selector func() ([]string, error)) {
 					errors.LogDebug(h.ctx, "scheduled health check not finished before next round, canceling previous one")
 					(*old)()
 				}
-				h.doCheck(subCtx, tags, interval, h.Settings.SamplingCount)
+				h.checkGroups(subCtx, groups, interval, h.Settings.SamplingCount)
 				h.cancelPending.CompareAndSwap(&cancel, nil)
-				h.Cleanup(tags)
+				h.Cleanup(flattenGroups(groups))
 			}()
 			select {
 			case <-ticker.C:
@@ -132,6 +142,41 @@ func (h *HealthPing) StartScheduler(selector func() ([]string, error)) {
 			}
 		}
 	}()
+}
+
+// checkGroups checks the given tag groups according to h.Settings.SelectorMode.
+// In the default mode, every group is checked together as a single pool,
+// matching the historical behavior. In SelectorModeLazy, groups are checked
+// in order and a group is only checked if at least one check in a
+// preceding group failed.
+func (h *HealthPing) checkGroups(ctx context.Context, groups [][]string, duration time.Duration, rounds int) {
+	if h.Settings.SelectorMode != SelectorModeLazy {
+		h.doCheck(ctx, flattenGroups(groups), duration, rounds)
+		return
+	}
+	for _, tags := range groups {
+		if len(tags) == 0 {
+			continue
+		}
+		if !h.doCheck(ctx, tags, duration, rounds) {
+			return
+		}
+	}
+}
+
+// flattenGroups merges tag groups into a single deduplicated tag list.
+func flattenGroups(groups [][]string) []string {
+	switch len(groups) {
+	case 0:
+		return nil
+	case 1:
+		return groups[0]
+	default:
+		tags := slices.Concat(groups...)
+		slices.Sort(tags)
+
+		return slices.Compact(tags)
+	}
 }
 
 // StopScheduler implements the HealthChecker
@@ -162,7 +207,8 @@ type rtt struct {
 // doCheck performs the 'rounds' amount checks in given 'duration'. You should make
 // sure all tags are valid for current balancer
 // cancel ctx will stop all pending checks
-func (h *HealthPing) doCheck(ctx context.Context, tags []string, duration time.Duration, rounds int) {
+// It returns true if at least one check failed (or could not be measured).
+func (h *HealthPing) doCheck(ctx context.Context, tags []string, duration time.Duration, rounds int) (hasFailed bool) {
 	count := len(tags) * rounds
 	if count == 0 {
 		return
@@ -221,13 +267,17 @@ func (h *HealthPing) doCheck(ctx context.Context, tags []string, duration time.D
 				// should not put results when network is down
 				h.PutResult(rtt.handler, rtt.value)
 			}
+			if rtt.value == rttFailed {
+				hasFailed = true
+			}
 		case <-ctx.Done():
 			for _, timer := range timers {
 				timer.Stop()
 			}
-			return
+			return true
 		}
 	}
+	return
 }
 
 // PutResult put a ping rtt to results

--- a/infra/conf/observatory.go
+++ b/infra/conf/observatory.go
@@ -22,6 +22,9 @@ func (o *ObservatoryConfig) Build() (proto.Message, error) {
 
 type BurstObservatoryConfig struct {
 	SubjectSelector []string `json:"subjectSelector"`
+	// selectorMode controls how subjectSelector entries are checked when
+	// there is more than one. See burst.SelectorModeLazy.
+	SelectorMode string `json:"selectorMode,omitempty"`
 	// health check settings
 	HealthCheck *healthCheckSettings `json:"pingConfig,omitempty"`
 }
@@ -30,8 +33,11 @@ func (b BurstObservatoryConfig) Build() (proto.Message, error) {
 	if b.HealthCheck == nil {
 		return nil, errors.New("BurstObservatory requires a valid pingConfig")
 	}
+	if b.SelectorMode != "" && b.SelectorMode != burst.SelectorModeLazy {
+		return nil, errors.New("unknown selectorMode: ", b.SelectorMode)
+	}
 	if result, err := b.HealthCheck.Build(); err == nil {
-		return &burst.Config{SubjectSelector: b.SubjectSelector, PingConfig: result.(*burst.HealthPingConfig)}, nil
+		return &burst.Config{SubjectSelector: b.SubjectSelector, SelectorMode: b.SelectorMode, PingConfig: result.(*burst.HealthPingConfig)}, nil
 	} else {
 		return nil, err
 	}


### PR DESCRIPTION
## Motivation                                                                                                                                                                                             
                                                                                                                                                                                                            
  In a balancer chain with a primary outbound group and a backup/fallback group, there is no reason to keep actively health-checking the backup group while the primary group is healthy — those probes are 
  wasted traffic/exposure against nodes that normally aren't even in use. This adds a `selectorMode` so the backup group is only probed once the primary group actually starts failing.                     
                                                                                                                                                                                                            
  ## Summary                                                                                                                                                                                                
                                                                                                                                                                                                            
  Adds an optional `selectorMode` setting to `BurstObservatory`. When set to `"lazy"`, `subjectSelector` entries are treated as an ordered chain of tag groups instead of one flat pool: the health checker 
  only probes a group's tags if at least one check in the *preceding* group failed. This lets a fallback group of outbounds stay unprobed as long as the primary group is healthy.                          
                                                                                                                                                                                                            
  Default behavior is unchanged: with `selectorMode` empty (or omitted), every tag matched by any `subjectSelector` entry is still checked together, concurrently, as before.                               
                                                                                                                                                                                                            
  ## Changes                                                                                                                                                                                                
                                                                                                                                                                                                            
  - **`app/observatory/burst/config.proto` / `config.pb.go`**: new `string selector_mode = 3` field on `Config` (`ping_config` renumbered to `4`).                                                          
  - **`infra/conf/observatory.go`**: new `selectorMode` JSON field on `BurstObservatoryConfig`; `Build()` rejects any value other than `""` or `"lazy"`.                                                    
  - **`app/observatory/burst/burstobserver.go`**: builds one tag group per `subjectSelector` entry (instead of a single flattened `Select` call) and passes the ordered groups to `StartScheduler`; wires   
  `SelectorMode` through to `NewHealthPing`.                                                                                                                                                                
  - **`app/observatory/burst/healthping.go`**:                                                                                                                                                              
    - `StartScheduler`'s selector callback now returns `[][]string` (one slice per group) instead of a flat `[]string`.                                                                                     
    - New `checkGroups`: in the default mode, groups are flattened and checked together (`flattenGroups`, dedup via `slices.Sort`/`slices.Compact`); in lazy mode, groups are checked in order and a group  
  is only checked once a preceding group reported a failure.                                                                                                                                                
    - `doCheck` now returns whether any check in the batch failed, which `checkGroups` uses to decide whether to advance to the next group.                                                                 
                                                                                                                                                                                                            
  ## Config example                                                                                                                                                                                         
                                                                                                                                                                                                            
  ```json                                                                                                                                                                                                   
  {                                                                                                                                                                                                         
    "burstObservatory": {                                                                                                                                                                                   
      "subjectSelector": ["primary-", "backup-"],                                                                                                                                                           
      "selectorMode": "lazy",                                                                                                                                                                               
      "pingConfig": { "destination": "https://example.com/" }                                                                                                                                               
    }                                                                                                                                                                                                       
  }                          