### PR TITLE
Routing: Add `localOS` that directly matches `runtime.GOOS`

### DIFF
--- a/app/router/condition.go
+++ b/app/router/condition.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"slices"
 	"strings"
 
@@ -392,4 +393,23 @@ func (m *ProcessNameMatcher) Apply(ctx routing.Context) bool {
 		}
 	}
 	return false
+}
+
+// LocalOSMatcher matches the operating system Xray itself is running on. That never
+// changes while Xray is running, so the result is resolved when the rule is built.
+type LocalOSMatcher struct {
+	matched bool
+}
+
+func NewLocalOSMatcher(names []string) *LocalOSMatcher {
+	return &LocalOSMatcher{
+		matched: slices.ContainsFunc(names, func(name string) bool {
+			return strings.EqualFold(name, runtime.GOOS)
+		}),
+	}
+}
+
+// Apply implements Condition.
+func (m *LocalOSMatcher) Apply(_ routing.Context) bool {
+	return m.matched
 }

--- a/app/router/condition_test.go
+++ b/app/router/condition_test.go
@@ -2,7 +2,9 @@ package router_test
 
 import (
 	"path/filepath"
+	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 
 	. "github.com/xtls/xray-core/app/router"
@@ -339,6 +341,31 @@ func TestChinaSites(t *testing.T) {
 		r := matcher.ApplyDomain(testCase.Domain)
 		if r != testCase.Output {
 			t.Error("DomainMatcher expected output ", testCase.Output, " for domain ", testCase.Domain, " but got ", r)
+		}
+	}
+}
+
+func TestLocalOSRule(t *testing.T) {
+	otherOS := "plan9"
+	if runtime.GOOS == otherOS {
+		otherOS = "linux"
+	}
+
+	cases := []struct {
+		localOS []string
+		output  bool
+	}{
+		{localOS: []string{runtime.GOOS}, output: true},
+		{localOS: []string{otherOS}, output: false},
+		{localOS: []string{otherOS, runtime.GOOS}, output: true},
+		{localOS: []string{strings.ToUpper(runtime.GOOS)}, output: true},
+	}
+
+	for _, test := range cases {
+		cond, err := (&RoutingRule{LocalOs: test.localOS}).BuildCondition()
+		common.Must(err)
+		if got := cond.Apply(withBackground()); got != test.output {
+			t.Errorf("for localOS %v on %s: expected %v, got %v", test.localOS, runtime.GOOS, test.output, got)
 		}
 	}
 }

