### PR TITLE
splithttp: close idle pooled HTTP/1.1 upload connections

### DIFF
--- a/transport/internet/splithttp/client.go
+++ b/transport/internet/splithttp/client.go
@@ -159,6 +159,9 @@ func (c *DefaultDialerClient) PostPacket(ctx context.Context, url string, sessio
 				}
 			}
 
+			// the connection is in use again, cancel a pending idle close
+			h1UploadConn.ResetIdle()
+
 			_, err := h1UploadConn.Write(requestBuff.Bytes())
 			// if the write failed, we try another connection from
 			// the pool, until the write on a new connection fails.
@@ -167,11 +170,17 @@ func (c *DefaultDialerClient) PostPacket(ctx context.Context, url string, sessio
 			if err == nil {
 				break
 			} else if newConnection {
+				common.Close(h1UploadConn)
 				return err
 			}
+
+			// the failed pooled connection is dropped; schedule a close
+			// so it does not linger until the GC collects it
+			h1UploadConn.SetIdle()
 		}
 
 		c.uploadRawPool.Put(uploadConn)
+		h1UploadConn.SetIdle()
 	}
 
 	return nil

--- a/transport/internet/splithttp/h1_conn.go
+++ b/transport/internet/splithttp/h1_conn.go
@@ -3,17 +3,61 @@ package splithttp
 import (
 	"bufio"
 	"net"
+	"sync"
+	"time"
+
+	xnet "github.com/xtls/xray-core/common/net"
 )
 
 type H1Conn struct {
 	UnreadedResponsesCount int
 	RespBufReader          *bufio.Reader
 	net.Conn
+
+	idleTimeout time.Duration
+	mu          sync.Mutex
+	idleTimer   *time.Timer
 }
 
 func NewH1Conn(conn net.Conn) *H1Conn {
 	return &H1Conn{
 		RespBufReader: bufio.NewReader(conn),
 		Conn:          conn,
+		idleTimeout:   xnet.ConnIdleTimeout,
 	}
+}
+
+// SetIdle starts (or restarts) the idle timer. When it fires, the
+// underlying connection is closed, bounding the lifetime of pooled
+// HTTP/1.1 upload connections that would otherwise stay open until
+// the GC collects the pool.
+func (h *H1Conn) SetIdle() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.idleTimeout <= 0 {
+		return
+	}
+	if h.idleTimer != nil {
+		h.idleTimer.Stop()
+	}
+	h.idleTimer = time.AfterFunc(h.idleTimeout, func() {
+		h.Conn.Close()
+	})
+}
+
+// ResetIdle cancels the idle timer, e.g. while the connection is back in use.
+func (h *H1Conn) ResetIdle() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.idleTimer != nil {
+		h.idleTimer.Stop()
+		h.idleTimer = nil
+	}
+}
+
+func (h *H1Conn) Close() error {
+	h.ResetIdle()
+	return h.Conn.Close()
 }

--- a/transport/internet/splithttp/h1_conn_test.go
+++ b/transport/internet/splithttp/h1_conn_test.go
@@ -1,0 +1,94 @@
+package splithttp
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// newPipeH1Conn creates an H1Conn over a real TCP pair and returns it
+// together with the server side of the connection.
+func newPipeH1Conn(t *testing.T) (*H1Conn, net.Conn) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverConn, err := ln.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		clientConn.Close()
+		serverConn.Close()
+	})
+
+	return NewH1Conn(clientConn), serverConn
+}
+
+func TestH1ConnIdleTimeoutClosesConn(t *testing.T) {
+	h1, server := newPipeH1Conn(t)
+
+	h1.idleTimeout = 50 * time.Millisecond
+	h1.SetIdle()
+
+	// the idle timer should close the underlying connection
+	server.SetReadDeadline(time.Now().Add(5 * time.Second))
+	buf := make([]byte, 1)
+	_, err := server.Read(buf)
+	if err == nil {
+		t.Fatal("expected the connection to be closed after the idle timeout")
+	}
+}
+
+func TestH1ConnResetIdleKeepsConnOpen(t *testing.T) {
+	h1, server := newPipeH1Conn(t)
+
+	h1.idleTimeout = 50 * time.Millisecond
+	h1.SetIdle()
+	time.Sleep(10 * time.Millisecond)
+	h1.ResetIdle()
+
+	// give the original timer time to fire; it must have been cancelled
+	time.Sleep(100 * time.Millisecond)
+
+	server.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	buf := make([]byte, 1)
+	_, err := server.Read(buf)
+	if err == nil {
+		t.Fatal("expected a timeout reading from a connection that is still open")
+	}
+	if netErr, ok := err.(net.Error); !ok || !netErr.Timeout() {
+		t.Fatalf("expected a read timeout, got: %v", err)
+	}
+}
+
+func TestH1ConnCloseStopsIdleTimer(t *testing.T) {
+	h1, server := newPipeH1Conn(t)
+
+	h1.idleTimeout = 50 * time.Millisecond
+	h1.SetIdle()
+	if err := h1.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// wait longer than the idle timeout; the timer must not panic or
+	// double-close after Close already ran
+	time.Sleep(100 * time.Millisecond)
+
+	server.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	buf := make([]byte, 1)
+	_, err := server.Read(buf)
+	if err != io.EOF {
+		t.Fatalf("expected EOF after Close, got: %v", err)
+	}
+}


### PR DESCRIPTION
## What

In `packet-up` mode with HTTP/1.1, `PostPacket` puts upload connections into a `sync.Pool` and reuses them across packets, but nothing ever closes them: no idle timeout, no size limit, no owner. A pooled connection therefore stays open until the GC collects the pool and the finalizer of the underlying `net.Conn` runs — visible as the client keeping more open sockets than expected (the issue reports exactly this). Every other connection cache in the same file has an idle bound (`IdleConnTimeout: net.ConnIdleTimeout` for the h2/h3 transports).

## Fix

- `H1Conn` gains an idle timer (default `net.ConnIdleTimeout`, the same 300s constant used by the other transports). The timer closes the underlying connection when it fires.
- The timer is started when a connection is returned to the pool (`SetIdle`) and cancelled while the connection is back in use (`ResetIdle`).
- A failed pooled connection that gets dropped instead of re-pooled is also put under the idle timer, so it does not linger until GC either; a failed fresh connection is closed immediately on the error return path.
- `H1Conn.Close` now cancels the pending timer, so closing never races a later fire.

## Tests

New `h1_conn_test.go` (internal package) covers:
- idle timeout closes the underlying connection,
- `ResetIdle` cancels a pending close and keeps the connection open,
- `Close` cancels the timer without double-close.

`go test ./transport/internet/splithttp/...` (incl. `-race`) and `go build ./...` pass.

Fixes #6560