### PR TITLE
Fix uTP sniffing never matching and correct the header layout

### DIFF
--- a/common/protocol/bittorrent/bittorrent.go
+++ b/common/protocol/bittorrent/bittorrent.go
@@ -3,11 +3,8 @@ package bittorrent
 import (
 	"encoding/binary"
 	"errors"
-	"math"
-	"time"
 
 	"github.com/xtls/xray-core/common"
-	"github.com/xtls/xray-core/common/buf"
 )
 
 type SniffHeader struct{}
@@ -19,6 +16,14 @@ func (h *SniffHeader) Protocol() string {
 func (h *SniffHeader) Domain() string {
 	return ""
 }
+
+const (
+	utpHeaderSize            = 20
+	utpVersion               = 1
+	utpPacketTypeMax         = 4
+	utpExtensionSelectiveAck = 1
+	utpWindowSizeMax         = 16 << 20
+)
 
 var errNotBittorrent = errors.New("not bittorrent header")
 
@@ -35,55 +40,44 @@ func SniffBittorrent(b []byte) (*SniffHeader, error) {
 }
 
 func SniffUTP(b []byte) (*SniffHeader, error) {
-	if len(b) < 20 {
+	if len(b) < utpHeaderSize {
 		return nil, common.ErrNoClue
 	}
 
-	buffer := buf.FromBytes(b)
-
-	var typeAndVersion uint8
-
-	if binary.Read(buffer, binary.BigEndian, &typeAndVersion) != nil {
-		return nil, common.ErrNoClue
-	} else if b[0]>>4&0xF > 4 || b[0]&0xF != 1 {
+	if b[0]&0xF != utpVersion || b[0]>>4 > utpPacketTypeMax {
 		return nil, errNotBittorrent
 	}
 
-	var extension uint8
-
-	if binary.Read(buffer, binary.BigEndian, &extension) != nil {
-		return nil, common.ErrNoClue
-	} else if extension != 0 && extension != 1 {
+	// The initiating endpoint picks a connection id at random. Zero is what a
+	// WireGuard handshake initiation presents here, because its three reserved
+	// bytes fall on the version, extension and connection id fields.
+	if binary.BigEndian.Uint16(b[2:4]) == 0 {
 		return nil, errNotBittorrent
 	}
 
+	// timestamp_microseconds and timestamp_difference_microseconds carry the
+	// sender's own clock, which bears no fixed relation to this host's, so they
+	// are read but not judged. wnd_size is a receive window in bytes and stays
+	// far below this bound in practice.
+	if binary.BigEndian.Uint32(b[12:16]) > utpWindowSizeMax {
+		return nil, errNotBittorrent
+	}
+
+	// Extension records follow the fixed header. Each carries the type of the
+	// next record and its own length, terminated by a type of zero.
+	// A datagram is a complete message, so a chain that does not fit inside it
+	// belongs to something that is not uTP rather than to a short read.
+	extension, rest := b[1], b[utpHeaderSize:]
 	for extension != 0 {
-		if extension != 1 {
+		if extension != utpExtensionSelectiveAck || len(rest) < 2 {
 			return nil, errNotBittorrent
 		}
-		if binary.Read(buffer, binary.BigEndian, &extension) != nil {
-			return nil, common.ErrNoClue
+		// BEP 29 sizes a selective ack in whole 32 bit words.
+		length := int(rest[1])
+		if length < 4 || length%4 != 0 || len(rest) < 2+length {
+			return nil, errNotBittorrent
 		}
-
-		var length uint8
-		if err := binary.Read(buffer, binary.BigEndian, &length); err != nil {
-			return nil, common.ErrNoClue
-		}
-		if common.Error2(buffer.ReadBytes(int32(length))) != nil {
-			return nil, common.ErrNoClue
-		}
-	}
-
-	if common.Error2(buffer.ReadBytes(2)) != nil {
-		return nil, common.ErrNoClue
-	}
-
-	var timestamp uint32
-	if err := binary.Read(buffer, binary.BigEndian, &timestamp); err != nil {
-		return nil, common.ErrNoClue
-	}
-	if math.Abs(float64(time.Now().UnixMicro()-int64(timestamp))) > float64(24*time.Hour) {
-		return nil, errNotBittorrent
+		extension, rest = rest[0], rest[2+length:]
 	}
 
 	return &SniffHeader{}, nil

--- a/common/protocol/bittorrent/bittorrent_test.go
+++ b/common/protocol/bittorrent/bittorrent_test.go
@@ -1,0 +1,118 @@
+package bittorrent_test
+
+import (
+	"encoding/binary"
+	"errors"
+	"testing"
+
+	"github.com/xtls/xray-core/common"
+	"github.com/xtls/xray-core/common/protocol/bittorrent"
+)
+
+// utpPacket builds the 20 byte fixed header described by BEP 29.
+func utpPacket(packetType, extension byte, timestamp uint32) []byte {
+	b := make([]byte, 20)
+	b[0] = packetType<<4 | 1
+	b[1] = extension
+	binary.BigEndian.PutUint16(b[2:4], 0x1234)
+	binary.BigEndian.PutUint32(b[4:8], timestamp)
+	binary.BigEndian.PutUint32(b[8:12], 0)
+	binary.BigEndian.PutUint32(b[12:16], 0x10000)
+	binary.BigEndian.PutUint16(b[16:18], 1)
+	binary.BigEndian.PutUint16(b[18:20], 0)
+	return b
+}
+
+// Extension records follow the fixed header rather than sitting inside it.
+func utpPacketWithSelectiveAck() []byte {
+	b := utpPacket(2, 1, 1)
+	return append(b, 0, 4, 0xFF, 0x00, 0xFF, 0x00)
+}
+
+func utpPacketWith(mutate func([]byte)) []byte {
+	b := utpPacket(4, 0, 1)
+	mutate(b)
+	return b
+}
+
+// A WireGuard handshake initiation is a message type of 1 followed by three
+// reserved zero bytes, which land on the version, extension and connection id
+// fields. It opens a session, so the sniffer sees it.
+func wireGuardInitiation() []byte {
+	b := make([]byte, 148)
+	b[0] = 0x01
+	for i := 4; i < len(b); i++ {
+		b[i] = byte(i * 7)
+	}
+	return b
+}
+
+func dnsQuery() []byte {
+	return []byte{
+		0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x03, 'w', 'w', 'w', 0x07, 'e', 'x', 'a', 'm', 'p', 'l', 'e',
+		0x03, 'c', 'o', 'm', 0x00, 0x00, 0x01, 0x00, 0x01,
+	}
+}
+
+func TestSniffUTP(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload []byte
+		want    bool
+	}{
+		{"syn", utpPacket(4, 0, 0x0102FF00), true},
+		{"data", utpPacket(0, 0, 1), true},
+		{"state with a large timestamp", utpPacket(2, 0, 0xFFFFFFFF), true},
+		{"selective ack extension", utpPacketWithSelectiveAck(), true},
+		{"shorter than the header", []byte{0x41, 0, 0, 0}, false},
+		{"wrong version", utpPacketWith(func(b []byte) { b[0] = 0x42 }), false},
+		{"unknown packet type", utpPacketWith(func(b []byte) { b[0] = 0x51 }), false},
+		{"zero connection id", utpPacketWith(func(b []byte) { binary.BigEndian.PutUint16(b[2:4], 0) }), false},
+		{"implausible window size", utpPacketWith(func(b []byte) { binary.BigEndian.PutUint32(b[12:16], 0xFFFFFFFF) }), false},
+		{"unknown extension type", utpPacketWith(func(b []byte) { b[1] = 3 }), false},
+		{"truncated extension record", append(utpPacket(4, 1, 1), 0), false},
+		{"wireguard handshake initiation", wireGuardInitiation(), false},
+		{"dns query", dnsQuery(), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h, err := bittorrent.SniffUTP(c.payload)
+			if c.want {
+				if err != nil || h == nil {
+					t.Fatalf("expected a uTP header, got header %v err %v", h, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected an error, got header %v", h)
+			}
+		})
+	}
+}
+
+// A payload that stops mid header leaves the sniffer without a verdict, while a
+// well formed packet that is not uTP is a definite reject. The dispatcher treats
+// the two differently, so the distinction is asserted.
+func TestSniffUTPErrorKind(t *testing.T) {
+	if _, err := bittorrent.SniffUTP([]byte{0x41, 0}); !errors.Is(err, common.ErrNoClue) {
+		t.Fatalf("a short payload should give no clue, got %v", err)
+	}
+	if _, err := bittorrent.SniffUTP(wireGuardInitiation()); errors.Is(err, common.ErrNoClue) {
+		t.Fatal("a complete non-uTP packet should be rejected outright")
+	}
+}
+
+func TestSniffBittorrent(t *testing.T) {
+	handshake := append([]byte{19}, []byte("BitTorrent protocol")...)
+	handshake = append(handshake, make([]byte, 8)...)
+	if _, err := bittorrent.SniffBittorrent(handshake); err != nil {
+		t.Fatalf("expected the cleartext handshake to be recognised: %v", err)
+	}
+	if _, err := bittorrent.SniffBittorrent([]byte("GET /announce HTTP/1.1\r\nHost: t\r\n\r\n")); err == nil {
+		t.Fatal("expected an error for a non-BitTorrent payload")
+	}
+	if _, err := bittorrent.SniffBittorrent([]byte{19, 'B'}); !errors.Is(err, common.ErrNoClue) {
+		t.Fatal("a short payload should give no clue")
+	}
+}


### PR DESCRIPTION
## Summary

`SniffUTP` could never return a match, and the header was parsed at the wrong offsets. Both are fixed, with tests.

## Why

The closing check compared `timestamp_microseconds` taken from the packet against `time.Now().UnixMicro()`, with a threshold of `float64(24*time.Hour)` — a nanosecond count:

```go
if math.Abs(float64(time.Now().UnixMicro()-int64(timestamp))) > float64(24*time.Hour) {
    return nil, errNotBittorrent
}
```

A `uint32` timestamp tops out at 4 294 967 295 while the epoch microsecond count is around 1.79e15. Even in the most favourable case the difference is 1 787 389 615 077 627 against a threshold of 86 400 000 000 000 — exceeded 21 times over, and 20 687 times over against 24 hours expressed in microseconds. The condition held for every possible input, so the function always returned `errNotBittorrent` and uTP has never been classified.

The comparison has no meaning beyond the units either: `timestamp_microseconds` carries the sender's own clock from an arbitrary epoch, so it cannot be validated against the receiver's wall clock at all.

Because the positive path never ran, the rest of the parse went unnoticed. The extension chain was walked from offset 2, where BEP 29 places `connection_id`, while extension records begin after the twenty byte fixed header.

## Scope

- read the fixed header fields at their documented offsets
- walk extension records after that header, requiring a selective ack length that is non zero and a multiple of four
- drop the timestamp comparison
- reject a zero connection id and an implausible receive window, so that reviving the sniffer does not pull in other UDP protocols that share the shape of the header
- add tests for the accepted and rejected shapes

## Validation

`go build ./...`, `go vet ./...` and `go test ./common/protocol/...` are clean. The new table covers thirteen cases.

That the old code never matched is shown by the tests themselves: restoring only `bittorrent.go` makes every positive case fail with `not bittorrent header`, including a packet whose timestamp is the largest a `uint32` can hold.

False positives over 1 000 000 generated packets of each kind:

| payload | timestamp check simply removed | this change |
| --- | --- | --- |
| DNS shaped queries | 177 | 1 |
| random UDP of 20 to 80 bytes | 64 | 0 |

A WireGuard handshake initiation is a message type of 1 followed by three reserved zero bytes, which land on the version, extension and connection id fields; it is rejected here. When `proxy/wireguard/bind.go` writes a non zero client id into those same bytes, 17 handshakes per 1 000 000 random client ids still match.

## Risk

Behaviour changes from never matching anything to actually classifying uTP, so a configuration carrying `protocol: ["bittorrent"] -> blocked` will start dropping traffic it previously passed. Sniffing stays a heuristic over a twenty byte header; the measurements above bound what is left.
