### PR TITLE
Tagged dialer: release the dispatched outbound when the conn closes

### DIFF
--- a/transport/internet/tagged/taggedimpl/impl.go
+++ b/transport/internet/tagged/taggedimpl/impl.go
@@ -22,8 +22,10 @@ func DialTaggedOutbound(ctx context.Context, dispatcher routing.Dispatcher, dest
 	ctx = session.ContextWithContent(ctx, content)
 	ctx = session.SetForcedOutboundTagToContext(ctx, tag)
 
+	ctx, cancel := context.WithCancel(ctx)
 	r, err := dispatcher.Dispatch(ctx, dest)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 	var readerOpt cnc.ConnectionOption
@@ -32,7 +34,16 @@ func DialTaggedOutbound(ctx context.Context, dispatcher routing.Dispatcher, dest
 	} else {
 		readerOpt = cnc.ConnectionOutputMultiUDP(r.Reader)
 	}
-	return cnc.NewConnection(cnc.ConnectionInputMulti(r.Writer), readerOpt), nil
+	// Closing the returned connection must also tear down the dispatched
+	// outbound, otherwise it keeps running until the whole instance stops.
+	return cnc.NewConnection(cnc.ConnectionInputMulti(r.Writer), readerOpt, cnc.ConnectionOnClose(cancelCloser(cancel))), nil
+}
+
+type cancelCloser context.CancelFunc
+
+func (c cancelCloser) Close() error {
+	c()
+	return nil
 }
 
 func init() {


### PR DESCRIPTION
`DialTaggedOutbound` wraps the pipes from `dispatcher.Dispatch` in a `cnc.Connection`. Closing that connection interrupts the pipes but leaves the dispatch context alone, so the outbound handler keeps running until the caller's context ends.

Every call site in tree passes a context that outlives the connection: `observer.go` derives it from `o.ctx`, `geodata/download.go` uses the downloader's, `burst/ping.go` passes the one `newPingClient` received. None of them ends when the conn closes.

Interrupting the pipes does not reach an outbound that has not started reading them. Against a peer that completes the TCP handshake and then stalls, the dispatched goroutine sits in `tcp/dialer.go:81` under `retry.On` and never touches `link.Reader` or `link.Writer`. I measured it on v26.7.28 with #6582 applied, so that the probe does close its conn: after 150s of health check probes at a 15s interval, 22 of these goroutines were still parked, while the probe side had none.

Derive a cancellable context for the dispatch and cancel it from `ConnectionOnClose`. A conn that nobody closes behaves as it does today.

One correction to what I first wrote here. I said `ConnectionOnClose` had no users. It has six call sites. The nearest one is `redirect` in `transport/internet/dialer.go`, which dispatches with `context.WithoutCancel` and attaches pipe closers instead, so this patch does go against that precedent. Bounding the handshake inside `tcp/dialer.go` would be the other way to reach the same goroutine.
