### PR TITLE
Fix process lookup

### DIFF
--- a/common/net/find_process_table.go
+++ b/common/net/find_process_table.go
@@ -1,0 +1,103 @@
+package net
+
+import (
+	"encoding/binary"
+	"net/netip"
+
+	"github.com/xtls/xray-core/common/errors"
+)
+
+type searcher struct {
+	itemSize   int
+	port       int
+	ip         int
+	ipSize     int
+	remotePort int
+	remoteIP   int
+	remoteSize int
+	pid        int
+	allowAnyIP bool
+}
+
+func (s *searcher) Search(b []byte, ip netip.Addr, port uint16, remoteIP netip.Addr, remotePort uint16) (uint32, error) {
+	n := int(readNativeUint32(b[:4]))
+	itemSize := s.itemSize
+	matchRemote := s.remoteIP >= 0 && remoteIP.IsValid() && remotePort != 0
+
+	for i := range n {
+		row := b[4+itemSize*i : 4+itemSize*(i+1)]
+
+		srcPort := readNetworkPort(row[s.port : s.port+4])
+		if srcPort != port {
+			continue
+		}
+
+		srcIP, _ := netip.AddrFromSlice(row[s.ip : s.ip+s.ipSize])
+		srcIP = srcIP.Unmap()
+		// Windows binds an unbound UDP socket to 0.0.0.0/[::] while first sendto.
+		if ip != srcIP && (!srcIP.IsUnspecified() || !s.allowAnyIP) {
+			continue
+		}
+
+		if matchRemote {
+			rowRemoteIP, _ := netip.AddrFromSlice(row[s.remoteIP : s.remoteIP+s.remoteSize])
+			rowRemoteIP = rowRemoteIP.Unmap()
+			rowRemotePort := readNetworkPort(row[s.remotePort : s.remotePort+4])
+			if remoteIP != rowRemoteIP || remotePort != rowRemotePort {
+				continue
+			}
+		}
+
+		pid := readNativeUint32(row[s.pid : s.pid+4])
+		return pid, nil
+	}
+	return 0, errors.New("not found")
+}
+
+func newSearcher(network Network, family AddressFamily) *searcher {
+	var itemSize, port, ip, ipSize, remotePort, remoteIP, remoteSize, pid int
+	allowAnyIP := false
+	remotePort, remoteIP, remoteSize = -1, -1, 0
+
+	switch network {
+	case Network_TCP:
+		if family == AddressFamilyIPv4 {
+			// struct MIB_TCPROW_OWNER_PID
+			itemSize, port, ip, ipSize, remotePort, remoteIP, remoteSize, pid = 24, 8, 4, 4, 16, 12, 4, 20
+		}
+		if family == AddressFamilyIPv6 {
+			// struct MIB_TCP6ROW_OWNER_PID
+			itemSize, port, ip, ipSize, remotePort, remoteIP, remoteSize, pid = 56, 20, 0, 16, 44, 24, 16, 52
+		}
+	case Network_UDP:
+		allowAnyIP = true
+		if family == AddressFamilyIPv4 {
+			// struct MIB_UDPROW_OWNER_PID
+			itemSize, port, ip, ipSize, pid = 12, 4, 0, 4, 8
+		}
+		if family == AddressFamilyIPv6 {
+			// struct MIB_UDP6ROW_OWNER_PID
+			itemSize, port, ip, ipSize, pid = 28, 20, 0, 16, 24
+		}
+	}
+
+	return &searcher{
+		itemSize:   itemSize,
+		port:       port,
+		ip:         ip,
+		ipSize:     ipSize,
+		remotePort: remotePort,
+		remoteIP:   remoteIP,
+		remoteSize: remoteSize,
+		pid:        pid,
+		allowAnyIP: allowAnyIP,
+	}
+}
+
+func readNetworkPort(b []byte) uint16 {
+	return binary.BigEndian.Uint16(b[:2])
+}
+
+func readNativeUint32(b []byte) uint32 {
+	return binary.LittleEndian.Uint32(b)
+}

