### PR TITLE
VLESS inbound: Add pull-through external HTTP validator

### DIFF
--- a/infra/conf/vless.go
+++ b/infra/conf/vless.go
@@ -30,13 +30,28 @@ type VLessInboundFallback struct {
 	Xver uint64          `json:"xver"`
 }
 
+// VLessInboundValidatorConfig selects and configures how VLESS users are
+// validated. Type "memory" (the default, used when the field is omitted)
+// checks only the local "clients"/"users" list. Type "external" additionally
+// queries an HTTP(S) endpoint for users not found locally.
+type VLessInboundValidatorConfig struct {
+	Type        string            `json:"type"`
+	URL         string            `json:"url"`
+	Timeout     uint32            `json:"timeout"`     // seconds, 0 = default
+	CacheTTL    uint32            `json:"cacheTtl"`    // seconds, 0 = default
+	NegativeTTL uint32            `json:"negativeTtl"` // seconds, 0 = default
+	Outbound    string            `json:"outbound"`    // tagged outbound to dial the endpoint through
+	Headers     map[string]string `json:"headers"`     // sent as-is on every lookup request
+}
+
 type VLessInboundConfig struct {
-	Users      []json.RawMessage       `json:"users"`
-	Clients    []json.RawMessage       `json:"clients"`
-	Decryption string                  `json:"decryption"`
-	Fallbacks  []*VLessInboundFallback `json:"fallbacks"`
-	Flow       string                  `json:"flow"`
-	Testseed   []uint32                `json:"testseed"`
+	Users      []json.RawMessage            `json:"users"`
+	Clients    []json.RawMessage            `json:"clients"`
+	Decryption string                       `json:"decryption"`
+	Fallbacks  []*VLessInboundFallback      `json:"fallbacks"`
+	Flow       string                       `json:"flow"`
+	Testseed   []uint32                     `json:"testseed"`
+	Validator  *VLessInboundValidatorConfig `json:"validator"`
 }
 
 // Build implements Buildable
@@ -103,6 +118,25 @@ func (c *VLessInboundConfig) Build() (proto.Message, error) {
 		return nil, err
 	}
 
+	if c.Validator != nil {
+		switch c.Validator.Type {
+		case "", "memory":
+		case "external":
+			if c.Validator.URL == "" {
+				return nil, errors.New(`VLESS "validator" of type "external" requires "url"`)
+			}
+			config.ExternalValidator = &inbound.ExternalValidator{
+				Url:         c.Validator.URL,
+				Timeout:     c.Validator.Timeout,
+				CacheTtl:    c.Validator.CacheTTL,
+				NegativeTtl: c.Validator.NegativeTTL,
+				Outbound:    c.Validator.Outbound,
+				Headers:     c.Validator.Headers,
+			}
+		default:
+			return nil, errors.New(`VLESS "validator.type" must be "memory" or "external", got "` + c.Validator.Type + `"`)
+		}
+	}
 	config.Decryption = c.Decryption
 	if !func() bool {
 		s := strings.Split(config.Decryption, ".")

--- a/infra/conf/vless_test.go
+++ b/infra/conf/vless_test.go
@@ -1,6 +1,7 @@
 package conf_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/xtls/xray-core/common/net"
@@ -155,5 +156,58 @@ func TestVLessInbound(t *testing.T) {
 				},
 			},
 		},
+		{
+			Input: `{
+				"clients": [
+					{
+						"id": "27848739-7e62-4138-9fd3-098a63964b6b"
+					}
+				],
+				"decryption": "none",
+				"validator": {
+					"type": "external",
+					"url": "https://auth.example.com/check",
+					"timeout": 2,
+					"cacheTtl": 300,
+					"negativeTtl": 30,
+					"outbound": "auth-out",
+					"headers": {"Authorization": "Bearer s3cr3t"}
+				}
+			}`,
+			Parser: loadJSON(creator),
+			Output: &inbound.Config{
+				Users: []*protocol.User{
+					{
+						Account: serial.ToTypedMessage(&vless.Account{
+							Id: "27848739-7e62-4138-9fd3-098a63964b6b",
+						}),
+					},
+				},
+				Decryption: "none",
+				ExternalValidator: &inbound.ExternalValidator{
+					Url:         "https://auth.example.com/check",
+					Timeout:     2,
+					CacheTtl:    300,
+					NegativeTtl: 30,
+					Outbound:    "auth-out",
+					Headers:     map[string]string{"Authorization": "Bearer s3cr3t"},
+				},
+			},
+		},
 	})
+}
+
+func TestVLessInboundValidatorErrors(t *testing.T) {
+	for _, input := range []string{
+		`{"clients": [{"id": "27848739-7e62-4138-9fd3-098a63964b6b"}], "decryption": "none", "validator": {"type": "external"}}`,
+		`{"clients": [{"id": "27848739-7e62-4138-9fd3-098a63964b6b"}], "decryption": "none", "validator": {"type": "bogus"}}`,
+	} {
+		c := new(VLessInboundConfig)
+		if err := json.Unmarshal([]byte(input), c); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := c.Build(); err == nil {
+			t.Fatalf("expected error for input: %s", input)
+		}
+	}
 }

