### PR TITLE
Feat/fix process name errors

### DIFF
--- a/app/router/condition.go
+++ b/app/router/condition.go
@@ -345,6 +345,13 @@ func (m *ProcessNameMatcher) Apply(ctx routing.Context) bool {
 	srcPort := uint16(ctx.GetSourcePort())
 	srcIP := ctx.GetSourceIPs()[0].String()
 
+	// Skip process lookup for loopback addresses — the source is a local proxy
+	// (SOCKS/HTTP), not the actual application. The connection may already be
+	// closed by the time we look it up in /proc/net/tcp, causing spurious errors.
+	if net.ParseIP(srcIP).IsLoopback() {
+		return false
+	}
+
 	var network string
 	switch ctx.GetNetwork() {
 	case net.Network_TCP:

--- a/app/router/condition.go
+++ b/app/router/condition.go
@@ -377,7 +377,7 @@ func (m *ProcessNameMatcher) Apply(ctx routing.Context) bool {
 
 	pid, name, absPath, err := net.FindProcess(network, srcIP, uint16(srcPort), dstIP, uint16(dstPort))
 	if err != nil {
-		if err != net.ErrNotLocal {
+		if err != net.ErrNotLocal && err != net.ErrProcessNotFound {
 			errors.LogError(context.Background(), "Unables to find local process name: ", err)
 		}
 		return false

--- a/common/net/find_process_linux.go
+++ b/common/net/find_process_linux.go
@@ -55,7 +55,7 @@ func FindProcess(network, srcIP string, srcPort uint16, destIP string, destPort 
 		return 0, "", "", errors.New("could not search in ", procFile).Base(err)
 	}
 	if inode == "" {
-		return 0, "", "", errors.New("connection for ", srcIP, ":", srcPort, " not found in ", procFile)
+		return 0, "", "", ErrProcessNotFound
 	}
 
 	pidStr, err := findPidByInode(inode)

--- a/common/net/net.go
+++ b/common/net/net.go
@@ -20,6 +20,7 @@ const QuicgoH3KeepAlivePeriod = 10 * time.Second
 const ChromeH2KeepAlivePeriod = 45 * time.Second
 
 var ErrNotLocal = errors.New("the source address is not from local machine.")
+var ErrProcessNotFound = errors.New("process not found for the connection")
 
 type localIPCacheEntry struct {
 	addrs      []net.Addr


### PR DESCRIPTION
## Description

Suppress two sources of spurious `[Error] app/router: Unables to find local process name` log messages that appear during normal operation and confuse users.

### Problem 1: Loopback source addresses

When a connection arrives through a local proxy (SOCKS/HTTP inbound), the source IP is `127.0.0.1` — the proxy address, not the actual application. `ProcessNameMatcher` calls `FindProcess("tcp", "127.0.0.1", port, ...)`, which 
looks up this address in `/proc/net/tcp`. This lookup is meaningless and often fails with a race condition (the connection is already closed):
[Error] app/router: Unables to find local process name: common/net: connection for 127.0.0.1:38056 not found in /proc/net/tcp

**Fix:** Skip process lookup entirely when the source IP is loopback (`127.0.0.0/8` or `::1`).

### Problem 2: TUN/gVisor connections

For TUN-mode connections, gVisor manages sockets internally and does not create entries in `/proc/net/tcp` or `/proc/net/udp`. When `FindProcess` looks up a TUN interface address (e.g. `172.18.0.1`), `IsLocal()` passes but the 
lookup fails:
[Error] app/router: Unables to find local process name: common/net: connection for 172.18.0.1:38871 not found in /proc/net/udp

**Fix:** Added `ErrProcessNotFound` sentinel error. `FindProcess` returns it instead of a formatted error string, and `ProcessNameMatcher` silently ignores it — the same way it already handles `ErrNotLocal`.

### Files changed

- `app/router/condition.go` — skip loopback, ignore `ErrProcessNotFound`
- `common/net/net.go` — add `ErrProcessNotFound`
- `common/net/find_process_linux.go` — return `ErrProcessNotFound` instead of formatted error

https://github.com/2dust/v2rayN/issues/9755