### PR TITLE
Extend BitTorrent sniffer

### DIFF
--- a/app/dispatcher/sniffer.go
+++ b/app/dispatcher/sniffer.go
@@ -41,6 +41,9 @@ func NewSniffer(ctx context.Context) *Sniffer {
 			{func(c context.Context, b []byte) (SniffResult, error) { return bittorrent.SniffBittorrent(b) }, false, net.Network_TCP},
 			{func(c context.Context, b []byte) (SniffResult, error) { return quic.SniffQUIC(b) }, false, net.Network_UDP},
 			{func(c context.Context, b []byte) (SniffResult, error) { return bittorrent.SniffUTP(b) }, false, net.Network_UDP},
+			{func(c context.Context, b []byte) (SniffResult, error) { return bittorrent.SniffUDPTracker(b) }, false, net.Network_UDP},
+			{func(c context.Context, b []byte) (SniffResult, error) { return bittorrent.SniffDHT(b) }, false, net.Network_UDP},
+			{func(c context.Context, b []byte) (SniffResult, error) { return bittorrent.SniffLSD(b) }, false, net.Network_UDP},
 		},
 	}
 	if sniffer, err := newFakeDNSSniffer(ctx); err == nil {

--- a/common/protocol/bittorrent/bittorrent.go
+++ b/common/protocol/bittorrent/bittorrent.go
@@ -1,6 +1,7 @@
 package bittorrent
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"math"
@@ -22,12 +23,14 @@ func (h *SniffHeader) Domain() string {
 
 var errNotBittorrent = errors.New("not bittorrent header")
 
+var bittorrentHandshake = []byte("BitTorrent protocol")
+
 func SniffBittorrent(b []byte) (*SniffHeader, error) {
 	if len(b) < 20 {
 		return nil, common.ErrNoClue
 	}
 
-	if b[0] == 19 && string(b[1:20]) == "BitTorrent protocol" {
+	if b[0] == 19 && bytes.HasPrefix(b[1:], bittorrentHandshake) {
 		return &SniffHeader{}, nil
 	}
 
@@ -87,4 +90,57 @@ func SniffUTP(b []byte) (*SniffHeader, error) {
 	}
 
 	return &SniffHeader{}, nil
+}
+
+func SniffUDPTracker(b []byte) (*SniffHeader, error) {
+	if len(b) < 16 {
+		return nil, common.ErrNoClue
+	}
+
+	// protocol_id
+	if binary.BigEndian.Uint64(b[0:8]) != 0x41727101980 {
+		return nil, errNotBittorrent
+	}
+
+	// action connect
+	if binary.BigEndian.Uint32(b[8:12]) != 0 {
+		return nil, errNotBittorrent
+	}
+
+	return &SniffHeader{}, nil
+}
+
+var dhtPrefixes = [][]byte{
+	[]byte("d1:ad"), // query
+	[]byte("d1:rd"), // response
+	[]byte("d2:ip"), // BEP-42
+	[]byte("d1:el"), // error
+}
+
+func SniffDHT(b []byte) (*SniffHeader, error) {
+	if len(b) < 5 {
+		return nil, common.ErrNoClue
+	}
+
+	for _, p := range dhtPrefixes {
+		if bytes.HasPrefix(b, p) {
+			return &SniffHeader{}, nil
+		}
+	}
+
+	return nil, errNotBittorrent
+}
+
+var lsdPrefix = []byte("BT-SEARCH * HTTP/1.1\r\n")
+
+func SniffLSD(b []byte) (*SniffHeader, error) {
+	if len(b) < len(lsdPrefix) {
+		return nil, common.ErrNoClue
+	}
+
+	if bytes.HasPrefix(b, lsdPrefix) {
+		return &SniffHeader{}, nil
+	}
+
+	return nil, errNotBittorrent
 }


### PR DESCRIPTION
Currently, the BitTorrent sniffer can only detect the BitTorrent Handshake and uTP (uTP is currently broken, but PR #6667 fixes it).

I decided to add detection for several protocols from the BitTorrent family:

- UDP Tracker ([BEP15](https://www.bittorrent.org/beps/bep_0015.html))
- DHT ([BEP5](https://www.bittorrent.org/beps/bep_0005.html) & [BEP42](https://www.bittorrent.org/beps/bep_0042.html))
- LSD ([BEP14](https://www.bittorrent.org/beps/bep_0014.html))

Also `string(b[1:20])` in `SniffBittorrent()` causes an allocation. It was replaced with `bytes.HasPrefix`.

I tested this using Wireshark and BitComet/qBittorrent