--- a/common/net/find_process_table_test.go
+++ b/common/net/find_process_table_test.go
@@ -1,0 +1,100 @@
+package net
+
+import (
+	"encoding/binary"
+	"net/netip"
+	"testing"
+)
+
+func TestTransportTableSearcherFindsSynSentTCPRow(t *testing.T) {
+	table := transportTable(
+		tcp4Row(3, [4]byte{172, 18, 0, 1}, 20543, [4]byte{175, 4, 62, 127}, 443, 8480),
+	)
+
+	pid, err := newSearcher(Network_TCP, AddressFamilyIPv4).Search(
+		table,
+		netip.MustParseAddr("172.18.0.1"),
+		20543,
+		netip.MustParseAddr("175.4.62.127"),
+		443,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pid != 8480 {
+		t.Fatalf("pid = %d, want 8480", pid)
+	}
+}
+
+func TestTransportTableSearcherMatchesTCPRemoteEndpoint(t *testing.T) {
+	table := transportTable(
+		tcp4Row(5, [4]byte{172, 18, 0, 1}, 20543, [4]byte{203, 0, 113, 1}, 443, 1111),
+		tcp4Row(3, [4]byte{172, 18, 0, 1}, 20543, [4]byte{175, 4, 62, 127}, 443, 2222),
+	)
+
+	pid, err := newSearcher(Network_TCP, AddressFamilyIPv4).Search(
+		table,
+		netip.MustParseAddr("172.18.0.1"),
+		20543,
+		netip.MustParseAddr("175.4.62.127"),
+		443,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pid != 2222 {
+		t.Fatalf("pid = %d, want 2222", pid)
+	}
+}
+
+func TestTransportTableSearcherAllowsUnspecifiedUDPAddress(t *testing.T) {
+	table := transportTable(udp4Row([4]byte{0, 0, 0, 0}, 49330, 1234))
+
+	pid, err := newSearcher(Network_UDP, AddressFamilyIPv4).Search(
+		table,
+		netip.MustParseAddr("172.18.0.1"),
+		49330,
+		netip.Addr{},
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pid != 1234 {
+		t.Fatalf("pid = %d, want 1234", pid)
+	}
+}
+
+func transportTable(rows ...[]byte) []byte {
+	size := 4
+	for _, row := range rows {
+		size += len(row)
+	}
+	table := make([]byte, size)
+	binary.LittleEndian.PutUint32(table[:4], uint32(len(rows)))
+	offset := 4
+	for _, row := range rows {
+		copy(table[offset:], row)
+		offset += len(row)
+	}
+	return table
+}
+
+func tcp4Row(state uint32, localIP [4]byte, localPort uint16, remoteIP [4]byte, remotePort uint16, pid uint32) []byte {
+	row := make([]byte, 24)
+	binary.LittleEndian.PutUint32(row[0:4], state)
+	copy(row[4:8], localIP[:])
+	binary.BigEndian.PutUint16(row[8:10], localPort)
+	copy(row[12:16], remoteIP[:])
+	binary.BigEndian.PutUint16(row[16:18], remotePort)
+	binary.LittleEndian.PutUint32(row[20:24], pid)
+	return row
+}
+
+func udp4Row(localIP [4]byte, localPort uint16, pid uint32) []byte {
+	row := make([]byte, 12)
+	copy(row[0:4], localIP[:])
+	binary.BigEndian.PutUint16(row[4:6], localPort)
+	binary.LittleEndian.PutUint32(row[8:12], pid)
+	return row
+}

--- a/common/net/find_process_windows.go
+++ b/common/net/find_process_windows.go
@@ -108,7 +108,16 @@ func FindProcess(network, srcIP string, srcPort uint16, destIP string, destPort 
 	}
 	s := newSearcher(networkType, familyType)
 
-	pid, err := s.Search(buf, addr, uint16(port))
+	var destAddr netip.Addr
+	if destIP != "" {
+		if ip := net.ParseIP(destIP); ip != nil {
+			if addr, ok := netip.AddrFromSlice(ip); ok {
+				destAddr = addr.Unmap()
+			}
+		}
+	}
+
+	pid, err := s.Search(buf, addr, uint16(port), destAddr, destPort)
 	if err != nil {
 		return 0, "", "", err
 	}
@@ -120,86 +129,6 @@ func FindProcess(network, srcIP string, srcPort uint16, destIP string, destPort 
 	procName := nameSplit[len(nameSplit)-1]
 	procName = strings.TrimSuffix(procName, ".exe")
 	return int(pid), procName, NameWithPath, err
-}
-
-type searcher struct {
-	itemSize int
-	port     int
-	ip       int
-	ipSize   int
-	pid      int
-	tcpState int
-}
-
-func (s *searcher) Search(b []byte, ip netip.Addr, port uint16) (uint32, error) {
-	n := int(readNativeUint32(b[:4]))
-	itemSize := s.itemSize
-	for i := range n {
-		row := b[4+itemSize*i : 4+itemSize*(i+1)]
-
-		if s.tcpState >= 0 {
-			tcpState := readNativeUint32(row[s.tcpState : s.tcpState+4])
-			// MIB_TCP_STATE_ESTAB, only check established connections for TCP
-			if tcpState != 5 {
-				continue
-			}
-		}
-
-		// according to MSDN, only the lower 16 bits of dwLocalPort are used and the port number is in network endian.
-		// this field can be illustrated as follows depends on different machine endianess:
-		//     little endian: [ MSB LSB  0   0  ]   interpret as native uint32 is ((LSB<<8)|MSB)
-		//       big  endian: [  0   0  MSB LSB ]   interpret as native uint32 is ((MSB<<8)|LSB)
-		// so we need an syscall.Ntohs on the lower 16 bits after read the port as native uint32
-		srcPort := syscall.Ntohs(uint16(readNativeUint32(row[s.port : s.port+4])))
-		if srcPort != port {
-			continue
-		}
-
-		srcIP, _ := netip.AddrFromSlice(row[s.ip : s.ip+s.ipSize])
-		srcIP = srcIP.Unmap()
-		// windows binds an unbound udp socket to 0.0.0.0/[::] while first sendto
-		if ip != srcIP && (!srcIP.IsUnspecified() || s.tcpState != -1) {
-			continue
-		}
-
-		pid := readNativeUint32(row[s.pid : s.pid+4])
-		return pid, nil
-	}
-	return 0, errors.New("not found")
-}
-
-func newSearcher(network Network, family AddressFamily) *searcher {
-	var itemSize, port, ip, ipSize, pid int
-	tcpState := -1
-	switch network {
-	case Network_TCP:
-		if family == AddressFamilyIPv4 {
-			// struct MIB_TCPROW_OWNER_PID
-			itemSize, port, ip, ipSize, pid, tcpState = 24, 8, 4, 4, 20, 0
-		}
-		if family == AddressFamilyIPv6 {
-			// struct MIB_TCP6ROW_OWNER_PID
-			itemSize, port, ip, ipSize, pid, tcpState = 56, 20, 0, 16, 52, 48
-		}
-	case Network_UDP:
-		if family == AddressFamilyIPv4 {
-			// struct MIB_UDPROW_OWNER_PID
-			itemSize, port, ip, ipSize, pid = 12, 4, 0, 4, 8
-		}
-		if family == AddressFamilyIPv6 {
-			// struct MIB_UDP6ROW_OWNER_PID
-			itemSize, port, ip, ipSize, pid = 28, 20, 0, 16, 24
-		}
-	}
-
-	return &searcher{
-		itemSize: itemSize,
-		port:     port,
-		ip:       ip,
-		ipSize:   ipSize,
-		pid:      pid,
-		tcpState: tcpState,
-	}
 }
 
 func getTransportTable(fn uintptr, family int, class int) ([]byte, error) {
@@ -216,10 +145,6 @@ func getTransportTable(fn uintptr, family int, class int) ([]byte, error) {
 			return nil, errors.New("syscall error: ", int(err))
 		}
 	}
-}
-
-func readNativeUint32(b []byte) uint32 {
-	return *(*uint32)(unsafe.Pointer(&b[0]))
 }
 
 func getExecPathFromPID(pid uint32) (string, error) {


### PR DESCRIPTION
https://github.com/XTLS/Xray-core/issues/6535
为了解决这个问题(该问题无需代理服务器), 里面说了, 和"高权限" 无关,而是TCP_TIME_WAIT(Fin_Wait1)或TCP_CLOSE(FIn_Wait2,是不是2,1之类的取决于你的教科书年代)阶段查进程误报common/net: not found.(这次79 条 TUN 处理记录,not found 计数0,并非掩耳盗铃如果全表扫完没找到也会返回 errors.New("not found"))

之前的"SYN_SENT阶段"写错了. 但不影响. @Fangliding 

所以现在不再只把ESTABLISHED记为有效结果.

新增tcp远端匹配,允许UDP 0.0.0.0/[::]匹配本机内网地址.(allowAnyIP为true)

有单元测试(三个测试用例). 全仓测试时 只有app/router因为缺geoip报错,一切正常.

移除了旧的searcher和readNativeUint32. tcpState去除 被改成remotePort/remoteIP/remoteSize.

有空介绍下newSearcher这个工厂函数.
