### PR TITLE
Sniffing: Add `portsExcluded` to skip the sniffer for given destination ports

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -229,6 +229,13 @@ func trackOnlineIP(ctx context.Context, sm stats.Manager, email, ip string) {
 	}
 }
 
+// shouldSniff reports whether the payload is worth reading at all. Ports listed
+// in portsExcluded are skipped here, before the sniffer waits for a first packet
+// the client may never send.
+func shouldSniff(request session.SniffingRequest, destination net.Destination) bool {
+	return request.Enabled && !request.ExcludeForPort.Contains(destination.Port)
+}
+
 func (d *DefaultDispatcher) shouldOverride(ctx context.Context, result SniffResult, request session.SniffingRequest, destination net.Destination) bool {
 	domain := result.Domain()
 	if domain == "" {
@@ -284,7 +291,7 @@ func (d *DefaultDispatcher) Dispatch(ctx context.Context, destination net.Destin
 
 	sniffingRequest := content.SniffingRequest
 	inbound, outbound := d.getLink(ctx)
-	if !sniffingRequest.Enabled {
+	if !shouldSniff(sniffingRequest, destination) {
 		go d.routedDispatch(ctx, outbound, destination)
 	} else {
 		go func() {
@@ -340,7 +347,7 @@ func (d *DefaultDispatcher) DispatchLink(ctx context.Context, destination net.De
 	}
 	outbound = WrapLink(ctx, d.policy, d.stats, outbound)
 	sniffingRequest := content.SniffingRequest
-	if !sniffingRequest.Enabled {
+	if !shouldSniff(sniffingRequest, destination) {
 		d.routedDispatch(ctx, outbound, destination)
 	} else {
 		cReader := &cachedReader{

--- a/app/dispatcher/default_test.go
+++ b/app/dispatcher/default_test.go
@@ -1,0 +1,36 @@
+package dispatcher
+
+import (
+	"testing"
+
+	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/session"
+)
+
+func TestShouldSniff(t *testing.T) {
+	excluded := net.MemoryPortList{{From: 22, To: 22}, {From: 993, To: 995}}
+
+	cases := []struct {
+		name    string
+		request session.SniffingRequest
+		port    net.Port
+		want    bool
+	}{
+		{"sniffing disabled", session.SniffingRequest{}, 443, false},
+		{"disabled and excluded", session.SniffingRequest{ExcludeForPort: excluded}, 22, false},
+		{"nothing excluded", session.SniffingRequest{Enabled: true}, 443, true},
+		{"single port excluded", session.SniffingRequest{Enabled: true, ExcludeForPort: excluded}, 22, false},
+		{"range start excluded", session.SniffingRequest{Enabled: true, ExcludeForPort: excluded}, 993, false},
+		{"range end excluded", session.SniffingRequest{Enabled: true, ExcludeForPort: excluded}, 995, false},
+		{"just past the range", session.SniffingRequest{Enabled: true, ExcludeForPort: excluded}, 996, true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			destination := net.TCPDestination(net.LocalHostIP, c.port)
+			if got := shouldSniff(c.request, destination); got != c.want {
+				t.Errorf("shouldSniff(port %v) = %v, want %v", c.port, got, c.want)
+			}
+		})
+	}
+}

--- a/app/proxyman/config.go
+++ b/app/proxyman/config.go
@@ -2,6 +2,7 @@ package proxyman
 
 import (
 	"github.com/xtls/xray-core/common/geodata"
+	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/session"
 )
 
@@ -29,6 +30,9 @@ func BuildSniffingRequest(config *SniffingConfig) (session.SniffingRequest, erro
 			return session.SniffingRequest{}, err
 		}
 		request.ExcludeForIP = excludeForIP
+	}
+	if portsExcluded := config.GetPortsExcluded(); portsExcluded != nil {
+		request.ExcludeForPort = net.PortListFromProto(portsExcluded)
 	}
 	return request, nil
 }

--- a/app/proxyman/config.pb.go
+++ b/app/proxyman/config.pb.go
@@ -70,6 +70,10 @@ type SniffingConfig struct {
 	DestinationOverride []string              `protobuf:"bytes,2,rep,name=destination_override,json=destinationOverride,proto3" json:"destination_override,omitempty"`
 	DomainsExcluded     []*geodata.DomainRule `protobuf:"bytes,3,rep,name=domains_excluded,json=domainsExcluded,proto3" json:"domains_excluded,omitempty"`
 	IpsExcluded         []*geodata.IPRule     `protobuf:"bytes,6,rep,name=ips_excluded,json=ipsExcluded,proto3" json:"ips_excluded,omitempty"`
+	// Skip the sniffer entirely when the destination port is in this list.
+	// Unlike domains_excluded and ips_excluded, which drop the override after
+	// sniffing, this is checked before any payload is read.
+	PortsExcluded *net.PortList `protobuf:"bytes,7,opt,name=ports_excluded,json=portsExcluded,proto3" json:"ports_excluded,omitempty"`
 	// Whether should only try to sniff metadata without waiting for client input.
 	// Can be used to support SMTP like protocol where server send the first
 	// message.
@@ -133,6 +137,13 @@ func (x *SniffingConfig) GetDomainsExcluded() []*geodata.DomainRule {
 func (x *SniffingConfig) GetIpsExcluded() []*geodata.IPRule {
 	if x != nil {
 		return x.IpsExcluded
+	}
+	return nil
+}
+
+func (x *SniffingConfig) GetPortsExcluded() *net.PortList {
+	if x != nil {
+		return x.PortsExcluded
 	}
 	return nil
 }
@@ -487,12 +498,13 @@ var File_app_proxyman_config_proto protoreflect.FileDescriptor
 const file_app_proxyman_config_proto_rawDesc = "" +
 	"\n" +
 	"\x19app/proxyman/config.proto\x12\x11xray.app.proxyman\x1a\x18common/net/address.proto\x1a\x15common/net/port.proto\x1a\x1ftransport/internet/config.proto\x1a!common/serial/typed_message.proto\x1a\x1bcommon/geodata/geodat.proto\"\x0f\n" +
-	"\rInboundConfig\"\xad\x02\n" +
+	"\rInboundConfig\"\xef\x02\n" +
 	"\x0eSniffingConfig\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x121\n" +
 	"\x14destination_override\x18\x02 \x03(\tR\x13destinationOverride\x12J\n" +
 	"\x10domains_excluded\x18\x03 \x03(\v2\x1f.xray.common.geodata.DomainRuleR\x0fdomainsExcluded\x12>\n" +
-	"\fips_excluded\x18\x06 \x03(\v2\x1b.xray.common.geodata.IPRuleR\vipsExcluded\x12#\n" +
+	"\fips_excluded\x18\x06 \x03(\v2\x1b.xray.common.geodata.IPRuleR\vipsExcluded\x12@\n" +
+	"\x0eports_excluded\x18\a \x01(\v2\x19.xray.common.net.PortListR\rportsExcluded\x12#\n" +
 	"\rmetadata_only\x18\x04 \x01(\bR\fmetadataOnly\x12\x1d\n" +
 	"\n" +
 	"route_only\x18\x05 \x01(\bR\trouteOnly\"\xe5\x02\n" +
@@ -554,22 +566,23 @@ var file_app_proxyman_config_proto_goTypes = []any{
 var file_app_proxyman_config_proto_depIdxs = []int32{
 	7,  // 0: xray.app.proxyman.SniffingConfig.domains_excluded:type_name -> xray.common.geodata.DomainRule
 	8,  // 1: xray.app.proxyman.SniffingConfig.ips_excluded:type_name -> xray.common.geodata.IPRule
-	9,  // 2: xray.app.proxyman.ReceiverConfig.port_list:type_name -> xray.common.net.PortList
-	10, // 3: xray.app.proxyman.ReceiverConfig.listen:type_name -> xray.common.net.IPOrDomain
-	11, // 4: xray.app.proxyman.ReceiverConfig.stream_settings:type_name -> xray.transport.internet.StreamConfig
-	1,  // 5: xray.app.proxyman.ReceiverConfig.sniffing_settings:type_name -> xray.app.proxyman.SniffingConfig
-	12, // 6: xray.app.proxyman.InboundHandlerConfig.receiver_settings:type_name -> xray.common.serial.TypedMessage
-	12, // 7: xray.app.proxyman.InboundHandlerConfig.proxy_settings:type_name -> xray.common.serial.TypedMessage
-	10, // 8: xray.app.proxyman.SenderConfig.via:type_name -> xray.common.net.IPOrDomain
-	11, // 9: xray.app.proxyman.SenderConfig.stream_settings:type_name -> xray.transport.internet.StreamConfig
-	13, // 10: xray.app.proxyman.SenderConfig.proxy_settings:type_name -> xray.transport.internet.ProxyConfig
-	6,  // 11: xray.app.proxyman.SenderConfig.multiplex_settings:type_name -> xray.app.proxyman.MultiplexingConfig
-	14, // 12: xray.app.proxyman.SenderConfig.target_strategy:type_name -> xray.transport.internet.DomainStrategy
-	13, // [13:13] is the sub-list for method output_type
-	13, // [13:13] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	9,  // 2: xray.app.proxyman.SniffingConfig.ports_excluded:type_name -> xray.common.net.PortList
+	9,  // 3: xray.app.proxyman.ReceiverConfig.port_list:type_name -> xray.common.net.PortList
+	10, // 4: xray.app.proxyman.ReceiverConfig.listen:type_name -> xray.common.net.IPOrDomain
+	11, // 5: xray.app.proxyman.ReceiverConfig.stream_settings:type_name -> xray.transport.internet.StreamConfig
+	1,  // 6: xray.app.proxyman.ReceiverConfig.sniffing_settings:type_name -> xray.app.proxyman.SniffingConfig
+	12, // 7: xray.app.proxyman.InboundHandlerConfig.receiver_settings:type_name -> xray.common.serial.TypedMessage
+	12, // 8: xray.app.proxyman.InboundHandlerConfig.proxy_settings:type_name -> xray.common.serial.TypedMessage
+	10, // 9: xray.app.proxyman.SenderConfig.via:type_name -> xray.common.net.IPOrDomain
+	11, // 10: xray.app.proxyman.SenderConfig.stream_settings:type_name -> xray.transport.internet.StreamConfig
+	13, // 11: xray.app.proxyman.SenderConfig.proxy_settings:type_name -> xray.transport.internet.ProxyConfig
+	6,  // 12: xray.app.proxyman.SenderConfig.multiplex_settings:type_name -> xray.app.proxyman.MultiplexingConfig
+	14, // 13: xray.app.proxyman.SenderConfig.target_strategy:type_name -> xray.transport.internet.DomainStrategy
+	14, // [14:14] is the sub-list for method output_type
+	14, // [14:14] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_app_proxyman_config_proto_init() }

--- a/app/proxyman/config.proto
+++ b/app/proxyman/config.proto
@@ -26,6 +26,11 @@ message SniffingConfig {
 
   repeated xray.common.geodata.IPRule ips_excluded = 6;
 
+  // Skip the sniffer entirely when the destination port is in this list.
+  // Unlike domains_excluded and ips_excluded, which drop the override after
+  // sniffing, this is checked before any payload is read.
+  xray.common.net.PortList ports_excluded = 7;
+
   // Whether should only try to sniff metadata without waiting for client input.
   // Can be used to support SMTP like protocol where server send the first
   // message.

--- a/app/proxyman/config_test.go
+++ b/app/proxyman/config_test.go
@@ -1,0 +1,36 @@
+package proxyman_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/xtls/xray-core/app/proxyman"
+	"github.com/xtls/xray-core/common/net"
+)
+
+func TestBuildSniffingRequestPortsExcluded(t *testing.T) {
+	request, err := proxyman.BuildSniffingRequest(&proxyman.SniffingConfig{
+		Enabled: true,
+		PortsExcluded: &net.PortList{
+			Range: []*net.PortRange{{From: 22, To: 22}, {From: 993, To: 995}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildSniffingRequest() failed: %v", err)
+	}
+
+	want := net.MemoryPortList{{From: 22, To: 22}, {From: 993, To: 995}}
+	if !reflect.DeepEqual(request.ExcludeForPort, want) {
+		t.Fatalf("BuildSniffingRequest() gave ExcludeForPort %v, want %v", request.ExcludeForPort, want)
+	}
+}
+
+func TestBuildSniffingRequestWithoutPortsExcluded(t *testing.T) {
+	request, err := proxyman.BuildSniffingRequest(&proxyman.SniffingConfig{Enabled: true})
+	if err != nil {
+		t.Fatalf("BuildSniffingRequest() failed: %v", err)
+	}
+	if len(request.ExcludeForPort) != 0 {
+		t.Fatalf("BuildSniffingRequest() gave ExcludeForPort %v, want empty", request.ExcludeForPort)
+	}
+}

--- a/common/session/session.go
+++ b/common/session/session.go
@@ -81,6 +81,7 @@ type Outbound struct {
 type SniffingRequest struct {
 	ExcludeForDomain               geodata.DomainMatcher
 	ExcludeForIP                   geodata.IPMatcher
+	ExcludeForPort                 net.MemoryPortList
 	OverrideDestinationForProtocol []string
 	Enabled                        bool
 	MetadataOnly                   bool

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -57,6 +57,7 @@ type SniffingConfig struct {
 	DestOverride    StringList `json:"destOverride"`
 	DomainsExcluded StringList `json:"domainsExcluded"`
 	IPsExcluded     StringList `json:"ipsExcluded"`
+	PortsExcluded   *PortList  `json:"portsExcluded"`
 	MetadataOnly    bool       `json:"metadataOnly"`
 	RouteOnly       bool       `json:"routeOnly"`
 }
@@ -89,11 +90,17 @@ func (c *SniffingConfig) Build() (*proxyman.SniffingConfig, error) {
 		return nil, err
 	}
 
+	var ports *net.PortList
+	if c.PortsExcluded != nil {
+		ports = c.PortsExcluded.Build()
+	}
+
 	return &proxyman.SniffingConfig{
 		Enabled:             c.Enabled,
 		DestinationOverride: protocols,
 		DomainsExcluded:     domains,
 		IpsExcluded:         ips,
+		PortsExcluded:       ports,
 		MetadataOnly:        c.MetadataOnly,
 		RouteOnly:           c.RouteOnly,
 	}, nil

--- a/infra/conf/xray_test.go
+++ b/infra/conf/xray_test.go
@@ -163,6 +163,7 @@ func TestSniffingConfig_Build(t *testing.T) {
 		DestOverride:    StringList{"http", "tls"},
 		DomainsExcluded: StringList{"full:api.example.com", "domain:blocked.example", "regexp:^test[0-9]+\\.internal$"},
 		IPsExcluded:     StringList{"192.168.1.1", "2001:db8::/32"},
+		PortsExcluded:   &PortList{Range: []PortRange{{From: 22, To: 22}, {From: 993, To: 995}}},
 		MetadataOnly:    true,
 		RouteOnly:       true,
 	}
@@ -183,6 +184,11 @@ func TestSniffingConfig_Build(t *testing.T) {
 	}
 	if len(built.IpsExcluded) != 2 {
 		t.Fatalf("SniffingConfig.Build() produced %d ip rules", len(built.IpsExcluded))
+	}
+
+	wantPorts := net.MemoryPortList{{From: 22, To: 22}, {From: 993, To: 995}}
+	if gotPorts := net.PortListFromProto(built.PortsExcluded); !reflect.DeepEqual(gotPorts, wantPorts) {
+		t.Fatalf("SniffingConfig.Build() produced ports %v, want %v", gotPorts, wantPorts)
 	}
 
 	want := []struct {


### PR DESCRIPTION
Adds `portsExcluded` to `sniffing`: a port list checked in the dispatcher **before** the sniffer reads anything, so a connection to a listed destination port takes the same path as sniffing being switched off.

Follows up on discussion #6654 — sending the patch since it is small enough to judge from the diff. Close it if the shape is unwanted.

### The problem

Where the peer speaks first — SSH, IMAP, SMTP — the client sends nothing for the sniffer to read, so `cacheDeadline` in `app/dispatcher/default.go` burns down in full before the dispatch continues. The cost is fixed and paid on every such connection.

`domainsExcluded` and `ipsExcluded` do not help: both are consulted in `shouldOverride`, i.e. *after* the sniffer has already waited, and they only suppress the destination override. #5927 shows that placement is deliberate, which is why this is a separate knob rather than a change to those.

### The change

- `ports_excluded` in `SniffingConfig` (field 7), `portsExcluded` in the JSON config, taking the usual port-list syntax: `"22,143,993-995"`
- `SniffingRequest.ExcludeForPort` as a `net.MemoryPortList`, filled by `BuildSniffingRequest`
- one check in the dispatcher — `shouldSniff(request, destination)` replaces the bare `request.Enabled` test at both call sites

```json
"sniffing": {
  "enabled": true,
  "destOverride": ["http", "tls"],
  "portsExcluded": "22,143,993-995"
}
```

### Measurements

socks inbound → freedom outbound, against a loopback server that sends its banner on connect, 30 connections each, median from SOCKS5 CONNECT to the first byte:

| setup | median |
|---|---|
| direct, no proxy | 0.2 ms |
| sniffing disabled | 66.3 ms |
| sniffing on, port excluded | 67.0 ms |
| sniffing on, port not excluded | 268.1 ms |

The excluded row lands on the sniffing-disabled row. Scope check on a single instance configured with `"portsExcluded": "2222"`: port 2222 answers in 66.8 ms, port 2223 in 267.7 ms, so the exclusion stays on the listed ports.

### Tests

- `shouldSniff` table test in `app/dispatcher` — disabled, no exclusions, single port, both range ends, just past the range
- `BuildSniffingRequest` with and without `portsExcluded` in `app/proxyman`; the nil case would panic in `PortListFromProto` without the guard
- `TestSniffingConfig_Build` in `infra/conf` extended over the JSON → proto path

`go build ./...` and `go test ./...` pass and `go run ./infra/vformat/main.go -mode check` is clean. `config.pb.go` was regenerated with protoc v33.5 and protoc-gen-go v1.36.11, so its header still matches every other `.pb.go` for the `check-proto` job. One local failure, `TestTCPLocalNameServer` in `app/dns`, reproduces identically on a clean checkout here — network-dependent, unrelated.

Docs for the field belong in Xray-docs-next; happy to send that too if this lands.
