### PR TITLE
XHTTP: close idle HTTP/1.1 upload connections

### DIFF
--- a/transport/internet/splithttp/client.go
+++ b/transport/internet/splithttp/client.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptrace"
-	"sync"
 
 	"github.com/apernet/quic-go/http3"
 	"github.com/xtls/xray-core/common"
@@ -35,7 +34,7 @@ type DefaultDialerClient struct {
 	closed          bool
 	httpVersion     string
 	// pool of net.Conn, created using dialUploadConn
-	uploadRawPool  *sync.Pool
+	uploadRawPool  *h1UploadPool
 	dialUploadConn func(ctxInner context.Context) (net.Conn, error)
 }
 
@@ -127,33 +126,34 @@ func (c *DefaultDialerClient) PostPacket(ctx context.Context, url string, sessio
 		requestBuff.Grow(512 + int(req.ContentLength))
 		common.Must(req.Write(requestBuff))
 
-		var uploadConn any
 		var h1UploadConn *H1Conn
 
 		for {
-			uploadConn = c.uploadRawPool.Get()
-			newConnection := uploadConn == nil
+			h1UploadConn = c.uploadRawPool.Get()
+			newConnection := h1UploadConn == nil
 			if newConnection {
 				newConn, err := c.dialUploadConn(context.WithoutCancel(ctx))
 				if err != nil {
 					return err
 				}
 				h1UploadConn = NewH1Conn(newConn)
-				uploadConn = h1UploadConn
+				if !c.uploadRawPool.Add(h1UploadConn) {
+					return errors.New("HTTP/1.1 upload client is closed")
+				}
 			} else {
-				h1UploadConn = uploadConn.(*H1Conn)
-
 				// TODO: Replace 0 here with a config value later
 				// Or add some other condition for optimization purposes
 				if h1UploadConn.UnreadedResponsesCount > 0 {
 					resp, err := http.ReadResponse(h1UploadConn.RespBufReader, req)
 					if err != nil {
 						c.closed = true
+						c.uploadRawPool.Discard(h1UploadConn)
 						return fmt.Errorf("error while reading response: %s", err.Error())
 					}
 					io.Copy(io.Discard, resp.Body)
 					defer resp.Body.Close()
 					if resp.StatusCode != 200 {
+						c.uploadRawPool.Discard(h1UploadConn)
 						return fmt.Errorf("got non-200 error response code: %d", resp.StatusCode)
 					}
 				}
@@ -167,18 +167,22 @@ func (c *DefaultDialerClient) PostPacket(ctx context.Context, url string, sessio
 			if err == nil {
 				break
 			} else if newConnection {
+				c.uploadRawPool.Discard(h1UploadConn)
 				return err
+			} else {
+				c.uploadRawPool.Discard(h1UploadConn)
 			}
 		}
 
-		c.uploadRawPool.Put(uploadConn)
+		c.uploadRawPool.Release(h1UploadConn)
 	}
 
 	return nil
 }
 
-// HTTP/1.1 and HTTP/2 will close itself, we only handle HTTP/3 here
 func (c *DefaultDialerClient) Close() error {
+	c.uploadRawPool.Close()
+
 	transport := c.client.Transport
 	if h3Transport, ok := transport.(*http3.Transport); ok {
 		h3Transport.Close()

--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -309,7 +309,7 @@ func createHTTPClient(dest net.Destination, streamSettings *internet.MemoryStrea
 			Transport: transport,
 		},
 		httpVersion:    httpVersion,
-		uploadRawPool:  &sync.Pool{},
+		uploadRawPool:  newH1UploadPool(net.ConnIdleTimeout),
 		dialUploadConn: dialContext,
 	}
 

--- a/transport/internet/splithttp/h1_upload_pool.go
+++ b/transport/internet/splithttp/h1_upload_pool.go
@@ -1,0 +1,134 @@
+package splithttp
+
+import (
+	"sync"
+	"time"
+)
+
+// h1UploadPool owns HTTP/1.1 upload connections. sync.Pool is not suitable
+// here because it can discard values without closing their sockets.
+type h1UploadPool struct {
+	mu          sync.Mutex
+	idleTimeout time.Duration
+	conns       map[*H1Conn]*h1UploadPoolEntry
+	closed      bool
+}
+
+type h1UploadPoolEntry struct {
+	idle       bool
+	generation uint64
+	timer      *time.Timer
+}
+
+func newH1UploadPool(idleTimeout time.Duration) *h1UploadPool {
+	return &h1UploadPool{
+		idleTimeout: idleTimeout,
+		conns:       make(map[*H1Conn]*h1UploadPoolEntry),
+	}
+}
+
+func (p *h1UploadPool) Get() *H1Conn {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return nil
+	}
+
+	for conn, entry := range p.conns {
+		if !entry.idle {
+			continue
+		}
+		entry.idle = false
+		entry.generation++
+		entry.timer.Stop()
+		return conn
+	}
+
+	return nil
+}
+
+func (p *h1UploadPool) Add(conn *H1Conn) bool {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		conn.Close()
+		return false
+	}
+	p.conns[conn] = &h1UploadPoolEntry{}
+	p.mu.Unlock()
+	return true
+}
+
+func (p *h1UploadPool) Release(conn *H1Conn) {
+	p.mu.Lock()
+	entry, found := p.conns[conn]
+	if p.closed || !found {
+		p.mu.Unlock()
+		conn.Close()
+		return
+	}
+
+	if entry.timer != nil {
+		entry.timer.Stop()
+	}
+	entry.idle = true
+	entry.generation++
+	generation := entry.generation
+	entry.timer = time.AfterFunc(p.idleTimeout, func() {
+		p.closeIdle(conn, generation)
+	})
+	p.mu.Unlock()
+}
+
+func (p *h1UploadPool) Discard(conn *H1Conn) {
+	p.mu.Lock()
+	entry, found := p.conns[conn]
+	if found {
+		delete(p.conns, conn)
+		if entry.timer != nil {
+			entry.timer.Stop()
+		}
+	}
+	p.mu.Unlock()
+
+	conn.Close()
+}
+
+func (p *h1UploadPool) closeIdle(conn *H1Conn, generation uint64) {
+	p.mu.Lock()
+	entry, found := p.conns[conn]
+	if !found || !entry.idle || entry.generation != generation {
+		p.mu.Unlock()
+		return
+	}
+	delete(p.conns, conn)
+	p.mu.Unlock()
+
+	conn.Close()
+}
+
+func (p *h1UploadPool) Close() error {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil
+	}
+	p.closed = true
+
+	conns := make([]*H1Conn, 0, len(p.conns))
+	for conn, entry := range p.conns {
+		if entry.timer != nil {
+			entry.timer.Stop()
+		}
+		conns = append(conns, conn)
+	}
+	clear(p.conns)
+	p.mu.Unlock()
+
+	for _, conn := range conns {
+		conn.Close()
+	}
+
+	return nil
+}