--- a/app/router/config.go
+++ b/app/router/config.go
@@ -33,6 +33,10 @@ func (r *Rule) Apply(ctx routing.Context) bool {
 func (rr *RoutingRule) BuildCondition() (Condition, error) {
 	conds := NewConditionChan()
 
+	if len(rr.LocalOs) > 0 {
+		conds.Add(NewLocalOSMatcher(rr.LocalOs))
+	}
+
 	if len(rr.InboundTag) > 0 {
 		conds.Add(NewInboundTagMatcher(rr.InboundTag))
 	}

--- a/app/router/config.pb.go
+++ b/app/router/config.pb.go
@@ -107,8 +107,10 @@ type RoutingRule struct {
 	VlessRouteList *net.PortList  `protobuf:"bytes,20,opt,name=vless_route_list,json=vlessRouteList,proto3" json:"vless_route_list,omitempty"`
 	Process        []string       `protobuf:"bytes,21,rep,name=process,proto3" json:"process,omitempty"`
 	Webhook        *WebhookConfig `protobuf:"bytes,22,opt,name=webhook,proto3" json:"webhook,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// List of operating systems for matching the one Xray itself is running on.
+	LocalOs       []string `protobuf:"bytes,23,rep,name=local_os,json=localOs,proto3" json:"local_os,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *RoutingRule) Reset() {
@@ -274,6 +276,13 @@ func (x *RoutingRule) GetProcess() []string {
 func (x *RoutingRule) GetWebhook() *WebhookConfig {
 	if x != nil {
 		return x.Webhook
+	}
+	return nil
+}
+
+func (x *RoutingRule) GetLocalOs() []string {
+	if x != nil {
+		return x.LocalOs
 	}
 	return nil
 }
@@ -637,7 +646,7 @@ var File_app_router_config_proto protoreflect.FileDescriptor
 
 const file_app_router_config_proto_rawDesc = "" +
 	"\n" +
-	"\x17app/router/config.proto\x12\x0fxray.app.router\x1a!common/serial/typed_message.proto\x1a\x15common/net/port.proto\x1a\x18common/net/network.proto\x1a\x1bcommon/geodata/geodat.proto\"\xc1\a\n" +
+	"\x17app/router/config.proto\x12\x0fxray.app.router\x1a!common/serial/typed_message.proto\x1a\x15common/net/port.proto\x1a\x18common/net/network.proto\x1a\x1bcommon/geodata/geodat.proto\"\xdc\a\n" +
 	"\vRoutingRule\x12\x12\n" +
 	"\x03tag\x18\x01 \x01(\tH\x00R\x03tag\x12%\n" +
 	"\rbalancing_tag\x18\f \x01(\tH\x00R\fbalancingTag\x12\x19\n" +
@@ -661,7 +670,8 @@ const file_app_router_config_proto_rawDesc = "" +
 	"\x0flocal_port_list\x18\x12 \x01(\v2\x19.xray.common.net.PortListR\rlocalPortList\x12C\n" +
 	"\x10vless_route_list\x18\x14 \x01(\v2\x19.xray.common.net.PortListR\x0evlessRouteList\x12\x18\n" +
 	"\aprocess\x18\x15 \x03(\tR\aprocess\x128\n" +
-	"\awebhook\x18\x16 \x01(\v2\x1e.xray.app.router.WebhookConfigR\awebhook\x1a=\n" +
+	"\awebhook\x18\x16 \x01(\v2\x1e.xray.app.router.WebhookConfigR\awebhook\x12\x19\n" +
+	"\blocal_os\x18\x17 \x03(\tR\alocalOs\x1a=\n" +
 	"\x0fAttributesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\f\n" +

--- a/app/router/config.proto
+++ b/app/router/config.proto
@@ -56,6 +56,9 @@ message RoutingRule {
 
   repeated string process = 21;
   WebhookConfig webhook = 22;
+
+  // List of operating systems for matching the one Xray itself is running on.
+  repeated string local_os = 23;
 }
 
 message WebhookConfig {

--- a/infra/conf/router.go
+++ b/infra/conf/router.go
@@ -148,6 +148,7 @@ func parseFieldRule(msg json.RawMessage) (*router.RoutingRule, error) {
 		LocalIP    *StringList        `json:"localIP"`
 		LocalPort  *PortList          `json:"localPort"`
 		Process    *StringList        `json:"process"`
+		LocalOS    *StringList        `json:"localOS"`
 		Webhook    *WebhookRuleConfig `json:"webhook"`
 	}
 	rawFieldRule := new(RawFieldRule)
@@ -259,6 +260,10 @@ func parseFieldRule(msg json.RawMessage) (*router.RoutingRule, error) {
 
 	if rawFieldRule.Process != nil && len(*rawFieldRule.Process) > 0 {
 		rule.Process = *rawFieldRule.Process
+	}
+
+	if rawFieldRule.LocalOS != nil && len(*rawFieldRule.LocalOS) > 0 {
+		rule.LocalOs = *rawFieldRule.LocalOS
 	}
 
 	if rawFieldRule.Webhook != nil && rawFieldRule.Webhook.URL != "" {


### PR DESCRIPTION
Adds `localOS` to routing rules: the rule only applies when Xray itself runs on
one of the listed operating systems. Values are `runtime.GOOS` (`android`, `ios`,
`windows`, `darwin`, `linux`, ...), compared case-insensitively. Since the OS
never changes at runtime, the result is resolved once when the rule is built, so
there is no cost on the hot path.

**Why:** clients commonly fetch a single config from a URL, and the same config
is shared across Android, iOS, Windows and desktop. Some rules are inherently
platform-specific — `process` values are package names on Android, and a `tun`
inbound only exists on mobile — so without a guard they either silently never
match or, in the case of a catch-all, do the wrong thing everywhere else.

In the example below the second rule blocks everything from `tun-in` that is not
an allowed app. Both rules are scoped to Android, so on Windows or macOS the
same shared config simply falls through them instead of blocking all traffic.

```json
{
  "inbounds": [
    {
      "protocol": "tun",
      "tag": "tun-in"
    }
  ],
  "outbounds": [
    {
      "protocol": "freedom",
      "tag": "direct-out"
    },
    {
      "protocol": "loopback",
      "settings": {
        "inboundTag": "allowed-apps-in"
      },
      "tag": "allowed-apps-out"
    },
    {
      "protocol": "blackhole",
      "tag": "block-out"
    }
  ],
  "routing": {
    "rules": [
      {
        "inboundTag": ["tun-in"],
        "process": [
          "com.google.android.youtube",
          "com.android.chrome"
        ],
        "localOS": ["android"],
        "outboundTag": "allowed-apps-out"
      },
      {
        "inboundTag": ["tun-in"],
        "localOS": ["android"],
        "outboundTag": "block-out"
      }
    ]
  }
}