### PR TITLE
Geodata: Catch up missed scheduled updates

### DIFF
--- a/app/geodata/geodata.go
+++ b/app/geodata/geodata.go
@@ -3,11 +3,13 @@ package geodata
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/robfig/cron/v3"
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/errors"
 	commongeodata "github.com/xtls/xray-core/common/geodata"
+	"github.com/xtls/xray-core/common/platform/filesystem"
 	"github.com/xtls/xray-core/core"
 	"github.com/xtls/xray-core/features/routing"
 )
@@ -16,8 +18,11 @@ type Instance struct {
 	assets     []*Asset
 	downloader *downloader
 	tasker     *cron.Cron
+	schedule   cron.Schedule
+	job        cron.Job
 
 	mu      sync.Mutex
+	wg      sync.WaitGroup
 	running bool
 }
 
@@ -40,13 +45,14 @@ func New(ctx context.Context, config *Config) (*Instance, error) {
 		g.downloader = newDownloader(ctx, dispatcher, config.Outbound)
 	}
 
-	g.tasker = cron.New(
-		cron.WithChain(cron.SkipIfStillRunning(cron.DiscardLogger)),
-		cron.WithLogger(cron.DiscardLogger),
-	)
-	if _, err := g.tasker.AddFunc(config.Cron, g.execute); err != nil {
+	schedule, err := cron.ParseStandard(config.Cron)
+	if err != nil {
 		return nil, errors.New("invalid geodata cron").Base(err)
 	}
+	g.schedule = schedule
+	g.job = cron.NewChain(cron.SkipIfStillRunning(cron.DiscardLogger)).Then(cron.FuncJob(g.execute))
+	g.tasker = cron.New(cron.WithLogger(cron.DiscardLogger))
+	g.tasker.Schedule(g.schedule, g.job)
 	errors.LogInfo(ctx, "scheduled geodata reload with cron: ", config.Cron)
 
 	return g, nil
@@ -89,6 +95,19 @@ func reload() error {
 	return errors.Combine(commongeodata.IPReg.Reload(), commongeodata.DomainReg.Reload())
 }
 
+func (g *Instance) shouldUpdate(now time.Time) bool {
+	if g.schedule == nil || g.downloader == nil {
+		return false
+	}
+	for _, asset := range g.assets {
+		info, err := filesystem.StatAsset(asset.File)
+		if err == nil && !g.schedule.Next(info.ModTime()).After(now) {
+			return true
+		}
+	}
+	return false
+}
+
 func (g *Instance) Type() interface{} {
 	return (*Instance)(nil)
 }
@@ -103,6 +122,13 @@ func (g *Instance) Start() error {
 
 	if g.tasker != nil {
 		g.tasker.Start()
+		if g.shouldUpdate(time.Now()) {
+			g.wg.Add(1)
+			go func() {
+				defer g.wg.Done()
+				g.job.Run()
+			}()
+		}
 	}
 
 	g.running = true
@@ -121,6 +147,7 @@ func (g *Instance) Close() error {
 	if g.tasker != nil {
 		<-g.tasker.Stop().Done()
 	}
+	g.wg.Wait()
 
 	g.running = false
 

--- a/app/geodata/geodata_test.go
+++ b/app/geodata/geodata_test.go
@@ -1,0 +1,63 @@
+package geodata
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+func TestShouldUpdate(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("xray.location.asset", dir)
+
+	path := filepath.Join(dir, "geoip.dat")
+	if err := os.WriteFile(path, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	schedule, err := cron.ParseStandard("0 4 * * *")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, time.August, 14, 10, 0, 0, 0, time.Local)
+	instance := &Instance{
+		assets:     []*Asset{{File: "geoip.dat"}},
+		downloader: &downloader{},
+		schedule:   schedule,
+	}
+
+	for _, test := range []struct {
+		name    string
+		modTime time.Time
+		want    bool
+	}{
+		{
+			name:    "before scheduled update",
+			modTime: time.Date(2026, time.August, 14, 3, 59, 0, 0, time.Local),
+			want:    true,
+		},
+		{
+			name:    "previous day",
+			modTime: time.Date(2026, time.August, 13, 4, 1, 0, 0, time.Local),
+			want:    true,
+		},
+		{
+			name:    "after scheduled update",
+			modTime: time.Date(2026, time.August, 14, 4, 1, 0, 0, time.Local),
+			want:    false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := os.Chtimes(path, test.modTime, test.modTime); err != nil {
+				t.Fatal(err)
+			}
+			if got := instance.shouldUpdate(now); got != test.want {
+				t.Fatalf("shouldUpdate() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- run a geodata update after startup when an asset predates the latest scheduled cron occurrence
- share the existing skip-if-running guard between scheduled and startup jobs
- wait for the startup catch-up job during shutdown

## Test
- `go test ./app/geodata`