### PR TITLE
Mux.Cool: actually send SessionStatusKeepAlive (0x04)

### DIFF
--- a/common/mux/keepalive_test.go
+++ b/common/mux/keepalive_test.go
@@ -1,0 +1,238 @@
+package mux_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/xtls/xray-core/common"
+	"github.com/xtls/xray-core/common/buf"
+	"github.com/xtls/xray-core/common/mux"
+	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/protocol"
+	"github.com/xtls/xray-core/common/session"
+	"github.com/xtls/xray-core/transport"
+)
+
+// readOneFrame reads a single mux frame metadata from the reader, draining
+// the data chunk if the frame carries one.
+func readOneFrame(reader *buf.BufferedReader) (*mux.FrameMetadata, error) {
+	var meta mux.FrameMetadata
+	if err := meta.Unmarshal(reader, false); err != nil {
+		return nil, err
+	}
+	if meta.Option.Has(mux.OptionData) {
+		if err := buf.Copy(mux.NewStreamReader(reader), buf.Discard); err != nil {
+			return nil, err
+		}
+	}
+	return &meta, nil
+}
+
+// openSession sends a SessionStatusNew frame (no data) for the given session
+// ID over the writer, emulating a client opening a mux session.
+func openSession(t *testing.T, writer buf.Writer, id uint16) {
+	t.Helper()
+	dest := net.TCPDestination(net.DomainAddress("www.example.com"), 80)
+	sessionWriter := mux.NewWriter(id, dest, writer, protocol.TransferTypeStream, [8]byte{}, nil)
+	common.Must(sessionWriter.WriteMultiBuffer(buf.MultiBuffer{}))
+}
+
+func setKeepAliveInterval(t *testing.T, interval time.Duration) {
+	t.Helper()
+	original := mux.ServerKeepAliveInterval
+	mux.ServerKeepAliveInterval = interval
+	t.Cleanup(func() {
+		mux.ServerKeepAliveInterval = original
+	})
+}
+
+func TestServerSendsKeepAliveWhenIdle(t *testing.T) {
+	setKeepAliveInterval(t, 50*time.Millisecond)
+
+	websiteUplink, websiteDownlink := newLinkPair()
+	dispatcher := TestDispatcher{
+		OnDispatch: func(ctx context.Context, dest net.Destination) (*transport.Link, error) {
+			return websiteDownlink, nil
+		},
+	}
+	defer common.Interrupt(websiteUplink.Reader)
+
+	muxServerUplink, muxServerDownlink := newLinkPair()
+	worker, err := mux.NewServerWorker(context.Background(), &dispatcher, muxServerUplink)
+	common.Must(err)
+	defer worker.Close()
+
+	// Open a session and keep it idle: no data in either direction.
+	openSession(t, muxServerDownlink.Writer, 1)
+
+	frames := make(chan *mux.FrameMetadata, 16)
+	go func() {
+		reader := &buf.BufferedReader{Reader: muxServerDownlink.Reader}
+		for {
+			meta, err := readOneFrame(reader)
+			if err != nil {
+				close(frames)
+				return
+			}
+			frames <- meta
+		}
+	}()
+
+	// The downlink is idle while a session is active: the server must emit
+	// keepalive frames. Expect at least two to confirm periodic emission.
+	for i := 0; i < 2; i++ {
+		select {
+		case meta, ok := <-frames:
+			if !ok {
+				t.Fatal("downlink closed before keepalive was received")
+			}
+			if meta.SessionStatus != mux.SessionStatusKeepAlive {
+				t.Fatalf("frame %d: expected status KeepAlive (0x04), got 0x%02x", i, byte(meta.SessionStatus))
+			}
+			if meta.Option != 0 {
+				t.Fatalf("frame %d: keepalive frame must carry no options, got 0x%02x", i, byte(meta.Option))
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("no keepalive frame received within 2s (got %d so far)", i)
+		}
+	}
+}
+
+func TestServerNoKeepAliveWhileDownlinkActive(t *testing.T) {
+	setKeepAliveInterval(t, 150*time.Millisecond)
+
+	websiteUplink, websiteDownlink := newLinkPair()
+	dispatcher := TestDispatcher{
+		OnDispatch: func(ctx context.Context, dest net.Destination) (*transport.Link, error) {
+			return websiteDownlink, nil
+		},
+	}
+
+	muxServerUplink, muxServerDownlink := newLinkPair()
+	worker, err := mux.NewServerWorker(context.Background(), &dispatcher, muxServerUplink)
+	common.Must(err)
+	defer worker.Close()
+
+	openSession(t, muxServerDownlink.Writer, 1)
+
+	type result struct {
+		keepAlives int
+		frames     int
+	}
+	done := make(chan result, 1)
+	go func() {
+		reader := &buf.BufferedReader{Reader: muxServerDownlink.Reader}
+		var r result
+		for {
+			meta, err := readOneFrame(reader)
+			if err != nil {
+				done <- r
+				return
+			}
+			r.frames++
+			if meta.SessionStatus == mux.SessionStatusKeepAlive {
+				r.keepAlives++
+			}
+		}
+	}()
+
+	// Keep the downlink busy for three keepalive intervals.
+	for i := 0; i < 18; i++ {
+		b := buf.New()
+		b.WriteString("data")
+		common.Must(websiteUplink.Writer.WriteMultiBuffer(buf.MultiBuffer{b}))
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	// Tear down promptly, before an idle period elapses.
+	common.Must(worker.Close())
+
+	select {
+	case r := <-done:
+		if r.frames == 0 {
+			t.Error("expected data frames on the downlink, got none")
+		}
+		if r.keepAlives != 0 {
+			t.Errorf("expected no keepalive frames while downlink is active, got %d (of %d frames)", r.keepAlives, r.frames)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("frame reader did not finish")
+	}
+}
+
+// TestClientTransparentToKeepAlive verifies backward compatibility: an
+// unmodified ClientWorker silently discards the server's keepalive frames
+// and continues to deliver data intact.
+func TestClientTransparentToKeepAlive(t *testing.T) {
+	setKeepAliveInterval(t, 40*time.Millisecond)
+
+	websiteUplink, websiteDownlink := newLinkPair()
+	dispatcher := TestDispatcher{
+		OnDispatch: func(ctx context.Context, dest net.Destination) (*transport.Link, error) {
+			return websiteDownlink, nil
+		},
+	}
+
+	muxServerUplink, muxServerDownlink := newLinkPair()
+	worker, err := mux.NewServerWorker(context.Background(), &dispatcher, muxServerUplink)
+	common.Must(err)
+	defer worker.Close()
+
+	client, err := mux.NewClientWorker(*muxServerDownlink, mux.ClientStrategy{})
+	common.Must(err)
+
+	clientCtx := session.ContextWithOutbounds(context.Background(), []*session.Outbound{{
+		Target: net.TCPDestination(net.DomainAddress("www.example.com"), 80),
+	}})
+
+	muxClientUplink, muxClientDownlink := newLinkPair()
+	if !client.Dispatch(clientCtx, muxClientUplink) {
+		t.Fatal("failed to dispatch")
+	}
+
+	{
+		b := buf.New()
+		b.WriteString("hello")
+		common.Must(muxClientDownlink.Writer.WriteMultiBuffer(buf.MultiBuffer{b}))
+	}
+
+	resMb, err := websiteUplink.Reader.ReadMultiBuffer()
+	common.Must(err)
+	if res := resMb.String(); res != "hello" {
+		t.Fatal("upload: ", res)
+	}
+
+	// Let several keepalive frames cross the wire while the download
+	// direction is idle.
+	time.Sleep(250 * time.Millisecond)
+
+	if client.Closed() {
+		t.Fatal("client closed after receiving keepalive frames")
+	}
+
+	{
+		b := buf.New()
+		b.WriteString("world")
+		common.Must(websiteUplink.Writer.WriteMultiBuffer(buf.MultiBuffer{b}))
+	}
+
+	readDone := make(chan string, 1)
+	go func() {
+		resMb, err := muxClientDownlink.Reader.ReadMultiBuffer()
+		if err != nil {
+			readDone <- "error: " + err.Error()
+			return
+		}
+		readDone <- resMb.String()
+	}()
+
+	select {
+	case res := <-readDone:
+		if res != "world" {
+			t.Fatal("download after keepalives: ", res)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("download did not arrive after keepalive frames")
+	}
+}

--- a/common/mux/server.go
+++ b/common/mux/server.go
@@ -3,6 +3,7 @@ package mux
 import (
 	"context"
 	"io"
+	"sync/atomic"
 	"time"
 
 	"github.com/xtls/xray-core/common"
@@ -10,6 +11,7 @@ import (
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/log"
 	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/platform"
 	"github.com/xtls/xray-core/common/protocol"
 	"github.com/xtls/xray-core/common/session"
 	"github.com/xtls/xray-core/common/signal/done"
@@ -18,6 +20,21 @@ import (
 	"github.com/xtls/xray-core/transport"
 	"github.com/xtls/xray-core/transport/pipe"
 )
+
+// ServerKeepAliveInterval is the interval at which ServerWorker sends a
+// SessionStatusKeepAlive frame when the downlink has been idle while
+// sessions are still active. This keeps otherwise idle download paths
+// (e.g. the server-to-client stream of XHTTP "packet-up" mode) from being
+// cut by middleboxes with short idle timeouts.
+// Configurable via the "xray.mux.server.keepalive" env flag
+// (XRAY_MUX_SERVER_KEEPALIVE), in seconds. 0 disables emission.
+var ServerKeepAliveInterval = func() time.Duration {
+	seconds := platform.NewEnvFlag(platform.MuxServerKeepAlive).GetValueAsInt(15)
+	if seconds < 0 {
+		seconds = 0
+	}
+	return time.Duration(seconds) * time.Second
+}()
 
 type Server struct {
 	dispatcher routing.Dispatcher
@@ -87,9 +104,23 @@ func (s *Server) Close() error {
 type ServerWorker struct {
 	dispatcher     routing.Dispatcher
 	link           *transport.Link
+	output         buf.Writer // wraps link.Writer, recording write times for the keepalive loop
 	sessionManager *SessionManager
 	done           *done.Instance
 	timer          *time.Ticker
+	keepAlive      time.Duration
+	lastWrite      atomic.Int64 // unix nano of the last downlink write
+}
+
+// downlinkWriter records the time of every downlink write, so that
+// keepAliveLoop only emits frames when the downlink is actually idle.
+type downlinkWriter struct {
+	worker *ServerWorker
+}
+
+func (w *downlinkWriter) WriteMultiBuffer(mb buf.MultiBuffer) error {
+	w.worker.lastWrite.Store(time.Now().UnixNano())
+	return w.worker.link.Writer.WriteMultiBuffer(mb)
 }
 
 func NewServerWorker(ctx context.Context, d routing.Dispatcher, link *transport.Link) (*ServerWorker, error) {
@@ -99,12 +130,18 @@ func NewServerWorker(ctx context.Context, d routing.Dispatcher, link *transport.
 		sessionManager: NewSessionManager(),
 		done:           done.New(),
 		timer:          time.NewTicker(60 * time.Second),
+		keepAlive:      ServerKeepAliveInterval,
 	}
+	worker.output = &downlinkWriter{worker: worker}
+	worker.lastWrite.Store(time.Now().UnixNano())
 	if inbound := session.InboundFromContext(ctx); inbound != nil {
 		inbound.CanSpliceCopy = 3
 	}
 	go worker.run(ctx)
 	go worker.monitor()
+	if worker.keepAlive > 0 {
+		go worker.keepAliveLoop()
+	}
 	return worker, nil
 }
 
@@ -137,6 +174,46 @@ func (w *ServerWorker) monitor() {
 			}
 		}
 	}
+}
+
+// keepAliveLoop periodically emits a SessionStatusKeepAlive frame while at
+// least one session is active and the downlink has been idle for at least
+// w.keepAlive. The receiving side has always discarded this frame (see
+// handleStatueKeepAlive in client.go, present since the protocol was
+// introduced), so emission is safe with any existing peer.
+func (w *ServerWorker) keepAliveLoop() {
+	ticker := time.NewTicker(w.keepAlive)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-w.done.Wait():
+			return
+		case <-ticker.C:
+			if w.sessionManager.Size() == 0 {
+				// Nothing to keep alive; let monitor() reap the connection.
+				continue
+			}
+			if time.Since(time.Unix(0, w.lastWrite.Load())) < w.keepAlive {
+				continue
+			}
+			if err := w.sendKeepAlive(); err != nil {
+				errors.LogInfoInner(context.Background(), err, "failed to send keepalive frame")
+				return
+			}
+		}
+	}
+}
+
+// sendKeepAlive writes a minimal SessionStatusKeepAlive frame: no options,
+// no payload, 6 bytes on the wire.
+func (w *ServerWorker) sendKeepAlive() error {
+	meta := FrameMetadata{
+		SessionStatus: SessionStatusKeepAlive,
+	}
+	frame := buf.New()
+	common.Must(meta.WriteTo(frame))
+	return w.output.WriteMultiBuffer(buf.MultiBuffer{frame})
 }
 
 func (w *ServerWorker) ActiveConnections() uint32 {
@@ -257,7 +334,7 @@ func (w *ServerWorker) handleStatusNew(ctx context.Context, meta *FrameMetadata,
 			x.Mux.Close(false)
 			return errors.New("failed to add new session")
 		}
-		go handle(ctx, x.Mux, w.link.Writer)
+		go handle(ctx, x.Mux, w.output)
 		return nil
 	}
 
@@ -282,7 +359,7 @@ func (w *ServerWorker) handleStatusNew(ctx context.Context, meta *FrameMetadata,
 		s.Close(false)
 		return errors.New("failed to add new session")
 	}
-	go handle(ctx, s, w.link.Writer)
+	go handle(ctx, s, w.output)
 	if !meta.Option.Has(OptionData) {
 		return nil
 	}
@@ -305,7 +382,7 @@ func (w *ServerWorker) handleStatusKeep(meta *FrameMetadata, reader *buf.Buffere
 	s, found := w.sessionManager.Get(meta.SessionID)
 	if !found {
 		// Notify remote peer to close this session.
-		closingWriter := NewResponseWriter(meta.SessionID, w.link.Writer, protocol.TransferTypeStream)
+		closingWriter := NewResponseWriter(meta.SessionID, w.output, protocol.TransferTypeStream)
 		closingWriter.Close()
 
 		return buf.Copy(NewStreamReader(reader), buf.Discard)

--- a/common/platform/platform.go
+++ b/common/platform/platform.go
@@ -25,6 +25,8 @@ const (
 	XUDPBaseKey          = "xray.xudp.basekey"
 
 	TunFdKey = "xray.tun.fd"
+
+	MuxServerKeepAlive = "xray.mux.server.keepalive"
 )
 
 type EnvFlag struct {


### PR DESCRIPTION
### What

`SessionStatusKeepAlive (0x04)` has been part of the Mux.Cool frame vocabulary since the protocol was introduced: it is defined in `common/mux/frame.go`, handled by the client (`handleStatueKeepAlive` — the typo itself dates back to v2ray days) and by the server (`handleStatusKeepAlive`). But a `grep -rn SessionStatusKeepAlive` over the tree yields exactly three hits — the definition and the two receivers. **No code path has ever emitted this frame.** An idle Mux connection is therefore idle on the wire.

This PR adds the missing emitter on the server side: while at least one session is active and the downlink has been idle for the keepalive interval, `ServerWorker` writes a minimal 6-byte `0x04` frame (no options, no payload).

### Why

In #6554 (XHTTP packet-up: download stream cut by middleboxes after idle) the suggested remedy was to enable Mux. With the current code that advice cannot work — nothing keeps the connection non-idle. This PR makes it work.

### Compatibility / risk

- **Zero wire risk.** Every existing client already discards a `0x04` frame without `OptionData` silently (`client.go` `handleStatueKeepAlive` returns `nil`). Covered by a test that runs an unmodified `ClientWorker` against the emitting server.
- **Server-only deploy fixes old clients** — no client update needed.
- Frames are only sent while sessions exist and only when the downlink is idle (a wrapper writer tracks the last write time), so active traffic and connection reaping (`CloseIfNoSessionAndIdle`) are unaffected.
- Interval: `xray.mux.server.keepalive` env flag (`XRAY_MUX_SERVER_KEEPALIVE`), seconds; default 15, `0` disables. Happy to flip the default to opt-in if preferred.

Tests: emitter fires on idle, stays silent under active traffic, unmodified client transparency. `go test -race ./common/mux/...` green.

Closes the gap behind #6554.

### 中文摘要

`SessionStatusKeepAlive (0x04)` 自协议诞生起就有定义和接收处理（客户端与服务端都会静默丢弃该帧），但**从未有任何代码发送过它**——空闲的 Mux 连接在线路上就是空闲的，中间设备照样掐断空闲下行（见 #6554，当时建议"开启 Mux"来保活，但现有代码做不到）。本 PR 补上缺失的发送端：服务端在有活跃会话且下行空闲达到间隔时，发送最小 6 字节的 0x04 帧。现有客户端本来就会静默丢弃该帧，因此**零线路兼容风险**，且**仅升级服务端即可修复老客户端**。间隔通过环境变量 `XRAY_MUX_SERVER_KEEPALIVE`（秒）配置，默认 15，0 为关闭。
