### PR TITLE
Routing: Fix `process` for macOS IPv4-mapped sockets

### DIFF
--- a/common/net/find_process_darwin.go
+++ b/common/net/find_process_darwin.go
@@ -198,7 +198,9 @@ func darwinSocketInfoMatchLevel(info []byte, network string, srcAddr netip.Addr,
 
 	vflag := info[darwinInSockInfoVFlagOff]
 	if srcAddr.Is4() {
-		if family != unix.AF_INET || vflag&darwinInSockInfoIPv4 == 0 {
+		// Dual-stack sockets expose IPv4-mapped connections as AF_INET6
+		// while marking the endpoint as IPv4 in ini_vflag.
+		if (family != unix.AF_INET && family != unix.AF_INET6) || vflag&darwinInSockInfoIPv4 == 0 {
 			return darwinSocketNoMatch
 		}
 	} else {

--- a/common/net/find_process_darwin_test.go
+++ b/common/net/find_process_darwin_test.go
@@ -52,6 +52,57 @@ func TestFindProcessDarwinTCP(t *testing.T) {
 	assertCurrentProcess(t, pid, name, path)
 }
 
+func TestFindProcessDarwinTCPIPv4Mapped(t *testing.T) {
+	listener, err := stdnet.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	accepted := make(chan stdnet.Conn, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err == nil {
+			accepted <- conn
+			return
+		}
+		close(accepted)
+	}()
+
+	listenerAddr := listener.Addr().(*stdnet.TCPAddr)
+	fd, err := unix.Socket(unix.AF_INET6, unix.SOCK_STREAM, unix.IPPROTO_TCP)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unix.Close(fd)
+
+	mappedAddr := [16]byte{10: 0xff, 11: 0xff, 12: 127, 15: 1}
+	if err := unix.Connect(fd, &unix.SockaddrInet6{
+		Port: listenerAddr.Port,
+		Addr: mappedAddr,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	serverConn := <-accepted
+	if serverConn == nil {
+		t.Fatal("server did not accept tcp connection")
+	}
+	defer serverConn.Close()
+
+	local, err := unix.Getsockname(fd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	localPort := local.(*unix.SockaddrInet6).Port
+
+	pid, name, path, err := FindProcess("tcp", "127.0.0.1", uint16(localPort), "127.0.0.1", uint16(listenerAddr.Port))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertCurrentProcess(t, pid, name, path)
+}
+
 func TestFindProcessDarwinUDP(t *testing.T) {
 	conn, err := stdnet.ListenUDP("udp", &stdnet.UDPAddr{IP: stdnet.ParseIP("127.0.0.1")})
 	if err != nil {
@@ -261,6 +312,18 @@ func TestDarwinSocketInfoMatchLevelFallbacks(t *testing.T) {
 				t.Fatalf("unexpected match level: got %d, want %d", level, test.wantLevel)
 			}
 		})
+	}
+}
+
+func TestDarwinSocketInfoMatchLevelIPv4Mapped(t *testing.T) {
+	src := netip.MustParseAddr("127.0.0.1")
+	dst := netip.MustParseAddr("203.0.113.10")
+	info := newDarwinSocketInfo("tcp", src, 12345, dst, 443)
+	writeDarwinNativeUint32(info, darwinSocketInfoFamilyOff, uint32(unix.AF_INET6))
+
+	level := darwinSocketInfoMatchLevel(info, "tcp", src, 12345, dst, 443, true)
+	if level != darwinSocketExactMatch {
+		t.Fatalf("unexpected match level: got %d, want %d", level, darwinSocketExactMatch)
 	}
 }
 


### PR DESCRIPTION
## Summary

- accept Darwin `AF_INET6` socket entries marked with the IPv4 `ini_vflag` when matching an IPv4 source
- add a real IPv4-mapped dual-stack TCP socket test
- add a synthetic socket-info regression test

## Root cause

Darwin reports IPv4 connections created by dual-stack sockets as `AF_INET6`
with the IPv4 bit set in `ini_vflag`. `FindProcess` unmapped the source address
to IPv4, but then required the socket family to be `AF_INET`, so these entries
were always rejected. The existing address comparison already supports the
IPv4 bytes stored in the final four bytes of the Darwin address structure.

The non-root case described in #6533 is caused by the minimal SOCKS client
closing immediately after receiving Xray's success response. Once the socket
has lost its owning file descriptor, process lookup cannot recover its owner.
With the connection kept open, non-root AF_INET lookup works normally.

Fixes #6533.

## Validation

- `CGO_ENABLED=0 go test ./common/net -count=1`
- `go test ./common/net ./app/router ./proxy/tun -count=1`
- `GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go test -c ./common/net`
- runtime SOCKS reproduction with AF_INET and IPv4-mapped dual-stack clients
- `git diff --check`
