### PR TITLE
common/units: fix ByteSize.String() leaving redundant .00 suffix

### DIFF
--- a/common/units/bytesize.go
+++ b/common/units/bytesize.go
@@ -60,7 +60,8 @@ func (b ByteSize) String() string {
 		value = float64(b) / float64(EB)
 	}
 	result := strconv.FormatFloat(value, 'f', 2, 64)
-	result = strings.TrimSuffix(result, ".0")
+	result = strings.TrimRight(result, "0")
+	result = strings.TrimSuffix(result, ".")
 	return result + unit
 }
 

--- a/common/units/bytesize_test.go
+++ b/common/units/bytesize_test.go
@@ -12,45 +12,47 @@ func TestByteSizes(t *testing.T) {
 	size++
 	assertSizeValue(
 		t,
-		assertSizeString(t, size, "1.00B"),
+		assertSizeString(t, size, "1B"),
 		size,
 	)
 	size <<= 10
 	assertSizeValue(
 		t,
-		assertSizeString(t, size, "1.00KB"),
+		assertSizeString(t, size, "1KB"),
 		size,
 	)
 	size <<= 10
 	assertSizeValue(
 		t,
-		assertSizeString(t, size, "1.00MB"),
+		assertSizeString(t, size, "1MB"),
 		size,
 	)
 	size <<= 10
 	assertSizeValue(
 		t,
-		assertSizeString(t, size, "1.00GB"),
+		assertSizeString(t, size, "1GB"),
 		size,
 	)
 	size <<= 10
 	assertSizeValue(
 		t,
-		assertSizeString(t, size, "1.00TB"),
+		assertSizeString(t, size, "1TB"),
 		size,
 	)
 	size <<= 10
 	assertSizeValue(
 		t,
-		assertSizeString(t, size, "1.00PB"),
+		assertSizeString(t, size, "1PB"),
 		size,
 	)
 	size <<= 10
 	assertSizeValue(
 		t,
-		assertSizeString(t, size, "1.00EB"),
+		assertSizeString(t, size, "1EB"),
 		size,
 	)
+
+	assertSizeString(t, units.ByteSize(1536), "1.5KB")
 }
 
 func assertSizeValue(t *testing.T, size string, expected units.ByteSize) {


### PR DESCRIPTION
## Summary

`ByteSize.String()` formats the value with `strconv.FormatFloat(value, 'f', 2, 64)`, which always produces exactly two decimal digits (e.g. `"1.00"`, `"1.50"`). It then tries to clean up whole numbers with `strings.TrimSuffix(result, ".0")`, but that suffix never occurs in the output (`"1.00"` ends in `.00`, not `.0`), so the trim never fires.

As a result every size prints with a redundant `.00`/`.50` instead of the intended `1KB`, `1.5KB`, etc.:

```go
ByteSize(1024).String()  // "1.00KB", expected "1KB"
ByteSize(1536).String()  // "1.50KB", expected "1.5KB"
```

## Fix

Trim trailing zeros and a trailing dot instead of matching an exact `.0` suffix. Updated the existing tests, which had the buggy `"1.00KB"`-style output baked into their expected values, and added a fractional case to cover the `1.5KB` behavior.

## Test plan

- [x] `go test ./common/units/...` passes