### PR TITLE
README.md: Add Rocket Proxy to iOS & macOS arm64 & tvOS in GUI Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@
   - [Streisand](https://apps.apple.com/app/streisand/id6450534064)
   - [OneXray](https://github.com/OneXray/OneXray)
   - [INCY](https://apps.apple.com/en/app/incy/id6756943388)
+  - [Rocket Proxy](https://apps.apple.com/app/id6785291194)
 - macOS arm64 & x64
   - [Happ](https://apps.apple.com/app/happ-proxy-utility/id6504287215) | [Happ RU](https://apps.apple.com/ru/app/happ-proxy-utility-plus/id6746188973)
   - [V2rayU](https://github.com/yanue/V2rayU)


### PR DESCRIPTION
Adds **Rocket Proxy** to the `iOS & macOS arm64 & tvOS` list under GUI Clients.

- App Store: https://apps.apple.com/app/id6785291194 (free)
- One universal app covering **iPhone, iPad, Mac and Apple TV**.
- Supports **VLESS (TCP / WS / gRPC / HTTPUpgrade / mKCP / xHTTP), REALITY, XTLS Vision, VMess (incl. Mux.Cool)** and Trojan, plus subscription import.

Placed in the combined iOS/macOS/tvOS group rather than dual-listing it in `macOS arm64 & x64`, since it is a single universal binary — happy to add it there too if you prefer the Happ/INCY style.

One line added, no other changes.
