### PR TITLE
splithttp: bound physical H2 carriers for maxConnections

### DIFF
--- a/transport/internet/splithttp/client.go
+++ b/transport/internet/splithttp/client.go
@@ -40,7 +40,13 @@ type DefaultDialerClient struct {
 }
 
 func (c *DefaultDialerClient) IsClosed() bool {
-	return c.closed
+	if c.closed {
+		return true
+	}
+	if carrier, ok := c.client.Transport.(interface{ IsClosed() bool }); ok {
+		return carrier.IsClosed()
+	}
+	return false
 }
 
 func (c *DefaultDialerClient) OpenStream(ctx context.Context, url string, sessionId string, body io.Reader, uploadOnly bool) (wrc io.ReadCloser, remoteAddr, localAddr net.Addr, err error) {
@@ -177,11 +183,14 @@ func (c *DefaultDialerClient) PostPacket(ctx context.Context, url string, sessio
 	return nil
 }
 
-// HTTP/1.1 and HTTP/2 will close itself, we only handle HTTP/3 here
 func (c *DefaultDialerClient) Close() error {
+	c.closed = true
 	transport := c.client.Transport
+	if closer, ok := transport.(io.Closer); ok {
+		return closer.Close()
+	}
 	if h3Transport, ok := transport.(*http3.Transport); ok {
-		h3Transport.Close()
+		return h3Transport.Close()
 	}
 	return nil
 }

--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -81,6 +81,81 @@ func getHTTPClient(ctx context.Context, dest net.Destination, streamSettings *in
 	return xmuxClient.XmuxConn.(DialerClient), xmuxClient
 }
 
+type fixedH2RoundTripper struct {
+	mu        sync.Mutex
+	transport *http2.Transport
+	dial      func(context.Context) (net.Conn, error)
+	conn      *http2.ClientConn
+	rawConn   net.Conn
+	closed    bool
+}
+
+func (t *fixedH2RoundTripper) getConn(ctx context.Context) (*http2.ClientConn, net.Conn, bool, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.closed {
+		return nil, nil, false, errors.New("fixed H2 carrier is closed")
+	}
+	if t.conn != nil {
+		state := t.conn.State()
+		if state.Closed || state.Closing {
+			return nil, t.rawConn, false, errors.New("fixed H2 carrier is no longer reusable")
+		}
+		return t.conn, t.rawConn, true, nil
+	}
+
+	raw, err := t.dial(ctx)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	cc, err := t.transport.NewClientConn(raw)
+	if err != nil {
+		raw.Close()
+		return nil, nil, false, err
+	}
+	t.conn = cc
+	t.rawConn = raw
+	return cc, raw, false, nil
+}
+
+func (t *fixedH2RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	cc, raw, reused, err := t.getConn(req.Context())
+	if err != nil {
+		return nil, err
+	}
+	if trace := httptrace.ContextClientTrace(req.Context()); trace != nil && trace.GotConn != nil {
+		trace.GotConn(httptrace.GotConnInfo{Conn: raw, Reused: reused})
+	}
+	return cc.RoundTrip(req)
+}
+
+func (t *fixedH2RoundTripper) IsClosed() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.closed {
+		return true
+	}
+	if t.conn == nil {
+		return false
+	}
+	state := t.conn.State()
+	return state.Closed || state.Closing
+}
+
+func (t *fixedH2RoundTripper) Close() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.closed = true
+	if t.conn == nil {
+		return nil
+	}
+	err := t.conn.Close()
+	t.conn = nil
+	t.rawConn = nil
+	return err
+}
+
 func decideHTTPVersion(tlsConfig *tls.Config, realityConfig *reality.Config) string {
 	if realityConfig != nil {
 		return "2"
@@ -281,12 +356,24 @@ func createHTTPClient(dest net.Destination, streamSettings *internet.MemoryStrea
 		if keepAlivePeriod < 0 {
 			keepAlivePeriod = 0
 		}
-		transport = &http2.Transport{
+		fixedPool := transportConfig.Xmux != nil && transportConfig.Xmux.GetNormalizedMaxConnections().To > 0
+		h2Transport := &http2.Transport{
 			DialTLSContext: func(ctxInner context.Context, network string, addr string, cfg *gotls.Config) (net.Conn, error) {
 				return dialContext(ctxInner)
 			},
-			IdleConnTimeout: net.ConnIdleTimeout,
-			ReadIdleTimeout: keepAlivePeriod,
+			IdleConnTimeout:            net.ConnIdleTimeout,
+			ReadIdleTimeout:            keepAlivePeriod,
+			StrictMaxConcurrentStreams: fixedPool,
+		}
+		if fixedPool {
+			// maxConnections describes physical carrier connections. A regular
+			// http2.Transport is itself a connection pool and may create multiple
+			// TCP connections internally under burst load. Bind one ClientConn to
+			// each XmuxClient so pool accounting matches the wire.
+			h2Transport.IdleConnTimeout = 0 // XMUX owns carrier lifetime/rotation.
+			transport = &fixedH2RoundTripper{transport: h2Transport, dial: dialContext}
+		} else {
+			transport = h2Transport
 		}
 	} else {
 		httpDialContext := func(ctxInner context.Context, network string, addr string) (net.Conn, error) {

--- a/transport/internet/splithttp/fixed_pool_test.go
+++ b/transport/internet/splithttp/fixed_pool_test.go
@@ -1,0 +1,136 @@
+package splithttp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	stdnet "net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/net/http2"
+)
+
+type poolTestConn struct{ closed atomic.Bool }
+
+func (c *poolTestConn) IsClosed() bool { return c.closed.Load() }
+func (c *poolTestConn) Close() error {
+	c.closed.Store(true)
+	return nil
+}
+
+func TestFixedPoolSerialRotation(t *testing.T) {
+	var created atomic.Int32
+	m := NewXmuxManager(XmuxConfig{MaxConnections: &RangeConfig{From: 4, To: 4}}, func() XmuxConn {
+		created.Add(1)
+		return &poolTestConn{}
+	})
+
+	clients := make([]*XmuxClient, 4)
+	for i := range clients {
+		clients[i] = m.GetXmuxClient(context.Background())
+		clients[i].AddRunning()
+	}
+	if created.Load() != 4 {
+		t.Fatalf("created=%d, want 4", created.Load())
+	}
+	for _, c := range clients {
+		c.UnreusableAt = time.Now().Add(-time.Second)
+	}
+
+	replacement := m.GetXmuxClient(context.Background())
+	replacement.AddRunning()
+	if created.Load() != 5 {
+		t.Fatalf("first rotation created=%d, want 5 total", created.Load())
+	}
+	if len(m.xmuxClients) != 4 {
+		t.Fatalf("active pool=%d, want 4", len(m.xmuxClients))
+	}
+	if m.draining == nil {
+		t.Fatal("expected one draining carrier")
+	}
+	firstDraining := m.draining
+
+	for range 100 {
+		m.GetXmuxClient(context.Background())
+	}
+	if created.Load() != 5 {
+		t.Fatalf("parallel rotation started while one carrier drains: created=%d", created.Load())
+	}
+	if m.draining != firstDraining {
+		t.Fatal("draining carrier changed before it finished")
+	}
+
+	firstDraining.DoneRunning()
+	if !firstDraining.XmuxConn.IsClosed() {
+		t.Fatal("drained carrier was not closed")
+	}
+	secondReplacement := m.GetXmuxClient(context.Background())
+	secondReplacement.AddRunning()
+	if created.Load() != 6 {
+		t.Fatalf("second rotation created=%d, want 6 total", created.Load())
+	}
+	if len(m.xmuxClients) != 4 || m.draining == nil {
+		t.Fatalf("second rotation state: active=%d draining=%v", len(m.xmuxClients), m.draining != nil)
+	}
+}
+
+func TestFixedH2RoundTripperUsesOnePhysicalConnection(t *testing.T) {
+	ln, err := stdnet.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	var accepts atomic.Int32
+	server := &http2.Server{MaxConcurrentStreams: 32}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			accepts.Add(1)
+			go server.ServeConn(conn, &http2.ServeConnOpts{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				time.Sleep(10 * time.Millisecond)
+				fmt.Fprint(w, "ok")
+			})})
+		}
+	}()
+
+	rt := &fixedH2RoundTripper{
+		transport: &http2.Transport{AllowHTTP: true, StrictMaxConcurrentStreams: true},
+		dial: func(context.Context) (stdnet.Conn, error) {
+			return stdnet.Dial("tcp", ln.Addr().String())
+		},
+	}
+	defer rt.Close()
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 256)
+	for range 256 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req, _ := http.NewRequest("GET", "http://xhttp.test/", nil)
+			resp, err := rt.RoundTrip(req)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatal(err)
+	}
+	if got := accepts.Load(); got != 1 {
+		t.Fatalf("physical H2 connections=%d, want 1", got)
+	}
+}

