### PR TITLE
SS2022 outbound: call deferred context cancel to avoid leak

### DIFF
--- a/proxy/shadowsocks_2022/outbound.go
+++ b/proxy/shadowsocks_2022/outbound.go
@@ -84,7 +84,9 @@ func (o *Outbound) Process(ctx context.Context, link *transport.Link, dialer int
 	}
 
 	if session.TimeoutOnlyFromContext(ctx) {
-		ctx, _ = context.WithCancel(context.Background())
+		cancelableCtx, cancel := context.WithCancel(context.Background())
+		ctx = cancelableCtx
+		defer cancel()
 	}
 
 	if network == net.Network_TCP {


### PR DESCRIPTION
## What does this PR do?

Fixes a context leak flagged by `go vet` in the SS2022 outbound ([link](proxy/shadowsocks_2022/outbound.go)).

When `session.TimeoutOnlyFromContext` is set, `context.WithCancel(context.Background())` was created and the returned `cancel` function was discarded, so the context could never be cancelled and leaked until GC.

## How to test

```bash
go build ./...
go vet ./proxy/shadowsocks_2022/...
go test ./proxy/...
```

No behavioral change: the cancel fires only when `Process` returns, which is exactly when the returned context is no longer needed.