### PR TITLE
Tunnel inbound: Support TPROXY on OpenBSD as well

### DIFF
--- a/proxy/dokodemo/fakeudp_openbsd.go
+++ b/proxy/dokodemo/fakeudp_openbsd.go
@@ -1,0 +1,58 @@
+//go:build openbsd
+// +build openbsd
+
+package dokodemo
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func FakeUDP(addr *net.UDPAddr, mark int) (net.PacketConn, error) {
+	ip4 := addr.IP.To4()
+	if ip4 == nil {
+		return nil, &net.OpError{Op: "fake", Err: fmt.Errorf("IPv6 is not supported by the OpenBSD transparent UDP patch")}
+	}
+
+	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM, 0)
+	if err != nil {
+		return nil, &net.OpError{Op: "fake", Err: fmt.Errorf("socket open: %w", err)}
+	}
+
+	closeFD := true
+	defer func() {
+		if closeFD {
+			unix.Close(fd)
+		}
+	}()
+
+	if err = unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_BINDANY, 1); err != nil {
+		return nil, &net.OpError{Op: "fake", Err: fmt.Errorf("set socket option SO_BINDANY: %w", err)}
+	}
+	if err = unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_REUSEADDR, 1); err != nil {
+		return nil, &net.OpError{Op: "fake", Err: fmt.Errorf("set socket option SO_REUSEADDR: %w", err)}
+	}
+
+	sockaddr := &unix.SockaddrInet4{Port: addr.Port}
+	copy(sockaddr.Addr[:], ip4)
+	if err = unix.Bind(fd, sockaddr); err != nil {
+		return nil, &net.OpError{Op: "fake", Err: fmt.Errorf("bind %s: %w", addr.String(), err)}
+	}
+
+	fdFile := os.NewFile(uintptr(fd), fmt.Sprintf("net-udp-bindany-%s", addr.String()))
+	if fdFile == nil {
+		return nil, &net.OpError{Op: "fake", Err: fmt.Errorf("convert descriptor to file")}
+	}
+	defer fdFile.Close()
+
+	packetConn, err := net.FilePacketConn(fdFile)
+	if err != nil {
+		return nil, &net.OpError{Op: "fake", Err: fmt.Errorf("convert descriptor to packet connection: %w", err)}
+	}
+
+	closeFD = false
+	return packetConn, nil
+}

--- a/proxy/dokodemo/fakeudp_other.go
+++ b/proxy/dokodemo/fakeudp_other.go
@@ -1,5 +1,5 @@
-//go:build !linux
-// +build !linux
+//go:build !linux && !openbsd
+// +build !linux,!openbsd
 
 package dokodemo
 

--- a/transport/internet/sockopt_openbsd.go
+++ b/transport/internet/sockopt_openbsd.go
@@ -1,0 +1,33 @@
+//go:build openbsd
+// +build openbsd
+
+package internet
+
+import (
+	"github.com/xtls/xray-core/common/errors"
+	"golang.org/x/sys/unix"
+)
+
+func applyOutboundSocketOptions(network string, address string, fd uintptr, config *SocketConfig) error {
+	return nil
+}
+
+func applyInboundSocketOptions(network string, fd uintptr, config *SocketConfig) error {
+	if config.ReceiveOriginalDestAddress && isUDPSocket(network) {
+		if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_IP, unix.IP_RECVDSTADDR, 1); err != nil {
+			return errors.New("failed to set IP_RECVDSTADDR").Base(err)
+		}
+		if err := unix.SetsockoptInt(int(fd), unix.IPPROTO_IP, unix.IP_RECVDSTPORT, 1); err != nil {
+			return errors.New("failed to set IP_RECVDSTPORT").Base(err)
+		}
+	}
+	return nil
+}
+
+func setReuseAddr(fd uintptr) error {
+	return nil
+}
+
+func setReusePort(fd uintptr) error {
+	return nil
+}

--- a/transport/internet/sockopt_other.go
+++ b/transport/internet/sockopt_other.go
@@ -1,5 +1,5 @@
-//go:build js || netbsd || openbsd || solaris
-// +build js netbsd openbsd solaris
+//go:build js || netbsd || solaris
+// +build js netbsd solaris
 
 package internet
 

