### PR TITLE
Hysteria: return an error instead of panicking when client "address" is missing

### DIFF
--- a/infra/conf/hysteria.go
+++ b/infra/conf/hysteria.go
@@ -20,6 +20,9 @@ func (c *HysteriaClientConfig) Build() (proto.Message, error) {
 	if c.Version != 2 {
 		return nil, errors.New("version != 2")
 	}
+	if c.Address == nil {
+		return nil, errors.New(`Hysteria client: "address" is not set`)
+	}
 
 	config := &hysteria.ClientConfig{}
 	config.Server = &protocol.ServerEndpoint{

--- a/infra/conf/hysteria_test.go
+++ b/infra/conf/hysteria_test.go
@@ -1,0 +1,37 @@
+package conf_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/xtls/xray-core/common"
+	. "github.com/xtls/xray-core/infra/conf"
+	"github.com/xtls/xray-core/proxy/hysteria"
+)
+
+func TestHysteriaClientConfig(t *testing.T) {
+	rawJSON := `{"version": 2, "address": "127.0.0.1", "port": 443}`
+	config := new(HysteriaClientConfig)
+	common.Must(json.Unmarshal([]byte(rawJSON), config))
+
+	message, err := config.Build()
+	common.Must(err)
+
+	client, ok := message.(*hysteria.ClientConfig)
+	if !ok {
+		t.Fatal("expected *hysteria.ClientConfig")
+	}
+	if client.Server.Port != 443 {
+		t.Error("port: ", client.Server.Port)
+	}
+}
+
+func TestHysteriaClientConfigWithoutAddress(t *testing.T) {
+	rawJSON := `{"version": 2, "port": 443}`
+	config := new(HysteriaClientConfig)
+	common.Must(json.Unmarshal([]byte(rawJSON), config))
+
+	if _, err := config.Build(); err == nil {
+		t.Error("expected error, but got nil")
+	}
+}


### PR DESCRIPTION
`HysteriaClientConfig.Build()` dereferences `c.Address` without a nil check, so an outbound that omits `"address"` takes the whole process down while the config is being loaded, instead of producing a config error:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x139c77a]

goroutine 1 [running]:
github.com/xtls/xray-core/infra/conf.(*Address).Build(...)
	github.com/xtls/xray-core/infra/conf/common.go:68
github.com/xtls/xray-core/infra/conf.(*HysteriaClientConfig).Build(...)
	github.com/xtls/xray-core/infra/conf/hysteria.go:26
github.com/xtls/xray-core/infra/conf.(*OutboundDetourConfig).Build(...)
	github.com/xtls/xray-core/infra/conf/xray.go:364
github.com/xtls/xray-core/infra/conf.(*Config).Build(...)
	github.com/xtls/xray-core/infra/conf/xray.go:681
```

Minimal outbound that reproduces it (v26.7.28 release binary and current `main`):

```json
{
  "protocol": "hysteria",
  "settings": { "version": 2, "port": 443 },
  "streamSettings": { "network": "hysteria", "security": "tls", "hysteriaSettings": { "version": 2 } }
}
```

Every other builder that reads an optional `*Address` already guards it and returns a descriptive error (`vless.go`, `vmess.go`, `trojan.go`, `shadowsocks.go`, `dns.go`), so this change only brings the Hysteria client builder in line with them.

Includes regression tests for both the valid config and the address-less one; the latter panics without the guard.

#6235 touched the same spot together with `fakedns.go` and was closed; this change is limited to the Hysteria builder.

Fixes #6653