--- a/transport/internet/splithttp/h1_upload_pool_test.go
+++ b/transport/internet/splithttp/h1_upload_pool_test.go
@@ -1,0 +1,112 @@
+package splithttp
+
+import (
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestH1UploadPoolClosesIdleConnection(t *testing.T) {
+	client, server := net.Pipe()
+	defer server.Close()
+
+	pool := newH1UploadPool(20 * time.Millisecond)
+	conn := NewH1Conn(client)
+	if !pool.Add(conn) {
+		t.Fatal("Add() rejected an open pool")
+	}
+	pool.Release(conn)
+	defer pool.Close()
+
+	server.SetReadDeadline(time.Now().Add(time.Second))
+	_, err := server.Read(make([]byte, 1))
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("idle connection was not closed: %v", err)
+	}
+}
+
+func TestH1UploadPoolGetCancelsIdleClose(t *testing.T) {
+	client, server := net.Pipe()
+	defer server.Close()
+
+	pool := newH1UploadPool(time.Hour)
+	conn := NewH1Conn(client)
+	if !pool.Add(conn) {
+		t.Fatal("Add() rejected an open pool")
+	}
+	pool.Release(conn)
+	pool.mu.Lock()
+	generation := pool.conns[conn].generation
+	pool.mu.Unlock()
+
+	conn = pool.Get()
+	if conn == nil {
+		t.Fatal("Get() returned no connection")
+	}
+	defer conn.Close()
+
+	pool.closeIdle(conn, generation)
+	readDone := make(chan error, 1)
+	go func() {
+		buffer := make([]byte, 1)
+		_, err := server.Read(buffer)
+		readDone <- err
+	}()
+
+	if _, err := conn.Write([]byte{1}); err != nil {
+		t.Fatalf("connection was closed while checked out: %v", err)
+	}
+	if err := <-readDone; err != nil {
+		t.Fatalf("failed to read checked-out connection: %v", err)
+	}
+}
+
+func TestDefaultDialerClientCloseClosesIdleConnections(t *testing.T) {
+	client, server := net.Pipe()
+	defer server.Close()
+
+	pool := newH1UploadPool(time.Hour)
+	conn := NewH1Conn(client)
+	if !pool.Add(conn) {
+		t.Fatal("Add() rejected an open pool")
+	}
+	pool.Release(conn)
+	clientUnderTest := &DefaultDialerClient{
+		client:        &http.Client{},
+		uploadRawPool: pool,
+	}
+	if err := clientUnderTest.Close(); err != nil {
+		t.Fatalf("Close() failed: %v", err)
+	}
+
+	server.SetReadDeadline(time.Now().Add(time.Second))
+	_, err := server.Read(make([]byte, 1))
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("idle connection was not closed: %v", err)
+	}
+}
+
+func TestH1UploadPoolCloseClosesCheckedOutConnections(t *testing.T) {
+	client, server := net.Pipe()
+	defer server.Close()
+
+	pool := newH1UploadPool(time.Hour)
+	conn := NewH1Conn(client)
+	if !pool.Add(conn) {
+		t.Fatal("Add() rejected an open pool")
+	}
+	if err := pool.Close(); err != nil {
+		t.Fatalf("Close() failed: %v", err)
+	}
+
+	server.SetReadDeadline(time.Now().Add(time.Second))
+	_, err := server.Read(make([]byte, 1))
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("checked-out connection was not closed: %v", err)
+	}
+
+	pool.Release(conn)
+}


### PR DESCRIPTION
Fixes #6560

HTTP/1.1 `packet-up` uses direct upload sockets outside the standard HTTP transports. Keeping those sockets in `sync.Pool` left no owner able to close them on idle expiry or XMUX retirement.

This adds an owned pool that:
- closes returned sockets after `net.ConnIdleTimeout`;
- closes all tracked sockets and cancels in-flight dials when the dialer client is retired;
- prevents stale idle timers from closing a connection after it has been checked out;
- closes discarded sockets after failed writes or invalid responses.

While exercising H1 reuse, this also makes the existing response accounting effective: each successful request records its pending response, and the next reuse consumes and validates it.

Tests:
- `go test ./transport/internet/splithttp`
- `go test -race ./transport/internet/splithttp -run 'Test(H1UploadPool|DefaultDialerClientClose|PostPacket)' -count=5