### PR TITLE
Observatory: cancel health-check probes when they time out

### DIFF
--- a/app/observatory/burst/healthping.go
+++ b/app/observatory/burst/healthping.go
@@ -172,7 +172,7 @@ func (h *HealthPing) doCheck(ctx context.Context, tags []string, duration time.D
 	for _, tag := range tags {
 		handler := tag
 		client := newPingClient(
-			h.ctx,
+			ctx,
 			h.dispatcher,
 			h.Settings.Destination,
 			h.Settings.Timeout,

--- a/app/observatory/burst/ping.go
+++ b/app/observatory/burst/ping.go
@@ -41,6 +41,7 @@ func newHTTPClient(ctxv context.Context, dispatcher routing.Dispatcher, handler 
 			}
 			return tagged.Dialer(ctxv, dispatcher, dest, handler)
 		},
+		TLSHandshakeTimeout: timeout,
 	}
 	return &http.Client{
 		Transport: tr,

--- a/app/observatory/burst/ping_test.go
+++ b/app/observatory/burst/ping_test.go
@@ -1,0 +1,59 @@
+package burst
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/core"
+	"github.com/xtls/xray-core/features/routing"
+	"github.com/xtls/xray-core/transport/internet/tagged"
+)
+
+// doCheck must hand its own context to the probes it starts, so that
+// canceling a round also cancels the dials that round created.
+func TestDoCheckPassesRoundContextToProbes(t *testing.T) {
+	originalDialer := tagged.Dialer
+	defer func() { tagged.Dialer = originalDialer }()
+
+	instance := new(core.Instance)
+	instanceCtx := context.WithValue(context.Background(), core.XrayKey(1), instance)
+
+	dialed := make(chan context.Context, 1)
+	tagged.Dialer = func(ctx context.Context, _ routing.Dispatcher, _ net.Destination, _ string) (net.Conn, error) {
+		select {
+		case dialed <- ctx:
+		default:
+		}
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	h := NewHealthPing(instanceCtx, nil, &HealthPingConfig{
+		Destination: "http://example.com",
+		Timeout:     int64(time.Minute),
+	})
+
+	roundCtx, cancelRound := context.WithCancel(h.ctx)
+	go h.doCheck(roundCtx, []string{"probe"}, 0, 1)
+
+	var dialCtx context.Context
+	select {
+	case dialCtx = <-dialed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("probe never dialed")
+	}
+
+	if core.FromContext(dialCtx) != instance {
+		t.Fatal("dial context lost the Xray instance")
+	}
+
+	cancelRound()
+
+	select {
+	case <-dialCtx.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("canceling the round did not cancel the probe dial")
+	}
+}


### PR DESCRIPTION
Two things let a probe outlive the round that started it.

`doCheck` takes a cancellable context and the scheduler cancels the previous round before starting the next one, but the probe client is still built from `h.ctx`. The machinery is there with nothing attached to it.

The probe transport also leaves `TLSHandshakeTimeout` unset, which Go reads as no limit. `http.Client.Timeout` ends the request, but the goroutine inside `addTLS` stays parked in the handshake, holding the dispatched outbound open.

Pass the round context to `newPingClient`, and give the handshake the same timeout as the probe that started it.

The test swaps in a `tagged.Dialer` that blocks until its context ends, runs a round, cancels it, and expects the dial to be cancelled too. It fails on main.
