### PR TITLE
XHTTP: Release the connections a retired xmux client is holding

### DIFF
--- a/transport/internet/splithttp/client.go
+++ b/transport/internet/splithttp/client.go
@@ -177,11 +177,12 @@ func (c *DefaultDialerClient) PostPacket(ctx context.Context, url string, sessio
 	return nil
 }
 
-// HTTP/1.1 and HTTP/2 will close itself, we only handle HTTP/3 here
 func (c *DefaultDialerClient) Close() error {
-	transport := c.client.Transport
-	if h3Transport, ok := transport.(*http3.Transport); ok {
-		h3Transport.Close()
+	switch transport := c.client.Transport.(type) {
+	case *http3.Transport:
+		transport.Close()
+	case interface{ CloseIdleConnections() }:
+		transport.CloseIdleConnections()
 	}
 	return nil
 }

--- a/transport/internet/splithttp/dialer.go
+++ b/transport/internet/splithttp/dialer.go
@@ -505,6 +505,15 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 
 		dynamicHTTPClient := httpClient
 		dynamicXmuxClient := xmuxClient
+
+		if dynamicXmuxClient != nil {
+			dynamicXmuxClient.AddRunning()
+			defer func() {
+				if dynamicXmuxClient != nil {
+					dynamicXmuxClient.DoneRunning()
+				}
+			}()
+		}
 		for {
 			// by offloading the uploads into a buffered pipe, multiple conn.Write
 			// calls get automatically batched together into larger POST requests.
@@ -541,10 +550,21 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 
 				if dynamicXmuxClient != nil && (dynamicXmuxClient.LeftRequests.Add(-1) <= 0 ||
 					(dynamicXmuxClient.UnreusableAt != time.Time{} && lastWrite.After(dynamicXmuxClient.UnreusableAt))) {
-					dynamicHTTPClient, dynamicXmuxClient = getHTTPClient(ctx, dest, streamSettings)
+					newHTTPClient, newXmuxClient := getHTTPClient(ctx, dest, streamSettings)
+					if newXmuxClient != nil {
+						newXmuxClient.AddRunning()
+					}
+					dynamicXmuxClient.DoneRunning()
+					dynamicHTTPClient, dynamicXmuxClient = newHTTPClient, newXmuxClient
 				}
 
-				go func(hClient DialerClient) {
+				if dynamicXmuxClient != nil {
+					dynamicXmuxClient.AddRunning()
+				}
+				go func(hClient DialerClient, hXmuxClient *XmuxClient) {
+					if hXmuxClient != nil {
+						defer hXmuxClient.DoneRunning()
+					}
 					err := hClient.PostPacket(
 						ctx,
 						requestURL.String(),
@@ -558,7 +578,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 						uploadPipeReader.Interrupt()
 						doSplit.Store(false)
 					}
-				}(dynamicHTTPClient)
+				}(dynamicHTTPClient, dynamicXmuxClient)
 
 				if _, ok := dynamicHTTPClient.(*DefaultDialerClient); ok {
 					<-wroteRequest.Wait()


### PR DESCRIPTION

## The bug

An xmux client retired by `hMaxRequestTimes` or `hMaxReusableSecs` keeps every TCP
connection it ever opened. Nothing closes them. They linger until `ConnIdleTimeout`
expires them five minutes later, and under continuous load retirements outpace that
timeout, so abandoned connections accumulate.

Two things have to be wrong at once for this, and both are.

**`DefaultDialerClient.Close` closed only an `http3.Transport`.** The comment claimed
HTTP/1.1 and HTTP/2 "will close itself", but nothing closes a transport nobody holds
any more: an `http2.Transport` keeps its `ClientConn`s until they idle out, and an idle
timer is not a substitute for closing. `maybeClose` was calling into a function that did
nothing at all for h1 and h2.

**The upload loop does not maintain `Running` across a rotation.** `maybeClose` fires
when `Running` reaches zero. The reference taken at dial time stays on the client the
session started on, while the posts go to the client that rotation picked up:

```go
dynamicHTTPClient, dynamicXmuxClient = getHTTPClient(ctx, dest, streamSettings)
```

That client therefore has a `Running` of zero no matter how much is in flight on it. So
`maybeClose` closes it while it is busy, `CloseIdleConnections` skips exactly the
connections that are in use, and nothing ever looks at a retired client again.

Either fix alone is close to useless; the numbers below show why.

## Second effect, arguably worth more than the leak

`maxConcurrency` is measured in `Running`. Since `Running` did not reflect the requests a
rotated-to client was carrying, `maxConcurrency` stopped limiting anything after the
first rotation, and work piled onto connections that were already saturated.

## How to verify

The mechanism needs three things: **HTTP/2** (h1 pools differently), **xmux rotation**
turned on, and **uplink traffic**, because it is the upload loop that rotates. A
download-only test will not trigger it.

1. Run an XHTTP server and client over TLS with `"alpn": ["h2"]` and `"mode": "packet-up"`.
2. On the client, force rotation to happen often:
   ```json
   "xmux": { "hMaxRequestTimes": "20-30" }
   ```
3. Push sustained upload traffic through the tunnel — several concurrent large POSTs to
   any host that discards the body. Eight concurrent 40 MB uploads is plenty.
4. Count the established TCP connections **the client process holds to the server port**:
   ```sh
   ss -tnp state established "( dport = :<your port> )" | grep -c "pid=<client pid>,"
   ```
   Attributing by pid matters — otherwise you may be counting the server side or
   something else on the box.

**The observation that identifies the bug: after every transfer has finished, the count
does not go down.** No traffic is flowing, no request is outstanding, and the number
stays exactly where it was. Sample it every 30 seconds for six minutes: it holds flat and
then drops to zero all at once, when `ConnIdleTimeout` (300s) expires the whole batch.
That is the tell — the connections are not being released by the code, they are timing
out.

Two controls make it conclusive:

- **Rotation off** (drop `hMaxRequestTimes`): the count stays in the single digits for the
  same workload. Nothing is retired, so nothing is abandoned.
- **With this patch**: the count falls to a couple of connections as soon as the transfers
  end, instead of five minutes later.

## Measured

Loopback, TLS+h2, `packet-up` uplink, eight concurrent uploads, `hMaxRequestTimes: "20-30"`.
Connections still established after the transfers finished:

| | held |
|---|---|
| rotation disabled (control) | 3 |
| unpatched | 27-28 |
| patched | 2 |

Distinct sockets opened over a run vs still open at the end: 9 / 9 unpatched, 6 / 2 patched.

Long observation, unpatched: flat at 28 through +275s, 0 at +320s, i.e. released by
`ConnIdleTimeout` rather than by the code.

## Why it costs more than a socket count

An idle HTTP/2 connection that has carried traffic holds its TLS record buffer plus its
framer and bufio buffers. Measured on linux/amd64 with a standalone probe: about 112 KB
of live heap and 205 KB of RSS each. Two hundred of them is 41 MB, which matters on
platforms that cap what a VPN extension may use.

## Risk

`CloseIdleConnections` is only reached through `maybeClose`, which requires
`NotUsed && Running <= 0`. With the accounting corrected, that state means nothing of
ours is in flight, so no live request can be torn down by this change. During rotation
the new reference is taken before the old one is released, so a client shared with other
sessions never transiently drops to zero.
