### PR TITLE
finalmask: let quic-go raise the UDP socket buffers on socket-holding mask conns

### DIFF
--- a/proxy/wireguard/client.go
+++ b/proxy/wireguard/client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/xtls/xray-core/features/stats"
 	"github.com/xtls/xray-core/transport"
 	"github.com/xtls/xray-core/transport/internet"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 	"golang.zx2c4.com/wireguard/device"
 )
 
@@ -279,7 +280,7 @@ func (h *Handler) init(ctx context.Context) error {
 			panic(reflect.TypeOf(c))
 		}
 		if h.streamSettings.UdpmaskManager != nil {
-			newConn, err := h.streamSettings.UdpmaskManager.WrapPacketConnClient(pktConn)
+			newConn, err := h.streamSettings.UdpmaskManager.WrapPacketConnClient(finalmask.WrapConn(pktConn))
 			if err != nil {
 				pktConn.Close()
 				return nil, errors.New("mask err").Base(err)

--- a/proxy/wireguard/server.go
+++ b/proxy/wireguard/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/xtls/xray-core/features/stats"
 	"github.com/xtls/xray-core/transport"
 	"github.com/xtls/xray-core/transport/internet"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 	"github.com/xtls/xray-core/transport/internet/stat"
 	"golang.org/x/crypto/curve25519"
 	"golang.zx2c4.com/wireguard/device"
@@ -263,7 +264,7 @@ func (s *Server) Start() error {
 			return nil, err
 		}
 		if s.streamSettings.UdpmaskManager != nil {
-			newConn, err := s.streamSettings.UdpmaskManager.WrapPacketConnServer(pktConn)
+			newConn, err := s.streamSettings.UdpmaskManager.WrapPacketConnServer(finalmask.WrapConn(pktConn))
 			if err != nil {
 				pktConn.Close()
 				return nil, errors.New("mask err").Base(err)

--- a/transport/internet/finalmask/finalmask.go
+++ b/transport/internet/finalmask/finalmask.go
@@ -9,11 +9,50 @@ import (
 	"github.com/xtls/xray-core/common/errors"
 )
 
+// quic-go raises UDP socket buffers only if the net.PacketConn asserts to SetRead/WriteBuffer; masks hold the socket
+// in an interface field, so nothing is promoted and the raise is lost. SyscallConn is deliberately absent: quic-go
+// aborts the dial on a failing SyscallConn/setDF, and a mask can wrap a non-socket (internet.FakePacketConn).
+type PacketConn interface {
+	net.PacketConn
+	SetReadBuffer(bytes int) error
+	SetWriteBuffer(bytes int) error
+}
+
+// WrapConn adapts a conn without the setters at the boundary, so masks always take a PacketConn.
+func WrapConn(pc net.PacketConn) PacketConn {
+	if c, ok := pc.(PacketConn); ok {
+		return c
+	}
+	return &noSockoptConn{PacketConn: pc}
+}
+
+// UnwrapUdpMask looks through the adapter, for masks that reject specific underlying transports.
+func UnwrapUdpMask(pc PacketConn) net.PacketConn {
+	if c, ok := pc.(*noSockoptConn); ok {
+		return c.PacketConn
+	}
+	return pc
+}
+
+type noSockoptConn struct {
+	net.PacketConn
+}
+
+// noSockoptConn only wraps conns with no socket-buffer setters at all (FakePacketConn and friends);
+// quic-go's raise has nowhere to land on those paths, so both setters are no-ops.
+func (c *noSockoptConn) SetReadBuffer(bytes int) error {
+	return nil
+}
+
+func (c *noSockoptConn) SetWriteBuffer(bytes int) error {
+	return nil
+}
+
 type Udpmask interface {
 	UDP()
 
-	WrapPacketConnClient(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error)
-	WrapPacketConnServer(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error)
+	WrapPacketConnClient(raw PacketConn, level int, levelCount int) (PacketConn, error)
+	WrapPacketConnServer(raw PacketConn, level int, levelCount int) (PacketConn, error)
 }
 
 type UdpmaskManager struct {
@@ -26,9 +65,9 @@ func NewUdpmaskManager(udpmasks []Udpmask) *UdpmaskManager {
 	}
 }
 
-func (m *UdpmaskManager) WrapPacketConnClient(raw net.PacketConn) (net.PacketConn, error) {
+func (m *UdpmaskManager) WrapPacketConnClient(raw PacketConn) (PacketConn, error) {
 	var sizes []int
-	var conns []net.PacketConn
+	var conns []PacketConn
 	for i, mask := range slices.Backward(m.udpmasks) {
 		if _, ok := mask.(headerConn); ok {
 			conn, err := mask.WrapPacketConnClient(nil, i, len(m.udpmasks)-1)
@@ -59,9 +98,9 @@ func (m *UdpmaskManager) WrapPacketConnClient(raw net.PacketConn) (net.PacketCon
 	return raw, nil
 }
 
-func (m *UdpmaskManager) WrapPacketConnServer(raw net.PacketConn) (net.PacketConn, error) {
+func (m *UdpmaskManager) WrapPacketConnServer(raw PacketConn) (PacketConn, error) {
 	var sizes []int
-	var conns []net.PacketConn
+	var conns []PacketConn
 	for i, mask := range slices.Backward(m.udpmasks) {
 		if _, ok := mask.(headerConn); ok {
 			conn, err := mask.WrapPacketConnServer(nil, i, len(m.udpmasks)-1)
@@ -105,10 +144,10 @@ type headerSize interface {
 }
 
 type headerManagerConn struct {
-	net.PacketConn
+	PacketConn
 
 	sizes []int
-	conns []net.PacketConn
+	conns []PacketConn
 }
 
 func (c *headerManagerConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {

--- a/transport/internet/finalmask/header/custom/config.go
+++ b/transport/internet/finalmask/header/custom/config.go
@@ -2,6 +2,8 @@ package custom
 
 import (
 	"net"
+
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 )
 
 func (c *TCPConfig) TCP() {}
@@ -16,20 +18,20 @@ func (c *TCPConfig) WrapConnServer(raw net.Conn) (net.Conn, error) {
 
 func (c *UDPConfig) UDP() {}
 
-func (c *UDPConfig) WrapPacketConnClient(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *UDPConfig) WrapPacketConnClient(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	return NewConnClientUDP(c, raw)
 }
 
-func (c *UDPConfig) WrapPacketConnServer(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *UDPConfig) WrapPacketConnServer(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	return NewConnServerUDP(c, raw)
 }
 
 func (c *UDPStandaloneConfig) UDP() {}
 
-func (c *UDPStandaloneConfig) WrapPacketConnClient(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *UDPStandaloneConfig) WrapPacketConnClient(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	return NewConnClientUDPStandalone(c, raw)
 }
 
-func (c *UDPStandaloneConfig) WrapPacketConnServer(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *UDPStandaloneConfig) WrapPacketConnServer(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	return NewConnServerUDPStandalone(c, raw)
 }

--- a/transport/internet/finalmask/header/custom/metadata_test.go
+++ b/transport/internet/finalmask/header/custom/metadata_test.go
@@ -156,7 +156,7 @@ func TestMetadataUDPStandaloneWriteUsesRemotePort(t *testing.T) {
 	}
 	defer serverRaw.Close()
 
-	client, err := finalmask.NewUdpmaskManager([]finalmask.Udpmask{cfg}).WrapPacketConnClient(clientRaw)
+	client, err := finalmask.NewUdpmaskManager([]finalmask.Udpmask{cfg}).WrapPacketConnClient(finalmask.WrapConn(clientRaw))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/transport/internet/finalmask/header/custom/state_test.go
+++ b/transport/internet/finalmask/header/custom/state_test.go
@@ -62,11 +62,11 @@ func TestStateUDPResponseReusesPriorCapturedValues(t *testing.T) {
 	}
 	defer serverRaw.Close()
 
-	client, err := maskManager.WrapPacketConnClient(clientRaw)
+	client, err := maskManager.WrapPacketConnClient(finalmask.WrapConn(clientRaw))
 	if err != nil {
 		t.Fatal(err)
 	}
-	server, err := maskManager.WrapPacketConnServer(serverRaw)
+	server, err := maskManager.WrapPacketConnServer(finalmask.WrapConn(serverRaw))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/transport/internet/finalmask/header/custom/udp.go
+++ b/transport/internet/finalmask/header/custom/udp.go
@@ -48,11 +48,11 @@ func (h *udpCustomClient) Match(b []byte, addr net.Addr) bool {
 }
 
 type udpCustomClientConn struct {
-	net.PacketConn
+	finalmask.PacketConn
 	header *udpCustomClient
 }
 
-func NewConnClientUDP(c *UDPConfig, raw net.PacketConn) (net.PacketConn, error) {
+func NewConnClientUDP(c *UDPConfig, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	conn := &udpCustomClientConn{
 		PacketConn: raw,
 		header: &udpCustomClient{
@@ -168,11 +168,11 @@ func (h *udpCustomServer) Match(b []byte, addr net.Addr) bool {
 }
 
 type udpCustomServerConn struct {
-	net.PacketConn
+	finalmask.PacketConn
 	header *udpCustomServer
 }
 
-func NewConnServerUDP(c *UDPConfig, raw net.PacketConn) (net.PacketConn, error) {
+func NewConnServerUDP(c *UDPConfig, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	conn := &udpCustomServerConn{
 		PacketConn: raw,
 		header: &udpCustomServer{
@@ -309,7 +309,7 @@ func udpStateKey(addr net.Addr) string {
 }
 
 type udpCustomStandaloneClientConn struct {
-	net.PacketConn
+	finalmask.PacketConn
 	client []*UDPItem
 	server []*UDPItem
 	state  *stateStore
@@ -331,7 +331,7 @@ type udpStandaloneWaiter struct {
 	done chan error
 }
 
-func NewConnClientUDPStandalone(c *UDPStandaloneConfig, raw net.PacketConn) (net.PacketConn, error) {
+func NewConnClientUDPStandalone(c *UDPStandaloneConfig, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	clientSavedSizes := collectSavedUDPSizes(c.Client)
 	read, err := measureUDPItemsWithFallback(c.Server, clientSavedSizes)
 	if err != nil {
@@ -471,14 +471,14 @@ func (c *udpCustomStandaloneClientConn) failWaiters(err error) {
 }
 
 type udpCustomStandaloneServerConn struct {
-	net.PacketConn
+	finalmask.PacketConn
 	client []*UDPItem
 	server []*UDPItem
 	state  *stateStore
 	read   int
 }
 
-func NewConnServerUDPStandalone(c *UDPStandaloneConfig, raw net.PacketConn) (net.PacketConn, error) {
+func NewConnServerUDPStandalone(c *UDPStandaloneConfig, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	read, err := measureUDPItems(c.Client)
 	if err != nil {
 		return nil, err

--- a/transport/internet/finalmask/mkcp/aes128gcm/config.go
+++ b/transport/internet/finalmask/mkcp/aes128gcm/config.go
@@ -1,17 +1,17 @@
 package aes128gcm
 
 import (
-	"net"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 )
 
 func (c *Config) UDP() {}
 
 func (c *Config) HeaderConn() {}
 
-func (c *Config) WrapPacketConnClient(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *Config) WrapPacketConnClient(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	return NewConnClient(c, raw)
 }
 
-func (c *Config) WrapPacketConnServer(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *Config) WrapPacketConnServer(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	return NewConnServer(c, raw)
 }

--- a/transport/internet/finalmask/mkcp/aes128gcm/conn.go
+++ b/transport/internet/finalmask/mkcp/aes128gcm/conn.go
@@ -8,14 +8,15 @@ import (
 
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/crypto"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 )
 
 type aes128gcmConn struct {
-	net.PacketConn
+	finalmask.PacketConn
 	aead cipher.AEAD
 }
 
-func NewConnClient(c *Config, raw net.PacketConn) (net.PacketConn, error) {
+func NewConnClient(c *Config, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	hashedPsk := sha256.Sum256([]byte(c.Password))
 	return &aes128gcmConn{
 		PacketConn: raw,
@@ -23,7 +24,7 @@ func NewConnClient(c *Config, raw net.PacketConn) (net.PacketConn, error) {
 	}, nil
 }
 
-func NewConnServer(c *Config, raw net.PacketConn) (net.PacketConn, error) {
+func NewConnServer(c *Config, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	return NewConnClient(c, raw)
 }
 

--- a/transport/internet/finalmask/mkcp/header/config.go
+++ b/transport/internet/finalmask/mkcp/header/config.go
@@ -1,17 +1,17 @@
 package header
 
 import (
-	"net"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 )
 
 func (c *Config) UDP() {}
 
 func (c *Config) HeaderConn() {}
 
-func (c *Config) WrapPacketConnClient(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *Config) WrapPacketConnClient(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	return NewConnClient(c, raw)
 }
 
-func (c *Config) WrapPacketConnServer(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *Config) WrapPacketConnServer(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	return NewConnServer(c, raw)
 }

--- a/transport/internet/finalmask/mkcp/header/conn.go
+++ b/transport/internet/finalmask/mkcp/header/conn.go
@@ -4,14 +4,15 @@ import (
 	"net"
 
 	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 )
 
 type headerConn struct {
-	net.PacketConn
+	finalmask.PacketConn
 	header Header
 }
 
-func NewConnClient(c *Config, raw net.PacketConn) (net.PacketConn, error) {
+func NewConnClient(c *Config, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	var header Header
 	switch HeaderID(c.ID) {
 	case DNS:
@@ -39,7 +40,7 @@ func NewConnClient(c *Config, raw net.PacketConn) (net.PacketConn, error) {
 	}, nil
 }
 
-func NewConnServer(c *Config, raw net.PacketConn) (net.PacketConn, error) {
+func NewConnServer(c *Config, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	return NewConnClient(c, raw)
 }
 

--- a/transport/internet/finalmask/mkcp/original/config.go
+++ b/transport/internet/finalmask/mkcp/original/config.go
@@ -1,17 +1,17 @@
 package original
 
 import (
-	"net"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 )
 
 func (c *Config) UDP() {}
 
 func (c *Config) HeaderConn() {}
 
-func (c *Config) WrapPacketConnClient(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *Config) WrapPacketConnClient(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	return NewConnClient(c, raw)
 }
 
-func (c *Config) WrapPacketConnServer(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *Config) WrapPacketConnServer(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	return NewConnServer(c, raw)
 }

--- a/transport/internet/finalmask/mkcp/original/conn.go
+++ b/transport/internet/finalmask/mkcp/original/conn.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 )
 
 type simple struct{}
@@ -72,18 +73,18 @@ func (a *simple) Open(dst, nonce, cipherText, extra []byte) ([]byte, error) {
 }
 
 type simpleConn struct {
-	net.PacketConn
+	finalmask.PacketConn
 	aead cipher.AEAD
 }
 
-func NewConnClient(c *Config, raw net.PacketConn) (net.PacketConn, error) {
+func NewConnClient(c *Config, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	return &simpleConn{
 		PacketConn: raw,
 		aead:       &simple{},
 	}, nil
 }
 
-func NewConnServer(c *Config, raw net.PacketConn) (net.PacketConn, error) {
+func NewConnServer(c *Config, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	return NewConnClient(c, raw)
 }
 

--- a/transport/internet/finalmask/noise/config.go
+++ b/transport/internet/finalmask/noise/config.go
@@ -1,14 +1,16 @@
 package noise
 
-import "net"
+import (
+	"github.com/xtls/xray-core/transport/internet/finalmask"
+)
 
 func (c *Config) UDP() {
 }
 
-func (c *Config) WrapPacketConnClient(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *Config) WrapPacketConnClient(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	return NewConnClient(c, raw)
 }
 
-func (c *Config) WrapPacketConnServer(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *Config) WrapPacketConnServer(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	return NewConnServer(c, raw)
 }

--- a/transport/internet/finalmask/noise/conn.go
+++ b/transport/internet/finalmask/noise/conn.go
@@ -6,16 +6,17 @@ import (
 	"time"
 
 	"github.com/xtls/xray-core/common/crypto"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 )
 
 type noiseConn struct {
-	net.PacketConn
+	finalmask.PacketConn
 	config *Config
 	m      map[string]time.Time
 	mu     sync.Mutex
 }
 
-func NewConnClient(c *Config, raw net.PacketConn) (net.PacketConn, error) {
+func NewConnClient(c *Config, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	return &noiseConn{
 		PacketConn: raw,
 		config:     c,
@@ -23,7 +24,7 @@ func NewConnClient(c *Config, raw net.PacketConn) (net.PacketConn, error) {
 	}, nil
 }
 
-func NewConnServer(c *Config, raw net.PacketConn) (net.PacketConn, error) {
+func NewConnServer(c *Config, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	return NewConnClient(c, raw)
 }
 

--- a/transport/internet/finalmask/packetconn_test.go
+++ b/transport/internet/finalmask/packetconn_test.go
@@ -1,0 +1,98 @@
+package finalmask_test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/xtls/xray-core/transport/internet"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
+	"github.com/xtls/xray-core/transport/internet/finalmask/header/custom"
+	"github.com/xtls/xray-core/transport/internet/finalmask/mkcp/aes128gcm"
+	"github.com/xtls/xray-core/transport/internet/finalmask/mkcp/header"
+	"github.com/xtls/xray-core/transport/internet/finalmask/mkcp/original"
+	"github.com/xtls/xray-core/transport/internet/finalmask/noise"
+	"github.com/xtls/xray-core/transport/internet/finalmask/realm"
+	"github.com/xtls/xray-core/transport/internet/finalmask/salamander"
+	"github.com/xtls/xray-core/transport/internet/finalmask/sudoku"
+	"github.com/xtls/xray-core/transport/internet/finalmask/xdns"
+	"github.com/xtls/xray-core/transport/internet/finalmask/xicmp"
+)
+
+// These masks dial (STUN/raw socket) on wrap, so they cannot join the cases below; the build still fails here
+// if a rebase brings one back on net.PacketConn, which memory_settings.go asserts unchecked.
+var _ = []finalmask.Udpmask{(*realm.Config)(nil), (*xicmp.Config)(nil), (*xdns.Config)(nil)}
+
+type sockoptConn struct {
+	readBuf  int
+	writeBuf int
+}
+
+func (c *sockoptConn) ReadFrom([]byte) (int, net.Addr, error) { return 0, nil, nil }
+func (c *sockoptConn) WriteTo([]byte, net.Addr) (int, error)  { return 0, nil }
+func (c *sockoptConn) Close() error                           { return nil }
+func (c *sockoptConn) LocalAddr() net.Addr                    { return nil }
+func (c *sockoptConn) SetDeadline(time.Time) error            { return nil }
+func (c *sockoptConn) SetReadDeadline(time.Time) error        { return nil }
+func (c *sockoptConn) SetWriteDeadline(time.Time) error       { return nil }
+func (c *sockoptConn) SetReadBuffer(bytes int) error          { c.readBuf = bytes; return nil }
+func (c *sockoptConn) SetWriteBuffer(bytes int) error         { c.writeBuf = bytes; return nil }
+
+// quic-go raises the socket buffers through this interface only, so every mask layer must pass them down.
+func TestMaskSockoptReachesSocket(t *testing.T) {
+	cases := []layerMask{
+		{name: "mkcp-header-dns", mask: &header.Config{ID: int32(header.DNS), Domain: "www.baidu.com"}},
+		{name: "mkcp-aes128gcm", mask: &aes128gcm.Config{Password: "123"}},
+		{name: "mkcp-original", mask: &original.Config{}},
+		{name: "header-custom", mask: &custom.UDPConfig{}},
+		{name: "noise", mask: &noise.Config{}},
+		{name: "salamander", mask: &salamander.Config{Password: "salamander-mask"}},
+		{name: "gecko", mask: &salamander.GeckoConfig{Password: "gecko-mask"}},
+		{name: "sudoku", mask: &sudoku.Config{Password: "sudoku-mask"}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			raw := &sockoptConn{}
+			manager := finalmask.NewUdpmaskManager([]finalmask.Udpmask{c.mask})
+
+			conn, err := manager.WrapPacketConnClient(raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer conn.Close()
+
+			if err := conn.SetReadBuffer(1 << 23); err != nil {
+				t.Fatalf("SetReadBuffer: %v", err)
+			}
+			if raw.readBuf != 1<<23 {
+				t.Errorf("read buffer = %d, want %d", raw.readBuf, 1<<23)
+			}
+
+			if err := conn.SetWriteBuffer(1 << 22); err != nil {
+				t.Fatalf("SetWriteBuffer: %v", err)
+			}
+			if raw.writeBuf != 1<<22 {
+				t.Errorf("write buffer = %d, want %d", raw.writeBuf, 1<<22)
+			}
+		})
+	}
+}
+
+// internet.FakePacketConn and friends lack the setters; the boundary adapter must swallow them, never fail a dial.
+func TestWrapConnWithoutSockopt(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	conn := finalmask.WrapConn(&internet.FakePacketConn{Conn: client})
+	if err := conn.SetReadBuffer(1 << 23); err != nil {
+		t.Errorf("SetReadBuffer: %v", err)
+	}
+	if err := conn.SetWriteBuffer(1 << 22); err != nil {
+		t.Errorf("SetWriteBuffer: %v", err)
+	}
+	if _, ok := finalmask.UnwrapUdpMask(conn).(*internet.FakePacketConn); !ok {
+		t.Error("UnwrapUdpMask did not return the underlying conn")
+	}
+}

--- a/transport/internet/finalmask/realm/client.go
+++ b/transport/internet/finalmask/realm/client.go
@@ -12,10 +12,11 @@ import (
 	"github.com/pion/stun/v3"
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 )
 
 type realmConnClient struct {
-	net.PacketConn
+	finalmask.PacketConn
 	peer *net.UDPAddr
 
 	realmClient   *Client
@@ -26,7 +27,7 @@ type realmConnClient struct {
 	punchInterval time.Duration
 }
 
-func NewConnClient(config *Config, raw net.PacketConn) (net.PacketConn, error) {
+func NewConnClient(config *Config, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	conn := &realmConnClient{
 		PacketConn: raw,
 
@@ -41,7 +42,7 @@ func NewConnClient(config *Config, raw net.PacketConn) (net.PacketConn, error) {
 	return conn.getpeer()
 }
 
-func (c *realmConnClient) getpeer() (net.PacketConn, error) {
+func (c *realmConnClient) getpeer() (finalmask.PacketConn, error) {
 	start := time.Now()
 	servers := resolveSTUNServers(c.PacketConn.LocalAddr().(*net.UDPAddr).IP, c.stunServers)
 	errors.LogDebug(context.Background(), "[realm] update stun servers ", servers, " with ", time.Since(start))

--- a/transport/internet/finalmask/realm/config.go
+++ b/transport/internet/finalmask/realm/config.go
@@ -1,25 +1,25 @@
 package realm
 
 import (
-	"net"
-
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/transport/internet"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 	"github.com/xtls/xray-core/transport/internet/hysteria/udphop"
 )
 
 func (c *Config) UDP() {}
 
-func (c *Config) WrapPacketConnClient(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
-	_, ok1 := raw.(*internet.FakePacketConn)
-	_, ok2 := raw.(*udphop.UdpHopPacketConn)
+func (c *Config) WrapPacketConnClient(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
+	under := finalmask.UnwrapUdpMask(raw)
+	_, ok1 := under.(*internet.FakePacketConn)
+	_, ok2 := under.(*udphop.UdpHopPacketConn)
 	if level != 0 || ok1 || ok2 {
 		return nil, errors.New("realm requires being at the outermost level")
 	}
 	return NewConnClient(c, raw)
 }
 
-func (c *Config) WrapPacketConnServer(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *Config) WrapPacketConnServer(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	if level != 0 {
 		return nil, errors.New("realm requires being at the outermost level")
 	}

--- a/transport/internet/finalmask/realm/server.go
+++ b/transport/internet/finalmask/realm/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pion/stun/v3"
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 )
 
 const (
@@ -36,7 +37,7 @@ type realmConnServer struct {
 	cleaned chan struct{}
 	ctx     context.Context
 	cancel  context.CancelFunc
-	net.PacketConn
+	finalmask.PacketConn
 
 	realmClient   *Client
 	realmID       string
@@ -54,7 +55,7 @@ type realmConnServer struct {
 	localsLast time.Time
 }
 
-func NewConnServer(config *Config, raw net.PacketConn) (net.PacketConn, error) {
+func NewConnServer(config *Config, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	conn := &realmConnServer{

--- a/transport/internet/finalmask/salamander/config.go
+++ b/transport/internet/finalmask/salamander/config.go
@@ -1,27 +1,27 @@
 package salamander
 
 import (
-	"net"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 )
 
 func (c *Config) UDP() {}
 
 func (c *Config) HeaderConn() {}
 
-func (c *Config) WrapPacketConnClient(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *Config) WrapPacketConnClient(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	return NewSalamanderConnClient(c, raw)
 }
 
-func (c *Config) WrapPacketConnServer(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *Config) WrapPacketConnServer(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	return NewSalamanderConnServer(c, raw)
 }
 
 func (c *GeckoConfig) UDP() {}
 
-func (c *GeckoConfig) WrapPacketConnClient(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *GeckoConfig) WrapPacketConnClient(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	return NewGeckoConnClient(c, raw)
 }
 
-func (c *GeckoConfig) WrapPacketConnServer(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *GeckoConfig) WrapPacketConnServer(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	return NewGeckoConnServer(c, raw)
 }

--- a/transport/internet/finalmask/salamander/conn.go
+++ b/transport/internet/finalmask/salamander/conn.go
@@ -14,11 +14,11 @@ import (
 )
 
 type salamanderConn struct {
-	net.PacketConn
+	finalmask.PacketConn
 	obfs *SalamanderObfuscator
 }
 
-func NewSalamanderConnClient(c *Config, raw net.PacketConn) (net.PacketConn, error) {
+func NewSalamanderConnClient(c *Config, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	ob, err := NewSalamanderObfuscator([]byte(c.Password))
 	if err != nil {
 		return nil, err
@@ -29,7 +29,7 @@ func NewSalamanderConnClient(c *Config, raw net.PacketConn) (net.PacketConn, err
 	}, nil
 }
 
-func NewSalamanderConnServer(c *Config, raw net.PacketConn) (net.PacketConn, error) {
+func NewSalamanderConnServer(c *Config, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	return NewSalamanderConnClient(c, raw)
 }
 
@@ -71,7 +71,7 @@ type reassemblyEntry struct {
 }
 
 type geckoConn struct {
-	net.PacketConn
+	finalmask.PacketConn
 	obfs           *SalamanderObfuscator
 	minPkt, maxPkt int
 
@@ -85,7 +85,7 @@ type geckoConn struct {
 	closeOnce sync.Once
 }
 
-func NewGeckoConnClient(c *GeckoConfig, raw net.PacketConn) (net.PacketConn, error) {
+func NewGeckoConnClient(c *GeckoConfig, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	ob, err := NewSalamanderObfuscator([]byte(c.Password))
 	if err != nil {
 		return nil, err
@@ -113,7 +113,7 @@ func NewGeckoConnClient(c *GeckoConfig, raw net.PacketConn) (net.PacketConn, err
 	return g, nil
 }
 
-func NewGeckoConnServer(c *GeckoConfig, raw net.PacketConn) (net.PacketConn, error) {
+func NewGeckoConnServer(c *GeckoConfig, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	return NewGeckoConnClient(c, raw)
 }
 

--- a/transport/internet/finalmask/sudoku/config.go
+++ b/transport/internet/finalmask/sudoku/config.go
@@ -4,6 +4,7 @@ import (
 	"net"
 
 	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 )
 
 func (c *Config) TCP() {
@@ -42,14 +43,14 @@ func newPackedDirectionalConn(raw net.Conn, config *Config, readPacked bool) (ne
 	return newWrappedConn(raw, reader, writer), nil
 }
 
-func (c *Config) WrapPacketConnClient(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *Config) WrapPacketConnClient(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	if level != levelCount {
 		return nil, errors.New("sudoku udp mask must be the innermost mask in chain")
 	}
 	return NewUDPConn(raw, c)
 }
 
-func (c *Config) WrapPacketConnServer(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *Config) WrapPacketConnServer(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	if level != levelCount {
 		return nil, errors.New("sudoku udp mask must be the innermost mask in chain")
 	}

--- a/transport/internet/finalmask/sudoku/conn_udp.go
+++ b/transport/internet/finalmask/sudoku/conn_udp.go
@@ -7,10 +7,11 @@ import (
 	"time"
 
 	"github.com/xtls/xray-core/common/errors"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 )
 
 type udpConn struct {
-	conn   net.PacketConn
+	conn   finalmask.PacketConn
 	tables []*table
 	pMin   int
 	pMax   int
@@ -21,7 +22,7 @@ type udpConn struct {
 	writeMu sync.Mutex
 }
 
-func NewUDPConn(raw net.PacketConn, config *Config) (net.PacketConn, error) {
+func NewUDPConn(raw finalmask.PacketConn, config *Config) (finalmask.PacketConn, error) {
 	tables, err := getTables(config)
 	if err != nil {
 		return nil, err
@@ -105,4 +106,12 @@ func (c *udpConn) SetReadDeadline(t time.Time) error {
 
 func (c *udpConn) SetWriteDeadline(t time.Time) error {
 	return c.conn.SetWriteDeadline(t)
+}
+
+func (c *udpConn) SetReadBuffer(bytes int) error {
+	return c.conn.SetReadBuffer(bytes)
+}
+
+func (c *udpConn) SetWriteBuffer(bytes int) error {
+	return c.conn.SetWriteBuffer(bytes)
 }

--- a/transport/internet/finalmask/udp_test.go
+++ b/transport/internet/finalmask/udp_test.go
@@ -227,11 +227,11 @@ func newUDPClientServerPair(t *testing.T, cfg *custom.UDPStandaloneConfig) (net.
 
 	maskManager := finalmask.NewUdpmaskManager([]finalmask.Udpmask{cfg})
 
-	client, err := maskManager.WrapPacketConnClient(clientRaw)
+	client, err := maskManager.WrapPacketConnClient(finalmask.WrapConn(clientRaw))
 	if err != nil {
 		t.Fatal(err)
 	}
-	server, err := maskManager.WrapPacketConnServer(serverRaw)
+	server, err := maskManager.WrapPacketConnServer(finalmask.WrapConn(serverRaw))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -359,7 +359,7 @@ func TestPacketConnReadWrite(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			client, err = maskManager.WrapPacketConnClient(client)
+			client, err = maskManager.WrapPacketConnClient(finalmask.WrapConn(client))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -369,7 +369,7 @@ func TestPacketConnReadWrite(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			server, err = maskManager.WrapPacketConnServer(server)
+			server, err = maskManager.WrapPacketConnServer(finalmask.WrapConn(server))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -411,7 +411,7 @@ func TestUDPcustomStaticHeaderWireShape(t *testing.T) {
 	}
 	defer serverRaw.Close()
 
-	client, err := maskManager.WrapPacketConnClient(clientRaw)
+	client, err := maskManager.WrapPacketConnClient(finalmask.WrapConn(clientRaw))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -876,7 +876,7 @@ func TestSudokuBDD(t *testing.T) {
 		}
 		defer raw.Close()
 
-		if _, err := cfg.WrapPacketConnClient(raw, 0, 1); err == nil {
+		if _, err := cfg.WrapPacketConnClient(finalmask.WrapConn(raw), 0, 1); err == nil {
 			t.Fatal("expected innermost check failure")
 		}
 	})
@@ -903,11 +903,11 @@ func TestSudokuBDD(t *testing.T) {
 		}
 		defer serverRaw.Close()
 
-		client, err := maskManager.WrapPacketConnClient(clientRaw)
+		client, err := maskManager.WrapPacketConnClient(finalmask.WrapConn(clientRaw))
 		if err != nil {
 			t.Fatal(err)
 		}
-		server, err := maskManager.WrapPacketConnServer(serverRaw)
+		server, err := maskManager.WrapPacketConnServer(finalmask.WrapConn(serverRaw))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/transport/internet/finalmask/xdns/client.go
+++ b/transport/internet/finalmask/xdns/client.go
@@ -36,7 +36,7 @@ type packet struct {
 }
 
 type xdnsConnClient struct {
-	net.PacketConn
+	finalmask.PacketConn
 
 	resolverAddrs []*net.UDPAddr
 	resolverTypes []uint16
@@ -54,7 +54,7 @@ type xdnsConnClient struct {
 	mutex  sync.Mutex
 }
 
-func NewConnClient(c *Config, raw net.PacketConn) (net.PacketConn, error) {
+func NewConnClient(c *Config, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	if len(c.Resolvers) == 0 {
 		return nil, errors.New("empty resolvers")
 	}

--- a/transport/internet/finalmask/xdns/config.go
+++ b/transport/internet/finalmask/xdns/config.go
@@ -1,13 +1,13 @@
 package xdns
 
 import (
-	"net"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 )
 
 func (c *Config) UDP() {
 }
 
-func (c *Config) WrapPacketConnClient(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *Config) WrapPacketConnClient(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	// _, ok1 := raw.(*internet.FakePacketConn)
 	// _, ok2 := raw.(*udphop.UdpHopPacketConn)
 	// if level != 0 || ok1 || ok2 {
@@ -16,7 +16,7 @@ func (c *Config) WrapPacketConnClient(raw net.PacketConn, level int, levelCount 
 	return NewConnClient(c, raw)
 }
 
-func (c *Config) WrapPacketConnServer(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *Config) WrapPacketConnServer(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	// if level != 0 {
 	// 	return nil, errors.New("xdns requires being at the outermost level")
 	// }

--- a/transport/internet/finalmask/xdns/server.go
+++ b/transport/internet/finalmask/xdns/server.go
@@ -53,7 +53,7 @@ type queue struct {
 }
 
 type xdnsConnServer struct {
-	net.PacketConn
+	finalmask.PacketConn
 
 	domains []domainSpec
 
@@ -65,7 +65,7 @@ type xdnsConnServer struct {
 	mutex  sync.Mutex
 }
 
-func NewConnServer(c *Config, raw net.PacketConn) (net.PacketConn, error) {
+func NewConnServer(c *Config, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	if len(c.Domains) == 0 {
 		return nil, errors.New("empty domains")
 	}

--- a/transport/internet/finalmask/xicmp/client.go
+++ b/transport/internet/finalmask/xicmp/client.go
@@ -36,7 +36,7 @@ type packet struct {
 }
 
 type xicmpConnClient struct {
-	conn     net.PacketConn
+	conn     finalmask.PacketConn
 	icmp4    *icmp.PacketConn
 	icmp6    *icmp.PacketConn
 	udp      bool
@@ -49,7 +49,7 @@ type xicmpConnClient struct {
 	mu       sync.Mutex
 }
 
-func NewConnClient(c *Config, raw net.PacketConn) (net.PacketConn, error) {
+func NewConnClient(c *Config, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	var icmp4, icmp6 *icmp.PacketConn
 	var err4, err6 error
 	if c.DGRAM {
@@ -312,6 +312,14 @@ func (c *xicmpConnClient) Close() error {
 	_ = c.icmp6.Close()
 	_ = c.conn.Close()
 	return nil
+}
+
+func (c *xicmpConnClient) SetReadBuffer(bytes int) error {
+	return c.conn.SetReadBuffer(bytes)
+}
+
+func (c *xicmpConnClient) SetWriteBuffer(bytes int) error {
+	return c.conn.SetWriteBuffer(bytes)
 }
 
 func (c *xicmpConnClient) LocalAddr() net.Addr {

--- a/transport/internet/finalmask/xicmp/config.go
+++ b/transport/internet/finalmask/xicmp/config.go
@@ -1,26 +1,26 @@
 package xicmp
 
 import (
-	"net"
-
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/transport/internet"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 	"github.com/xtls/xray-core/transport/internet/hysteria/udphop"
 )
 
 func (c *Config) UDP() {
 }
 
-func (c *Config) WrapPacketConnClient(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
-	_, ok1 := raw.(*internet.FakePacketConn)
-	_, ok2 := raw.(*udphop.UdpHopPacketConn)
+func (c *Config) WrapPacketConnClient(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
+	under := finalmask.UnwrapUdpMask(raw)
+	_, ok1 := under.(*internet.FakePacketConn)
+	_, ok2 := under.(*udphop.UdpHopPacketConn)
 	if level != 0 || ok1 || ok2 {
 		return nil, errors.New("xicmp requires being at the outermost level")
 	}
 	return NewConnClient(c, raw)
 }
 
-func (c *Config) WrapPacketConnServer(raw net.PacketConn, level int, levelCount int) (net.PacketConn, error) {
+func (c *Config) WrapPacketConnServer(raw finalmask.PacketConn, level int, levelCount int) (finalmask.PacketConn, error) {
 	if level != 0 {
 		return nil, errors.New("xicmp requires being at the outermost level")
 	}

--- a/transport/internet/finalmask/xicmp/server.go
+++ b/transport/internet/finalmask/xicmp/server.go
@@ -37,7 +37,7 @@ type record struct {
 }
 
 type xicmpConnServer struct {
-	conn     net.PacketConn
+	conn     finalmask.PacketConn
 	icmp4    *icmp.PacketConn
 	icmp6    *icmp.PacketConn
 	ips      map[netip.Addr]struct{}
@@ -47,7 +47,7 @@ type xicmpConnServer struct {
 	mu       sync.Mutex
 }
 
-func NewConnServer(c *Config, raw net.PacketConn) (net.PacketConn, error) {
+func NewConnServer(c *Config, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	icmp4, err := icmp.ListenPacket("ip4:icmp", "0.0.0.0")
 	if err != nil {
 		return nil, err
@@ -328,6 +328,14 @@ func (c *xicmpConnServer) Close() error {
 	_ = c.icmp6.Close()
 	_ = c.conn.Close()
 	return nil
+}
+
+func (c *xicmpConnServer) SetReadBuffer(bytes int) error {
+	return c.conn.SetReadBuffer(bytes)
+}
+
+func (c *xicmpConnServer) SetWriteBuffer(bytes int) error {
+	return c.conn.SetWriteBuffer(bytes)
 }
 
 func (c *xicmpConnServer) LocalAddr() net.Addr {

--- a/transport/internet/finalmask/xicmp/server_oob.go
+++ b/transport/internet/finalmask/xicmp/server_oob.go
@@ -39,7 +39,7 @@ type record struct {
 }
 
 type xicmpConnServer struct {
-	conn     net.PacketConn
+	conn     finalmask.PacketConn
 	icmp4    *icmp.PacketConn
 	icmp6    *icmp.PacketConn
 	ipv4PC   *ipv4.PacketConn
@@ -51,7 +51,7 @@ type xicmpConnServer struct {
 	mu       sync.Mutex
 }
 
-func NewConnServer(c *Config, raw net.PacketConn) (net.PacketConn, error) {
+func NewConnServer(c *Config, raw finalmask.PacketConn) (finalmask.PacketConn, error) {
 	icmp4, err := icmp.ListenPacket("ip4:icmp", "0.0.0.0")
 	if err != nil {
 		return nil, err
@@ -339,6 +339,14 @@ func (c *xicmpConnServer) Close() error {
 	_ = c.icmp6.Close()
 	_ = c.conn.Close()
 	return nil
+}
+
+func (c *xicmpConnServer) SetReadBuffer(bytes int) error {
+	return c.conn.SetReadBuffer(bytes)
+}
+
+func (c *xicmpConnServer) SetWriteBuffer(bytes int) error {
+	return c.conn.SetWriteBuffer(bytes)
 }
 
 func (c *xicmpConnServer) LocalAddr() net.Addr {

--- a/transport/internet/hysteria/dialer.go
+++ b/transport/internet/hysteria/dialer.go
@@ -164,7 +164,7 @@ func (c *client) dial(ctx context.Context) error {
 	}
 
 	if c.udpmaskManager != nil {
-		newConn, err := c.udpmaskManager.WrapPacketConnClient(pktConn)
+		newConn, err := c.udpmaskManager.WrapPacketConnClient(finalmask.WrapConn(pktConn))
 		if err != nil {
 			pktConn.Close()
 			return errors.New("mask err").Base(err)

--- a/transport/internet/hysteria/hub.go
+++ b/transport/internet/hysteria/hub.go
@@ -21,6 +21,7 @@ import (
 	"github.com/xtls/xray-core/common/protocol"
 	"github.com/xtls/xray-core/proxy/hysteria/account"
 	"github.com/xtls/xray-core/transport/internet"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 	"github.com/xtls/xray-core/transport/internet/hysteria/congestion"
 	"github.com/xtls/xray-core/transport/internet/hysteria/congestion/bbr"
 	"github.com/xtls/xray-core/transport/internet/tls"
@@ -299,7 +300,7 @@ func Listen(ctx context.Context, address net.Address, port net.Port, streamSetti
 	}
 
 	if streamSettings.UdpmaskManager != nil {
-		newConn, err := streamSettings.UdpmaskManager.WrapPacketConnServer(pktConn)
+		newConn, err := streamSettings.UdpmaskManager.WrapPacketConnServer(finalmask.WrapConn(pktConn))
 		if err != nil {
 			pktConn.Close()
 			return nil, errors.New("mask err").Base(err)

--- a/transport/internet/kcp/dialer.go
+++ b/transport/internet/kcp/dialer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/net/cnc"
 	"github.com/xtls/xray-core/transport/internet"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 	"github.com/xtls/xray-core/transport/internet/stat"
 	"github.com/xtls/xray-core/transport/internet/tls"
 )
@@ -69,7 +70,7 @@ func DialKCP(ctx context.Context, dest net.Destination, streamSettings *internet
 		default:
 			panic(reflect.TypeOf(c))
 		}
-		newConn, err := streamSettings.UdpmaskManager.WrapPacketConnClient(pktConn)
+		newConn, err := streamSettings.UdpmaskManager.WrapPacketConnClient(finalmask.WrapConn(pktConn))
 		if err != nil {
 			pktConn.Close()
 			return nil, errors.New("mask err").Base(err)

--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -26,6 +26,7 @@ import (
 	"github.com/xtls/xray-core/common/signal/done"
 	"github.com/xtls/xray-core/transport/internet"
 	"github.com/xtls/xray-core/transport/internet/browser_dialer"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 	"github.com/xtls/xray-core/transport/internet/hysteria/congestion"
 	"github.com/xtls/xray-core/transport/internet/hysteria/congestion/bbr"
 	"github.com/xtls/xray-core/transport/internet/hysteria/udphop"
@@ -247,7 +248,7 @@ func createHTTPClient(dest net.Destination, streamSettings *internet.MemoryStrea
 				}
 
 				if streamSettings.UdpmaskManager != nil {
-					newConn, err := streamSettings.UdpmaskManager.WrapPacketConnClient(pktConn)
+					newConn, err := streamSettings.UdpmaskManager.WrapPacketConnClient(finalmask.WrapConn(pktConn))
 					if err != nil {
 						pktConn.Close()
 						return nil, errors.New("mask err").Base(err)

--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -25,6 +25,7 @@ import (
 	http_proto "github.com/xtls/xray-core/common/protocol/http"
 	"github.com/xtls/xray-core/common/signal/done"
 	"github.com/xtls/xray-core/transport/internet"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 	"github.com/xtls/xray-core/transport/internet/hysteria/congestion"
 	"github.com/xtls/xray-core/transport/internet/hysteria/congestion/bbr"
 	"github.com/xtls/xray-core/transport/internet/reality"
@@ -480,7 +481,7 @@ func ListenXH(ctx context.Context, address net.Address, port net.Port, streamSet
 			return nil, errors.New("failed to listen UDP for XHTTP/3 on ", address, ":", port).Base(err)
 		}
 		if streamSettings.UdpmaskManager != nil {
-			newConn, err := streamSettings.UdpmaskManager.WrapPacketConnServer(Conn)
+			newConn, err := streamSettings.UdpmaskManager.WrapPacketConnServer(finalmask.WrapConn(Conn))
 			if err != nil {
 				Conn.Close()
 				return nil, errors.New("mask err").Base(err)

--- a/transport/internet/udp/dialer.go
+++ b/transport/internet/udp/dialer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/net/cnc"
 	"github.com/xtls/xray-core/transport/internet"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 	"github.com/xtls/xray-core/transport/internet/stat"
 )
 
@@ -37,7 +38,7 @@ func init() {
 				default:
 					panic(reflect.TypeOf(c))
 				}
-				newConn, err := streamSettings.UdpmaskManager.WrapPacketConnClient(pktConn)
+				newConn, err := streamSettings.UdpmaskManager.WrapPacketConnClient(finalmask.WrapConn(pktConn))
 				if err != nil {
 					pktConn.Close()
 					return nil, errors.New("mask err").Base(err)

--- a/transport/internet/udp/hub.go
+++ b/transport/internet/udp/hub.go
@@ -8,6 +8,7 @@ import (
 	"github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/protocol/udp"
 	"github.com/xtls/xray-core/transport/internet"
+	"github.com/xtls/xray-core/transport/internet/finalmask"
 )
 
 type HubOption func(h *Hub)
@@ -69,7 +70,7 @@ func ListenUDP(ctx context.Context, address net.Address, port net.Port, streamSe
 	raw := hub.conn
 
 	if streamSettings.UdpmaskManager != nil {
-		hub.conn, err = streamSettings.UdpmaskManager.WrapPacketConnServer(raw)
+		hub.conn, err = streamSettings.UdpmaskManager.WrapPacketConnServer(finalmask.WrapConn(raw))
 		if err != nil {
 			raw.Close()
 			return nil, errors.New("mask err").Base(err)


### PR DESCRIPTION
## Problem

The UDP mask conns in `transport/internet/finalmask` hold the socket behind an **interface** field, so `SetReadBuffer` and `SetWriteBuffer` of the underlying `*net.UDPConn` are not promoted.

quic-go raises the socket buffers only if the `net.PacketConn` it is handed asserts to those methods, and it discards the failure — `_ = setReceiveBuffer(pc)` in `sys_conn.go`. The assertion fails against a mask conn, the error goes nowhere, and the socket stays at `net.core.rmem_default` instead of the 8 MiB quic-go asks for.

On a hysteria2 outbound with `obfs=salamander` this shows up as drops on the receive path with no error anywhere: UDP has no feedback, so QUIC just sees loss and retransmits. The user gets a slower connection and the logs are clean.

## Fix

`WrapPacketConnClient` / `WrapPacketConnServer` take and return a dedicated interface instead of `net.PacketConn`:

```go
type PacketConn interface {
	net.PacketConn
	SetReadBuffer(bytes int) error
	SetWriteBuffer(bytes int) error
}
```

Mask conns that embed the socket now embed `finalmask.PacketConn`, so the two setters are promoted and reach the real socket with no code of their own: `headerManagerConn`, `mkcp/header`, `mkcp/aes128gcm`, `mkcp/original`, `header/custom`, `noise`, `salamander`, `xdns` client and server, `realm`. The masks that keep the conn in a named field — `sudoku`'s `udpConn` and `xicmp`'s client/server — delegate in one line each.

Because the interface is the signature, a mask that regresses to `net.PacketConn` stops satisfying `Udpmask` and fails the build, instead of silently dropping the raise again. `transport/internet/memory_settings.go` asserts `instance.(finalmask.Udpmask)` unchecked, so the alternative is a startup panic. `packetconn_test.go` pins that with a compile-time conformance list plus runtime cases that check the setters actually reach the socket through each wrapper shape.

One adapter sits at the boundary for conns that have no setters at all:

```go
func WrapConn(pc net.PacketConn) PacketConn
```

It returns the conn unchanged when it already satisfies `PacketConn`, and wraps it in a no-op otherwise. `internet.FakePacketConn` is the case that matters — it embeds a `net.Conn` interface, so no setter is reachable through it, and the adapter returns nil rather than pretending. `UnwrapUdpMask` looks back through the adapter, so `xicmp`'s rejection of `FakePacketConn` and `udphop.UdpHopPacketConn` still sees the real conn.

Call sites wrapped: `hysteria` dialer and hub, `kcp` dialer, `splithttp` dialer and hub, `udp` dialer and hub, `proxy/wireguard` client and server.

## Why there is no `SyscallConn`

`wrapConn` discards the buffer errors, but it **returns** the error from `SyscallConn` and from the `setDF` that follows it. A wrapper that advertises a `SyscallConn` it cannot deliver therefore aborts `quic.DialEarly` on any path where the conn is not a real `*net.UDPConn` — `internet.FakePacketConn`, i.e. hysteria2 dialled through another outbound. `udphop` can declare it because its conns always are real sockets. The reasoning sits as a comment on `PacketConn` so the trio does not get "completed" later.

## Verification

Measured on a live relay running hysteria2 with `obfs=salamander`. Masked socket with the patch: `rb=16777216`, which is the kernel storing twice quic-go's 8 MiB `DesiredReceiveBufferSize`. Unmasked sockets on the same host, same kernel: `rb=4194304`, i.e. `net.core.rmem_default` untouched. `SetWriteBuffer` takes as well.

No throughput claim: on my load the rcvbuf drop counter does not move, so the change is about the raise reaching the kernel at all, not about a measurable speed win.

Tests: `packetconn_test.go` covers each wrapper shape (embedded interface, named field, adapter) and the no-op case for a conn without the setters. `go build ./...` green on linux, windows and darwin.
