### PR TITLE
README: add MoaV to One Click installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@
   - [Xray-REALITY](https://github.com/zxcvos/Xray-script), [xray-reality](https://github.com/sajjaddg/xray-reality), [reality-ezpz](https://github.com/aleskxyz/reality-ezpz)
   - [Xray_bash_onekey](https://github.com/hello-yunshu/Xray_bash_onekey), [XTool](https://github.com/LordPenguin666/XTool), [VPainLess](https://github.com/vpainless/vpainless)
   - [v2ray-agent](https://github.com/mack-a/v2ray-agent), [Xray_onekey](https://github.com/wulabing/Xray_onekey), [ProxySU](https://github.com/proxysu/ProxySU)
+  - [MoaV (Mother of all VPNs)](https://github.com/MotherofallVPNs/MoaV)
 - Magisk
   - [Magic_V2Ray](https://github.com/vincentng295/Magic_V2Ray)
   - [Xray_For_Magisk](https://github.com/E7KMbb/Xray_For_Magisk)


### PR DESCRIPTION
Adds [MoaV (Mother of all VPNs)](https://github.com/MotherofallVPNs/MoaV) to the **Installation → One Click** list.

MoaV is an open-source (MIT), one-line server installer that deploys a multi-protocol VPN stack with Xray-core at its core — VLESS, Reality, Trojan, VMess and more, alongside other fallback transports. It fits the same category as the other one-click deployers already listed.

Repo: https://github.com/MotherofallVPNs/MoaV