### PR TITLE
XHTTP: bound the dial phase with a deadline

### DIFF
--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -46,6 +46,10 @@ var (
 	globalDialerAccess sync.Mutex
 )
 
+// dialHandshakeTimeout bounds the connection-establishment phase of an XHTTP
+// dial. Matches the default policy handshake timeout.
+const dialHandshakeTimeout = 60 * time.Second
+
 func getHTTPClient(ctx context.Context, dest net.Destination, streamSettings *internet.MemoryStreamConfig) (DialerClient, *XmuxClient) {
 	realityConfig := reality.ConfigFromStreamSettings(streamSettings)
 
@@ -118,6 +122,14 @@ func createHTTPClient(dest net.Destination, streamSettings *internet.MemoryStrea
 	transportConfig := streamSettings.ProtocolSettings.(*Config)
 
 	dialContext := func(ctxInner context.Context) (net.Conn, error) {
+		// Requests are created with context.WithoutCancel so that an
+		// established stream is never torn down mid-transfer. That also makes
+		// the dial phase uncancellable, so a stalled TCP/TLS/REALITY handshake
+		// would keep its goroutine forever. Bound the establishment phase
+		// explicitly; ctxInner is not referenced once a conn is returned.
+		ctxInner, cancel := context.WithTimeout(ctxInner, dialHandshakeTimeout)
+		defer cancel()
+
 		conn, err := internet.DialSystem(ctxInner, dest, streamSettings.SocketSettings)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
`OpenStream` and `PostPacket` build requests with `context.WithoutCancel` so an established stream survives cancellation of the caller's context. That part is intended.

The side effect is that the same uncancellable context reaches `DialTLSContext`, and `http2.Transport` has no dial timeout of its own. Connection setup runs with no deadline at all. A server that completes the TCP handshake and then goes quiet during TLS parks the dial goroutine in `clientConnPool.getClientConn` with nothing left to wake it.

Give the establishment phase its own deadline. `ctxInner` is not referenced once a connection is returned, so `defer cancel()` cannot disturb an established stream.

The value is a package constant matching the default `policy.Timeouts.Handshake`. Reading the policy would need a `policyManager`, and `createHTTPClient` cannot reach one: it runs inside the `XmuxManager` factory closure, and its clients are cached in `globalDialerMap` and reused, so capturing a request context there would pin the first caller's context to every reuse.

For comparison, `grpc/dial.go` marks its nested dial with `session.ContextWithTimeoutOnly`, detaching it from the parent while keeping an idle timeout. XHTTP detached it from the parent and from any timeout.
