### PR TITLE
fix(tun): add default IPv4 gateway and split-horizon routes for Linux

### DIFF
--- a/proxy/tun/tun_linux.go
+++ b/proxy/tun/tun_linux.go
@@ -17,6 +17,8 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
 )
 
+const defaultLinuxGateway = "198.18.0.1/15"
+
 // LinuxTun is an object that handles tun network interface on linux
 // current version is heavily stripped to do nothing more,
 // then create a network interface, to be provided as file descriptor to gVisor ip stack
@@ -26,6 +28,7 @@ type LinuxTun struct {
 	options *Config
 	ownsTun bool
 
+	gateway            netip.Prefix
 	interfaceAddresses []netlink.Addr
 	systemRoutes       []netlink.Route
 	routeMonitorStop   chan struct{}
@@ -60,11 +63,18 @@ func NewTun(options *Config) (Tun, error) {
 		return nil, err
 	}
 
+	gateway, err := selectLinuxGateway(options.Gateway)
+	if err != nil {
+		_ = unix.Close(tunFd)
+		return nil, err
+	}
+
 	linuxTun := &LinuxTun{
 		tunFd:   tunFd,
 		tunLink: tunLink,
 		options: options,
 		ownsTun: true,
+		gateway: gateway,
 	}
 
 	return linuxTun, nil
@@ -233,10 +243,11 @@ func setinterface(network, address string, fd uintptr, iface *net.Interface) err
 }
 
 func (t *LinuxTun) setInterfaceAddresses() error {
-	if len(t.options.Gateway) == 0 {
-		return nil
+	addrs := t.options.Gateway
+	if len(addrs) == 0 {
+		addrs = []string{t.gateway.String()}
 	}
-	for _, address := range t.options.Gateway {
+	for _, address := range addrs {
 		addr, err := netlink.ParseAddr(address)
 		if err != nil {
 			_ = t.unsetInterfaceAddresses()
@@ -264,17 +275,37 @@ func (t *LinuxTun) unsetInterfaceAddresses() error {
 }
 
 func (t *LinuxTun) setSystemRoutes() error {
-	if len(t.options.AutoSystemRoutingTable) == 0 {
+	tunIndex := t.tunLink.Attrs().Index
+
+	if len(t.options.AutoSystemRoutingTable) > 0 {
+		for _, cidr := range t.options.AutoSystemRoutingTable {
+			prefix, err := netip.ParsePrefix(cidr)
+			if err != nil {
+				return errors.New("invalid system route ", cidr).Base(err)
+			}
+			prefix = prefix.Masked()
+			_, ipNet, _ := net.ParseCIDR(prefix.String())
+			route := netlink.Route{
+				LinkIndex: tunIndex,
+				Dst:       ipNet,
+				Priority:  1,
+			}
+			if err := netlink.RouteAdd(&route); err != nil {
+				_ = t.unsetSystemRoutes()
+				return errors.New("failed to add system route ", cidr).Base(err)
+			}
+			t.systemRoutes = append(t.systemRoutes, route)
+		}
 		return nil
 	}
-	tunIndex := t.tunLink.Attrs().Index
-	for _, cidr := range t.options.AutoSystemRoutingTable {
-		prefix, err := netip.ParsePrefix(cidr)
+
+	// Default split-horizon routes: 0.0.0.0/1 + 128.0.0.0/1 cover the entire IPv4 space
+	// without replacing the existing default gateway, avoiding network loops.
+	for _, cidr := range []string{"0.0.0.0/1", "128.0.0.0/1"} {
+		_, ipNet, err := net.ParseCIDR(cidr)
 		if err != nil {
-			return errors.New("invalid system route ", cidr).Base(err)
+			return errors.New("invalid default route ", cidr).Base(err)
 		}
-		prefix = prefix.Masked()
-		_, ipNet, _ := net.ParseCIDR(prefix.String())
 		route := netlink.Route{
 			LinkIndex: tunIndex,
 			Dst:       ipNet,
@@ -282,10 +313,11 @@ func (t *LinuxTun) setSystemRoutes() error {
 		}
 		if err := netlink.RouteAdd(&route); err != nil {
 			_ = t.unsetSystemRoutes()
-			return errors.New("failed to add system route ", cidr).Base(err)
+			return errors.New("failed to add default route ", cidr).Base(err)
 		}
 		t.systemRoutes = append(t.systemRoutes, route)
 	}
+
 	return nil
 }
 
@@ -359,6 +391,25 @@ func findOutboundInterface(tunIndex int, fixedName string) (*net.Interface, erro
 	}
 
 	return nil, errors.New("no usable outbound interface found")
+}
+
+func selectLinuxGateway(configured []string) (netip.Prefix, error) {
+	if len(configured) == 0 {
+		return netip.ParsePrefix(defaultLinuxGateway)
+	}
+
+	for _, value := range configured {
+		prefix, err := netip.ParsePrefix(value)
+		if err != nil {
+			return netip.Prefix{}, errors.New("invalid Linux gateway ", value).Base(err)
+		}
+		if !prefix.Addr().Is4() {
+			continue
+		}
+		return prefix, nil
+	}
+
+	return netip.Prefix{}, errors.New("Linux gateway requires at least one IPv4 prefix")
 }
 
 func findDefaultInterface(family int, tunIndex int) (*net.Interface, error) {

--- a/proxy/tun/tun_linux_test.go
+++ b/proxy/tun/tun_linux_test.go
@@ -1,0 +1,80 @@
+package tun
+
+import (
+	"net/netip"
+	"testing"
+)
+
+func TestSelectLinuxGatewayDefault(t *testing.T) {
+	gateway, err := selectLinuxGateway(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := gateway.String(); got != defaultLinuxGateway {
+		t.Fatalf("unexpected default gateway: got %s, want %s", got, defaultLinuxGateway)
+	}
+}
+
+func TestSelectLinuxGatewayDefaultEmpty(t *testing.T) {
+	gateway, err := selectLinuxGateway([]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := gateway.String(); got != defaultLinuxGateway {
+		t.Fatalf("unexpected default gateway: got %s, want %s", got, defaultLinuxGateway)
+	}
+}
+
+func TestSelectLinuxGatewayConfiguredIPv4(t *testing.T) {
+	gateway, err := selectLinuxGateway([]string{"10.0.0.1/24"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := gateway.String(); got != "10.0.0.1/24" {
+		t.Fatalf("unexpected gateway: got %s, want %s", got, "10.0.0.1/24")
+	}
+}
+
+func TestSelectLinuxGatewaySkipsIPv6(t *testing.T) {
+	gateway, err := selectLinuxGateway([]string{"fc00::1/64", "198.18.0.1/15"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := gateway.String(); got != "198.18.0.1/15" {
+		t.Fatalf("unexpected gateway: got %s, want %s", got, "198.18.0.1/15")
+	}
+}
+
+func TestSelectLinuxGatewayRequiresIPv4(t *testing.T) {
+	if _, err := selectLinuxGateway([]string{"fc00::1/64"}); err == nil {
+		t.Fatal("expected error for IPv6-only gateway list")
+	}
+}
+
+func TestSelectLinuxGatewayInvalid(t *testing.T) {
+	if _, err := selectLinuxGateway([]string{"invalid"}); err == nil {
+		t.Fatal("expected error for invalid gateway")
+	}
+}
+
+func TestSelectLinuxGatewayParsesCorrectly(t *testing.T) {
+	gateway, err := selectLinuxGateway([]string{"198.18.0.1/15"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !gateway.Addr().Is4() {
+		t.Fatal("expected IPv4 gateway")
+	}
+	if gateway.Bits() != 15 {
+		t.Fatalf("expected /15 mask, got /%d", gateway.Bits())
+	}
+	if !gateway.Contains(netip.MustParseAddr("198.18.0.1")) {
+		t.Fatal("gateway should contain its own address")
+	}
+	if !gateway.Contains(netip.MustParseAddr("198.19.255.255")) {
+		t.Fatal("gateway should contain last address in /15 range")
+	}
+	if gateway.Contains(netip.MustParseAddr("198.20.0.1")) {
+		t.Fatal("gateway should not contain address outside /15 range")
+	}
+}


### PR DESCRIPTION
## Description

When `autoSystemRoutingTable` is empty (which is the common case with v2rayN on Linux), the TUN interface was brought up with an IPv4 address but **without any routes**. Traffic never entered the TUN stack, making TUN mode non-functional on Linux.

### Changes

- **Default gateway fallback**: Added `defaultLinuxGateway = "198.18.0.1/15"` — if `gateway` is not configured in the TUN config, Xray-core now assigns this address to the TUN interface, matching the existing macOS behavior (`defaultDarwinGateway = "169.254.10.1/30"`)
- **Split-horizon routes**: When `autoSystemRoutingTable` is empty, Xray-core now adds `0.0.0.0/1` and `128.0.0.0/1` routes through the TUN interface. These two routes cover the entire IPv4 space without replacing the system's existing default gateway, avoiding network loops
- **Cleanup**: Routes and interface address are properly removed on shutdown via the existing `unsetSystemRoutes()` / `unsetInterfaceAddresses()` path

### Why split-horizon?

Using `0.0.0.0/1` + `128.0.0.0/1` instead of `0.0.0.0/0` ensures the system default gateway remains intact. Xray's own outbound connections to upstream servers still use the physical interface, preventing the infinite network loop described in the TUN README.

### Testing

- `go build ./proxy/tun/` — compiles cleanly
- `go test ./proxy/tun/ -v` — all tests pass (including 7 new tests for `selectLinuxGateway()`)
- Verified with v2rayN v7.24.3 on Linux — TUN mode now works correctly

https://github.com/2dust/v2rayN/issues/9755