--- a/transport/internet/splithttp/mux.go
+++ b/transport/internet/splithttp/mux.go
@@ -47,6 +47,7 @@ type XmuxManager struct {
 	connections int32
 	newConnFunc func() XmuxConn
 	xmuxClients []*XmuxClient
+	draining    *XmuxClient
 }
 
 func NewXmuxManager(xmuxConfig XmuxConfig, newConnFunc func() XmuxConn) *XmuxManager {
@@ -79,23 +80,62 @@ func (m *XmuxManager) newXmuxClient() *XmuxClient {
 }
 
 func (m *XmuxManager) GetXmuxClient(ctx context.Context) *XmuxClient { // when locking
+	// Planned fixed-pool rotation is make-before-break, but only one old
+	// carrier drains at a time. This bounds a maxConnections=N pool to N+1
+	// physical carriers during graceful rotation instead of letting multiple
+	// generations accumulate when long-lived flows pin old carriers.
+	if m.connections > 0 && m.draining != nil && (m.draining.Running.Load() <= 0 || m.draining.XmuxConn.IsClosed()) {
+		m.draining.NotUsed.Store(true)
+		m.draining.maybeClose()
+		m.draining = nil
+	}
+
+	now := time.Now()
 	for i := 0; i < len(m.xmuxClients); {
 		xmuxClient := m.xmuxClients[i]
-		if xmuxClient.XmuxConn.IsClosed() ||
-			xmuxClient.leftUsage == 0 ||
+		closed := xmuxClient.XmuxConn.IsClosed()
+		exhausted := xmuxClient.leftUsage == 0 ||
 			xmuxClient.LeftRequests.Load() <= 0 ||
-			(xmuxClient.UnreusableAt != time.Time{} && time.Now().After(xmuxClient.UnreusableAt)) {
-			errors.LogDebug(ctx, "XMUX: removing xmuxClient, IsClosed() = ", xmuxClient.XmuxConn.IsClosed(),
-				", Running = ", xmuxClient.Running.Load(),
+			(xmuxClient.UnreusableAt != time.Time{} && now.After(xmuxClient.UnreusableAt))
+
+		if closed {
+			errors.LogDebug(ctx, "XMUX: removing closed xmuxClient, Running = ", xmuxClient.Running.Load())
+			xmuxClient.NotUsed.Store(true)
+			xmuxClient.maybeClose()
+			m.xmuxClients = append(m.xmuxClients[:i], m.xmuxClients[i+1:]...)
+			continue
+		}
+
+		if exhausted {
+			if m.connections > 0 && xmuxClient.Running.Load() > 0 {
+				if m.draining == nil {
+					errors.LogDebug(ctx, "XMUX: serial-draining xmuxClient, Running = ", xmuxClient.Running.Load(),
+						", leftUsage = ", xmuxClient.leftUsage,
+						", LeftRequests = ", xmuxClient.LeftRequests.Load(),
+						", UnreusableAt = ", xmuxClient.UnreusableAt)
+					xmuxClient.NotUsed.Store(true)
+					xmuxClient.maybeClose()
+					m.draining = xmuxClient
+					m.xmuxClients = append(m.xmuxClients[:i], m.xmuxClients[i+1:]...)
+					continue
+				}
+
+				// Another carrier is already draining. Keep this expired carrier
+				// active temporarily; it will become the next rotation candidate.
+				i++
+				continue
+			}
+
+			errors.LogDebug(ctx, "XMUX: removing exhausted xmuxClient, Running = ", xmuxClient.Running.Load(),
 				", leftUsage = ", xmuxClient.leftUsage,
 				", LeftRequests = ", xmuxClient.LeftRequests.Load(),
 				", UnreusableAt = ", xmuxClient.UnreusableAt)
 			xmuxClient.NotUsed.Store(true)
 			xmuxClient.maybeClose()
 			m.xmuxClients = append(m.xmuxClients[:i], m.xmuxClients[i+1:]...)
-		} else {
-			i++
+			continue
 		}
+		i++
 	}
 
 	if len(m.xmuxClients) == 0 {
@@ -104,7 +144,7 @@ func (m *XmuxManager) GetXmuxClient(ctx context.Context) *XmuxClient { // when l
 	}
 
 	if m.connections > 0 && len(m.xmuxClients) < int(m.connections) {
-		errors.LogDebug(ctx, "XMUX: creating xmuxClient because maxConnections was not hit, xmuxClients = ", len(m.xmuxClients))
+		errors.LogDebug(ctx, "XMUX: creating xmuxClient because fixed pool has a free active slot, xmuxClients = ", len(m.xmuxClients))
 		return m.newXmuxClient()
 	}
 
@@ -112,6 +152,20 @@ func (m *XmuxManager) GetXmuxClient(ctx context.Context) *XmuxClient { // when l
 	if m.concurrency > 0 {
 		for _, xmuxClient := range m.xmuxClients {
 			if xmuxClient.Running.Load() < m.concurrency {
+				xmuxClients = append(xmuxClients, xmuxClient)
+			}
+		}
+	} else if m.connections > 0 {
+		// Keep new proxy flows spread across the least-loaded active carriers.
+		// Each flow remains pinned to the chosen XmuxClient for its lifetime.
+		minRunning := int32(math.MaxInt32)
+		for _, xmuxClient := range m.xmuxClients {
+			running := xmuxClient.Running.Load()
+			if running < minRunning {
+				minRunning = running
+				xmuxClients = xmuxClients[:0]
+			}
+			if running == minRunning {
 				xmuxClients = append(xmuxClients, xmuxClient)
 			}
 		}

--- a/transport/internet/splithttp/mux_test.go
+++ b/transport/internet/splithttp/mux_test.go
@@ -90,3 +90,29 @@ func TestDefault(t *testing.T) {
 		t.Error("did not get 1 distinct clients, got ", len(xmuxClients))
 	}
 }
+
+func TestMaxConnectionsPreferLeastLoaded(t *testing.T) {
+	xmuxConfig := XmuxConfig{
+		MaxConnections: &RangeConfig{From: 4, To: 4},
+	}
+
+	xmuxManager := NewXmuxManager(xmuxConfig, func() XmuxConn {
+		return &fakeRoundTripper{}
+	})
+
+	clients := make([]*XmuxClient, 4)
+	for i := range clients {
+		clients[i] = xmuxManager.GetXmuxClient(context.Background())
+		clients[i].AddRunning()
+	}
+
+	clients[0].AddRunning()
+	clients[0].AddRunning()
+	clients[1].AddRunning()
+	clients[2].AddRunning()
+
+	got := xmuxManager.GetXmuxClient(context.Background())
+	if got != clients[3] {
+		t.Fatalf("expected least-loaded xmux client, got %p want %p", got, clients[3])
+	}
+}


### PR DESCRIPTION
## Summary

Make XHTTP `xmux.maxConnections` behave like a bounded physical HTTP/2 carrier pool instead of only bounding logical `http2.Transport` instances.

When `maxConnections` is configured for HTTP/2, this change:

- binds one `http2.ClientConn` to each `XmuxClient`, so one logical carrier cannot silently create additional TCP connections;
- assigns new proxy flows to the least-loaded active carrier while keeping each flow pinned to that carrier for its lifetime;
- rotates expired carriers serially with make-before-break semantics: keep `N` active carriers and at most one planned draining carrier while long-lived flows finish.

There is no XHTTP wire-format or server-side protocol change. Non-`maxConnections` behavior keeps the existing transport path.

## Why

There are two independent layers of connection pooling today:

1. XMUX creates up to `maxConnections` `XmuxClient` objects.
2. Every `XmuxClient` uses an `http2.Transport`, which is itself allowed to create multiple physical H2/TCP connections.

There is also a rotation issue: when an XMUX client reaches its reuse/request/time limit, it is removed from the active slice even when pinned proxy flows are still running. The replacement is then created while the old transport is still draining.

For configurations that use `maxConnections` as an outer TCP/H2 recovery-domain budget, the number therefore does not directly describe the number of physical carrier connections.

## Rotation behavior

For fixed `maxConnections = N`:

- the active pool contains `N` carriers;
- each carrier owns one physical H2 `ClientConn`;
- only one expired carrier is removed from new-flow selection at a time;
- its replacement is created immediately, so service remains make-before-break;
- the old carrier remains alive only for its already-pinned flows;
- the next planned rotation waits until that drain finishes.

Thus normal planned rotation is bounded to `N active + at most 1 draining` physical carrier.

Unexpected connection failures/GOAWAY still prioritize recovery rather than waiting for planned rotation.

## Reproducer / live validation

I ran stock v26.7.28 and the patched build as two separate client processes with the same outbound configuration:

- `maxConnections = 8`
- `hMaxReusableSecs = 10-12` (intentionally shortened for the test)
- 8 long-lived throttled downloads were started first, giving both implementations exactly 8 carrier TCP connections
- after 15 seconds, while all 8 original proxy flows were still pinned and running, 8 new proxy flows were opened

Result after the second group connected:

```text
stock v26.7.28: 16 physical TCP carriers
patched:        9 physical TCP carriers
```

All new requests succeeded in both cases. The patched result is the intended 8 active + 1 draining make-before-break state.

A separate throughput check used an incompressible random file and verified the actual HTTP 206 byte counts. One run produced:

```text
                         stock       patched
1 x 64 MiB              394 Mbps     375 Mbps
4 x 64 MiB aggregate    890 Mbps    1032 Mbps
8 x 64 MiB aggregate    899 Mbps     945 Mbps
```

The throughput differences are within normal network variance; the relevant result is that bounding the physical pool did not introduce an aggregate-throughput regression in this test.

## Tests

Added tests cover:

- serial make-before-break rotation of a fixed pool;
- one fixed H2 carrier accepting exactly one physical TCP connection under 256 concurrent requests with server `MaxConcurrentStreams = 32`;
- least-loaded carrier selection for fixed `maxConnections` pools.

Validation on current `main`:

```text
go test ./transport/internet/splithttp
go test -race ./transport/internet/splithttp -run 'Test(FixedPoolSerialRotation|FixedH2RoundTripperUsesOnePhysicalConnection|MaxConnectionsPreferLeastLoaded)' -count=1
CGO_ENABLED=0 go build ./main
```
