### PR TITLE
XHTTP client: Define Request.GetBody() for packet-up so h2 can replay after GOAWAY

### DIFF
--- a/transport/internet/splithttp/config.go
+++ b/transport/internet/splithttp/config.go
@@ -1,6 +1,7 @@
 package splithttp
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -330,14 +331,26 @@ func (c *Config) FillStreamRequest(request *http.Request, sessionId string, seqS
 func (c *Config) FillPacketRequest(request *http.Request, sessionId string, seqStr string, payload buf.MultiBuffer) error {
 	dataPlacement := c.GetNormalizedUplinkDataPlacement()
 
+	// Materialize the payload so that GetBody can hand out a fresh reader.
+	// Without GetBody, http2 cannot replay a request whose body was already
+	// written: the transport gives up with "cannot retry ... after
+	// Request.Body was written". For packet-up that packet is then never
+	// sent, and since the server waits for an exact seq and never skips, the
+	// stalled reassembly queue tears down the whole connection. Duplicate
+	// seqs caused by a replay are harmless: uploadQueue drops any packet
+	// with seq below nextSeq.
+	data := make([]byte, payload.Len())
+	payload.Copy(data)
+	buf.ReleaseMulti(payload)
+
 	if dataPlacement == PlacementBody || dataPlacement == PlacementAuto {
 		request.Header = c.GetRequestHeader()
-		request.Body = io.NopCloser(&buf.MultiBufferContainer{MultiBuffer: payload})
-		request.ContentLength = int64(payload.Len())
+		request.Body = io.NopCloser(bytes.NewReader(data))
+		request.ContentLength = int64(len(data))
+		request.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(data)), nil
+		}
 	} else {
-		data := make([]byte, payload.Len())
-		payload.Copy(data)
-		buf.ReleaseMulti(payload)
 		switch dataPlacement {
 		case PlacementHeader:
 			request.Header = c.GetRequestHeaderWithPayload(data)

--- a/transport/internet/splithttp/config.go
+++ b/transport/internet/splithttp/config.go
@@ -331,14 +331,6 @@ func (c *Config) FillStreamRequest(request *http.Request, sessionId string, seqS
 func (c *Config) FillPacketRequest(request *http.Request, sessionId string, seqStr string, payload buf.MultiBuffer) error {
 	dataPlacement := c.GetNormalizedUplinkDataPlacement()
 
-	// Materialize the payload so that GetBody can hand out a fresh reader.
-	// Without GetBody, http2 cannot replay a request whose body was already
-	// written: the transport gives up with "cannot retry ... after
-	// Request.Body was written". For packet-up that packet is then never
-	// sent, and since the server waits for an exact seq and never skips, the
-	// stalled reassembly queue tears down the whole connection. Duplicate
-	// seqs caused by a replay are harmless: uploadQueue drops any packet
-	// with seq below nextSeq.
 	data := make([]byte, payload.Len())
 	payload.Copy(data)
 	buf.ReleaseMulti(payload)

--- a/transport/internet/splithttp/config_test.go
+++ b/transport/internet/splithttp/config_test.go
@@ -1,9 +1,13 @@
 package splithttp_test
 
 import (
+	"io"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/xtls/xray-core/common"
+	"github.com/xtls/xray-core/common/buf"
 	. "github.com/xtls/xray-core/transport/internet/splithttp"
 )
 
@@ -75,5 +79,37 @@ func Test_GetNormalizedPath(t *testing.T) {
 			}
 			assert.Equal(t, test.Expected, c.GetNormalizedPath())
 		})
+	}
+}
+
+func Test_FillPacketRequest_GetBody(t *testing.T) {
+	data := []byte("hello xray")
+	payload := buf.MergeBytes(nil, data)
+
+	req, err := http.NewRequest("POST", "https://example.com/", nil)
+	common.Must(err)
+
+	config := &Config{}
+	config.FillPacketRequest(req, "sess", "0", payload)
+
+	if req.GetBody == nil {
+		t.Fatalf("Expected GetBody to be set")
+	}
+
+	first, err := io.ReadAll(req.Body)
+	common.Must(err)
+
+	if string(data) != string(first) {
+		t.Fatalf("Body mismatch. Format %q and %q are not equal", data, first)
+	}
+
+	body2, err := req.GetBody()
+	common.Must(err)
+
+	second, err := io.ReadAll(body2)
+	common.Must(err)
+
+	if string(data) != string(second) {
+		t.Fatalf("Replayed body mismatch. Format %q and %q are not equal", data, second)
 	}
 }


### PR DESCRIPTION
> **Not part of this PR.** The download leg fails independently and earlier:
> three CDNs on Russia's IP whitelist cut the idle response stream long before
> the ~100s this has generally been assumed to be — VK Cloud at **10s**, Timeweb
> at **30s**, Yandex Cloud at **60s**. Cloudflare, which is not on it, is the
> only one at ~125s. During an upload that leg is idle by construction.
> Measurements, and the things that do not fix them:
> [comment on #4846](https://github.com/XTLS/Xray-core/issues/4846#issuecomment-5160438029).
> The diff below is the uplink only.

---
## Problem

In `packet-up` mode every chunk is sent as a separate POST carrying a sequence
number. `FillPacketRequest` assigns `request.Body` by hand, after the request
was created with a nil body, so `Request.GetBody` is never populated.

When the peer sends GOAWAY while a request body is being written,
`golang.org/x/net/http2` cannot replay the request and gives up with:

```
http2: Transport: cannot retry err [http2: Transport received Server's graceful
shutdown GOAWAY] after Request.Body was written; define Request.GetBody to
avoid this error
```

For `packet-up` this is not a retriable loss of bytes. That `seq` never
arrives, and the server's reassembly queue waits for it forever — it matches
`nextSeq` exactly and never skips (`upload_queue.go`) — so the session is torn
down. `dialer.go` interrupts the upload pipe on any `PostPacket` error, which
kills the uplink outright.

## Fix

Copy the payload into a plain slice once, release the pooled buffers
immediately, and serve both `Body` and `GetBody` from that copy. The `else`
branch of the same function already did exactly this copy, so it is hoisted and
shared instead of duplicated.

Duplicate `seq` values produced by a replay are harmless: `uploadQueue`
silently drops any packet whose `Seq` is below `nextSeq`.

Side effect: this also closes a buffer-pool leak. `io.NopCloser` suppressed
`MultiBufferContainer.Close()`, so when a request was aborted mid-write the
unread buffers were never returned to the pool. Release is now explicit and
unconditional.

## Evidence

Measured against Timeweb CDN, which closes
each HTTP/2 connection after ~200 requests.

A minimal probe reproducing the pre-patch code path (`Body` assigned by hand,
`GetBody` left nil), 8 concurrent requests, 400 KB bodies, 5 minutes, routed
through the Xray tunnel itself:

- **15 unrecoverable failures out of 1329 requests** with the error above
- 6 of 7 connections died at 201-204 requests, confirming the CDN's limit
- failures arrive in bursts of 2-4, exactly at connection boundaries

A patched client carrying that same traffic in the same window, instrumented to
log every `GetBody` call:

- **4 replays, 0 `cannot retry`, 0 `failed to send upload`** over ~530 MB
  uploaded

Under test, `GetBody()` returns the full payload even after `Body` has already
been read to completion, and the `splithttp` suite passes unchanged.

## Cost

One copy of the chunk per in-flight request, bounded by `scMaxEachPostBytes`.
The copy is released by GC once the request completes. `GetBody` itself is only
called on the retry path, so there is no cost in the normal case.