### PR TITLE
refactor: rewrite packed directional conn handling

### DIFF
--- a/transport/internet/finalmask/sudoku/config.go
+++ b/transport/internet/finalmask/sudoku/config.go
@@ -23,22 +23,22 @@ func (c *Config) WrapConnServer(raw net.Conn) (net.Conn, error) {
 }
 
 func newPackedDirectionalConn(raw net.Conn, config *Config, readPacked bool) (net.Conn, error) {
-    tables, err := getTables(config)
-    if err != nil {
-        return nil, err
-    }
-    pMin, pMax := normalizedPadding(config)
+	tables, err := getTables(config)
+	if err != nil {
+		return nil, err
+	}
+	pMin, pMax := normalizedPadding(config)
 
-    if readPacked {
-        reader := newStreamReader(raw, &packedStreamDecoder{layouts: tablesToLayouts(tables)})
-        c := newCodec(tables, pMin, pMax)
-        writer := newStreamWriter(raw, c.encode)
-        return newWrappedConn(raw, reader, writer), nil
-    }
-    reader := newStreamReader(raw, newHintStreamDecoder(tables))
-    encoder := newPackedEncoder(tables, pMin, pMax)
-    writer := newStreamWriter(raw, encoder.encode)
-    return newWrappedConn(raw, reader, writer), nil
+	if readPacked {
+		reader := newStreamReader(raw, &packedStreamDecoder{layouts: tablesToLayouts(tables)})
+		c := newCodec(tables, pMin, pMax)
+		writer := newStreamWriter(raw, c.encode)
+		return newWrappedConn(raw, reader, writer), nil
+	}
+	reader := newStreamReader(raw, newHintStreamDecoder(tables))
+	encoder := newPackedEncoder(tables, pMin, pMax)
+	writer := newStreamWriter(raw, encoder.encode)
+	return newWrappedConn(raw, reader, writer), nil
 }
 
 func (c *Config) WrapPacketConnClient(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {

--- a/transport/internet/finalmask/sudoku/config.go
+++ b/transport/internet/finalmask/sudoku/config.go
@@ -23,23 +23,22 @@ func (c *Config) WrapConnServer(raw net.Conn) (net.Conn, error) {
 }
 
 func newPackedDirectionalConn(raw net.Conn, config *Config, readPacked bool) (net.Conn, error) {
-	pureReader, pureWriter, err := newPureReaderWriter(raw, config)
-	if err != nil {
-		return nil, err
-	}
-	packedReader, packedWriter, err := newPackedReaderWriter(raw, config)
-	if err != nil {
-		return nil, err
-	}
+    tables, err := getTables(config)
+    if err != nil {
+        return nil, err
+    }
+    pMin, pMax := normalizedPadding(config)
 
-	reader, writer := pureReader, pureWriter
-	if readPacked {
-		reader = packedReader
-	} else {
-		writer = packedWriter
-	}
-
-	return newWrappedConn(raw, reader, writer), nil
+    if readPacked {
+        reader := newStreamReader(raw, &packedStreamDecoder{layouts: tablesToLayouts(tables)})
+        c := newCodec(tables, pMin, pMax)
+        writer := newStreamWriter(raw, c.encode)
+        return newWrappedConn(raw, reader, writer), nil
+    }
+    reader := newStreamReader(raw, newHintStreamDecoder(tables))
+    encoder := newPackedEncoder(tables, pMin, pMax)
+    writer := newStreamWriter(raw, encoder.encode)
+    return newWrappedConn(raw, reader, writer), nil
 }
 
 func (c *Config) WrapPacketConnClient(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {


### PR DESCRIPTION
之前newPackedDirectionalConn对同一个raw调用了两次不同的初始化.
经过我多次的运行 改动过后 在两万个连接中 平均
WrapConnClient和WrapConnServer的allocs/conn分配的字节比原来分配的字节少了50%
建连耗时比原来的建连耗时少了15%