### PR TITLE
Commands: Unify command help information and initialization method

### DIFF
--- a/main/commands/all/api/inbound_user_add.go
+++ b/main/commands/all/api/inbound_user_add.go
@@ -27,12 +27,16 @@ var cmdAddInboundUsers = &base.Command{
 	Short:       "Add users to inbounds",
 	Long: `
 Add users to inbounds.
+
 Arguments:
+
 	-s, -server
 		The API server address. Default 127.0.0.1:8080
+
 	-t, -timeout
 		Timeout seconds to call API. Default 3
 Example:
+
     {{.Exec}} {{.LongName}} --server=127.0.0.1:8080  c1.json c2.json
 `,
 	Run: executeAddInboundUsers,

--- a/main/commands/all/api/inbound_user_remove.go
+++ b/main/commands/all/api/inbound_user_remove.go
@@ -46,9 +46,6 @@ func executeRemoveUsers(cmd *base.Command, args []string) {
 	for _, email := range emails {
 		fmt.Println("remove user:", email)
 		tmsg := cserial.ToTypedMessage(&handlerService.RemoveUserOperation{Email: email})
-		if tmsg == nil {
-			base.Fatalf(("failed to format config to TypedMessage"))
-		}
 		_, err := client.AlterInbound(ctx, &handlerService.AlterInboundRequest{
 			Tag:       tag,
 			Operation: tmsg,

--- a/main/commands/all/api/inbound_user_remove.go
+++ b/main/commands/all/api/inbound_user_remove.go
@@ -45,13 +45,13 @@ func executeRemoveUsers(cmd *base.Command, args []string) {
 	success := 0
 	for _, email := range emails {
 		fmt.Println("remove user:", email)
+		tmsg := cserial.ToTypedMessage(&handlerService.RemoveUserOperation{Email: email})
+		if tmsg == nil {
+			base.Fatalf(("failed to format config to TypedMessage"))
+		}
 		_, err := client.AlterInbound(ctx, &handlerService.AlterInboundRequest{
-			Tag: tag,
-			Operation: cserial.ToTypedMessage(
-				&handlerService.RemoveUserOperation{
-					Email: email,
-				},
-			),
+			Tag:       tag,
+			Operation: tmsg,
 		})
 		if err == nil {
 			success += 1

--- a/main/commands/all/api/inbounds_list.go
+++ b/main/commands/all/api/inbounds_list.go
@@ -29,17 +29,15 @@ Example:
 
 func executeListInbounds(cmd *base.Command, args []string) {
 	setSharedFlags(cmd)
-	var isOnlyTagsStr string
-	cmd.Flag.StringVar(&isOnlyTagsStr, "isOnlyTags", "", "")
+	isOnlyTags := cmd.Flag.Bool("isOnlyTags", false, "")
 	cmd.Flag.Parse(args)
-	isOnlyTags := isOnlyTagsStr == "true"
 
 	conn, ctx, close := dialAPIServer()
 	defer close()
 
 	client := handlerService.NewHandlerServiceClient(conn)
 
-	resp, err := client.ListInbounds(ctx, &handlerService.ListInboundsRequest{IsOnlyTags: isOnlyTags})
+	resp, err := client.ListInbounds(ctx, &handlerService.ListInboundsRequest{IsOnlyTags: *isOnlyTags})
 	if err != nil {
 		base.Fatalf("failed to list inbounds: %s", err)
 	}

--- a/main/commands/all/api/rules_add.go
+++ b/main/commands/all/api/rules_add.go
@@ -80,9 +80,6 @@ func executeAddRules(cmd *base.Command, args []string) {
 			base.Fatalf("failed to build conf: %s", err)
 		}
 		tmsg := cserial.ToTypedMessage(config)
-		if tmsg == nil {
-			base.Fatalf("failed to format config to TypedMessage.")
-		}
 
 		ra := &routerService.AddRuleRequest{
 			Config:       tmsg,

--- a/main/commands/all/api/source_ip_block.go
+++ b/main/commands/all/api/source_ip_block.go
@@ -115,9 +115,6 @@ func executeSourceIpBlock(cmd *base.Command, args []string) {
 		base.Fatalf("failed to build conf: %s", err)
 	}
 	tmsg := cserial.ToTypedMessage(config)
-	if tmsg == nil {
-		base.Fatalf("failed to format config to TypedMessage.")
-	}
 
 	if reset {
 		rr := &routerService.RemoveRuleRequest{

--- a/main/commands/all/api/source_ip_block.go
+++ b/main/commands/all/api/source_ip_block.go
@@ -18,6 +18,8 @@ var cmdSourceIpBlock = &base.Command{
 	Long: `
 Block connections by source IP address.
 
+> Before using it, please ensure that there is an outbound pointing to blackhole.
+
 Arguments:
 
 	-s, -server <server:port>
@@ -41,20 +43,20 @@ Arguments:
 Example:
 
 	{{.Exec}} {{.LongName}} --server=127.0.0.1:8080 -outbound=blocked -inbound=socks 1.2.3.4
-	{{.Exec}} {{.LongName}} --server=127.0.0.1:8080 -outbound=blocked -inbound=socks 1.2.3.4 -reset
+	{{.Exec}} {{.LongName}} --server=127.0.0.1:8080 -outbound=blocked -inbound=socks -inbound=http 1.2.3.4 -reset
 `,
 	Run: executeSourceIpBlock,
 }
 
 func executeSourceIpBlock(cmd *base.Command, args []string) {
 	var (
-		inbound  string
+		inbound  base.OptionList
 		outbound string
 		ruletag  string
 		reset    bool
 	)
 	setSharedFlags(cmd)
-	cmd.Flag.StringVar(&inbound, "inbound", "", "")
+	cmd.Flag.Var(&inbound, "inbound", "")
 	cmd.Flag.StringVar(&outbound, "outbound", "", "")
 	cmd.Flag.StringVar(&ruletag, "ruletag", "sourceIpBlock", "")
 	cmd.Flag.BoolVar(&reset, "reset", false, "")
@@ -63,8 +65,7 @@ func executeSourceIpBlock(cmd *base.Command, args []string) {
 
 	unnamedArgs := cmd.Flag.Args()
 	if len(unnamedArgs) == 0 {
-		fmt.Println("reading from stdin:")
-		unnamedArgs = []string{"stdin:"}
+		base.Fatalf("No source ip specified.")
 	}
 	conn, ctx, close := dialAPIServer()
 	defer close()
@@ -77,14 +78,16 @@ func executeSourceIpBlock(cmd *base.Command, args []string) {
 		return
 	}
 
-	jsonInbound, err := json.Marshal([]string{inbound})
-	if inbound == "" {
-		jsonInbound, err = json.Marshal([]string{})
+	jsonInbound := []string(inbound)
+	if jsonInbound == nil {
+		jsonInbound = []string{}
 	}
+	jsonInboundBytes, err := json.Marshal(jsonInbound)
 	if err != nil {
 		fmt.Println("Error marshaling JSON:", err)
 		return
 	}
+
 	stringConfig := fmt.Sprintf(`
 	{
 		"routing": {
@@ -99,7 +102,7 @@ func executeSourceIpBlock(cmd *base.Command, args []string) {
 		  }
 	  }
 	  
-	`, ruletag, string(jsonInbound), outbound, string(jsonIps))
+	`, ruletag, string(jsonInboundBytes), outbound, string(jsonIps))
 
 	conf, err := serial.DecodeJSONConfig(strings.NewReader(stringConfig))
 	if err != nil {

--- a/main/commands/all/curve25519.go
+++ b/main/commands/all/curve25519.go
@@ -11,7 +11,7 @@ import (
 
 func Curve25519Genkey(StdEncoding bool, input_base64 string) {
 	var encoding *base64.Encoding
-	if *input_stdEncoding || StdEncoding {
+	if StdEncoding {
 		encoding = base64.StdEncoding
 	} else {
 		encoding = base64.RawURLEncoding

--- a/main/commands/all/mldsa65.go
+++ b/main/commands/all/mldsa65.go
@@ -10,24 +10,28 @@ import (
 )
 
 var cmdMLDSA65 = &base.Command{
-	UsageLine: `{{.Exec}} mldsa65 [-i "seed (base64.RawURLEncoding)"]`,
-	Short:     `Generate key pair for ML-DSA-65 post-quantum signature (REALITY)`,
+	CustomFlags: true,
+	UsageLine:   `{{.Exec}} mldsa65 [-i "seed (base64.RawURLEncoding)"]`,
+	Short:       `Generate key pair for ML-DSA-65 post-quantum signature (REALITY)`,
 	Long: `
 Generate key pair for ML-DSA-65 post-quantum signature (REALITY).
 
-Random: {{.Exec}} mldsa65
+Arguments:
 
-From seed: {{.Exec}} mldsa65 -i "seed (base64.RawURLEncoding)"
+	-i
+		Generate key pair from seed (base64.RawURLEncoding).
+
+Example:
+
+	Random: {{.Exec}} {{.LongName}}
+	From seed: {{.Exec}} {{.LongName}} -i "seed (base64.RawURLEncoding)"
 `,
+	Run: executeMLDSA65,
 }
-
-func init() {
-	cmdMLDSA65.Run = executeMLDSA65 // break init loop
-}
-
-var input_mldsa65 = cmdMLDSA65.Flag.String("i", "", "")
 
 func executeMLDSA65(cmd *base.Command, args []string) {
+	var input_mldsa65 = cmd.Flag.String("i", "", "")
+	cmd.Flag.Parse(args)
 	var seed [32]byte
 	if len(*input_mldsa65) > 0 {
 		s, _ := base64.RawURLEncoding.DecodeString(*input_mldsa65)

--- a/main/commands/all/mlkem768.go
+++ b/main/commands/all/mlkem768.go
@@ -11,24 +11,28 @@ import (
 )
 
 var cmdMLKEM768 = &base.Command{
-	UsageLine: `{{.Exec}} mlkem768 [-i "seed (base64.RawURLEncoding)"]`,
-	Short:     `Generate key pair for ML-KEM-768 post-quantum key exchange (VLESS Encryption)`,
+	CustomFlags: true,
+	UsageLine:   `{{.Exec}} mlkem768 [-i "seed (base64.RawURLEncoding)"]`,
+	Short:       `Generate key pair for ML-KEM-768 post-quantum key exchange (VLESS Encryption)`,
 	Long: `
 Generate key pair for ML-KEM-768 post-quantum key exchange (VLESS Encryption).
 
-Random: {{.Exec}} mlkem768
+Arguments:
 
-From seed: {{.Exec}} mlkem768 -i "seed (base64.RawURLEncoding)"
+	-i
+		Generate key pair from seed (base64.RawURLEncoding).
+
+Example:
+
+	Random: {{.Exec}} {{.LongName}}
+	From seed: {{.Exec}} {{.LongName}} -i "seed (base64.RawURLEncoding)"
 `,
+	Run: executeMLKEM768,
 }
-
-func init() {
-	cmdMLKEM768.Run = executeMLKEM768 // break init loop
-}
-
-var input_mlkem768 = cmdMLKEM768.Flag.String("i", "", "")
 
 func executeMLKEM768(cmd *base.Command, args []string) {
+	var input_mlkem768 = cmd.Flag.String("i", "", "")
+	cmd.Flag.Parse(args)
 	var seed [64]byte
 	if len(*input_mlkem768) > 0 {
 		s, _ := base64.RawURLEncoding.DecodeString(*input_mlkem768)

--- a/main/commands/all/tls/cert.go
+++ b/main/commands/all/tls/cert.go
@@ -16,8 +16,9 @@ import (
 
 // cmdCert is the tls cert command
 var cmdCert = &base.Command{
-	UsageLine: "{{.Exec}} tls cert [--ca] [--domain=example.com] [--expire=240h]",
-	Short:     "Generate TLS certificates",
+	CustomFlags: true,
+	UsageLine:   "{{.Exec}} tls cert [--ca] [--domain=example.com] [--expire=240h]",
+	Short:       "Generate TLS certificates",
 	Long: `
 Generate TLS certificates.
 
@@ -33,10 +34,10 @@ Arguments:
 		The organization name for the certificate.
 
 	-ca 
-		Whether this certificate is a CA
+		Whether this certificate is a CA.
 
 	-json 
-		The output of certificate to JSON
+		The output of certificate to JSON.
 
 	-file 
 		The certificate path to save.
@@ -44,28 +45,19 @@ Arguments:
 	-expire 
 		Expire time of the certificate. Default value 3 months.
 `,
+	Run: executeCert,
 }
-
-func init() {
-	cmdCert.Run = executeCert // break init loop
-}
-
-var (
-	certDomainNames stringList
-	_               = func() bool {
-		cmdCert.Flag.Var(&certDomainNames, "domain", "Domain name for the certificate")
-		return true
-	}()
-
-	certCommonName   = cmdCert.Flag.String("name", "Xray Inc", "The common name of this certificate")
-	certOrganization = cmdCert.Flag.String("org", "Xray Inc", "Organization of the certificate")
-	certIsCA         = cmdCert.Flag.Bool("ca", false, "Whether this certificate is a CA")
-	certJSONOutput   = cmdCert.Flag.Bool("json", true, "Print certificate in JSON format")
-	certFileOutput   = cmdCert.Flag.String("file", "", "Save certificate in file.")
-	certExpire       = cmdCert.Flag.Duration("expire", time.Hour*24*90 /* 90 days */, "Time until the certificate expires. Default value 3 months.")
-)
 
 func executeCert(cmd *base.Command, args []string) {
+	var certDomainNames base.OptionList
+	cmd.Flag.Var(&certDomainNames, "domain", "Domain name for the certificate")
+	certCommonName := cmd.Flag.String("name", "Xray Inc", "The common name of this certificate")
+	certOrganization := cmd.Flag.String("org", "Xray Inc", "Organization of the certificate")
+	certIsCA := cmd.Flag.Bool("ca", false, "Whether this certificate is a CA")
+	certJSONOutput := cmd.Flag.Bool("json", true, "Print certificate in JSON format")
+	certFileOutput := cmd.Flag.String("file", "", "Save certificate in file.")
+	certExpire := cmd.Flag.Duration("expire", time.Hour*24*90 /* 90 days */, "Time until the certificate expires. Default value 3 months.")
+	cmd.Flag.Parse(args)
 	var opts []cert.Option
 	if *certIsCA {
 		opts = append(opts, cert.Authority(*certIsCA))
@@ -124,20 +116,6 @@ func printFile(certificate *cert.Certificate, name string) error {
 	}, func() error {
 		return writeFile(keyPEM, name+".key")
 	})
-}
-
-type stringList []string
-
-func (l *stringList) String() string {
-	return "String list"
-}
-
-func (l *stringList) Set(v string) error {
-	if v == "" {
-		base.Fatalf("empty value")
-	}
-	*l = append(*l, v)
-	return nil
 }
 
 type jsonCert struct {

--- a/main/commands/all/tls/ech.go
+++ b/main/commands/all/tls/ech.go
@@ -16,43 +16,45 @@ import (
 )
 
 var cmdECH = &base.Command{
-	UsageLine: `{{.Exec}} tls ech [--serverName (string)] [--pem] [-i "ECHServerKeys (base64.StdEncoding)"]`,
-	Short:     `Generate TLS-ECH certificates`,
+	CustomFlags: true,
+	UsageLine:   `{{.Exec}} tls ech [--serverName (string)] [--pem] [-i "ECHServerKeys (base64.StdEncoding)"]`,
+	Short:       `Generate TLS-ECH certificates`,
 	Long: `
 Generate TLS-ECH certificates.
 
-Set serverName to your custom string: {{.Exec}} tls ech --serverName (string)
-Generate into pem format: {{.Exec}} tls ech --pem
-Restore ECHConfigs from ECHServerKeys: {{.Exec}} tls ech -i "ECHServerKeys (base64.StdEncoding)"
-`, // Enable PQ signature schemes: {{.Exec}} tls ech --pq-signature-schemes-enabled
+Arguments:
+
+	-serverName
+		Set serverName to your custom string.
+	
+	-pem
+		Generate into pem format.
+
+	-i
+		Restore ECHConfigs from ECHServerKeys.
+`,
+	// --pq-signature-schemes-enabled
+	//     Enable PQ signature schemes.
+	Run: executeECH,
 }
-
-func init() {
-	cmdECH.Run = executeECH
-}
-
-var input_echServerKeys = cmdECH.Flag.String("i", "", "ECHServerKeys (base64.StdEncoding)")
-
-// var input_pqSignatureSchemesEnabled = cmdECH.Flag.Bool("pqSignatureSchemesEnabled", false, "")
-var (
-	input_serverName = cmdECH.Flag.String("serverName", "cloudflare-ech.com", "")
-	input_pem        = cmdECH.Flag.Bool("pem", false, "True == turn on pem output")
-)
 
 func executeECH(cmd *base.Command, args []string) {
+	var input_echServerKeys = cmd.Flag.String("i", "", "ECHServerKeys (base64.StdEncoding)")
+	// var input_pqSignatureSchemesEnabled = cmdECH.Flag.Bool("pqSignatureSchemesEnabled", false, "")
+	var input_serverName = cmd.Flag.String("serverName", "cloudflare-ech.com", "")
+	var input_pem = cmd.Flag.Bool("pem", false, "True == turn on pem output")
+	cmd.Flag.Parse(args)
 	var kem uint16
-
-	// if *input_pqSignatureSchemesEnabled {
-	// 	kem = 0x30 // hpke.KEM_X25519_KYBER768_DRAFT00
-	// } else {
-	kem = hpke.DHKEM(ecdh.X25519()).ID()
-	// }
-
-	echConfig, priv, err := generateECHKeySet(0, *input_serverName, kem)
-	common.Must(err)
 
 	var configBuffer, keyBuffer []byte
 	if *input_echServerKeys == "" {
+		// if *input_pqSignatureSchemesEnabled {
+		// 	kem = 0x30 // hpke.KEM_X25519_KYBER768_DRAFT00
+		// } else {
+		kem = hpke.DHKEM(ecdh.X25519()).ID()
+		// }
+		echConfig, priv, err := generateECHKeySet(0, *input_serverName, kem)
+		common.Must(err)
 		configBytes, _ := marshalBinary(echConfig)
 		var b cryptobyte.Builder
 		b.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {

--- a/main/commands/all/tls/hash.go
+++ b/main/commands/all/tls/hash.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"crypto/x509"
 	"encoding/pem"
-	"flag"
+
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -14,26 +14,23 @@ import (
 )
 
 var cmdHash = &base.Command{
-	UsageLine: "{{.Exec}} tls hash",
-	Short:     "Calculate TLS certificate hash.",
+	CustomFlags: true,
+	UsageLine:   "{{.Exec}} tls hash [-cert=cert.pem]",
+	Short:       "Calculate TLS certificate hash.",
 	Long: `
-	xray tls hash --cert <cert.pem>
-	Calculate TLS certificate hash.
-	`,
-}
+Calculate TLS certificate hash.
 
-func init() {
-	cmdHash.Run = executeHash // break init loop
-}
+Arguments:
 
-var input = cmdHash.Flag.String("cert", "fullchain.pem", "The file path of the certificate")
+	-cert
+		The certificate file to be calculated.
+`,
+	Run: executeHash,
+}
 
 func executeHash(cmd *base.Command, args []string) {
-	fs := flag.NewFlagSet("hash", flag.ContinueOnError)
-	if err := fs.Parse(args); err != nil {
-		fmt.Println(err)
-		return
-	}
+	var input = cmd.Flag.String("cert", "fullchain.pem", "The file path of the certificate")
+	cmd.Flag.Parse(args)
 	certContent, err := os.ReadFile(*input)
 	if err != nil {
 		fmt.Println(err)

--- a/main/commands/all/tls/ping.go
+++ b/main/commands/all/tls/ping.go
@@ -19,8 +19,9 @@ import (
 
 // cmdPing is the tls ping command
 var cmdPing = &base.Command{
-	UsageLine: "{{.Exec}} tls ping [-ip <ip>] <domain>",
-	Short:     "Ping the domain with TLS handshake",
+	CustomFlags: true,
+	UsageLine:   "{{.Exec}} tls ping [-ip <ip>] <domain>",
+	Short:       "Ping the domain with TLS handshake",
 	Long: `
 Ping the domain with TLS handshake.
 
@@ -29,20 +30,17 @@ Arguments:
 	-ip
 		The IP address of the domain.
 `,
+	Run: executePing,
 }
-
-func init() {
-	cmdPing.Run = executePing // break init loop
-}
-
-var pingIPStr = cmdPing.Flag.String("ip", "", "")
 
 func executePing(cmd *base.Command, args []string) {
-	if cmdPing.Flag.NArg() < 1 {
+	pingIPStr := cmd.Flag.String("ip", "", "")
+	cmd.Flag.Parse(args)
+	if cmd.Flag.NArg() < 1 {
 		base.Fatalf("domain not specified")
 	}
 
-	domainWithPort := cmdPing.Flag.Arg(0)
+	domainWithPort := cmd.Flag.Arg(0)
 	fmt.Println("TLS ping: ", domainWithPort)
 	TargetPort := 443
 	domain, port, err := net.SplitHostPort(domainWithPort)

--- a/main/commands/all/uuid.go
+++ b/main/commands/all/uuid.go
@@ -8,24 +8,28 @@ import (
 )
 
 var cmdUUID = &base.Command{
-	UsageLine: `{{.Exec}} uuid [-i "example"]`,
-	Short:     `Generate UUIDv4 or UUIDv5 (VLESS)`,
+	CustomFlags: true,
+	UsageLine:   `{{.Exec}} uuid [-i "example"]`,
+	Short:       `Generate UUIDv4 or UUIDv5 (VLESS)`,
 	Long: `
 Generate UUIDv4 or UUIDv5 (VLESS).
 
-UUIDv4 (random): {{.Exec}} uuid
+Arguments:
 
-UUIDv5 (from input): {{.Exec}} uuid -i "example"
+	-i
+		Generate uuid from input (UUIDv5).
+
+Example:
+
+	UUIDv4 (random): {{.Exec}} {{.LongName}}
+	UUIDv5 (from input): {{.Exec}} {{.LongName}} -i example
 `,
+	Run: executeUUID,
 }
-
-func init() {
-	cmdUUID.Run = executeUUID // break init loop
-}
-
-var input = cmdUUID.Flag.String("i", "", "")
 
 func executeUUID(cmd *base.Command, args []string) {
+	var input = cmd.Flag.String("i", "", "")
+	cmd.Flag.Parse(args)
 	var output string
 	if l := len(*input); l == 0 {
 		u := uuid.New()

--- a/main/commands/all/vlessenc.go
+++ b/main/commands/all/vlessenc.go
@@ -14,10 +14,7 @@ var cmdVLESSEnc = &base.Command{
 	Long: `
 Generate decryption/encryption json pair (VLESS Encryption).
 `,
-}
-
-func init() {
-	cmdVLESSEnc.Run = executeVLESSEnc // break init loop
+	Run: executeVLESSEnc,
 }
 
 func executeVLESSEnc(cmd *base.Command, args []string) {

--- a/main/commands/all/wg.go
+++ b/main/commands/all/wg.go
@@ -5,23 +5,27 @@ import (
 )
 
 var cmdWG = &base.Command{
-	UsageLine: `{{.Exec}} wg [-i "private key (base64.StdEncoding)"]`,
-	Short:     `Generate key pair for X25519 key exchange (WireGuard)`,
+	CustomFlags: true,
+	UsageLine:   `{{.Exec}} wg [-i "private key (base64.StdEncoding)"]`,
+	Short:       `Generate key pair for X25519 key exchange (WireGuard)`,
 	Long: `
 Generate key pair for X25519 key exchange (WireGuard).
 
-Random: {{.Exec}} wg
+Arguments:
 
-From private key: {{.Exec}} wg -i "private key (base64.StdEncoding)"
+	-i
+		Generate key pair from private key (base64.StdEncoding).
+
+Example:
+
+	Random: {{.Exec}} {{.LongName}}
+	From private key: {{.Exec}} {{.LongName}} -i "private key (base64.StdEncoding)"
 `,
+	Run: executeWG,
 }
-
-func init() {
-	cmdWG.Run = executeWG // break init loop
-}
-
-var input_wireguard = cmdWG.Flag.String("i", "", "")
 
 func executeWG(cmd *base.Command, args []string) {
+	var input_wireguard = cmd.Flag.String("i", "", "")
+	cmd.Flag.Parse(args)
 	Curve25519Genkey(true, *input_wireguard)
 }

--- a/main/commands/all/x25519.go
+++ b/main/commands/all/x25519.go
@@ -5,27 +5,32 @@ import (
 )
 
 var cmdX25519 = &base.Command{
-	UsageLine: `{{.Exec}} x25519 [-i "private key (base64.RawURLEncoding)"] [--std-encoding]`,
-	Short:     `Generate key pair for X25519 key exchange (REALITY, VLESS Encryption)`,
+	CustomFlags: true,
+	UsageLine:   `{{.Exec}} x25519 [-i "private key (base64.RawURLEncoding)"] [--std-encoding]`,
+	Short:       `Generate key pair for X25519 key exchange (REALITY, VLESS Encryption)`,
 	Long: `
 Generate key pair for X25519 key exchange (REALITY, VLESS Encryption).
 
-Random: {{.Exec}} x25519
+Arguments:
 
-From private key: {{.Exec}} x25519 -i "private key (base64.RawURLEncoding)"
-For Std Encoding: {{.Exec}} x25519 --std-encoding
+	-i
+		Generate key pair from private key (base64.RawURLEncoding).
+	
+	--std-encoding
+		Use standard Base64 encoding format instead of URL-friendly format.
+
+Example:
+
+	Random: {{.Exec}} {{.LongName}}
+	From private key: {{.Exec}} {{.LongName}} -i "private key (base64.RawURLEncoding)"
+	For Std Encoding: {{.Exec}} {{.LongName}} --std-encoding
 `,
+	Run: executeX25519,
 }
-
-func init() {
-	cmdX25519.Run = executeX25519 // break init loop
-}
-
-var (
-	input_stdEncoding = cmdX25519.Flag.Bool("std-encoding", false, "")
-	input_x25519      = cmdX25519.Flag.String("i", "", "")
-)
 
 func executeX25519(cmd *base.Command, args []string) {
-	Curve25519Genkey(false, *input_x25519)
+	var input_stdEncoding = cmd.Flag.Bool("std-encoding", false, "")
+	var input_x25519 = cmd.Flag.String("i", "", "")
+	cmd.Flag.Parse(args)
+	Curve25519Genkey(*input_stdEncoding, *input_x25519)
 }

--- a/main/commands/base/command.go
+++ b/main/commands/base/command.go
@@ -131,3 +131,18 @@ func SetExitStatus(n int) {
 func GetExitStatus() int {
 	return exitStatus
 }
+
+// OptionList supports flag reuse
+type OptionList []string
+
+func (l *OptionList) String() string {
+	return "String list"
+}
+
+func (l *OptionList) Set(v string) error {
+	if v == "" {
+		Fatalf("empty value")
+	}
+	*l = append(*l, v)
+	return nil
+}


### PR DESCRIPTION
主要统一了命令行提示信息和初始化方式，利用execute时传入的参数列表而不是全局变量读取flag。

顺带解决了一些小问题：

- `x25519`命令的`--std-encoding`选项不生效。
- 为`api sib`增加了多Inbound支持。
- 移除对`cserial.ToTypedMessage`返回结果的无意义检查。