--- a/transport/internet/udp/hub_openbsd.go
+++ b/transport/internet/udp/hub_openbsd.go
@@ -1,0 +1,57 @@
+//go:build openbsd
+// +build openbsd
+
+package udp
+
+import (
+	"encoding/binary"
+
+	"github.com/xtls/xray-core/common/net"
+	"golang.org/x/sys/unix"
+)
+
+func retrieveOriginalDestFromControlMessages(msgs []unix.SocketControlMessage) net.Destination {
+	var ip []byte
+	var port uint16
+	var haveAddress bool
+	var havePort bool
+
+	for _, msg := range msgs {
+		if msg.Header.Level != unix.IPPROTO_IP {
+			continue
+		}
+
+		switch msg.Header.Type {
+		case unix.IP_RECVDSTADDR:
+			if len(msg.Data) < 4 {
+				continue
+			}
+			ip = append(ip[:0], msg.Data[:4]...)
+			haveAddress = true
+		case unix.IP_RECVDSTPORT:
+			if len(msg.Data) < 2 {
+				continue
+			}
+			port = binary.BigEndian.Uint16(msg.Data[:2])
+			havePort = true
+		}
+	}
+
+	if !haveAddress || !havePort || port == 0 {
+		return net.Destination{}
+	}
+
+	return net.UDPDestination(net.IPAddress(ip), net.Port(port))
+}
+
+func RetrieveOriginalDest(oob []byte) net.Destination {
+	msgs, err := unix.ParseSocketControlMessage(oob)
+	if err != nil {
+		return net.Destination{}
+	}
+	return retrieveOriginalDestFromControlMessages(msgs)
+}
+
+func ReadUDPMsg(conn *net.UDPConn, payload []byte, oob []byte) (int, int, int, *net.UDPAddr, error) {
+	return conn.ReadMsgUDP(payload, oob)
+}

--- a/transport/internet/udp/hub_openbsd_test.go
+++ b/transport/internet/udp/hub_openbsd_test.go
@@ -1,0 +1,57 @@
+//go:build openbsd
+// +build openbsd
+
+package udp
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestRetrieveOriginalDestFromControlMessages(t *testing.T) {
+	msgs := []unix.SocketControlMessage{
+		{
+			Header: unix.Cmsghdr{Level: unix.IPPROTO_IP, Type: unix.IP_RECVDSTPORT},
+			Data:   []byte{0x30, 0x39},
+		},
+		{
+			Header: unix.Cmsghdr{Level: unix.IPPROTO_IP, Type: unix.IP_RECVDSTADDR},
+			Data:   []byte{203, 0, 113, 7},
+		},
+	}
+
+	dest := retrieveOriginalDestFromControlMessages(msgs)
+	if !dest.IsValid() {
+		t.Fatal("destination is invalid")
+	}
+	if got, want := dest.Address.String(), "203.0.113.7"; got != want {
+		t.Fatalf("address = %q, want %q", got, want)
+	}
+	if got, want := dest.Port.Value(), uint16(12345); got != want {
+		t.Fatalf("port = %d, want %d", got, want)
+	}
+}
+
+func TestRetrieveOriginalDestRequiresAddressAndPort(t *testing.T) {
+	tests := [][]unix.SocketControlMessage{
+		{
+			{
+				Header: unix.Cmsghdr{Level: unix.IPPROTO_IP, Type: unix.IP_RECVDSTADDR},
+				Data:   []byte{203, 0, 113, 7},
+			},
+		},
+		{
+			{
+				Header: unix.Cmsghdr{Level: unix.IPPROTO_IP, Type: unix.IP_RECVDSTPORT},
+				Data:   []byte{0x30, 0x39},
+			},
+		},
+	}
+
+	for _, msgs := range tests {
+		if dest := retrieveOriginalDestFromControlMessages(msgs); dest.IsValid() {
+			t.Fatalf("unexpected destination: %v", dest)
+		}
+	}
+}

