### PR TITLE
VLESS: Support XTLS Vision on non-RAW transports (e.g. XHTTP)

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -258,16 +258,20 @@ func (w *VisionReader) ReadMultiBuffer() (buf.MultiBuffer, error) {
 
 	if *switchToDirectCopy {
 		// XTLS Vision processes TLS-like conn's input and rawInput
-		if inputBuffer, err := buf.ReadFrom(w.input); err == nil && !inputBuffer.IsEmpty() {
-			buffer, _ = buf.MergeMulti(buffer, inputBuffer)
+		if w.input != nil {
+			if inputBuffer, err := buf.ReadFrom(w.input); err == nil && !inputBuffer.IsEmpty() {
+				buffer, _ = buf.MergeMulti(buffer, inputBuffer)
+			}
+			*w.input = bytes.Reader{} // release memory
+			w.input = nil
 		}
-		if rawInputBuffer, err := buf.ReadFrom(w.rawInput); err == nil && !rawInputBuffer.IsEmpty() {
-			buffer, _ = buf.MergeMulti(buffer, rawInputBuffer)
+		if w.rawInput != nil {
+			if rawInputBuffer, err := buf.ReadFrom(w.rawInput); err == nil && !rawInputBuffer.IsEmpty() {
+				buffer, _ = buf.MergeMulti(buffer, rawInputBuffer)
+			}
+			*w.rawInput = bytes.Buffer{} // release memory
+			w.rawInput = nil
 		}
-		*w.input = bytes.Reader{} // release memory
-		w.input = nil
-		*w.rawInput = bytes.Buffer{} // release memory
-		w.rawInput = nil
 
 		if inbound := session.InboundFromContext(w.ctx); inbound != nil && inbound.Conn != nil {
 			// if w.isUplink && inbound.CanSpliceCopy == 2 { // TODO: enable uplink splice

--- a/proxy/vless/inbound/inbound.go
+++ b/proxy/vless/inbound/inbound.go
@@ -577,13 +577,18 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection s
 				} else if realityConn, ok := iConn.(*reality.Conn); ok {
 					t = reflect.TypeOf(realityConn.Conn).Elem()
 					p = uintptr(unsafe.Pointer(realityConn.Conn))
+				} else if !proxy.IsRAWTransportWithoutSecurity(iConn) {
+					// Non-RAW transport (e.g. XHTTP): Vision is used in padding mode, without TLS/REALITY penetration.
+					inbound.CanSpliceCopy = 3
 				} else {
 					return errors.New("XTLS only supports TLS and REALITY directly for now.").AtWarning()
 				}
-				i, _ := t.FieldByName("input")
-				r, _ := t.FieldByName("rawInput")
-				input = (*bytes.Reader)(unsafe.Pointer(p + i.Offset))
-				rawInput = (*bytes.Buffer)(unsafe.Pointer(p + r.Offset))
+				if t != nil {
+					i, _ := t.FieldByName("input")
+					r, _ := t.FieldByName("rawInput")
+					input = (*bytes.Reader)(unsafe.Pointer(p + i.Offset))
+					rawInput = (*bytes.Buffer)(unsafe.Pointer(p + r.Offset))
+				}
 			}
 		} else {
 			return errors.New("account " + account.ID.String() + " is not able to use the flow " + requestAddons.Flow).AtWarning()

--- a/proxy/vless/outbound/outbound.go
+++ b/proxy/vless/outbound/outbound.go
@@ -280,13 +280,18 @@ func (h *Handler) Process(ctx context.Context, link *transport.Link, dialer inte
 			} else if realityConn, ok := iConn.(*reality.UConn); ok {
 				t = reflect.TypeOf(realityConn.Conn).Elem()
 				p = uintptr(unsafe.Pointer(realityConn.Conn))
+			} else if !proxy.IsRAWTransportWithoutSecurity(iConn) {
+				// Non-RAW transport (e.g. XHTTP): Vision is used in padding mode, without TLS/REALITY penetration.
+				ob.CanSpliceCopy = 3
 			} else {
 				return errors.New("XTLS only supports TLS and REALITY directly for now.").AtWarning()
 			}
-			i, _ := t.FieldByName("input")
-			r, _ := t.FieldByName("rawInput")
-			input = (*bytes.Reader)(unsafe.Pointer(p + i.Offset))
-			rawInput = (*bytes.Buffer)(unsafe.Pointer(p + r.Offset))
+			if t != nil {
+				i, _ := t.FieldByName("input")
+				r, _ := t.FieldByName("rawInput")
+				input = (*bytes.Reader)(unsafe.Pointer(p + i.Offset))
+				rawInput = (*bytes.Buffer)(unsafe.Pointer(p + r.Offset))
+			}
 		default:
 			panic("unknown VLESS request command")
 		}


### PR DESCRIPTION
﻿## What does this PR do?

Allows the VLESS flow `xtls-rprx-vision` to be used on non-RAW transports (e.g. XHTTP, WebSocket, gRPC), instead of rejecting them with `"XTLS only supports TLS and REALITY directly for now."`.

Currently both the VLESS inbound and outbound hard-require the connection to be a `tls.Conn` / `reality.Conn` / `encryption.CommonConn` when Vision is enabled. XHTTP (and other packet/capsule transports) wraps the TLS conn, so Vision was rejected even though the padding part of the protocol works fine on any reliable stream.

## How it works

- When the transport is not RAW (checked with `proxy.IsRAWTransportWithoutSecurity`), `CanSpliceCopy` is set to `3` (same convention as Shadowsocks/Hysteria/WireGuard/Trojan) so no splice/penetration is attempted.
- `VisionReader` no longer assumes `input`/`rawInput` are non-nil: the direct-copy branch now nil-checks them and releases them safely.
- Vision still runs in padding mode as usual: padding + filtering are applied, and after the inner TLS handshake is detected both sides keep relaying raw bytes over the existing stream.

## Tests

- `go build ./...` passes.
- End-to-end verified against a real server (Xray 26.7.28 built from this branch, `main` commit `7d214f8b`):
  - VLESS + XHTTP + REALITY + `flow=xtls-rprx-vision` (client and server): TCP transfers, 10MB downloads, and UDP (via mux) all work.
  - Control groups (TCP+REALITY+Vision, XHTTP+REALITY without flow) also pass.

Related: #5576
