### PR TITLE
api: add `obs` command to retrieve observatory outbound status

### DIFF
--- a/main/commands/all/api/api.go
+++ b/main/commands/all/api/api.go
@@ -34,5 +34,6 @@ var CmdAPI = &base.Command{
 		cmdOnlineStats,
 		cmdOnlineStatsIpList,
 		cmdGetAllOnlineUsers,
+		cmdObservatoryStatus,
 	},
 }

--- a/main/commands/all/api/observatory_status.go
+++ b/main/commands/all/api/observatory_status.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"fmt"
+	"sort"
+
+	obsService "github.com/xtls/xray-core/app/observatory/command"
+	"github.com/xtls/xray-core/main/commands/base"
+)
+
+var cmdObservatoryStatus = &base.Command{
+	CustomFlags: true,
+	UsageLine:   "{{.Exec}} api obs [--server=127.0.0.1:8080]",
+	Short:       "Retrieve observatory outbound status",
+	Long: `
+Retrieve outbound status from observatory, including alive, delay and last error.
+
+> Ensure that "ObservatoryService" is enabled under "config.api.services" in the server configuration.
+
+Arguments:
+
+	-s, -server <server:port>
+		The API server address. Default 127.0.0.1:8080
+
+	-t, -timeout <seconds>
+		Timeout in seconds for calling API. Default 3
+
+Example:
+
+    {{.Exec}} {{.LongName}} --server=127.0.0.1:8080
+`,
+	Run: executeObservatoryStatus,
+}
+
+func executeObservatoryStatus(cmd *base.Command, args []string) {
+	setSharedFlags(cmd)
+	cmd.Flag.Parse(args)
+
+	conn, ctx, close := dialAPIServer()
+	defer close()
+	client := obsService.NewObservatoryServiceClient(conn)
+	resp, err := client.GetOutboundStatus(ctx, &obsService.GetOutboundStatusRequest{})
+	if err != nil {
+		base.Fatalf("failed to get observatory status: %s", err)
+	}
+
+	if apiJSON {
+		showJSONResponse(resp)
+		return
+	}
+
+	statuses := resp.GetStatus().GetStatus()
+	if len(statuses) == 0 {
+		fmt.Println("no outbound status available")
+		return
+	}
+
+	// Sort by outbound tag for stable output
+	sort.Slice(statuses, func(i, j int) bool {
+		return statuses[i].OutboundTag < statuses[j].OutboundTag
+	})
+
+	fmt.Printf("%-20s %-6s %-10s %s\n", "TAG", "ALIVE", "DELAY(ms)", "LAST_ERROR")
+	fmt.Println("---")
+
+	for _, s := range statuses {
+		alive := "no"
+		if s.Alive {
+			alive = "yes"
+		}
+		delay := "-"
+		if s.Alive && s.Delay > 0 {
+			delay = fmt.Sprintf("%d", s.Delay)
+		}
+		errReason := s.LastErrorReason
+		if len(errReason) > 60 {
+			errReason = errReason[:60] + "..."
+		}
+		fmt.Printf("%-20s %-6s %-10s %s\n", s.OutboundTag, alive, delay, errReason)
+	}
+}


### PR DESCRIPTION
## What

Add a new `xray api obs` CLI command that calls `ObservatoryService.GetOutboundStatus` and prints each outbound's `alive` / `delay(ms)` / `last_error` in a table. Supports the shared `-json` flag like other `api` subcommands.

## Why

The existing `xray api lso` only lists static outbound definitions (tag + protocol). It does **not** reflect the runtime health state observed by the observatory (alive/dead, latency, last error reason).

When outbounds are managed dynamically via `HandlerService.AddOutbound`/`RemoveOutbound` (e.g. balancer pools with rotating nodes), operators currently have no CLI way to inspect which outbounds the observatory considers alive and what their measured delay is. The only alternative is parsing the gRPC response manually or reading logs.

This command complements `lso` the same way `bi` (balancer info) complements routing inspection — it surfaces runtime observation state.

## How

New file `main/commands/all/api/observatory_status.go`:
- `cmdObservatoryStatus` registered as `api obs`
- Calls `obsService.NewObservatoryServiceClient(conn).GetOutboundStatus(ctx, &GetOutboundStatusRequest{})`
- Sorts results by `OutboundTag` for stable output
- Prints a `TAG / ALIVE / DELAY(ms) / LAST_ERROR` table (truncates error to 60 chars)
- `-json` flag delegates to the shared `showJSONResponse`

Style mirrors `balancer_info.go` (`bi`): `setSharedFlags` + `dialAPIServer` + `base.Fatalf` on error + `apiJSON` branch + table output, and the `Long` help notes that `ObservatoryService` must be enabled under `config.api.services` — same wording pattern as `bi`.

`main/commands/all/api/api.go`: append `cmdObservatoryStatus` to the `CmdAPI` subcommand list.

## Edge cases handled

- **ObservatoryService not enabled** → gRPC returns `Unimplemented`, `base.Fatalf` exits (same as `lso`/`bi` when their service is missing).
- **Observatory not configured / no probe completed yet** → `o.status` is nil → `resp.GetStatus().GetStatus()` returns nil → prints `no outbound status available`.
- **Proto nil chain** `resp.GetStatus().GetStatus()` is safe — proto getters return nil/zero for nil receivers.
- **burst observatory** → `burst.Observer.createResult()` builds fresh `OutboundStatus` under `hp.access.Lock()`; `LastErrorReason` is empty and `Delay` is the average — output renders normally.
- **Dead outbound delay** → `observer.go` sets `Delay = 99999999` (sentinel) on probe failure. The command shows `-` for dead outbounds instead of the sentinel value, by checking `s.Alive && s.Delay > 0`.
- **`sort.Slice`** operates on the post-gRPC-deserialization slice (fresh objects), no mutation of server-side state.

## Output example

```
$ xray api obs --server=127.0.0.1:45021
TAG                 ALIVE  DELAY(ms)  LAST_ERROR
---
proxy_0             yes    142        -
proxy_1             no     -          the outbound proxy_1 is dead: GET request...
proxy_2             yes    187        -
```

## Verification

- `gofmt -l` clean
- `go build ./main/commands/all/api/...` clean
- `go vet ./main/commands/all/api/...` clean
- Manually tested against a running Xray with 10 outbounds + observatory enabled: table renders correctly, alive/delay/error match log state, `-json` emits valid protobuf JSON.

## Scope

Single new command file + 1-line registration. No changes to existing commands, proto definitions, or runtime behavior.