--- a/proxy/vless/inbound/config.pb.go
+++ b/proxy/vless/inbound/config.pb.go
@@ -106,22 +106,110 @@ func (x *Fallback) GetXver() uint64 {
 	return 0
 }
 
-type Config struct {
+// ExternalValidator delegates user lookups to an HTTP(S) endpoint, layered on
+// top of the inbound's local user list. Its presence on Config selects the
+// external validator; nil means the local user list alone is used.
+type ExternalValidator struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Users         []*protocol.User       `protobuf:"bytes,1,rep,name=users,proto3" json:"users,omitempty"`
-	Fallbacks     []*Fallback            `protobuf:"bytes,2,rep,name=fallbacks,proto3" json:"fallbacks,omitempty"`
-	Decryption    string                 `protobuf:"bytes,3,opt,name=decryption,proto3" json:"decryption,omitempty"`
-	XorMode       uint32                 `protobuf:"varint,4,opt,name=xorMode,proto3" json:"xorMode,omitempty"`
-	SecondsFrom   int64                  `protobuf:"varint,5,opt,name=seconds_from,json=secondsFrom,proto3" json:"seconds_from,omitempty"`
-	SecondsTo     int64                  `protobuf:"varint,6,opt,name=seconds_to,json=secondsTo,proto3" json:"seconds_to,omitempty"`
-	Padding       string                 `protobuf:"bytes,7,opt,name=padding,proto3" json:"padding,omitempty"`
+	Url           string                 `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
+	Timeout       uint32                 `protobuf:"varint,2,opt,name=timeout,proto3" json:"timeout,omitempty"`                            // seconds, 0 = default
+	CacheTtl      uint32                 `protobuf:"varint,3,opt,name=cache_ttl,json=cacheTtl,proto3" json:"cache_ttl,omitempty"`          // seconds, 0 = default
+	NegativeTtl   uint32                 `protobuf:"varint,4,opt,name=negative_ttl,json=negativeTtl,proto3" json:"negative_ttl,omitempty"` // seconds, 0 = default
+	Outbound      string                 `protobuf:"bytes,5,opt,name=outbound,proto3" json:"outbound,omitempty"`
+	Headers       map[string]string      `protobuf:"bytes,6,rep,name=headers,proto3" json:"headers,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // sent as-is on every lookup request
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
+func (x *ExternalValidator) Reset() {
+	*x = ExternalValidator{}
+	mi := &file_proxy_vless_inbound_config_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExternalValidator) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExternalValidator) ProtoMessage() {}
+
+func (x *ExternalValidator) ProtoReflect() protoreflect.Message {
+	mi := &file_proxy_vless_inbound_config_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExternalValidator.ProtoReflect.Descriptor instead.
+func (*ExternalValidator) Descriptor() ([]byte, []int) {
+	return file_proxy_vless_inbound_config_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *ExternalValidator) GetUrl() string {
+	if x != nil {
+		return x.Url
+	}
+	return ""
+}
+
+func (x *ExternalValidator) GetTimeout() uint32 {
+	if x != nil {
+		return x.Timeout
+	}
+	return 0
+}
+
+func (x *ExternalValidator) GetCacheTtl() uint32 {
+	if x != nil {
+		return x.CacheTtl
+	}
+	return 0
+}
+
+func (x *ExternalValidator) GetNegativeTtl() uint32 {
+	if x != nil {
+		return x.NegativeTtl
+	}
+	return 0
+}
+
+func (x *ExternalValidator) GetOutbound() string {
+	if x != nil {
+		return x.Outbound
+	}
+	return ""
+}
+
+func (x *ExternalValidator) GetHeaders() map[string]string {
+	if x != nil {
+		return x.Headers
+	}
+	return nil
+}
+
+type Config struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	Users             []*protocol.User       `protobuf:"bytes,1,rep,name=users,proto3" json:"users,omitempty"`
+	Fallbacks         []*Fallback            `protobuf:"bytes,2,rep,name=fallbacks,proto3" json:"fallbacks,omitempty"`
+	Decryption        string                 `protobuf:"bytes,3,opt,name=decryption,proto3" json:"decryption,omitempty"`
+	XorMode           uint32                 `protobuf:"varint,4,opt,name=xorMode,proto3" json:"xorMode,omitempty"`
+	SecondsFrom       int64                  `protobuf:"varint,5,opt,name=seconds_from,json=secondsFrom,proto3" json:"seconds_from,omitempty"`
+	SecondsTo         int64                  `protobuf:"varint,6,opt,name=seconds_to,json=secondsTo,proto3" json:"seconds_to,omitempty"`
+	Padding           string                 `protobuf:"bytes,7,opt,name=padding,proto3" json:"padding,omitempty"`
+	ExternalValidator *ExternalValidator     `protobuf:"bytes,8,opt,name=external_validator,json=externalValidator,proto3" json:"external_validator,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
 func (x *Config) Reset() {
 	*x = Config{}
-	mi := &file_proxy_vless_inbound_config_proto_msgTypes[1]
+	mi := &file_proxy_vless_inbound_config_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -133,7 +221,7 @@ func (x *Config) String() string {
 func (*Config) ProtoMessage() {}
 
 func (x *Config) ProtoReflect() protoreflect.Message {
-	mi := &file_proxy_vless_inbound_config_proto_msgTypes[1]
+	mi := &file_proxy_vless_inbound_config_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -146,7 +234,7 @@ func (x *Config) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Config.ProtoReflect.Descriptor instead.
 func (*Config) Descriptor() ([]byte, []int) {
-	return file_proxy_vless_inbound_config_proto_rawDescGZIP(), []int{1}
+	return file_proxy_vless_inbound_config_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *Config) GetUsers() []*protocol.User {
@@ -198,6 +286,13 @@ func (x *Config) GetPadding() string {
 	return ""
 }
 
+func (x *Config) GetExternalValidator() *ExternalValidator {
+	if x != nil {
+		return x.ExternalValidator
+	}
+	return nil
+}
+
 var File_proxy_vless_inbound_config_proto protoreflect.FileDescriptor
 
 const file_proxy_vless_inbound_config_proto_rawDesc = "" +
@@ -209,7 +304,17 @@ const file_proxy_vless_inbound_config_proto_rawDesc = "" +
 	"\x04path\x18\x03 \x01(\tR\x04path\x12\x12\n" +
 	"\x04type\x18\x04 \x01(\tR\x04type\x12\x12\n" +
 	"\x04dest\x18\x05 \x01(\tR\x04dest\x12\x12\n" +
-	"\x04xver\x18\x06 \x01(\x04R\x04xver\"\x92\x02\n" +
+	"\x04xver\x18\x06 \x01(\x04R\x04xver\"\xab\x02\n" +
+	"\x11ExternalValidator\x12\x10\n" +
+	"\x03url\x18\x01 \x01(\tR\x03url\x12\x18\n" +
+	"\atimeout\x18\x02 \x01(\rR\atimeout\x12\x1b\n" +
+	"\tcache_ttl\x18\x03 \x01(\rR\bcacheTtl\x12!\n" +
+	"\fnegative_ttl\x18\x04 \x01(\rR\vnegativeTtl\x12\x1a\n" +
+	"\boutbound\x18\x05 \x01(\tR\boutbound\x12R\n" +
+	"\aheaders\x18\x06 \x03(\v28.xray.proxy.vless.inbound.ExternalValidator.HeadersEntryR\aheaders\x1a:\n" +
+	"\fHeadersEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xee\x02\n" +
 	"\x06Config\x120\n" +
 	"\x05users\x18\x01 \x03(\v2\x1a.xray.common.protocol.UserR\x05users\x12@\n" +
 	"\tfallbacks\x18\x02 \x03(\v2\".xray.proxy.vless.inbound.FallbackR\tfallbacks\x12\x1e\n" +
@@ -220,7 +325,8 @@ const file_proxy_vless_inbound_config_proto_rawDesc = "" +
 	"\fseconds_from\x18\x05 \x01(\x03R\vsecondsFrom\x12\x1d\n" +
 	"\n" +
 	"seconds_to\x18\x06 \x01(\x03R\tsecondsTo\x12\x18\n" +
-	"\apadding\x18\a \x01(\tR\apaddingBj\n" +
+	"\apadding\x18\a \x01(\tR\apadding\x12Z\n" +
+	"\x12external_validator\x18\b \x01(\v2+.xray.proxy.vless.inbound.ExternalValidatorR\x11externalValidatorBj\n" +
 	"\x1ccom.xray.proxy.vless.inboundP\x01Z-github.com/xtls/xray-core/proxy/vless/inbound\xaa\x02\x18Xray.Proxy.Vless.Inboundb\x06proto3"
 
 var (
@@ -235,20 +341,24 @@ func file_proxy_vless_inbound_config_proto_rawDescGZIP() []byte {
 	return file_proxy_vless_inbound_config_proto_rawDescData
 }
 
-var file_proxy_vless_inbound_config_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_proxy_vless_inbound_config_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_proxy_vless_inbound_config_proto_goTypes = []any{
-	(*Fallback)(nil),      // 0: xray.proxy.vless.inbound.Fallback
-	(*Config)(nil),        // 1: xray.proxy.vless.inbound.Config
-	(*protocol.User)(nil), // 2: xray.common.protocol.User
+	(*Fallback)(nil),          // 0: xray.proxy.vless.inbound.Fallback
+	(*ExternalValidator)(nil), // 1: xray.proxy.vless.inbound.ExternalValidator
+	(*Config)(nil),            // 2: xray.proxy.vless.inbound.Config
+	nil,                       // 3: xray.proxy.vless.inbound.ExternalValidator.HeadersEntry
+	(*protocol.User)(nil),     // 4: xray.common.protocol.User
 }
 var file_proxy_vless_inbound_config_proto_depIdxs = []int32{
-	2, // 0: xray.proxy.vless.inbound.Config.users:type_name -> xray.common.protocol.User
-	0, // 1: xray.proxy.vless.inbound.Config.fallbacks:type_name -> xray.proxy.vless.inbound.Fallback
-	2, // [2:2] is the sub-list for method output_type
-	2, // [2:2] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	3, // 0: xray.proxy.vless.inbound.ExternalValidator.headers:type_name -> xray.proxy.vless.inbound.ExternalValidator.HeadersEntry
+	4, // 1: xray.proxy.vless.inbound.Config.users:type_name -> xray.common.protocol.User
+	0, // 2: xray.proxy.vless.inbound.Config.fallbacks:type_name -> xray.proxy.vless.inbound.Fallback
+	1, // 3: xray.proxy.vless.inbound.Config.external_validator:type_name -> xray.proxy.vless.inbound.ExternalValidator
+	4, // [4:4] is the sub-list for method output_type
+	4, // [4:4] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_proxy_vless_inbound_config_proto_init() }
@@ -262,7 +372,7 @@ func file_proxy_vless_inbound_config_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proxy_vless_inbound_config_proto_rawDesc), len(file_proxy_vless_inbound_config_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proxy/vless/inbound/config.proto
+++ b/proxy/vless/inbound/config.proto
@@ -17,6 +17,18 @@ message Fallback {
   uint64 xver = 6;
 }
 
+// ExternalValidator delegates user lookups to an HTTP(S) endpoint, layered on
+// top of the inbound's local user list. Its presence on Config selects the
+// external validator; nil means the local user list alone is used.
+message ExternalValidator {
+  string url = 1;
+  uint32 timeout = 2;      // seconds, 0 = default
+  uint32 cache_ttl = 3;    // seconds, 0 = default
+  uint32 negative_ttl = 4; // seconds, 0 = default
+  string outbound = 5;
+  map<string, string> headers = 6; // sent as-is on every lookup request
+}
+
 message Config {
   repeated xray.common.protocol.User users = 1;
   repeated Fallback fallbacks = 2;
@@ -26,4 +38,5 @@ message Config {
   int64 seconds_from = 5;
   int64 seconds_to = 6;
   string padding = 7;
+  ExternalValidator external_validator = 8;
 }

--- a/proxy/vless/inbound/inbound.go
+++ b/proxy/vless/inbound/inbound.go
@@ -174,6 +174,21 @@ func New(ctx context.Context, config *Config, dc dns.Client, validator vless.Val
 		}
 	}
 
+	if ev := config.ExternalValidator; ev != nil {
+		external, err := vless.NewExternalValidator(ctx, handler.defaultDispatcher, validator, vless.ExternalValidatorConfig{
+			URL:         ev.Url,
+			Timeout:     time.Duration(ev.Timeout) * time.Second,
+			CacheTTL:    time.Duration(ev.CacheTtl) * time.Second,
+			NegativeTTL: time.Duration(ev.NegativeTtl) * time.Second,
+			Outbound:    ev.Outbound,
+			Headers:     ev.Headers,
+		})
+		if err != nil {
+			return nil, errors.New("failed to use validator").Base(err).AtError()
+		}
+		handler.validator = external
+	}
+
 	return handler, nil
 }
 
@@ -300,6 +315,7 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection s
 	var request *protocol.RequestHeader
 	var requestAddons *encoding.Addons
 	var err error
+	var inbound *session.Inbound
 
 	napfb := h.fallbacks
 	isfb := napfb != nil
@@ -307,7 +323,12 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection s
 	if isfb && firstLen < 18 {
 		err = errors.New("fallback directly")
 	} else {
-		userSentID, request, requestAddons, isfb, err = encoding.DecodeRequestHeader(isfb, first, reader, h.validator)
+		inbound = session.InboundFromContext(ctx)
+		validator := h.validator
+		if aware, ok := validator.(vless.SourceAware); ok && inbound != nil {
+			validator = aware.WithSource(inbound.Source)
+		}
+		userSentID, request, requestAddons, isfb, err = encoding.DecodeRequestHeader(isfb, first, reader, validator)
 	}
 
 	if err != nil {
@@ -529,7 +550,6 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection s
 	}
 	errors.LogInfo(ctx, "received request for ", request.Destination())
 
-	inbound := session.InboundFromContext(ctx)
 	if inbound == nil {
 		panic("no inbound metadata")
 	}

--- a/proxy/vless/validator_external.go
+++ b/proxy/vless/validator_external.go
@@ -1,0 +1,301 @@
+package vless
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/xtls/xray-core/common"
+	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/protocol"
+	"github.com/xtls/xray-core/common/task"
+	"github.com/xtls/xray-core/common/uuid"
+	"github.com/xtls/xray-core/features/routing"
+	"github.com/xtls/xray-core/transport/internet/tagged"
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	defaultExternalTimeout     = 2 * time.Second
+	defaultExternalCacheTTL    = 5 * time.Minute
+	defaultExternalNegativeTTL = 30 * time.Second
+	maxExternalErrorTTL        = 5 * time.Second // transport errors only, so a recovered endpoint is retried quickly
+)
+
+// ExternalValidatorConfig configures an ExternalValidator. Zero durations
+// fall back to package defaults.
+type ExternalValidatorConfig struct {
+	URL         string
+	Timeout     time.Duration
+	CacheTTL    time.Duration
+	NegativeTTL time.Duration
+	Outbound    string            // tagged outbound to dial the endpoint through, if any
+	Headers     map[string]string // sent as-is on every lookup request
+}
+
+// externalEntry is a cached lookup result, negative if user is nil.
+type externalEntry struct {
+	user   *protocol.MemoryUser
+	expiry time.Time
+}
+
+// ExternalValidator asks an external HTTP endpoint whether a UUID is a valid
+// user, caching answers in memory. Lookup failures fail closed into fallback.
+// It delegates Add, GetByEmail, GetAll, and GetCount to the base validator
+// unmodified, since the external endpoint has no reverse email index and no
+// full user listing.
+type ExternalValidator struct {
+	base Validator
+
+	ctx         context.Context
+	url         string
+	headers     map[string]string
+	client      *http.Client
+	cacheTTL    time.Duration
+	negativeTTL time.Duration
+
+	cache   sync.Map // ProcessUUID bytes + source IP -> *externalEntry
+	group   singleflight.Group
+	sweeper *task.Periodic
+}
+
+// NewExternalValidator creates an ExternalValidator on top of base, querying
+// cfg.URL (with "?uuid=<id>" or "&uuid=<id>" appended) for unknown users.
+func NewExternalValidator(ctx context.Context, dispatcher routing.Dispatcher, base Validator, cfg ExternalValidatorConfig) (*ExternalValidator, error) {
+	u, err := url.Parse(cfg.URL)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+		return nil, errors.New(`"validator" url must be an http(s) URL: `, cfg.URL)
+	}
+
+	v := &ExternalValidator{
+		base:        base,
+		ctx:         ctx,
+		headers:     cfg.Headers,
+		cacheTTL:    defaultExternalCacheTTL,
+		negativeTTL: defaultExternalNegativeTTL,
+	}
+	timeout := defaultExternalTimeout
+	if cfg.Timeout > 0 {
+		timeout = cfg.Timeout
+	}
+	if cfg.CacheTTL > 0 {
+		v.cacheTTL = cfg.CacheTTL
+	}
+	if cfg.NegativeTTL > 0 {
+		v.negativeTTL = cfg.NegativeTTL
+	}
+
+	sep := "?"
+	if u.RawQuery != "" {
+		sep = "&"
+	}
+	v.url = u.String() + sep + "uuid="
+
+	transport := &http.Transport{
+		MaxConnsPerHost: 8,
+		IdleConnTimeout: 90 * time.Second,
+	}
+	if cfg.Outbound != "" {
+		outbound := cfg.Outbound
+		transport.DialContext = func(reqCtx context.Context, network, addr string) (net.Conn, error) {
+			var conn net.Conn
+			err := task.Run(reqCtx, func() error {
+				if tagged.Dialer == nil {
+					return errors.New("tagged dialer is not initialized")
+				}
+				dest, err := net.ParseDestination(network + ":" + addr)
+				if err != nil {
+					return err
+				}
+				conn, err = tagged.Dialer(ctx, dispatcher, dest, outbound)
+				return err
+			})
+			return conn, err
+		}
+	}
+	v.client = &http.Client{Transport: transport, Timeout: timeout}
+
+	v.sweeper = &task.Periodic{Interval: time.Minute, Execute: v.sweep}
+	common.Must(v.sweeper.Start())
+	return v, nil
+}
+
+func (v *ExternalValidator) Add(u *protocol.MemoryUser) error {
+	return v.base.Add(u)
+}
+
+func (v *ExternalValidator) GetByEmail(email string) *protocol.MemoryUser {
+	return v.base.GetByEmail(email)
+}
+
+func (v *ExternalValidator) GetAll() []*protocol.MemoryUser {
+	return v.base.GetAll()
+}
+
+func (v *ExternalValidator) GetCount() int64 {
+	return v.base.GetCount()
+}
+
+// sourcedValidator is a per-connection view of an ExternalValidator whose
+// endpoint lookups carry the connection's source IP.
+type sourcedValidator struct {
+	*ExternalValidator
+	ip string
+}
+
+func (v sourcedValidator) Get(id uuid.UUID) *protocol.MemoryUser {
+	return v.get(id, v.ip)
+}
+
+// SourceAware is implemented by validators whose lookups can be scoped to a
+// connection's source address.
+type SourceAware interface {
+	WithSource(source net.Destination) Validator
+}
+
+// WithSource returns a Validator whose endpoint lookups carry source's IP,
+// caching answers per user-IP pair so the endpoint may limit IPs per user.
+func (v *ExternalValidator) WithSource(source net.Destination) Validator {
+	if !source.IsValid() {
+		return v
+	}
+	return sourcedValidator{v, source.Address.String()}
+}
+
+// externalCacheKey is the cache key for id looked up from ip, or the shared
+// prefix of all of id's entries (across source IPs) when ip is empty.
+func externalCacheKey(id uuid.UUID, ip string) string {
+	uuidKey := ProcessUUID(id)
+	return string(uuidKey[:]) + ip
+}
+
+// Del evicts cached entries matching the email or UUID, then removes any local user.
+func (v *ExternalValidator) Del(e string) error {
+	if e == "" {
+		return v.base.Del(e)
+	}
+	uuidKey := "" // ParseString also maps arbitrary strings, so email match stays in play
+	if id, err := uuid.ParseString(e); err == nil {
+		uuidKey = externalCacheKey(id, "")
+	}
+	evictedPositive := false
+	v.cache.Range(func(key, value interface{}) bool {
+		u := value.(*externalEntry).user
+		if (uuidKey != "" && strings.HasPrefix(key.(string), uuidKey)) ||
+			(u != nil && strings.EqualFold(u.Email, e)) {
+			v.cache.Delete(key)
+			evictedPositive = evictedPositive || u != nil
+		}
+		return true
+	})
+	if err := v.base.Del(e); err != nil && !evictedPositive {
+		return err
+	}
+	return nil
+}
+
+// Get a VLESS user with UUID via cache or the endpoint, nil if user doesn't exist.
+func (v *ExternalValidator) Get(id uuid.UUID) *protocol.MemoryUser {
+	return v.get(id, "")
+}
+
+func (v *ExternalValidator) get(id uuid.UUID, ip string) *protocol.MemoryUser {
+	if u := v.base.Get(id); u != nil {
+		return u
+	}
+	key := externalCacheKey(id, ip)
+	if e, ok := v.cache.Load(key); ok {
+		if entry := e.(*externalEntry); time.Now().Before(entry.expiry) {
+			return entry.user
+		}
+	}
+	u, _, _ := v.group.Do(key, func() (interface{}, error) {
+		user, ttl := v.fetch(id, ip)
+		v.cache.Store(key, &externalEntry{user: user, expiry: time.Now().Add(ttl)})
+		return user, nil
+	})
+	return u.(*protocol.MemoryUser)
+}
+
+func (v *ExternalValidator) fetch(id uuid.UUID, ip string) (*protocol.MemoryUser, time.Duration) {
+	errorTTL := min(v.negativeTTL, maxExternalErrorTTL)
+	target := v.url + id.String()
+	if ip != "" {
+		target += "&ip=" + url.QueryEscape(ip)
+	}
+	req, err := http.NewRequestWithContext(v.ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return nil, errorTTL
+	}
+	for k, val := range v.headers {
+		req.Header.Set(k, val)
+	}
+	resp, err := v.client.Do(req)
+	if err != nil {
+		errors.LogWarning(v.ctx, "external validator lookup failed: ", err)
+		return nil, errorTTL
+	}
+	defer resp.Body.Close()
+	body := io.LimitReader(resp.Body, 4096)
+	if resp.StatusCode == http.StatusUnauthorized {
+		io.Copy(io.Discard, body)
+		errors.LogWarning(v.ctx, "external validator returned 401 Unauthorized, check configured headers")
+		return nil, errorTTL // likely a config problem, not "no such user"; retry soon
+	}
+	if resp.StatusCode != http.StatusOK {
+		io.Copy(io.Discard, body)
+		return nil, v.negativeTTL
+	}
+
+	var r struct {
+		Email string `json:"email"`
+		Level uint32 `json:"level"`
+		Flow  string `json:"flow"`
+		TTL   uint32 `json:"ttl"` // optional per-user seconds, overrides cacheTtl
+	}
+	if err := json.NewDecoder(body).Decode(&r); err != nil {
+		errors.LogWarning(v.ctx, "external validator returned invalid JSON: ", err)
+		return nil, errorTTL
+	}
+	if r.Flow != "" && r.Flow != XRV {
+		errors.LogWarning(v.ctx, "external validator returned unsupported flow: ", r.Flow)
+		return nil, v.negativeTTL
+	}
+
+	ttl := v.cacheTTL
+	if r.TTL > 0 {
+		ttl = time.Duration(r.TTL) * time.Second
+	}
+	return &protocol.MemoryUser{
+		Account: &MemoryAccount{
+			ID:   protocol.NewID(id),
+			Flow: r.Flow,
+		},
+		Email: r.Email,
+		Level: r.Level,
+	}, ttl
+}
+
+// sweep keeps random-UUID probes from growing the negative cache without bound.
+func (v *ExternalValidator) sweep() error {
+	now := time.Now()
+	v.cache.Range(func(key, value interface{}) bool {
+		if now.After(value.(*externalEntry).expiry) {
+			v.cache.Delete(key)
+		}
+		return true
+	})
+	return nil
+}
+
+// Close implements common.Closable.
+func (v *ExternalValidator) Close() error {
+	v.client.CloseIdleConnections()
+	return errors.Combine(v.sweeper.Close(), common.Close(v.base))
+}

--- a/proxy/vless/validator_external_test.go
+++ b/proxy/vless/validator_external_test.go
@@ -1,0 +1,206 @@
+package vless_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/xtls/xray-core/common"
+	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/protocol"
+	"github.com/xtls/xray-core/common/uuid"
+	. "github.com/xtls/xray-core/proxy/vless"
+)
+
+func TestExternalValidator(t *testing.T) {
+	valid := uuid.New()
+	staticID := uuid.New()
+	var hits int32
+	shortLived := uuid.New()
+	limited := uuid.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		switch r.URL.Query().Get("uuid") {
+		case valid.String():
+			w.Write([]byte(`{"email":"a@b.c","level":1,"flow":""}`))
+		case shortLived.String():
+			w.Write([]byte(`{"email":"s@b.c","ttl":1}`))
+		case limited.String():
+			if r.URL.Query().Get("ip") != "1.1.1.1" {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+			w.Write([]byte(`{"email":"l@b.c"}`))
+		default:
+			w.WriteHeader(http.StatusForbidden)
+		}
+	}))
+	defer srv.Close()
+
+	base := new(MemoryValidator)
+	common.Must(base.Add(&protocol.MemoryUser{
+		Account: &MemoryAccount{ID: protocol.NewID(staticID)},
+		Email:   "static@example.com",
+	}))
+
+	v, err := NewExternalValidator(context.Background(), nil, base, ExternalValidatorConfig{
+		URL:         srv.URL,
+		CacheTTL:    60 * time.Second,
+		NegativeTTL: 60 * time.Second,
+	})
+	common.Must(err)
+	defer v.Close()
+
+	if u := v.Get(staticID); u == nil || u.Email != "static@example.com" {
+		t.Fatal("static user not resolved locally")
+	}
+	if atomic.LoadInt32(&hits) != 0 {
+		t.Fatal("static user lookup hit the backend")
+	}
+
+	if u := v.Get(valid); u == nil || u.Email != "a@b.c" || u.Level != 1 {
+		t.Fatal("external user not resolved")
+	}
+	if u := v.Get(valid); u == nil {
+		t.Fatal("cached user not resolved")
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatal("expected 1 backend hit, got ", got)
+	}
+
+	unknown := uuid.New()
+	if u := v.Get(unknown); u != nil {
+		t.Fatal("unknown user resolved")
+	}
+	if u := v.Get(unknown); u != nil {
+		t.Fatal("unknown user resolved from cache")
+	}
+	if got := atomic.LoadInt32(&hits); got != 2 {
+		t.Fatal("negative result not cached, backend hits: ", got)
+	}
+
+	if u := v.Get(shortLived); u == nil || u.Email != "s@b.c" {
+		t.Fatal("short-lived user not resolved")
+	}
+	if u := v.Get(shortLived); u == nil {
+		t.Fatal("short-lived user not cached")
+	}
+	if got := atomic.LoadInt32(&hits); got != 3 {
+		t.Fatal("server ttl not cached, backend hits: ", got)
+	}
+	time.Sleep(1100 * time.Millisecond)
+	if u := v.Get(shortLived); u == nil {
+		t.Fatal("short-lived user not re-resolved")
+	}
+	if got := atomic.LoadInt32(&hits); got != 4 {
+		t.Fatal("server ttl not honored, backend hits: ", got)
+	}
+
+	dev1 := v.WithSource(net.TCPDestination(net.ParseAddress("1.1.1.1"), 443))
+	dev2 := v.WithSource(net.TCPDestination(net.ParseAddress("2.2.2.2"), 443))
+	if u := dev1.Get(limited); u == nil || u.Email != "l@b.c" {
+		t.Fatal("allowed source ip not resolved")
+	}
+	if u := dev2.Get(limited); u != nil {
+		t.Fatal("denied source ip resolved")
+	}
+	dev1.Get(limited)
+	dev2.Get(limited)
+	if got := atomic.LoadInt32(&hits); got != 6 {
+		t.Fatal("per-ip results not cached separately, backend hits: ", got)
+	}
+
+	common.Must(v.Del(limited.String()))
+	if u := dev1.Get(limited); u == nil {
+		t.Fatal("user not re-resolved after eviction by uuid")
+	}
+	if got := atomic.LoadInt32(&hits); got != 7 {
+		t.Fatal("eviction by uuid did not drop cache entries, backend hits: ", got)
+	}
+
+	common.Must(v.Del("a@b.c"))
+	if u := v.Get(valid); u == nil {
+		t.Fatal("user not re-resolved after eviction by email")
+	}
+	if got := atomic.LoadInt32(&hits); got != 8 {
+		t.Fatal("eviction by email did not drop cache entries, backend hits: ", got)
+	}
+
+	if err := v.Del(unknown.String()); err == nil {
+		t.Fatal("expected error deleting a uuid that was only ever negatively cached")
+	}
+
+	if err := v.Del("nobody@example.com"); err == nil {
+		t.Fatal("expected error for unknown email")
+	}
+	common.Must(v.Del("static@example.com"))
+	if u := base.Get(staticID); u != nil {
+		t.Fatal("static user not removed from base validator")
+	}
+}
+
+func TestExternalValidatorHeaders(t *testing.T) {
+	id := uuid.New()
+	var gotAuth, gotMeta string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotMeta = r.Header.Get("X-Node-Region")
+		if gotAuth != "Bearer s3cr3t" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Write([]byte(`{"email":"tok@b.c"}`))
+	}))
+	defer srv.Close()
+
+	v, err := NewExternalValidator(context.Background(), nil, new(MemoryValidator), ExternalValidatorConfig{
+		URL: srv.URL,
+		Headers: map[string]string{
+			"Authorization": "Bearer s3cr3t",
+			"X-Node-Region": "fra",
+		},
+	})
+	common.Must(err)
+	defer v.Close()
+
+	if u := v.Get(id); u == nil || u.Email != "tok@b.c" {
+		t.Fatal("user not resolved with configured headers")
+	}
+	if gotAuth != "Bearer s3cr3t" || gotMeta != "fra" {
+		t.Fatal("headers not sent as expected, got Authorization=", gotAuth, " X-Node-Region=", gotMeta)
+	}
+}
+
+func TestExternalValidatorFailClosed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	v, err := NewExternalValidator(context.Background(), nil, new(MemoryValidator), ExternalValidatorConfig{
+		URL:     srv.URL,
+		Timeout: 50 * time.Millisecond,
+	})
+	common.Must(err)
+	defer v.Close()
+
+	start := time.Now()
+	if u := v.Get(uuid.New()); u != nil {
+		t.Fatal("expected nil on backend timeout")
+	}
+	if time.Since(start) > 400*time.Millisecond {
+		t.Fatal("lookup timeout not enforced")
+	}
+}
+
+func TestExternalValidatorBadConfig(t *testing.T) {
+	base := new(MemoryValidator)
+	for _, url := range []string{"ftp://example.com", "not a url"} {
+		if _, err := NewExternalValidator(context.Background(), nil, base, ExternalValidatorConfig{URL: url}); err == nil {
+			t.Fatal("expected error for ", url)
+		}
+	}
+}


### PR DESCRIPTION
Adds another implementation of Validator that checks uuids against external server via HTTP queries, instead of JSON file modifications or gRPC handler API.

## Reasoning

The gRPC `HandlerService` (`AddUserOperation`/`RemoveUserOperation`) is inherently **push-based**. This has numerous disadvantages:

- A lot more work has to be done by panels and node harnesses to ensure consistency of inbounds across multiple Xray servers; and even that provides only _eventual consistency_. The problem is worsening with the increasing node count: essentially, each user addition produces N network requests to nodes.
- Inbound has to contain all of the users authenticating against it at any given time. Sure, in-memory search against them is fast even after 100k+, but loading users to the inbound after Xray boot takes considerable time and has to be front-loaded for the inbound to become functional. Also, keeping all of the required user uuids in an inbound is a bigger potential attack surface — better have _some_ user uuids stolen than _all_ of them.
- IP limiting is retroactive, not proactive — node harness has to poll Xray api for list of the client IPs per user, which creates excessive workload that still lets a user with known bad IP slip before being caught. And since uuid auth authenticates _connections_, not _packets_, the malicious user can keep sending data after being removed from the inbound, so it's better to not let the malicious user in than later show him out.

## Implementation

```jsonc
"inbounds": [{
  "protocol": "vless",
  "settings": {
    "clients": [
      { "id": "...", "email": "static@example.com" }  // still checked first, still gRPC-manageable
    ],
    "decryption": "none",
    "validator": {
      "type": "external",              // "memory" (default) or "external"
      "url": "https://auth.example.com/check",
      "timeout": 2,                    // seconds, optional, default 2
      "cacheTtl": 300,                 // seconds, optional, default 300
      "negativeTtl": 30,               // seconds, optional, default 30
      "outbound": "auth-out",          // optional: dial the endpoint through a tagged outbound
      "headers": {                     // optional: sent as-is on every lookup request
        "Authorization": "Bearer s3cr3t",
        "X-Node-Region": "fra"
      }
    }
  }
}]
```

`ExternalValidator` works like a pull-through cache. With `"type": "external"`, the local clients list is still checked first (and still fully manageable through the existing gRPC API); only UUIDs not found locally fall through to the endpoint, as `GET <url>?uuid=<uuid>`, expecting either:

- 200 with `{"email": "...", "level": 0, "flow": "", "ttl": 0}` (`ttl` optionally overrides `cacheTtl` per user, e.g. for short-lived trial accounts, will get to that later), or
- any non-200 status, treated as "not a user" and cached under `negativeTtl` (5s on transport errors and 401s, so a recovered endpoint or a fixed credential is retried quickly rather than waiting out a full negative-cache window).

`headers` is an arbitrary string map, mostly intended for Bearer tokens, but not limited to it — any static per-request metadata the backend wants (region, node id, a shared secret) goes here unchanged.

Lookups are deduplicated via `singleflight` so concurrent connections on an unresolved UUID produce one request, not one per connection.

## Per-IP admission

To address the elephant in the room: it's optional. The way it works, if backend wants to cap distinct source IPs per user, each lookup can also carry `&ip=<source-ip>` and results are cached per `(uuid, ip)` pair rather than per `uuid` alone — so an endpoint enforcing `"N devices per account"` only needs to answer truthfully per IP; the inbound handles the caching split.

Ofc, it's not only useful to provide low bound cap, Xray sends ip, backend can also use it as an anti-DDoS mark, denying after a huge number of unique IPs, or based on region, etc etc.

## Do I have to wait for TTL to end to instantly ban the user?

No. RemoveUserOperation (gRPC) still works against the external mode: Del evicts matching cache entries (by UUID or by email) before falling through to the local list, so revoking a user that only exists in the external cache doesn't require waiting out cacheTtl.

## Additional concerns

- **LLM usage:** I have used LLMs for tests and style consistency; the logic is hand-written.
- **Cache behaviour:** Better check the code yourself; it's really straightforward, defaults are sane and it can be turned off completely. Me yapping here would do the code disservice.
- **Error messages and logging:** errors are a bit verbose on purpose (for example, you'd get prompted to check the token if you got 401 back)
- **Why re-implement in-memory validators methods to call them under the hood?** Basically, to make it easier to future-proof. If at any point the implementation of in-memory validator I rely upon changes, the PR that does this will have it easier.

Otherwise, I'm up to to discussion and changes. 