### PR TITLE
Add SKIPI to Android GUI Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@
   - [AnyPortal](https://github.com/AnyPortal/AnyPortal)
   - [OneXray](https://github.com/OneXray/OneXray)
   - [AsteriskNG](https://github.com/Asterisk4Magisk/AsteriskNG)
+  - [SKIPI](https://github.com/ZloyRadetski/skipi-box)
 - iOS & macOS arm64 & tvOS
   - [Happ](https://apps.apple.com/app/happ-proxy-utility/id6504287215) | [Happ RU](https://apps.apple.com/ru/app/happ-proxy-utility-plus/id6746188973) | [Happ tvOS](https://apps.apple.com/us/app/happ-proxy-utility-for-tv/id6748297274)
   - [Streisand](https://apps.apple.com/app/streisand/id6450534064)


### PR DESCRIPTION
Hello XTLS team!

I would like to add **[SKIPI](https://github.com/ZloyRadetski/skipi-box)** to the list of Android GUI clients.

### About SKIPI:
- **Core:** Powered by Xray-core with native support for VLESS (Reality, Vision), Trojan, Shadowsocks, and Hysteria 2.
- **Tech Stack:** Modern Android client built with Kotlin and Jetpack Compose (Miuix/Material).
- **Features:** Smart GeoIP/GeoSite routing, automated On-Demand network switching, proxy sharing (LAN/Hotspot), and battery-optimized background service.
- **License:** Fully open-source (GPL-3.0), zero ads, no trackers.

Repository: https://github.com/ZloyRadetski/skipi-box

Thank you for your incredible work on Xray-core!