### PR TITLE
Add WinDivert support for scenarios exceeding standard filtering capabilities.

### DIFF
--- a/app/router/condition.go
+++ b/app/router/condition.go
@@ -297,6 +297,8 @@ type ProcessNameMatcher struct {
 }
 
 func NewProcessNameMatcher(names []string) *ProcessNameMatcher {
+	net.EnableProcessAttribution()
+
 	processNames := []string{}
 	folders := []string{}
 	absPaths := []string{}

--- a/common/net/find_process_table.go
+++ b/common/net/find_process_table.go
@@ -1,0 +1,103 @@
+package net
+
+import (
+	"encoding/binary"
+	"net/netip"
+
+	"github.com/xtls/xray-core/common/errors"
+)
+
+type searcher struct {
+	itemSize   int
+	port       int
+	ip         int
+	ipSize     int
+	remotePort int
+	remoteIP   int
+	remoteSize int
+	pid        int
+	allowAnyIP bool
+}
+
+func (s *searcher) Search(b []byte, ip netip.Addr, port uint16, remoteIP netip.Addr, remotePort uint16) (uint32, error) {
+	n := int(readNativeUint32(b[:4]))
+	itemSize := s.itemSize
+	matchRemote := s.remoteIP >= 0 && remoteIP.IsValid() && remotePort != 0
+
+	for i := range n {
+		row := b[4+itemSize*i : 4+itemSize*(i+1)]
+
+		srcPort := readNetworkPort(row[s.port : s.port+4])
+		if srcPort != port {
+			continue
+		}
+
+		srcIP, _ := netip.AddrFromSlice(row[s.ip : s.ip+s.ipSize])
+		srcIP = srcIP.Unmap()
+		// Windows binds an unbound UDP socket to 0.0.0.0/[::] while first sendto.
+		if ip != srcIP && (!srcIP.IsUnspecified() || !s.allowAnyIP) {
+			continue
+		}
+
+		if matchRemote {
+			rowRemoteIP, _ := netip.AddrFromSlice(row[s.remoteIP : s.remoteIP+s.remoteSize])
+			rowRemoteIP = rowRemoteIP.Unmap()
+			rowRemotePort := readNetworkPort(row[s.remotePort : s.remotePort+4])
+			if remoteIP != rowRemoteIP || remotePort != rowRemotePort {
+				continue
+			}
+		}
+
+		pid := readNativeUint32(row[s.pid : s.pid+4])
+		return pid, nil
+	}
+	return 0, errors.New("not found")
+}
+
+func newSearcher(network Network, family AddressFamily) *searcher {
+	var itemSize, port, ip, ipSize, remotePort, remoteIP, remoteSize, pid int
+	allowAnyIP := false
+	remotePort, remoteIP, remoteSize = -1, -1, 0
+
+	switch network {
+	case Network_TCP:
+		if family == AddressFamilyIPv4 {
+			// struct MIB_TCPROW_OWNER_PID
+			itemSize, port, ip, ipSize, remotePort, remoteIP, remoteSize, pid = 24, 8, 4, 4, 16, 12, 4, 20
+		}
+		if family == AddressFamilyIPv6 {
+			// struct MIB_TCP6ROW_OWNER_PID
+			itemSize, port, ip, ipSize, remotePort, remoteIP, remoteSize, pid = 56, 20, 0, 16, 44, 24, 16, 52
+		}
+	case Network_UDP:
+		allowAnyIP = true
+		if family == AddressFamilyIPv4 {
+			// struct MIB_UDPROW_OWNER_PID
+			itemSize, port, ip, ipSize, pid = 12, 4, 0, 4, 8
+		}
+		if family == AddressFamilyIPv6 {
+			// struct MIB_UDP6ROW_OWNER_PID
+			itemSize, port, ip, ipSize, pid = 28, 20, 0, 16, 24
+		}
+	}
+
+	return &searcher{
+		itemSize:   itemSize,
+		port:       port,
+		ip:         ip,
+		ipSize:     ipSize,
+		remotePort: remotePort,
+		remoteIP:   remoteIP,
+		remoteSize: remoteSize,
+		pid:        pid,
+		allowAnyIP: allowAnyIP,
+	}
+}
+
+func readNetworkPort(b []byte) uint16 {
+	return binary.BigEndian.Uint16(b[:2])
+}
+
+func readNativeUint32(b []byte) uint32 {
+	return binary.LittleEndian.Uint32(b)
+}

--- a/common/net/find_process_table_test.go
+++ b/common/net/find_process_table_test.go
@@ -1,0 +1,100 @@
+package net
+
+import (
+	"encoding/binary"
+	"net/netip"
+	"testing"
+)
+
+func TestTransportTableSearcherFindsSynSentTCPRow(t *testing.T) {
+	table := transportTable(
+		tcp4Row(3, [4]byte{172, 18, 0, 1}, 20543, [4]byte{175, 4, 62, 127}, 443, 8480),
+	)
+
+	pid, err := newSearcher(Network_TCP, AddressFamilyIPv4).Search(
+		table,
+		netip.MustParseAddr("172.18.0.1"),
+		20543,
+		netip.MustParseAddr("175.4.62.127"),
+		443,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pid != 8480 {
+		t.Fatalf("pid = %d, want 8480", pid)
+	}
+}
+
+func TestTransportTableSearcherMatchesTCPRemoteEndpoint(t *testing.T) {
+	table := transportTable(
+		tcp4Row(5, [4]byte{172, 18, 0, 1}, 20543, [4]byte{203, 0, 113, 1}, 443, 1111),
+		tcp4Row(3, [4]byte{172, 18, 0, 1}, 20543, [4]byte{175, 4, 62, 127}, 443, 2222),
+	)
+
+	pid, err := newSearcher(Network_TCP, AddressFamilyIPv4).Search(
+		table,
+		netip.MustParseAddr("172.18.0.1"),
+		20543,
+		netip.MustParseAddr("175.4.62.127"),
+		443,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pid != 2222 {
+		t.Fatalf("pid = %d, want 2222", pid)
+	}
+}
+
+func TestTransportTableSearcherAllowsUnspecifiedUDPAddress(t *testing.T) {
+	table := transportTable(udp4Row([4]byte{0, 0, 0, 0}, 49330, 1234))
+
+	pid, err := newSearcher(Network_UDP, AddressFamilyIPv4).Search(
+		table,
+		netip.MustParseAddr("172.18.0.1"),
+		49330,
+		netip.Addr{},
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pid != 1234 {
+		t.Fatalf("pid = %d, want 1234", pid)
+	}
+}
+
+func transportTable(rows ...[]byte) []byte {
+	size := 4
+	for _, row := range rows {
+		size += len(row)
+	}
+	table := make([]byte, size)
+	binary.LittleEndian.PutUint32(table[:4], uint32(len(rows)))
+	offset := 4
+	for _, row := range rows {
+		copy(table[offset:], row)
+		offset += len(row)
+	}
+	return table
+}
+
+func tcp4Row(state uint32, localIP [4]byte, localPort uint16, remoteIP [4]byte, remotePort uint16, pid uint32) []byte {
+	row := make([]byte, 24)
+	binary.LittleEndian.PutUint32(row[0:4], state)
+	copy(row[4:8], localIP[:])
+	binary.BigEndian.PutUint16(row[8:10], localPort)
+	copy(row[12:16], remoteIP[:])
+	binary.BigEndian.PutUint16(row[16:18], remotePort)
+	binary.LittleEndian.PutUint32(row[20:24], pid)
+	return row
+}
+
+func udp4Row(localIP [4]byte, localPort uint16, pid uint32) []byte {
+	row := make([]byte, 12)
+	copy(row[0:4], localIP[:])
+	binary.BigEndian.PutUint16(row[4:6], localPort)
+	binary.LittleEndian.PutUint32(row[8:12], pid)
+	return row
+}

--- a/common/net/find_process_windows.go
+++ b/common/net/find_process_windows.go
@@ -108,7 +108,16 @@ func FindProcess(network, srcIP string, srcPort uint16, destIP string, destPort 
 	}
 	s := newSearcher(networkType, familyType)
 
-	pid, err := s.Search(buf, addr, uint16(port))
+	var destAddr netip.Addr
+	if destIP != "" {
+		if ip := net.ParseIP(destIP); ip != nil {
+			if addr, ok := netip.AddrFromSlice(ip); ok {
+				destAddr = addr.Unmap()
+			}
+		}
+	}
+
+	pid, err := s.Search(buf, addr, uint16(port), destAddr, destPort)
 	if err != nil {
 		return 0, "", "", err
 	}
@@ -120,86 +129,6 @@ func FindProcess(network, srcIP string, srcPort uint16, destIP string, destPort 
 	procName := nameSplit[len(nameSplit)-1]
 	procName = strings.TrimSuffix(procName, ".exe")
 	return int(pid), procName, NameWithPath, err
-}
-
-type searcher struct {
-	itemSize int
-	port     int
-	ip       int
-	ipSize   int
-	pid      int
-	tcpState int
-}
-
-func (s *searcher) Search(b []byte, ip netip.Addr, port uint16) (uint32, error) {
-	n := int(readNativeUint32(b[:4]))
-	itemSize := s.itemSize
-	for i := range n {
-		row := b[4+itemSize*i : 4+itemSize*(i+1)]
-
-		if s.tcpState >= 0 {
-			tcpState := readNativeUint32(row[s.tcpState : s.tcpState+4])
-			// MIB_TCP_STATE_ESTAB, only check established connections for TCP
-			if tcpState != 5 {
-				continue
-			}
-		}
-
-		// according to MSDN, only the lower 16 bits of dwLocalPort are used and the port number is in network endian.
-		// this field can be illustrated as follows depends on different machine endianess:
-		//     little endian: [ MSB LSB  0   0  ]   interpret as native uint32 is ((LSB<<8)|MSB)
-		//       big  endian: [  0   0  MSB LSB ]   interpret as native uint32 is ((MSB<<8)|LSB)
-		// so we need an syscall.Ntohs on the lower 16 bits after read the port as native uint32
-		srcPort := syscall.Ntohs(uint16(readNativeUint32(row[s.port : s.port+4])))
-		if srcPort != port {
-			continue
-		}
-
-		srcIP, _ := netip.AddrFromSlice(row[s.ip : s.ip+s.ipSize])
-		srcIP = srcIP.Unmap()
-		// windows binds an unbound udp socket to 0.0.0.0/[::] while first sendto
-		if ip != srcIP && (!srcIP.IsUnspecified() || s.tcpState != -1) {
-			continue
-		}
-
-		pid := readNativeUint32(row[s.pid : s.pid+4])
-		return pid, nil
-	}
-	return 0, errors.New("not found")
-}
-
-func newSearcher(network Network, family AddressFamily) *searcher {
-	var itemSize, port, ip, ipSize, pid int
-	tcpState := -1
-	switch network {
-	case Network_TCP:
-		if family == AddressFamilyIPv4 {
-			// struct MIB_TCPROW_OWNER_PID
-			itemSize, port, ip, ipSize, pid, tcpState = 24, 8, 4, 4, 20, 0
-		}
-		if family == AddressFamilyIPv6 {
-			// struct MIB_TCP6ROW_OWNER_PID
-			itemSize, port, ip, ipSize, pid, tcpState = 56, 20, 0, 16, 52, 48
-		}
-	case Network_UDP:
-		if family == AddressFamilyIPv4 {
-			// struct MIB_UDPROW_OWNER_PID
-			itemSize, port, ip, ipSize, pid = 12, 4, 0, 4, 8
-		}
-		if family == AddressFamilyIPv6 {
-			// struct MIB_UDP6ROW_OWNER_PID
-			itemSize, port, ip, ipSize, pid = 28, 20, 0, 16, 24
-		}
-	}
-
-	return &searcher{
-		itemSize: itemSize,
-		port:     port,
-		ip:       ip,
-		ipSize:   ipSize,
-		pid:      pid,
-		tcpState: tcpState,
-	}
 }
 
 func getTransportTable(fn uintptr, family int, class int) ([]byte, error) {
@@ -216,10 +145,6 @@ func getTransportTable(fn uintptr, family int, class int) ([]byte, error) {
 			return nil, errors.New("syscall error: ", int(err))
 		}
 	}
-}
-
-func readNativeUint32(b []byte) uint32 {
-	return *(*uint32)(unsafe.Pointer(&b[0]))
 }
 
 func getExecPathFromPID(pid uint32) (string, error) {

--- a/common/net/find_process_windows.go
+++ b/common/net/find_process_windows.go
@@ -67,6 +67,9 @@ func FindProcess(network, srcIP string, srcPort uint16, destIP string, destPort 
 	if network != "tcp" && network != "udp" {
 		panic("Unsupported network type for process lookup.")
 	}
+	if pid, name, absolutePath, found := lookupProcessAttribution(network, srcIP, srcPort, destIP, destPort); found {
+		return pid, name, absolutePath, nil
+	}
 	var class int
 	var fn uintptr
 	switch network {
@@ -119,6 +122,9 @@ func FindProcess(network, srcIP string, srcPort uint16, destIP string, destPort 
 
 	pid, err := s.Search(buf, addr, uint16(port), destAddr, destPort)
 	if err != nil {
+		if pid, name, absolutePath, found := waitProcessAttribution(network, srcIP, srcPort, destIP, destPort); found {
+			return pid, name, absolutePath, nil
+		}
 		return 0, "", "", err
 	}
 	NameWithPath, err := getExecPathFromPID(pid)
@@ -128,6 +134,7 @@ func FindProcess(network, srcIP string, srcPort uint16, destIP string, destPort 
 	nameSplit := strings.Split(NameWithPath, "/")
 	procName := nameSplit[len(nameSplit)-1]
 	procName = strings.TrimSuffix(procName, ".exe")
+	storeProcessAttribution(network, srcIP, srcPort, destIP, destPort, int(pid), procName, NameWithPath)
 	return int(pid), procName, NameWithPath, err
 }
 

--- a/common/net/process_attribution.go
+++ b/common/net/process_attribution.go
@@ -1,0 +1,119 @@
+package net
+
+import (
+	"net/netip"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const processAttributionTTL = 10 * time.Second
+
+type processAttributionKey struct {
+	network  string
+	srcIP    string
+	srcPort  uint16
+	destIP   string
+	destPort uint16
+}
+
+type processAttributionEntry struct {
+	pid          int
+	name         string
+	absolutePath string
+	expires      time.Time
+}
+
+var (
+	processAttributionCache  sync.Map
+	processAttributionSweep  atomic.Int64
+	processAttributionActive atomic.Bool
+)
+
+func EnableProcessAttribution() {
+	startProcessAttribution()
+}
+
+func lookupProcessAttribution(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (int, string, string, bool) {
+	key := processAttributionKey{
+		network:  network,
+		srcIP:    canonicalProcessAttributionIP(srcIP),
+		srcPort:  srcPort,
+		destIP:   canonicalProcessAttributionIP(destIP),
+		destPort: destPort,
+	}
+	value, found := processAttributionCache.Load(key)
+	if !found {
+		return 0, "", "", false
+	}
+
+	entry := value.(processAttributionEntry)
+	if time.Now().After(entry.expires) {
+		processAttributionCache.Delete(key)
+		return 0, "", "", false
+	}
+	return entry.pid, entry.name, entry.absolutePath, true
+}
+
+func waitProcessAttribution(network, srcIP string, srcPort uint16, destIP string, destPort uint16) (int, string, string, bool) {
+	if !processAttributionActive.Load() {
+		return 0, "", "", false
+	}
+
+	deadline := time.Now().Add(50 * time.Millisecond)
+	for {
+		if pid, name, absolutePath, found := lookupProcessAttribution(network, srcIP, srcPort, destIP, destPort); found {
+			return pid, name, absolutePath, true
+		}
+		if time.Now().After(deadline) {
+			return 0, "", "", false
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func setProcessAttributionActive() {
+	processAttributionActive.Store(true)
+}
+
+func storeProcessAttribution(network, srcIP string, srcPort uint16, destIP string, destPort uint16, pid int, name string, absolutePath string) {
+	now := time.Now()
+	processAttributionCache.Store(processAttributionKey{
+		network:  network,
+		srcIP:    canonicalProcessAttributionIP(srcIP),
+		srcPort:  srcPort,
+		destIP:   canonicalProcessAttributionIP(destIP),
+		destPort: destPort,
+	}, processAttributionEntry{
+		pid:          pid,
+		name:         name,
+		absolutePath: absolutePath,
+		expires:      now.Add(processAttributionTTL),
+	})
+
+	lastSweep := processAttributionSweep.Load()
+	if now.Unix()-lastSweep < int64(processAttributionTTL.Seconds()) {
+		return
+	}
+	if !processAttributionSweep.CompareAndSwap(lastSweep, now.Unix()) {
+		return
+	}
+	processAttributionCache.Range(func(key, value interface{}) bool {
+		entry := value.(processAttributionEntry)
+		if now.After(entry.expires) {
+			processAttributionCache.Delete(key)
+		}
+		return true
+	})
+}
+
+func canonicalProcessAttributionIP(ip string) string {
+	if ip == "" {
+		return ""
+	}
+	addr, err := netip.ParseAddr(ip)
+	if err != nil {
+		return ip
+	}
+	return addr.Unmap().String()
+}

--- a/common/net/process_attribution_others.go
+++ b/common/net/process_attribution_others.go
@@ -1,0 +1,6 @@
+//go:build !windows
+
+package net
+
+func startProcessAttribution() {
+}

--- a/common/net/process_attribution_test.go
+++ b/common/net/process_attribution_test.go
@@ -1,0 +1,28 @@
+package net
+
+import "testing"
+
+func TestProcessAttributionUsesDestination(t *testing.T) {
+	storeProcessAttribution("udp", "192.0.2.1", 43210, "198.51.100.1", 53, 1234, "proc", "/tmp/proc")
+
+	pid, name, path, found := lookupProcessAttribution("udp", "192.0.2.1", 43210, "198.51.100.1", 53)
+	if !found {
+		t.Fatal("process attribution entry not found")
+	}
+	if pid != 1234 || name != "proc" || path != "/tmp/proc" {
+		t.Fatalf("attribution entry = (%d, %q, %q), want (1234, \"proc\", \"/tmp/proc\")", pid, name, path)
+	}
+
+	if _, _, _, found := lookupProcessAttribution("udp", "192.0.2.1", 43210, "203.0.113.1", 53); found {
+		t.Fatal("process attribution matched a different destination")
+	}
+}
+
+func TestProcessAttributionCanonicalizesIP(t *testing.T) {
+	storeProcessAttribution("tcp", "::ffff:192.0.2.2", 44321, "::ffff:198.51.100.2", 443, 5678, "proc2", "/tmp/proc2")
+
+	_, _, _, found := lookupProcessAttribution("tcp", "192.0.2.2", 44321, "198.51.100.2", 443)
+	if !found {
+		t.Fatal("process attribution did not canonicalize IPv4-mapped addresses")
+	}
+}

--- a/common/net/process_attribution_windows.go
+++ b/common/net/process_attribution_windows.go
@@ -1,0 +1,214 @@
+//go:build windows
+
+package net
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/xtls/xray-core/common/errors"
+)
+
+const (
+	windivertLayerFlow = 2
+
+	windivertEventFlowEstablished = 1
+
+	windivertFlagSniff    = 0x0001
+	windivertFlagRecvOnly = 0x0004
+
+	windivertProtocolTCP = 6
+	windivertProtocolUDP = 17
+)
+
+var processAttributionOnce sync.Once
+
+type windivertAddress struct {
+	Timestamp int64
+	Flags     uint32
+	Reserved2 uint32
+	Flow      windivertDataFlow
+}
+
+type windivertDataFlow struct {
+	EndpointID       uint64
+	ParentEndpointID uint64
+	ProcessID        uint32
+	LocalAddr        [4]uint32
+	RemoteAddr       [4]uint32
+	LocalPort        uint16
+	RemotePort       uint16
+	Protocol         uint8
+	_                [7]byte
+}
+
+var (
+	_ [80 - unsafe.Sizeof(windivertAddress{})]byte
+	_ [unsafe.Sizeof(windivertAddress{}) - 80]byte
+	_ [64 - unsafe.Sizeof(windivertDataFlow{})]byte
+	_ [unsafe.Sizeof(windivertDataFlow{}) - 64]byte
+)
+
+type windivertFlowAttributor struct {
+	handle     windows.Handle
+	dll        *windows.DLL
+	recv       *windows.Proc
+	formatIPv6 *windows.Proc
+}
+
+func startProcessAttribution() {
+	processAttributionOnce.Do(func() {
+		attributor, err := newWinDivertFlowAttributor()
+		if err != nil {
+			errors.LogDebugInner(context.Background(), err, "WinDivert process attribution unavailable")
+			return
+		}
+		go attributor.run()
+	})
+}
+
+func newWinDivertFlowAttributor() (*windivertFlowAttributor, error) {
+	dll, err := windows.LoadDLL("WinDivert.dll")
+	if err != nil {
+		return nil, err
+	}
+
+	open, err := dll.FindProc("WinDivertOpen")
+	if err != nil {
+		return nil, err
+	}
+	recv, err := dll.FindProc("WinDivertRecv")
+	if err != nil {
+		return nil, err
+	}
+	formatIPv6, err := dll.FindProc("WinDivertHelperFormatIPv6Address")
+	if err != nil {
+		return nil, err
+	}
+
+	filter, err := windows.BytePtrFromString("true")
+	if err != nil {
+		return nil, err
+	}
+
+	handle, err := windivertOpen(open, filter, windivertFlagSniff|windivertFlagRecvOnly)
+	if err != nil {
+		handle, err = windivertOpen(open, filter, windivertFlagRecvOnly)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	setProcessAttributionActive()
+	return &windivertFlowAttributor{
+		handle:     handle,
+		dll:        dll,
+		recv:       recv,
+		formatIPv6: formatIPv6,
+	}, nil
+}
+
+func windivertOpen(open *windows.Proc, filter *byte, flags uint64) (windows.Handle, error) {
+	r0, _, e1 := open.Call(
+		uintptr(unsafe.Pointer(filter)),
+		uintptr(windivertLayerFlow),
+		0,
+		uintptr(flags),
+	)
+	handle := windows.Handle(r0)
+	if handle == 0 || handle == windows.InvalidHandle {
+		if e1 != windows.ERROR_SUCCESS {
+			return 0, e1
+		}
+		return 0, windows.ERROR_INVALID_HANDLE
+	}
+	return handle, nil
+}
+
+func (a *windivertFlowAttributor) run() {
+	for {
+		var addr windivertAddress
+		r0, _, e1 := a.recv.Call(
+			uintptr(a.handle),
+			0,
+			0,
+			0,
+			uintptr(unsafe.Pointer(&addr)),
+		)
+		if r0 == 0 {
+			if e1 != windows.ERROR_SUCCESS {
+				errors.LogDebugInner(context.Background(), e1, "WinDivert process attribution stopped")
+			}
+			return
+		}
+		a.handleFlow(addr)
+	}
+}
+
+func (a *windivertFlowAttributor) handleFlow(addr windivertAddress) {
+	if windivertEvent(addr.Flags) != windivertEventFlowEstablished || addr.Flow.ProcessID == 0 {
+		return
+	}
+
+	network := ""
+	switch addr.Flow.Protocol {
+	case windivertProtocolTCP:
+		network = "tcp"
+	case windivertProtocolUDP:
+		network = "udp"
+	default:
+		return
+	}
+
+	localIP, ok := a.formatAddr(addr.Flow.LocalAddr)
+	if !ok {
+		return
+	}
+	remoteIP, ok := a.formatAddr(addr.Flow.RemoteAddr)
+	if !ok {
+		return
+	}
+
+	pid, name, absolutePath, ok := processIdentityFromPID(addr.Flow.ProcessID)
+	if !ok {
+		return
+	}
+
+	storeProcessAttribution(network, localIP, addr.Flow.LocalPort, remoteIP, addr.Flow.RemotePort, pid, name, absolutePath)
+}
+
+func windivertEvent(flags uint32) uint8 {
+	return uint8((flags >> 8) & 0xff)
+}
+
+func (a *windivertFlowAttributor) formatAddr(raw [4]uint32) (string, bool) {
+	var buf [64]byte
+	r0, _, _ := a.formatIPv6.Call(
+		uintptr(unsafe.Pointer(&raw[0])),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(len(buf)),
+	)
+	if r0 == 0 {
+		return "", false
+	}
+	addr := windows.BytePtrToString(&buf[0])
+	return canonicalProcessAttributionIP(addr), true
+}
+
+func processIdentityFromPID(pid uint32) (int, string, string, bool) {
+	absolutePath, err := getExecPathFromPID(pid)
+	if err != nil {
+		return 0, "", "", false
+	}
+	absolutePath = filepath.ToSlash(absolutePath)
+
+	nameSplit := strings.Split(absolutePath, "/")
+	name := nameSplit[len(nameSplit)-1]
+	name = strings.TrimSuffix(name, ".exe")
+	return int(pid), name, absolutePath, true
+}


### PR DESCRIPTION
https://github.com/XTLS/Xray-core/issues/6535
https://github.com/XTLS/Xray-core/pull/6587
https://github.com/XTLS/Xray-core/issues/6588
前置(指的是在当前内容之前必须看过的)段落,按照时间顺序.否则你也许会问"UDP也有流?"等奇怪问题.

补充: 流建立是WINDIVERT_EVENT_FLOW_ESTABLISHED,流删除(UDP连接结束)是WINDIVERT_EVENT_FLOW_DELETED 
每个事件都有一个Flow结构体,Flow结构体里有ProcessID,但是因为Flow层是Sniff-Only的.所以需要建一个短ttl的cache
FindProcess函数应该先查cache,再走原来的逻辑,而当DLL/SYS文件缺失时也要走原来的逻辑.(即查询udp/tcp table的r3 api)

需要注意的是不仅仅是误报的问题还会导致断网,比如我当时看逗比的雀巢谈B站真相时,错误1066了,只能读评论. 

为什么被关闭是因为我把tcp_state 6,7说成了SYN_SENT,但SYN_SENT不是其中的情况,因为已经到了嗅探数据的那一层.风扇滑翔翼认为我没确认问题.

但问题已解决了一半.所以另一半 https://github.com/XTLS/Xray-core/commit/44059de6c881e6e790cd17d901e3c2b5842f0a90 也来了. 描述如上.