--- a/transport/internet/udp/hub_other.go
+++ b/transport/internet/udp/hub_other.go
@@ -1,5 +1,5 @@
-//go:build !linux && !freebsd && !darwin
-// +build !linux,!freebsd,!darwin
+//go:build !linux && !freebsd && !darwin && !openbsd
+// +build !linux,!freebsd,!darwin,!openbsd
 
 package udp
 


### PR DESCRIPTION
Right now Xray can't work as a transparent proxy on OpenBSD. `GetOriginalDestination` for TCP is a stub that returns an empty destination, and the UDP hub never learns where a packet was originally headed, so a `tunnel` inbound with `followRedirect: true` dies with "unable to get destination". The usual workaround, `followRedirect: false` plus sniffing, only covers HTTP and TLS. SSH and anything else sniffing can't identify ends up going to 127.0.0.1 and silently fails.

This PR fills in the missing pieces. The mechanisms differ from both Linux and FreeBSD, which I suspect is why nobody ported this before:

- TCP original destination. pf `divert-to` does not rewrite the packet, so `getsockname(2)` on the accepted socket still returns the original destination. This is documented in pf.conf(5) and it's how relayd does it, so `transport/internet/tcp/sockopt_openbsd.go` just reads `conn.LocalAddr()`. No natlook ioctl needed, unlike FreeBSD.
- UDP original destination. `applyInboundSocketOptions` sets `IP_RECVDSTADDR` and `IP_RECVDSTPORT` when `ReceiveOriginalDestAddress` is requested, and the UDP hub parses both control messages. There is no single cmsg carrying address and port together like Linux's `IP_RECVORIGDSTADDR`; `IP_RECVDSTPORT` is OpenBSD specific and both messages are required.
- UDP replies. A reply has to leave with the original destination as its source address, otherwise the client drops it. `FakeUDP` for OpenBSD binds a socket to that address with `SO_BINDANY`, and a pf `divert-reply` rule gets the packet back to the client.

Everything sits behind `openbsd` build tags with matching exclusions in the `*_other.go` files, so no other platform is touched. There's a small unit test for the control message parsing.

No config changes are needed, the existing tunnel inbound options simply start working:

```jsonc
{
  "listen": "127.0.0.1",
  "port": 12345,
  "protocol": "tunnel",
  "settings": { "allowedNetwork": "tcp", "followRedirect": true }
},
{
  "listen": "127.0.0.1",
  "port": 12346,
  "protocol": "tunnel",
  "settings": { "allowedNetwork": "udp", "followRedirect": true }
}
```

with pf rules along these lines:

```pf
pass in quick on $lan_if inet proto tcp from $lan_net to ! <bypass> divert-to 127.0.0.1 port 12345
pass in quick on $lan_if inet proto udp from $lan_net to ! <bypass> divert-to 127.0.0.1 port 12346
pass out quick on $lan_if inet proto udp from ! <bypass> to $lan_net divert-reply
```

Testing. This is running on two OpenBSD routers, 7.7 and 7.8, both amd64, each serving a small LAN. Verified there: plain web traffic, SSH out to external hosts and other protocols sniffing cannot classify, DNS, QUIC/HTTP3, and Telegram and WhatsApp voice calls. `go test ./transport/internet/udp` passes on OpenBSD, and `gofmt` and `go vet` are clean on the touched packages. I have not run it on 7.9 yet. I went through the 7.9 release notes and changelog and found nothing touching divert, `SO_BINDANY` or the recvdst options, so I expect it to work unchanged, and I'll report back once I've upgraded a box.

Limitations, to be upfront about them:

- IPv4 only. `FakeUDP` returns a clear error for IPv6 targets. Doing v6 properly means `IPV6_RECVPKTINFO` based plumbing, and I didn't want to ship code I can't test.
- `SO_BINDANY` needs root, but that's inherent to transparent proxying on OpenBSD, relayd has the same requirement.

One more thing. #5824 moves OpenBSD out of regular releases for lack of manpower, and says the platform can rejoin the standard build process once it gets reasonably active support. I run Xray on OpenBSD daily and I'm willing to be that support: testing on real hardware, keeping the OpenBSD specific code building and working across releases, and picking up OpenBSD issues as they come in. Happy to adjust naming or structure if you'd rather have this organized differently.