### PR TITLE
WireGuard outbound: Fix `sendThrough` support

### DIFF
--- a/app/proxyman/outbound/handler.go
+++ b/app/proxyman/outbound/handler.go
@@ -347,7 +347,6 @@ func (h *Handler) SetOutboundGateway(ctx context.Context, ob *session.Outbound) 
 		// case addr.Family().IsDomain():
 		default:
 			ob.Gateway = addr
-
 		}
 
 	}

--- a/proxy/wireguard/client.go
+++ b/proxy/wireguard/client.go
@@ -138,6 +138,7 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 	}
 	ob.Name = "wireguard"
 	ob.CanSpliceCopy = 3
+	dialer.SetOutboundGateway(ctx, ob)
 
 	if err := h.init(ctx); err != nil {
 		return err


### PR DESCRIPTION
fix #6559 