### PR TITLE
Transport: add source-aware PROXY protocol v2

### DIFF
--- a/app/proxyman/inbound/always.go
+++ b/app/proxyman/inbound/always.go
@@ -68,6 +68,9 @@ func NewAlwaysOnInboundHandler(ctx context.Context, tag string, receiverConfig *
 	if err != nil {
 		return nil, errors.New("failed to parse stream config").Base(err).AtWarning()
 	}
+	if err := internet.ValidateProxyProtocolTransportConfig(mss.SocketSettings, mss.ProtocolSettings); err != nil {
+		return nil, errors.New("invalid PROXY protocol transport configuration").Base(err)
+	}
 
 	newCtx := session.ContextWithInbound(ctx, &session.Inbound{Tag: tag, Source: src})
 	newCtx = session.ContextWithContent(newCtx, &session.Content{SniffingRequest: sniffingRequest})
@@ -81,6 +84,10 @@ func NewAlwaysOnInboundHandler(ctx context.Context, tag string, receiverConfig *
 	if !ok {
 		return nil, errors.New("not an inbound proxy.")
 	}
+	nl := p.Network()
+	if err := internet.ValidateProxyProtocolInboundConfig(mss.SocketSettings, receiverConfig.PortList, nl, mss); err != nil {
+		return nil, errors.New("invalid PROXY protocol listener configuration").Base(err)
+	}
 
 	h := &AlwaysOnInboundHandler{
 		receiverConfig: receiverConfig,
@@ -92,7 +99,6 @@ func NewAlwaysOnInboundHandler(ctx context.Context, tag string, receiverConfig *
 
 	uplinkCounter, downlinkCounter := getStatCounter(core.MustFromContext(ctx), tag)
 
-	nl := p.Network()
 	pl := receiverConfig.PortList
 	address := receiverConfig.Listen.AsAddress()
 	if address == nil {

--- a/app/proxyman/inbound/proxy_protocol_test.go
+++ b/app/proxyman/inbound/proxy_protocol_test.go
@@ -1,0 +1,151 @@
+package inbound_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/xtls/xray-core/app/proxyman"
+	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/serial"
+	core "github.com/xtls/xray-core/core"
+	featureinbound "github.com/xtls/xray-core/features/inbound"
+	"github.com/xtls/xray-core/proxy/dokodemo"
+	"github.com/xtls/xray-core/transport/internet"
+	"github.com/xtls/xray-core/transport/internet/hysteria"
+	"github.com/xtls/xray-core/transport/internet/kcp"
+	"github.com/xtls/xray-core/transport/internet/splithttp"
+	"github.com/xtls/xray-core/transport/internet/tcp"
+	"github.com/xtls/xray-core/transport/internet/tls"
+)
+
+func TestSourceAwareMixedTCPUDPRejectedBeforeHandlerRegistration(t *testing.T) {
+	config := &core.Config{
+		App: []*serial.TypedMessage{
+			serial.ToTypedMessage(&proxyman.InboundConfig{}),
+		},
+		Inbound: []*core.InboundHandlerConfig{
+			{
+				Tag: "mixed-source-aware",
+				ReceiverSettings: serial.ToTypedMessage(&proxyman.ReceiverConfig{
+					PortList: &net.PortList{Range: []*net.PortRange{net.SinglePortRange(24443)}},
+					StreamSettings: &internet.StreamConfig{
+						ProtocolName: "tcp",
+						TransportSettings: []*internet.TransportConfig{
+							{ProtocolName: "tcp", Settings: serial.ToTypedMessage(&tcp.Config{})},
+						},
+						SocketSettings: &internet.SocketConfig{
+							ProxyProtocolMode:           internet.SocketConfig_ProxyProtocolTrustedSources,
+							ProxyProtocolTrustedSources: []string{"192.0.2.10"},
+						},
+					},
+				}),
+				ProxySettings: serial.ToTypedMessage(&dokodemo.Config{
+					RewriteAddress:  net.NewIPOrDomain(net.LocalHostIP),
+					RewritePort:     80,
+					AllowedNetworks: []net.Network{net.Network_TCP, net.Network_UDP},
+				}),
+			},
+		},
+	}
+
+	instance, err := core.New(config)
+	if instance != nil {
+		_ = instance.Close()
+	}
+	if err == nil {
+		t.Fatal("mixed TCP/UDP source-aware inbound was registered")
+	}
+}
+
+func TestSourceAwarePacketTransportsRejectedBeforeHandlerRegistration(t *testing.T) {
+	h3TLS := serial.ToTypedMessage(&tls.Config{NextProtocol: []string{"h3"}})
+	tests := []struct {
+		name   string
+		stream *internet.StreamConfig
+	}{
+		{
+			name:   "mKCP",
+			stream: sourceAwareStream("mkcp", serial.ToTypedMessage(&kcp.Config{})),
+		},
+		{
+			name:   "Hysteria",
+			stream: sourceAwareStream("hysteria", serial.ToTypedMessage(&hysteria.Config{Auth: "test"})),
+		},
+		{
+			name: "XHTTP H3",
+			stream: func() *internet.StreamConfig {
+				stream := sourceAwareStream("splithttp", serial.ToTypedMessage(&splithttp.Config{}))
+				stream.SecurityType = h3TLS.Type
+				stream.SecuritySettings = []*serial.TypedMessage{h3TLS}
+				return stream
+			}(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			instance, err := core.New(&core.Config{
+				App:     []*serial.TypedMessage{serial.ToTypedMessage(&proxyman.InboundConfig{})},
+				Inbound: []*core.InboundHandlerConfig{sourceAwareInbound("packet-source-aware", test.stream)},
+			})
+			if instance != nil {
+				_ = instance.Close()
+			}
+			if err == nil {
+				t.Fatal("packet-based source-aware transport passed core.New")
+			}
+		})
+	}
+}
+
+func TestSourceAwarePacketTransportHotAddDoesNotRegisterHandler(t *testing.T) {
+	instance, err := core.New(&core.Config{
+		App: []*serial.TypedMessage{serial.ToTypedMessage(&proxyman.InboundConfig{})},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = instance.Close() })
+	if err := instance.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	const tag = "hot-mkcp-source-aware"
+	config := sourceAwareInbound(tag, sourceAwareStream("mkcp", serial.ToTypedMessage(&kcp.Config{})))
+	if err := core.AddInboundHandler(instance, config); err == nil {
+		t.Fatal("hot AddInbound accepted packet-based source-aware transport")
+	}
+
+	manager := instance.GetFeature(featureinbound.ManagerType()).(featureinbound.Manager)
+	if _, err := manager.GetHandler(context.Background(), tag); err == nil {
+		t.Fatal("failed hot AddInbound left its handler registered")
+	}
+}
+
+func sourceAwareStream(protocol string, settings *serial.TypedMessage) *internet.StreamConfig {
+	return &internet.StreamConfig{
+		ProtocolName: protocol,
+		TransportSettings: []*internet.TransportConfig{
+			{ProtocolName: protocol, Settings: settings},
+		},
+		SocketSettings: &internet.SocketConfig{
+			ProxyProtocolMode:           internet.SocketConfig_ProxyProtocolTrustedSources,
+			ProxyProtocolTrustedSources: []string{"192.0.2.10"},
+		},
+	}
+}
+
+func sourceAwareInbound(tag string, stream *internet.StreamConfig) *core.InboundHandlerConfig {
+	return &core.InboundHandlerConfig{
+		Tag: tag,
+		ReceiverSettings: serial.ToTypedMessage(&proxyman.ReceiverConfig{
+			PortList:       &net.PortList{Range: []*net.PortRange{net.SinglePortRange(24443)}},
+			StreamSettings: stream,
+		}),
+		ProxySettings: serial.ToTypedMessage(&dokodemo.Config{
+			RewriteAddress:  net.NewIPOrDomain(net.LocalHostIP),
+			RewritePort:     80,
+			AllowedNetworks: []net.Network{net.Network_TCP},
+		}),
+	}
+}

--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -306,6 +306,14 @@ func (c *StreamConfig) Build() (*internet.StreamConfig, error) {
 		}
 	}
 
+	transportSettings, err := config.GetEffectiveTransportSettings()
+	if err != nil {
+		return nil, err
+	}
+	if err := internet.ValidateProxyProtocolTransportConfig(config.SocketSettings, transportSettings); err != nil {
+		return nil, errors.New("invalid PROXY protocol transport configuration").Base(err)
+	}
+
 	return config, nil
 }
 

--- a/infra/conf/transport_sockopt.go
+++ b/infra/conf/transport_sockopt.go
@@ -43,30 +43,42 @@ func (h *HappyEyeballsConfig) UnmarshalJSON(data []byte) error {
 }
 
 type SocketConfig struct {
-	Mark                  int32                  `json:"mark"`
-	TFO                   interface{}            `json:"tcpFastOpen"`
-	TProxy                string                 `json:"tproxy"`
-	AcceptProxyProtocol   bool                   `json:"acceptProxyProtocol"`
-	DomainStrategy        string                 `json:"domainStrategy"`
-	DialerProxy           string                 `json:"dialerProxy"`
-	TCPKeepAliveInterval  int32                  `json:"tcpKeepAliveInterval"`
-	TCPKeepAliveIdle      int32                  `json:"tcpKeepAliveIdle"`
-	TCPCongestion         string                 `json:"tcpCongestion"`
-	TCPWindowClamp        int32                  `json:"tcpWindowClamp"`
-	TCPMaxSeg             int32                  `json:"tcpMaxSeg"`
-	Penetrate             bool                   `json:"penetrate"`
-	TCPUserTimeout        int32                  `json:"tcpUserTimeout"`
-	V6only                bool                   `json:"v6only"`
-	Interface             string                 `json:"interface"`
-	TcpMptcp              bool                   `json:"tcpMptcp"`
-	CustomSockopt         []*CustomSockoptConfig `json:"customSockopt"`
-	AddressPortStrategy   string                 `json:"addressPortStrategy"`
-	HappyEyeballsSettings *HappyEyeballsConfig   `json:"happyEyeballs"`
-	TrustedXForwardedFor  []string               `json:"trustedXForwardedFor"`
+	Mark                        int32                  `json:"mark"`
+	TFO                         interface{}            `json:"tcpFastOpen"`
+	TProxy                      string                 `json:"tproxy"`
+	AcceptProxyProtocol         bool                   `json:"acceptProxyProtocol"`
+	DomainStrategy              string                 `json:"domainStrategy"`
+	DialerProxy                 string                 `json:"dialerProxy"`
+	TCPKeepAliveInterval        int32                  `json:"tcpKeepAliveInterval"`
+	TCPKeepAliveIdle            int32                  `json:"tcpKeepAliveIdle"`
+	TCPCongestion               string                 `json:"tcpCongestion"`
+	TCPWindowClamp              int32                  `json:"tcpWindowClamp"`
+	TCPMaxSeg                   int32                  `json:"tcpMaxSeg"`
+	Penetrate                   bool                   `json:"penetrate"`
+	TCPUserTimeout              int32                  `json:"tcpUserTimeout"`
+	V6only                      bool                   `json:"v6only"`
+	Interface                   string                 `json:"interface"`
+	TcpMptcp                    bool                   `json:"tcpMptcp"`
+	CustomSockopt               []*CustomSockoptConfig `json:"customSockopt"`
+	AddressPortStrategy         string                 `json:"addressPortStrategy"`
+	HappyEyeballsSettings       *HappyEyeballsConfig   `json:"happyEyeballs"`
+	TrustedXForwardedFor        []string               `json:"trustedXForwardedFor"`
+	ProxyProtocolMode           string                 `json:"proxyProtocolMode"`
+	ProxyProtocolTrustedSources []string               `json:"proxyProtocolTrustedSources"`
+	ProxyProtocolListenPorts    []uint32               `json:"proxyProtocolListenPorts"`
 }
 
 // Build implements Buildable.
 func (c *SocketConfig) Build() (*internet.SocketConfig, error) {
+	proxyProtocolMode := internet.SocketConfig_ProxyProtocolDefault
+	switch strings.ToLower(strings.TrimSpace(c.ProxyProtocolMode)) {
+	case "":
+	case "trusted-sources", "trustedsources":
+		proxyProtocolMode = internet.SocketConfig_ProxyProtocolTrustedSources
+	default:
+		return nil, errors.New("unsupported proxy protocol mode: ", c.ProxyProtocolMode)
+	}
+
 	tfo := int32(0) // don't invoke setsockopt() for TFO
 	if c.TFO != nil {
 		switch v := c.TFO.(type) {
@@ -162,26 +174,36 @@ func (c *SocketConfig) Build() (*internet.SocketConfig, error) {
 		happyEyeballs.MaxConcurrentTry = c.HappyEyeballsSettings.MaxConcurrentTry
 	}
 
-	return &internet.SocketConfig{
-		Mark:                 c.Mark,
-		Tfo:                  tfo,
-		Tproxy:               tproxy,
-		DomainStrategy:       dStrategy,
-		AcceptProxyProtocol:  c.AcceptProxyProtocol,
-		DialerProxy:          c.DialerProxy,
-		TcpKeepAliveInterval: c.TCPKeepAliveInterval,
-		TcpKeepAliveIdle:     c.TCPKeepAliveIdle,
-		TcpCongestion:        c.TCPCongestion,
-		TcpWindowClamp:       c.TCPWindowClamp,
-		TcpMaxSeg:            c.TCPMaxSeg,
-		Penetrate:            c.Penetrate,
-		TcpUserTimeout:       c.TCPUserTimeout,
-		V6Only:               c.V6only,
-		Interface:            c.Interface,
-		TcpMptcp:             c.TcpMptcp,
-		CustomSockopt:        customSockopts,
-		AddressPortStrategy:  addressPortStrategy,
-		HappyEyeballs:        happyEyeballs,
-		TrustedXForwardedFor: c.TrustedXForwardedFor,
-	}, nil
+	config := &internet.SocketConfig{
+		Mark:           c.Mark,
+		Tfo:            tfo,
+		Tproxy:         tproxy,
+		DomainStrategy: dStrategy,
+		// Keep the legacy bit independent from source-aware mode. Older cores
+		// ignore the new fields; setting this bit implicitly would make them
+		// fall back to trusting PROXY headers from every source.
+		AcceptProxyProtocol:         c.AcceptProxyProtocol,
+		DialerProxy:                 c.DialerProxy,
+		TcpKeepAliveInterval:        c.TCPKeepAliveInterval,
+		TcpKeepAliveIdle:            c.TCPKeepAliveIdle,
+		TcpCongestion:               c.TCPCongestion,
+		TcpWindowClamp:              c.TCPWindowClamp,
+		TcpMaxSeg:                   c.TCPMaxSeg,
+		Penetrate:                   c.Penetrate,
+		TcpUserTimeout:              c.TCPUserTimeout,
+		V6Only:                      c.V6only,
+		Interface:                   c.Interface,
+		TcpMptcp:                    c.TcpMptcp,
+		CustomSockopt:               customSockopts,
+		AddressPortStrategy:         addressPortStrategy,
+		HappyEyeballs:               happyEyeballs,
+		TrustedXForwardedFor:        c.TrustedXForwardedFor,
+		ProxyProtocolMode:           proxyProtocolMode,
+		ProxyProtocolTrustedSources: c.ProxyProtocolTrustedSources,
+		ProxyProtocolListenPorts:    c.ProxyProtocolListenPorts,
+	}
+	if err := internet.ValidateProxyProtocolConfig(config); err != nil {
+		return nil, err
+	}
+	return config, nil
 }

--- a/infra/conf/transport_test.go
+++ b/infra/conf/transport_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/xtls/xray-core/infra/conf"
 	"github.com/xtls/xray-core/transport/internet"
 	finalmaskcustom "github.com/xtls/xray-core/transport/internet/finalmask/header/custom"
+	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -289,5 +290,101 @@ func TestHeaderCustomUDPBuildRejectsExprWithoutArgs(t *testing.T) {
 	}`)
 	if err == nil || !strings.Contains(err.Error(), "transform args") {
 		t.Fatalf("expected transform arg rejection, got %v", err)
+	}
+}
+
+func TestProxyProtocolTrustedSources(t *testing.T) {
+	config := new(SocketConfig)
+	if err := json.Unmarshal([]byte(`{
+		"proxyProtocolMode": "trusted-sources",
+		"proxyProtocolTrustedSources": ["192.0.2.10", "2001:db8::/32"],
+		"proxyProtocolListenPorts": [18443]
+	}`), config); err != nil {
+		t.Fatal(err)
+	}
+	built, err := config.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if built.AcceptProxyProtocol {
+		t.Fatal("source-aware mode unexpectedly enabled the legacy acceptProxyProtocol bit")
+	}
+	wire, err := proto.Marshal(built)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for len(wire) > 0 {
+		fieldNumber, fieldType, tagLength := protowire.ConsumeTag(wire)
+		if tagLength < 0 {
+			t.Fatalf("invalid encoded SocketConfig: %v", protowire.ParseError(tagLength))
+		}
+		wire = wire[tagLength:]
+		if fieldNumber == 7 {
+			t.Fatal("source-aware config serialized the legacy accept_proxy_protocol field")
+		}
+		fieldLength := protowire.ConsumeFieldValue(fieldNumber, fieldType, wire)
+		if fieldLength < 0 {
+			t.Fatalf("invalid encoded SocketConfig field: %v", protowire.ParseError(fieldLength))
+		}
+		wire = wire[fieldLength:]
+	}
+	if len(built.ProxyProtocolTrustedSources) != 2 {
+		t.Fatalf("unexpected trusted source count: %d", len(built.ProxyProtocolTrustedSources))
+	}
+	if built.ProxyProtocolMode != internet.SocketConfig_ProxyProtocolTrustedSources {
+		t.Fatalf("unexpected proxy protocol mode: %v", built.ProxyProtocolMode)
+	}
+	if len(built.ProxyProtocolListenPorts) != 1 || built.ProxyProtocolListenPorts[0] != 18443 {
+		t.Fatalf("unexpected proxy protocol listen ports: %v", built.ProxyProtocolListenPorts)
+	}
+
+	for _, input := range []string{
+		`{"proxyProtocolTrustedSources":["192.0.2.10"]}`,
+		`{"proxyProtocolMode":"trusted-sources"}`,
+		`{"proxyProtocolMode":"trusted-sources","proxyProtocolTrustedSources":["not-an-address"]}`,
+		`{"proxyProtocolMode":"trusted-sources","proxyProtocolTrustedSources":["192.0.2.10/24"]}`,
+		`{"proxyProtocolMode":"trusted-sources","proxyProtocolTrustedSources":["fe80::1"]}`,
+		`{"proxyProtocolMode":"trusted-sources","proxyProtocolTrustedSources":["fe80::/10"]}`,
+		`{"proxyProtocolMode":"trusted-sources","proxyProtocolTrustedSources":["192.0.2.10"],"proxyProtocolListenPorts":[0]}`,
+		`{"proxyProtocolMode":"trusted-sources","proxyProtocolTrustedSources":["192.0.2.10"],"proxyProtocolListenPorts":[18443,18443]}`,
+		`{"proxyProtocolMode":"unknown","proxyProtocolTrustedSources":["192.0.2.10"]}`,
+	} {
+		config := new(SocketConfig)
+		if err := json.Unmarshal([]byte(input), config); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := config.Build(); err == nil {
+			t.Fatalf("expected configuration error for %s", input)
+		}
+	}
+}
+
+func TestProxyProtocolTrustedSourcesRejectsLegacyTransportSettings(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		network string
+		field   string
+	}{
+		{name: "raw", network: "tcp", field: "rawSettings"},
+		{name: "websocket", network: "ws", field: "wsSettings"},
+		{name: "httpupgrade", network: "httpupgrade", field: "httpupgradeSettings"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			input := `{
+				"network":"` + test.network + `",
+				"` + test.field + `":{"acceptProxyProtocol":true},
+				"sockopt":{
+					"proxyProtocolMode":"trusted-sources",
+					"proxyProtocolTrustedSources":["192.0.2.10"]
+				}
+			}`
+			config := new(StreamConfig)
+			if err := json.Unmarshal([]byte(input), config); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := config.Build(); err == nil {
+				t.Fatal("source-aware mode accepted a legacy transport-level acceptProxyProtocol flag")
+			}
+		})
 	}
 }

--- a/transport/internet/config.pb.go
+++ b/transport/internet/config.pb.go
@@ -209,6 +209,55 @@ func (SocketConfig_TProxyMode) EnumDescriptor() ([]byte, []int) {
 	return file_transport_internet_config_proto_rawDescGZIP(), []int{6, 0}
 }
 
+type SocketConfig_ProxyProtocolMode int32
+
+const (
+	// Preserve the legacy accept_proxy_protocol behavior.
+	SocketConfig_ProxyProtocolDefault SocketConfig_ProxyProtocolMode = 0
+	// Trust source-bearing TCP PROXY v2 headers only from explicitly
+	// configured IP prefixes. LOCAL, UNKNOWN and datagram headers are rejected.
+	SocketConfig_ProxyProtocolTrustedSources SocketConfig_ProxyProtocolMode = 1
+)
+
+// Enum value maps for SocketConfig_ProxyProtocolMode.
+var (
+	SocketConfig_ProxyProtocolMode_name = map[int32]string{
+		0: "ProxyProtocolDefault",
+		1: "ProxyProtocolTrustedSources",
+	}
+	SocketConfig_ProxyProtocolMode_value = map[string]int32{
+		"ProxyProtocolDefault":        0,
+		"ProxyProtocolTrustedSources": 1,
+	}
+)
+
+func (x SocketConfig_ProxyProtocolMode) Enum() *SocketConfig_ProxyProtocolMode {
+	p := new(SocketConfig_ProxyProtocolMode)
+	*p = x
+	return p
+}
+
+func (x SocketConfig_ProxyProtocolMode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SocketConfig_ProxyProtocolMode) Descriptor() protoreflect.EnumDescriptor {
+	return file_transport_internet_config_proto_enumTypes[3].Descriptor()
+}
+
+func (SocketConfig_ProxyProtocolMode) Type() protoreflect.EnumType {
+	return &file_transport_internet_config_proto_enumTypes[3]
+}
+
+func (x SocketConfig_ProxyProtocolMode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SocketConfig_ProxyProtocolMode.Descriptor instead.
+func (SocketConfig_ProxyProtocolMode) EnumDescriptor() ([]byte, []int) {
+	return file_transport_internet_config_proto_rawDescGZIP(), []int{6, 1}
+}
+
 type TransportConfig struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Transport protocol name.
@@ -747,8 +796,25 @@ type SocketConfig struct {
 	AddressPortStrategy        AddressPortStrategy  `protobuf:"varint,21,opt,name=address_port_strategy,json=addressPortStrategy,proto3,enum=xray.transport.internet.AddressPortStrategy" json:"address_port_strategy,omitempty"`
 	HappyEyeballs              *HappyEyeballsConfig `protobuf:"bytes,22,opt,name=happy_eyeballs,json=happyEyeballs,proto3" json:"happy_eyeballs,omitempty"`
 	TrustedXForwardedFor       []string             `protobuf:"bytes,23,rep,name=trusted_x_forwarded_for,json=trustedXForwardedFor,proto3" json:"trusted_x_forwarded_for,omitempty"`
-	unknownFields              protoimpl.UnknownFields
-	sizeCache                  protoimpl.SizeCache
+	// Source IP addresses or canonical CIDR prefixes trusted to send PROXY
+	// protocol in ProxyProtocolTrustedSources mode. IPv6 link-local addresses
+	// and prefixes are unsupported because their runtime peer requires a zone.
+	ProxyProtocolTrustedSources []string `protobuf:"bytes,24,rep,name=proxy_protocol_trusted_sources,json=proxyProtocolTrustedSources,proto3" json:"proxy_protocol_trusted_sources,omitempty"`
+	// Explicitly enables source-aware TCP PROXY protocol v2. Packet-based
+	// transports, packet listeners and Unix domain sockets reject this mode.
+	// Legacy accept_proxy_protocol flags must be disabled in this mode. The
+	// default value keeps legacy behavior unchanged.
+	ProxyProtocolMode SocketConfig_ProxyProtocolMode `protobuf:"varint,25,opt,name=proxy_protocol_mode,json=proxyProtocolMode,proto3,enum=xray.transport.internet.SocketConfig_ProxyProtocolMode" json:"proxy_protocol_mode,omitempty"`
+	// When non-empty in ProxyProtocolTrustedSources mode, only these local TCP
+	// listener ports accept PROXY protocol v2. Other ports remain ordinary direct
+	// listeners. Untrusted peers on the selected ports are dropped before any
+	// application bytes are read. An empty list enables same-port coexistence:
+	// trusted peers must send PROXY protocol v2, while parsing is bypassed for all
+	// other peers and their bytes are delivered unchanged. Every configured
+	// port must belong to the inbound listener set.
+	ProxyProtocolListenPorts []uint32 `protobuf:"varint,26,rep,packed,name=proxy_protocol_listen_ports,json=proxyProtocolListenPorts,proto3" json:"proxy_protocol_listen_ports,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *SocketConfig) Reset() {
@@ -928,6 +994,27 @@ func (x *SocketConfig) GetTrustedXForwardedFor() []string {
 	return nil
 }
 
+func (x *SocketConfig) GetProxyProtocolTrustedSources() []string {
+	if x != nil {
+		return x.ProxyProtocolTrustedSources
+	}
+	return nil
+}
+
+func (x *SocketConfig) GetProxyProtocolMode() SocketConfig_ProxyProtocolMode {
+	if x != nil {
+		return x.ProxyProtocolMode
+	}
+	return SocketConfig_ProxyProtocolDefault
+}
+
+func (x *SocketConfig) GetProxyProtocolListenPorts() []uint32 {
+	if x != nil {
+		return x.ProxyProtocolListenPorts
+	}
+	return nil
+}
+
 type HappyEyeballsConfig struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	PrioritizeIpv6   bool                   `protobuf:"varint,1,opt,name=prioritize_ipv6,json=prioritizeIpv6,proto3" json:"prioritize_ipv6,omitempty"`
@@ -1050,7 +1137,7 @@ const file_transport_internet_config_proto_rawDesc = "" +
 	"\x05level\x18\x03 \x01(\tR\x05level\x12\x10\n" +
 	"\x03opt\x18\x04 \x01(\tR\x03opt\x12\x14\n" +
 	"\x05value\x18\x05 \x01(\tR\x05value\x12\x12\n" +
-	"\x04type\x18\x06 \x01(\tR\x04type\"\xc9\b\n" +
+	"\x04type\x18\x06 \x01(\tR\x04type\"\x86\v\n" +
 	"\fSocketConfig\x12\x12\n" +
 	"\x04mark\x18\x01 \x01(\x05R\x04mark\x12\x10\n" +
 	"\x03tfo\x18\x02 \x01(\x05R\x03tfo\x12H\n" +
@@ -1073,13 +1160,19 @@ const file_transport_internet_config_proto_rawDesc = "" +
 	"\rcustomSockopt\x18\x14 \x03(\v2&.xray.transport.internet.CustomSockoptR\rcustomSockopt\x12`\n" +
 	"\x15address_port_strategy\x18\x15 \x01(\x0e2,.xray.transport.internet.AddressPortStrategyR\x13addressPortStrategy\x12S\n" +
 	"\x0ehappy_eyeballs\x18\x16 \x01(\v2,.xray.transport.internet.HappyEyeballsConfigR\rhappyEyeballs\x125\n" +
-	"\x17trusted_x_forwarded_for\x18\x17 \x03(\tR\x14trustedXForwardedFor\"/\n" +
+	"\x17trusted_x_forwarded_for\x18\x17 \x03(\tR\x14trustedXForwardedFor\x12C\n" +
+	"\x1eproxy_protocol_trusted_sources\x18\x18 \x03(\tR\x1bproxyProtocolTrustedSources\x12g\n" +
+	"\x13proxy_protocol_mode\x18\x19 \x01(\x0e27.xray.transport.internet.SocketConfig.ProxyProtocolModeR\x11proxyProtocolMode\x12=\n" +
+	"\x1bproxy_protocol_listen_ports\x18\x1a \x03(\rR\x18proxyProtocolListenPorts\"/\n" +
 	"\n" +
 	"TProxyMode\x12\a\n" +
 	"\x03Off\x10\x00\x12\n" +
 	"\n" +
 	"\x06TProxy\x10\x01\x12\f\n" +
-	"\bRedirect\x10\x02\"\xad\x01\n" +
+	"\bRedirect\x10\x02\"N\n" +
+	"\x11ProxyProtocolMode\x12\x18\n" +
+	"\x14ProxyProtocolDefault\x10\x00\x12\x1f\n" +
+	"\x1bProxyProtocolTrustedSources\x10\x01\"\xad\x01\n" +
 	"\x13HappyEyeballsConfig\x12'\n" +
 	"\x0fprioritize_ipv6\x18\x01 \x01(\bR\x0eprioritizeIpv6\x12\x1e\n" +
 	"\n" +
@@ -1126,43 +1219,45 @@ func file_transport_internet_config_proto_rawDescGZIP() []byte {
 	return file_transport_internet_config_proto_rawDescData
 }
 
-var file_transport_internet_config_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_transport_internet_config_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
 var file_transport_internet_config_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_transport_internet_config_proto_goTypes = []any{
-	(DomainStrategy)(0),          // 0: xray.transport.internet.DomainStrategy
-	(AddressPortStrategy)(0),     // 1: xray.transport.internet.AddressPortStrategy
-	(SocketConfig_TProxyMode)(0), // 2: xray.transport.internet.SocketConfig.TProxyMode
-	(*TransportConfig)(nil),      // 3: xray.transport.internet.TransportConfig
-	(*StreamConfig)(nil),         // 4: xray.transport.internet.StreamConfig
-	(*UdpHop)(nil),               // 5: xray.transport.internet.UdpHop
-	(*QuicParams)(nil),           // 6: xray.transport.internet.QuicParams
-	(*ProxyConfig)(nil),          // 7: xray.transport.internet.ProxyConfig
-	(*CustomSockopt)(nil),        // 8: xray.transport.internet.CustomSockopt
-	(*SocketConfig)(nil),         // 9: xray.transport.internet.SocketConfig
-	(*HappyEyeballsConfig)(nil),  // 10: xray.transport.internet.HappyEyeballsConfig
-	(*serial.TypedMessage)(nil),  // 11: xray.common.serial.TypedMessage
-	(*net.IPOrDomain)(nil),       // 12: xray.common.net.IPOrDomain
+	(DomainStrategy)(0),                 // 0: xray.transport.internet.DomainStrategy
+	(AddressPortStrategy)(0),            // 1: xray.transport.internet.AddressPortStrategy
+	(SocketConfig_TProxyMode)(0),        // 2: xray.transport.internet.SocketConfig.TProxyMode
+	(SocketConfig_ProxyProtocolMode)(0), // 3: xray.transport.internet.SocketConfig.ProxyProtocolMode
+	(*TransportConfig)(nil),             // 4: xray.transport.internet.TransportConfig
+	(*StreamConfig)(nil),                // 5: xray.transport.internet.StreamConfig
+	(*UdpHop)(nil),                      // 6: xray.transport.internet.UdpHop
+	(*QuicParams)(nil),                  // 7: xray.transport.internet.QuicParams
+	(*ProxyConfig)(nil),                 // 8: xray.transport.internet.ProxyConfig
+	(*CustomSockopt)(nil),               // 9: xray.transport.internet.CustomSockopt
+	(*SocketConfig)(nil),                // 10: xray.transport.internet.SocketConfig
+	(*HappyEyeballsConfig)(nil),         // 11: xray.transport.internet.HappyEyeballsConfig
+	(*serial.TypedMessage)(nil),         // 12: xray.common.serial.TypedMessage
+	(*net.IPOrDomain)(nil),              // 13: xray.common.net.IPOrDomain
 }
 var file_transport_internet_config_proto_depIdxs = []int32{
-	11, // 0: xray.transport.internet.TransportConfig.settings:type_name -> xray.common.serial.TypedMessage
-	12, // 1: xray.transport.internet.StreamConfig.address:type_name -> xray.common.net.IPOrDomain
-	3,  // 2: xray.transport.internet.StreamConfig.transport_settings:type_name -> xray.transport.internet.TransportConfig
-	11, // 3: xray.transport.internet.StreamConfig.security_settings:type_name -> xray.common.serial.TypedMessage
-	11, // 4: xray.transport.internet.StreamConfig.udpmasks:type_name -> xray.common.serial.TypedMessage
-	11, // 5: xray.transport.internet.StreamConfig.tcpmasks:type_name -> xray.common.serial.TypedMessage
-	6,  // 6: xray.transport.internet.StreamConfig.quic_params:type_name -> xray.transport.internet.QuicParams
-	9,  // 7: xray.transport.internet.StreamConfig.socket_settings:type_name -> xray.transport.internet.SocketConfig
-	5,  // 8: xray.transport.internet.QuicParams.udp_hop:type_name -> xray.transport.internet.UdpHop
+	12, // 0: xray.transport.internet.TransportConfig.settings:type_name -> xray.common.serial.TypedMessage
+	13, // 1: xray.transport.internet.StreamConfig.address:type_name -> xray.common.net.IPOrDomain
+	4,  // 2: xray.transport.internet.StreamConfig.transport_settings:type_name -> xray.transport.internet.TransportConfig
+	12, // 3: xray.transport.internet.StreamConfig.security_settings:type_name -> xray.common.serial.TypedMessage
+	12, // 4: xray.transport.internet.StreamConfig.udpmasks:type_name -> xray.common.serial.TypedMessage
+	12, // 5: xray.transport.internet.StreamConfig.tcpmasks:type_name -> xray.common.serial.TypedMessage
+	7,  // 6: xray.transport.internet.StreamConfig.quic_params:type_name -> xray.transport.internet.QuicParams
+	10, // 7: xray.transport.internet.StreamConfig.socket_settings:type_name -> xray.transport.internet.SocketConfig
+	6,  // 8: xray.transport.internet.QuicParams.udp_hop:type_name -> xray.transport.internet.UdpHop
 	2,  // 9: xray.transport.internet.SocketConfig.tproxy:type_name -> xray.transport.internet.SocketConfig.TProxyMode
 	0,  // 10: xray.transport.internet.SocketConfig.domain_strategy:type_name -> xray.transport.internet.DomainStrategy
-	8,  // 11: xray.transport.internet.SocketConfig.customSockopt:type_name -> xray.transport.internet.CustomSockopt
+	9,  // 11: xray.transport.internet.SocketConfig.customSockopt:type_name -> xray.transport.internet.CustomSockopt
 	1,  // 12: xray.transport.internet.SocketConfig.address_port_strategy:type_name -> xray.transport.internet.AddressPortStrategy
-	10, // 13: xray.transport.internet.SocketConfig.happy_eyeballs:type_name -> xray.transport.internet.HappyEyeballsConfig
-	14, // [14:14] is the sub-list for method output_type
-	14, // [14:14] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	11, // 13: xray.transport.internet.SocketConfig.happy_eyeballs:type_name -> xray.transport.internet.HappyEyeballsConfig
+	3,  // 14: xray.transport.internet.SocketConfig.proxy_protocol_mode:type_name -> xray.transport.internet.SocketConfig.ProxyProtocolMode
+	15, // [15:15] is the sub-list for method output_type
+	15, // [15:15] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_transport_internet_config_proto_init() }
@@ -1175,7 +1270,7 @@ func file_transport_internet_config_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_transport_internet_config_proto_rawDesc), len(file_transport_internet_config_proto_rawDesc)),
-			NumEnums:      3,
+			NumEnums:      4,
 			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/transport/internet/config.proto
+++ b/transport/internet/config.proto
@@ -117,6 +117,14 @@ message SocketConfig {
     Redirect = 2;
   }
 
+  enum ProxyProtocolMode {
+    // Preserve the legacy accept_proxy_protocol behavior.
+    ProxyProtocolDefault = 0;
+    // Trust source-bearing TCP PROXY v2 headers only from explicitly
+    // configured IP prefixes. LOCAL, UNKNOWN and datagram headers are rejected.
+    ProxyProtocolTrustedSources = 1;
+  }
+
   // TProxy is for enabling TProxy socket option.
   TProxyMode tproxy = 3;
 
@@ -157,6 +165,26 @@ message SocketConfig {
   HappyEyeballsConfig happy_eyeballs = 22;
 
   repeated string trusted_x_forwarded_for = 23;
+
+  // Source IP addresses or canonical CIDR prefixes trusted to send PROXY
+  // protocol in ProxyProtocolTrustedSources mode. IPv6 link-local addresses
+  // and prefixes are unsupported because their runtime peer requires a zone.
+  repeated string proxy_protocol_trusted_sources = 24;
+
+  // Explicitly enables source-aware TCP PROXY protocol v2. Packet-based
+  // transports, packet listeners and Unix domain sockets reject this mode.
+  // Legacy accept_proxy_protocol flags must be disabled in this mode. The
+  // default value keeps legacy behavior unchanged.
+  ProxyProtocolMode proxy_protocol_mode = 25;
+
+  // When non-empty in ProxyProtocolTrustedSources mode, only these local TCP
+  // listener ports accept PROXY protocol v2. Other ports remain ordinary direct
+  // listeners. Untrusted peers on the selected ports are dropped before any
+  // application bytes are read. An empty list enables same-port coexistence:
+  // trusted peers must send PROXY protocol v2, while parsing is bypassed for all
+  // other peers and their bytes are delivered unchanged. Every configured
+  // port must belong to the inbound listener set.
+  repeated uint32 proxy_protocol_listen_ports = 26;
 }
 
 message HappyEyeballsConfig {

--- a/transport/internet/grpc/encoding/hunkconn.go
+++ b/transport/internet/grpc/encoding/hunkconn.go
@@ -36,8 +36,9 @@ func NewHunkReadWriter(hc HunkConn, cancel context.CancelFunc) *HunkReaderWriter
 	return &HunkReaderWriter{hc, cancel, done.New(), nil, 0}
 }
 
-func NewHunkConn(hc HunkConn, cancel context.CancelFunc, trustedXForwardedFor []string) net.Conn {
-	rAddr := remoteAddrFromContext(hc.Context(), trustedXForwardedFor)
+func NewHunkConn(hc HunkConn, cancel context.CancelFunc, trustedXForwardedFor []string, canUseXForwardedFor ...bool) net.Conn {
+	allowXForwardedFor := len(canUseXForwardedFor) == 0 || canUseXForwardedFor[0]
+	rAddr := remoteAddrFromContext(hc.Context(), trustedXForwardedFor, allowXForwardedFor)
 	lAddr := localAddrFromContext(hc.Context())
 	wrc := NewHunkReadWriter(hc, cancel)
 	return cnc.NewConnection(

--- a/transport/internet/grpc/encoding/multiconn.go
+++ b/transport/internet/grpc/encoding/multiconn.go
@@ -31,8 +31,9 @@ func NewMultiHunkReadWriter(hc MultiHunkConn, cancel context.CancelFunc) *MultiH
 	return &MultiHunkReaderWriter{hc, cancel, done.New(), nil}
 }
 
-func NewMultiHunkConn(hc MultiHunkConn, cancel context.CancelFunc, trustedXForwardedFor []string) net.Conn {
-	rAddr := remoteAddrFromContext(hc.Context(), trustedXForwardedFor)
+func NewMultiHunkConn(hc MultiHunkConn, cancel context.CancelFunc, trustedXForwardedFor []string, canUseXForwardedFor ...bool) net.Conn {
+	allowXForwardedFor := len(canUseXForwardedFor) == 0 || canUseXForwardedFor[0]
+	rAddr := remoteAddrFromContext(hc.Context(), trustedXForwardedFor, allowXForwardedFor)
 	lAddr := localAddrFromContext(hc.Context())
 	wrc := NewMultiHunkReadWriter(hc, cancel)
 	return cnc.NewConnection(

--- a/transport/internet/grpc/encoding/remoteaddr.go
+++ b/transport/internet/grpc/encoding/remoteaddr.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc/peer"
 )
 
-func remoteAddrFromContext(ctx context.Context, trusted []string) net.Addr {
+func remoteAddrFromContext(ctx context.Context, trusted []string, canUseXForwardedFor bool) net.Addr {
 	var remoteAddr net.Addr
 	if pr, ok := peer.FromContext(ctx); ok {
 		remoteAddr = pr.Addr
@@ -19,6 +19,9 @@ func remoteAddrFromContext(ctx context.Context, trusted []string) net.Addr {
 			IP:   []byte{0, 0, 0, 0},
 			Port: 0,
 		}
+	}
+	if !canUseXForwardedFor {
+		return remoteAddr
 	}
 
 	md, ok := metadata.FromIncomingContext(ctx)

--- a/transport/internet/grpc/encoding/remoteaddr_test.go
+++ b/transport/internet/grpc/encoding/remoteaddr_test.go
@@ -14,6 +14,7 @@ func TestRemoteAddrFromContext(t *testing.T) {
 		name                  string
 		metadata              metadata.MD
 		trustedXForwardedFor  []string
+		disableXForwardedFor  bool
 		expectedRemoteAddress string
 	}{
 		{
@@ -34,6 +35,13 @@ func TestRemoteAddrFromContext(t *testing.T) {
 			trustedXForwardedFor:  []string{"X-Trusted-CDN"},
 			expectedRemoteAddress: "127.0.0.1:12345",
 		},
+		{
+			name:                  "source-aware listener preserves PROXY peer address",
+			metadata:              metadata.Pairs("X-Forwarded-For", "6.6.6.6"),
+			trustedXForwardedFor:  []string{"X-Forwarded-For"},
+			disableXForwardedFor:  true,
+			expectedRemoteAddress: "127.0.0.1:12345",
+		},
 	}
 
 	for _, test := range tests {
@@ -44,7 +52,7 @@ func TestRemoteAddrFromContext(t *testing.T) {
 					Port: 12345,
 				},
 			})
-			remoteAddr := remoteAddrFromContext(ctx, test.trustedXForwardedFor)
+			remoteAddr := remoteAddrFromContext(ctx, test.trustedXForwardedFor, !test.disableXForwardedFor)
 			if remoteAddr.String() != test.expectedRemoteAddress {
 				t.Fatalf("unexpected remote address: %s", remoteAddr.String())
 			}

--- a/transport/internet/grpc/hub.go
+++ b/transport/internet/grpc/hub.go
@@ -24,20 +24,21 @@ type Listener struct {
 	local                net.Addr
 	config               *Config
 	trustedXForwardedFor []string
+	canUseXForwardedFor  bool
 
 	s *grpc.Server
 }
 
 func (l Listener) Tun(server encoding.GRPCService_TunServer) error {
 	tunCtx, cancel := context.WithCancel(l.ctx)
-	l.handler(encoding.NewHunkConn(server, cancel, l.trustedXForwardedFor))
+	l.handler(encoding.NewHunkConn(server, cancel, l.trustedXForwardedFor, l.canUseXForwardedFor))
 	<-tunCtx.Done()
 	return nil
 }
 
 func (l Listener) TunMulti(server encoding.GRPCService_TunMultiServer) error {
 	tunCtx, cancel := context.WithCancel(l.ctx)
-	l.handler(encoding.NewMultiHunkConn(server, cancel, l.trustedXForwardedFor))
+	l.handler(encoding.NewMultiHunkConn(server, cancel, l.trustedXForwardedFor, l.canUseXForwardedFor))
 	<-tunCtx.Done()
 	return nil
 }
@@ -53,6 +54,14 @@ func (l Listener) Addr() net.Addr {
 
 func Listen(ctx context.Context, address net.Address, port net.Port, settings *internet.MemoryStreamConfig, handler internet.ConnHandler) (internet.Listener, error) {
 	grpcSettings := settings.ProtocolSettings.(*Config)
+	if err := internet.ValidateProxyProtocolTransportConfig(settings.SocketSettings, grpcSettings); err != nil {
+		return nil, errors.New("invalid PROXY protocol transport configuration").Base(err)
+	}
+	if port == net.Port(0) {
+		if err := internet.ValidateProxyProtocolListenerSet(settings.SocketSettings, nil); err != nil {
+			return nil, errors.New("invalid PROXY protocol listener configuration").Base(err)
+		}
+	}
 	var listener *Listener
 	if port == net.Port(0) { // unix
 		listener = &Listener{
@@ -75,6 +84,7 @@ func Listen(ctx context.Context, address net.Address, port net.Port, settings *i
 	}
 
 	listener.ctx = ctx
+	listener.canUseXForwardedFor = internet.CanUseXForwardedFor(settings.SocketSettings, uint32(port))
 	if settings.SocketSettings != nil {
 		listener.trustedXForwardedFor = settings.SocketSettings.TrustedXForwardedFor
 	}
@@ -96,10 +106,6 @@ func Listen(ctx context.Context, address net.Address, port net.Port, settings *i
 
 	s = grpc.NewServer(options...)
 	listener.s = s
-
-	if settings.SocketSettings != nil && settings.SocketSettings.AcceptProxyProtocol {
-		errors.LogWarning(ctx, "accepting PROXY protocol")
-	}
 
 	go func() {
 		var streamListener net.Listener

--- a/transport/internet/grpc/proxy_protocol_test.go
+++ b/transport/internet/grpc/proxy_protocol_test.go
@@ -1,0 +1,50 @@
+package grpc
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/transport/internet"
+)
+
+func TestTrustedSourcesUDSFailsSynchronously(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "xray.sock")
+	listener, err := Listen(context.Background(), net.DomainAddress(path), 0, &internet.MemoryStreamConfig{
+		ProtocolName:     "grpc",
+		ProtocolSettings: &Config{},
+		SocketSettings: &internet.SocketConfig{
+			ProxyProtocolMode:           internet.SocketConfig_ProxyProtocolTrustedSources,
+			ProxyProtocolTrustedSources: []string{"127.0.0.1"},
+		},
+	}, nil)
+	if listener != nil {
+		_ = listener.Close()
+		t.Fatal("unexpected gRPC UDS listener")
+	}
+	if err == nil {
+		t.Fatal("expected source-aware gRPC UDS validation error")
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("gRPC reported an error but left a UDS socket behind: %v", statErr)
+	}
+}
+
+func TestTrustedSourcesInvalidTCPConfigFailsSynchronously(t *testing.T) {
+	listener, err := Listen(context.Background(), net.LocalHostIP, 24443, &internet.MemoryStreamConfig{
+		ProtocolName:     "grpc",
+		ProtocolSettings: &Config{},
+		SocketSettings: &internet.SocketConfig{
+			ProxyProtocolMode: internet.SocketConfig_ProxyProtocolTrustedSources,
+		},
+	}, nil)
+	if listener != nil {
+		_ = listener.Close()
+		t.Fatal("unexpected gRPC TCP listener")
+	}
+	if err == nil {
+		t.Fatal("invalid source-aware gRPC TCP configuration returned success")
+	}
+}

--- a/transport/internet/httpupgrade/httpupgrade_test.go
+++ b/transport/internet/httpupgrade/httpupgrade_test.go
@@ -3,6 +3,7 @@ package httpupgrade_test
 import (
 	"context"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -132,49 +133,67 @@ func Test_listenHTTPUpgradeAndDialWithHeaders(t *testing.T) {
 }
 
 func TestDialWithRemoteAddr(t *testing.T) {
-	listenPort := tcp.PickPort()
-	listen, err := ListenHTTPUpgrade(context.Background(), net.LocalHostIP, listenPort, &internet.MemoryStreamConfig{
-		ProtocolName: "httpupgrade",
-		ProtocolSettings: &Config{
-			Path: "httpupgrade",
-		},
-		SocketSettings: &internet.SocketConfig{
-			TrustedXForwardedFor: []string{"X-Forwarded-For"},
-		},
-	}, func(conn stat.Connection) {
-		go func(c stat.Connection) {
-			defer c.Close()
+	for _, test := range []struct {
+		name       string
+		mode       string
+		want       string
+		wantPrefix string
+	}{
+		{name: "legacy X-Forwarded-For", want: "1.1.1.1:0"},
+		{name: "dedicated direct listener keeps X-Forwarded-For", mode: "dedicated-direct", want: "1.1.1.1:0"},
+		{name: "same-port source-aware listener ignores X-Forwarded-For", mode: "same-port", wantPrefix: "127.0.0.1:"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			listenPort := tcp.PickPort()
+			socketSettings := &internet.SocketConfig{TrustedXForwardedFor: []string{"X-Forwarded-For"}}
+			if test.mode != "" {
+				socketSettings.ProxyProtocolMode = internet.SocketConfig_ProxyProtocolTrustedSources
+				socketSettings.ProxyProtocolTrustedSources = []string{"192.0.2.10"}
+				if test.mode == "dedicated-direct" {
+					proxyPort := tcp.PickPort()
+					for proxyPort == listenPort {
+						proxyPort = tcp.PickPort()
+					}
+					socketSettings.ProxyProtocolListenPorts = []uint32{uint32(proxyPort)}
+				}
+			}
+			listen, err := ListenHTTPUpgrade(context.Background(), net.LocalHostIP, listenPort, &internet.MemoryStreamConfig{
+				ProtocolName:     "httpupgrade",
+				ProtocolSettings: &Config{Path: "httpupgrade"},
+				SocketSettings:   socketSettings,
+			}, func(conn stat.Connection) {
+				go func(c stat.Connection) {
+					defer c.Close()
+					var b [1024]byte
+					if _, err := c.Read(b[:]); err == nil {
+						_, _ = c.Write([]byte(c.RemoteAddr().String()))
+					}
+				}(conn)
+			})
+			common.Must(err)
+			defer listen.Close()
+
+			conn, err := Dial(context.Background(), net.TCPDestination(net.DomainAddress("localhost"), listenPort), &internet.MemoryStreamConfig{
+				ProtocolName:     "httpupgrade",
+				ProtocolSettings: &Config{Path: "httpupgrade", Header: map[string]string{"X-Forwarded-For": "1.1.1.1"}},
+			})
+			common.Must(err)
+			defer conn.Close()
+			_, err = conn.Write([]byte("Test connection 1"))
+			common.Must(err)
 
 			var b [1024]byte
-			_, err := c.Read(b[:])
-			// common.Must(err)
-			if err != nil {
-				return
-			}
-
-			_, err = c.Write([]byte(c.RemoteAddr().String()))
+			n, err := conn.Read(b[:])
 			common.Must(err)
-		}(conn)
-	})
-	common.Must(err)
-
-	conn, err := Dial(context.Background(), net.TCPDestination(net.DomainAddress("localhost"), listenPort), &internet.MemoryStreamConfig{
-		ProtocolName:     "httpupgrade",
-		ProtocolSettings: &Config{Path: "httpupgrade", Header: map[string]string{"X-Forwarded-For": "1.1.1.1"}},
-	})
-
-	common.Must(err)
-	_, err = conn.Write([]byte("Test connection 1"))
-	common.Must(err)
-
-	var b [1024]byte
-	n, err := conn.Read(b[:])
-	common.Must(err)
-	if string(b[:n]) != "1.1.1.1:0" {
-		t.Error("response: ", string(b[:n]))
+			got := string(b[:n])
+			if test.want != "" && got != test.want {
+				t.Fatalf("response = %q, want %q", got, test.want)
+			}
+			if test.wantPrefix != "" && !strings.HasPrefix(got, test.wantPrefix) {
+				t.Fatalf("response = %q, want prefix %q", got, test.wantPrefix)
+			}
+		})
 	}
-
-	common.Must(listen.Close())
 }
 
 func Test_listenHTTPUpgradeAndDial_TLS(t *testing.T) {

--- a/transport/internet/httpupgrade/hub.go
+++ b/transport/internet/httpupgrade/hub.go
@@ -19,10 +19,11 @@ import (
 )
 
 type server struct {
-	config         *Config
-	addConn        internet.ConnHandler
-	innnerListener net.Listener
-	socketSettings *internet.SocketConfig
+	config              *Config
+	addConn             internet.ConnHandler
+	innnerListener      net.Listener
+	socketSettings      *internet.SocketConfig
+	canUseXForwardedFor bool
 }
 
 func (s *server) Close() error {
@@ -87,11 +88,13 @@ func (s *server) upgrade(conn net.Conn) (stat.Connection, error) {
 	}
 
 	remoteAddr := conn.RemoteAddr()
-	var trustedXFF []string
-	if s.socketSettings != nil {
-		trustedXFF = s.socketSettings.TrustedXForwardedFor
+	if s.canUseXForwardedFor {
+		var trustedXFF []string
+		if s.socketSettings != nil {
+			trustedXFF = s.socketSettings.TrustedXForwardedFor
+		}
+		remoteAddr = http_proto.ApplyTrustedXForwardedFor(req.Header, trustedXFF, remoteAddr)
 	}
-	remoteAddr = http_proto.ApplyTrustedXForwardedFor(req.Header, trustedXFF, remoteAddr)
 
 	return stat.Connection(newConnection(conn, remoteAddr)), nil
 }
@@ -116,6 +119,9 @@ func (s *server) keepAccepting() {
 
 func ListenHTTPUpgrade(ctx context.Context, address net.Address, port net.Port, streamSettings *internet.MemoryStreamConfig, addConn internet.ConnHandler) (internet.Listener, error) {
 	transportConfiguration := streamSettings.ProtocolSettings.(*Config)
+	if err := internet.ValidateProxyProtocolTransportConfig(streamSettings.SocketSettings, transportConfiguration); err != nil {
+		return nil, errors.New("invalid PROXY protocol transport configuration").Base(err)
+	}
 	if transportConfiguration != nil {
 		if streamSettings.SocketSettings == nil {
 			streamSettings.SocketSettings = &internet.SocketConfig{}
@@ -148,10 +154,6 @@ func ListenHTTPUpgrade(ctx context.Context, address net.Address, port net.Port, 
 		listener, _ = streamSettings.TcpmaskManager.WrapListener(listener)
 	}
 
-	if streamSettings.SocketSettings != nil && streamSettings.SocketSettings.AcceptProxyProtocol {
-		errors.LogWarning(ctx, "accepting PROXY protocol")
-	}
-
 	if config := v2tls.ConfigFromStreamSettings(streamSettings); config != nil {
 		if tlsConfig := config.GetTLSConfig(); tlsConfig != nil {
 			listener = tls.NewListener(listener, tlsConfig)
@@ -159,10 +161,11 @@ func ListenHTTPUpgrade(ctx context.Context, address net.Address, port net.Port, 
 	}
 
 	serverInstance := &server{
-		config:         transportConfiguration,
-		addConn:        addConn,
-		innnerListener: listener,
-		socketSettings: streamSettings.SocketSettings,
+		config:              transportConfiguration,
+		addConn:             addConn,
+		innnerListener:      listener,
+		socketSettings:      streamSettings.SocketSettings,
+		canUseXForwardedFor: internet.CanUseXForwardedFor(streamSettings.SocketSettings, uint32(port)),
 	}
 	go serverInstance.keepAccepting()
 	return serverInstance, nil

--- a/transport/internet/proxy_protocol.go
+++ b/transport/internet/proxy_protocol.go
@@ -1,0 +1,312 @@
+package internet
+
+import (
+	stdnet "net"
+	"net/netip"
+
+	"github.com/pires/go-proxyproto"
+	"github.com/xtls/xray-core/common/errors"
+	xnet "github.com/xtls/xray-core/common/net"
+)
+
+type proxyProtocolListenerConfig struct {
+	policy    proxyproto.ConnPolicyFunc
+	validator proxyproto.Validator
+}
+
+var ipv6LinkLocalPrefix = netip.MustParsePrefix("fe80::/10")
+
+// ValidateProxyProtocolConfig validates both JSON-built and programmatically
+// constructed SocketConfig values before they are used by a listener.
+func ValidateProxyProtocolConfig(config *SocketConfig) error {
+	if config == nil {
+		return nil
+	}
+
+	switch config.ProxyProtocolMode {
+	case SocketConfig_ProxyProtocolDefault:
+		if len(config.ProxyProtocolTrustedSources) > 0 {
+			return errors.New("proxyProtocolTrustedSources requires proxyProtocolMode trusted-sources")
+		}
+		if len(config.ProxyProtocolListenPorts) > 0 {
+			return errors.New("proxyProtocolListenPorts requires proxyProtocolMode trusted-sources")
+		}
+	case SocketConfig_ProxyProtocolTrustedSources:
+		if config.AcceptProxyProtocol {
+			return errors.New("acceptProxyProtocol cannot be combined with proxyProtocolMode trusted-sources")
+		}
+		if len(config.ProxyProtocolTrustedSources) == 0 {
+			return errors.New("proxyProtocolMode trusted-sources requires a non-empty proxyProtocolTrustedSources list")
+		}
+		if _, err := parseProxyProtocolTrustedSources(config.ProxyProtocolTrustedSources); err != nil {
+			return err
+		}
+		seenPorts := make(map[uint32]struct{}, len(config.ProxyProtocolListenPorts))
+		for _, port := range config.ProxyProtocolListenPorts {
+			if port == 0 || port > 65535 {
+				return errors.New("invalid proxy protocol listen port: ", port)
+			}
+			if _, found := seenPorts[port]; found {
+				return errors.New("duplicate proxy protocol listen port: ", port)
+			}
+			seenPorts[port] = struct{}{}
+		}
+	default:
+		return errors.New("unsupported proxy protocol mode: ", config.ProxyProtocolMode)
+	}
+
+	return nil
+}
+
+// ValidateProxyProtocolTransportConfig rejects legacy transport-level PROXY
+// flags when source-aware mode is active. Keeping the legacy bits clear makes
+// mixed-version rollback fail closed instead of reverting to trust-all.
+func ValidateProxyProtocolTransportConfig(config *SocketConfig, transportSettings interface{}) error {
+	if err := ValidateProxyProtocolConfig(config); err != nil {
+		return err
+	}
+	if config == nil || config.ProxyProtocolMode != SocketConfig_ProxyProtocolTrustedSources {
+		return nil
+	}
+	if legacy, ok := transportSettings.(interface{ GetAcceptProxyProtocol() bool }); ok && legacy.GetAcceptProxyProtocol() {
+		return errors.New("transport acceptProxyProtocol cannot be combined with proxyProtocolMode trusted-sources")
+	}
+	return nil
+}
+
+// ValidateProxyProtocolListenerSet validates settings that depend on the
+// complete inbound listener set rather than on one listener at a time.
+func ValidateProxyProtocolListenerSet(config *SocketConfig, listenerPorts *xnet.PortList) error {
+	if err := ValidateProxyProtocolConfig(config); err != nil {
+		return err
+	}
+	if config == nil || config.ProxyProtocolMode != SocketConfig_ProxyProtocolTrustedSources {
+		return nil
+	}
+	if listenerPorts == nil {
+		return errors.New("proxyProtocolMode trusted-sources requires TCP listener ports and is unsupported for Unix domain sockets")
+	}
+	if len(config.ProxyProtocolListenPorts) == 0 {
+		return nil
+	}
+
+	for _, configuredPort := range config.ProxyProtocolListenPorts {
+		matched := false
+		for _, listenerRange := range listenerPorts.Range {
+			if listenerRange.From <= configuredPort && configuredPort <= listenerRange.To {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return errors.New("proxyProtocolListenPort does not belong to the inbound listener set: ", configuredPort)
+		}
+	}
+	return nil
+}
+
+// ValidateProxyProtocolInboundConfig validates constraints that depend on the
+// complete inbound network/listener set before any worker can open a socket.
+func ValidateProxyProtocolInboundConfig(config *SocketConfig, listenerPorts *xnet.PortList, networks []xnet.Network, streamSettings *MemoryStreamConfig) error {
+	if err := ValidateProxyProtocolListenerSet(config, listenerPorts); err != nil {
+		return err
+	}
+	if config == nil || config.ProxyProtocolMode != SocketConfig_ProxyProtocolTrustedSources {
+		return nil
+	}
+	if xnet.HasNetwork(networks, xnet.Network_UDP) {
+		return errors.New("proxyProtocolMode trusted-sources does not support UDP or mixed TCP/UDP inbounds")
+	}
+	if err := validateProxyProtocolEffectiveTransport(streamSettings); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateProxyProtocolEffectiveTransport rejects transports whose logical
+// inbound network is TCP but whose actual listener is packet based. This must
+// run before workers are created, because ListenPacket is otherwise reached
+// only from Start and a hot AddInbound may already have registered its handler.
+func validateProxyProtocolEffectiveTransport(streamSettings *MemoryStreamConfig) error {
+	protocol := "tcp"
+	if streamSettings != nil && streamSettings.ProtocolName != "" {
+		protocol = streamSettings.ProtocolName
+	}
+
+	switch protocol {
+	case "tcp", "websocket", "httpupgrade", "grpc":
+		return nil
+	case "splithttp":
+		if streamSettings != nil && isHTTP3SecuritySettings(streamSettings.SecuritySettings) {
+			return errors.New("proxyProtocolMode trusted-sources does not support the packet-based XHTTP-H3 listener")
+		}
+		return nil
+	case "mkcp", "hysteria":
+		return errors.New("proxyProtocolMode trusted-sources does not support packet-based transport: ", protocol)
+	default:
+		return errors.New("proxyProtocolMode trusted-sources does not support unknown effective transport: ", protocol)
+	}
+}
+
+func isHTTP3SecuritySettings(settings interface{}) bool {
+	nextProtocolSettings, ok := settings.(interface{ GetNextProtocol() []string })
+	if !ok {
+		return false
+	}
+	nextProtocols := nextProtocolSettings.GetNextProtocol()
+	return len(nextProtocols) == 1 && nextProtocols[0] == "h3"
+}
+
+// CanUseXForwardedFor reports whether an HTTP transport listener may replace
+// its socket peer address with a forwarded header. The decision is made from
+// the configured listener port before any PROXY-derived LocalAddr is applied.
+func CanUseXForwardedFor(config *SocketConfig, listenerPort uint32) bool {
+	if config == nil || config.ProxyProtocolMode != SocketConfig_ProxyProtocolTrustedSources {
+		return true
+	}
+	if len(config.ProxyProtocolListenPorts) == 0 {
+		return false
+	}
+	return !containsProxyProtocolPort(config.ProxyProtocolListenPorts, listenerPort)
+}
+
+func parseProxyProtocolTrustedSources(sources []string) ([]netip.Prefix, error) {
+	prefixes := make([]netip.Prefix, 0, len(sources))
+	for _, source := range sources {
+		if addr, err := netip.ParseAddr(source); err == nil {
+			if addr.Zone() != "" {
+				return nil, errors.New("proxy protocol trusted source must not contain an IPv6 zone: ", source)
+			}
+			addr = addr.Unmap()
+			if addr.Is6() && addr.IsLinkLocalUnicast() {
+				return nil, errors.New("IPv6 link-local proxy protocol trusted sources are unsupported: ", source)
+			}
+			prefixes = append(prefixes, netip.PrefixFrom(addr, addr.BitLen()))
+			continue
+		}
+
+		prefix, err := netip.ParsePrefix(source)
+		if err != nil {
+			return nil, errors.New("invalid proxy protocol trusted source: ", source).Base(err)
+		}
+		if prefix.Addr().Zone() != "" {
+			return nil, errors.New("proxy protocol trusted source must not contain an IPv6 zone: ", source)
+		}
+		if prefix.Addr().Is4In6() {
+			return nil, errors.New("IPv4-mapped proxy protocol prefixes are unsupported; use an IPv4 prefix: ", source)
+		}
+		if prefix != prefix.Masked() {
+			return nil, errors.New("proxy protocol trusted CIDR must use its canonical network address: ", source)
+		}
+		if prefix.Addr().Is6() && prefix.Overlaps(ipv6LinkLocalPrefix) {
+			return nil, errors.New("IPv6 link-local proxy protocol trusted prefixes are unsupported: ", source)
+		}
+		prefixes = append(prefixes, prefix)
+	}
+	return prefixes, nil
+}
+
+func newProxyProtocolListenerConfig(addr stdnet.Addr, socketConfig *SocketConfig) (*proxyProtocolListenerConfig, error) {
+	if err := ValidateProxyProtocolConfig(socketConfig); err != nil {
+		return nil, err
+	}
+	if socketConfig == nil {
+		return nil, nil
+	}
+
+	if socketConfig.ProxyProtocolMode == SocketConfig_ProxyProtocolDefault {
+		if !socketConfig.AcceptProxyProtocol {
+			return nil, nil
+		}
+		return &proxyProtocolListenerConfig{
+			policy: func(proxyproto.ConnPolicyOptions) (proxyproto.Policy, error) {
+				return proxyproto.REQUIRE, nil
+			},
+		}, nil
+	}
+
+	tcpListener, ok := addr.(*stdnet.TCPAddr)
+	if !ok {
+		if _, unix := addr.(*stdnet.UnixAddr); unix {
+			return nil, errors.New("proxyProtocolMode trusted-sources is unsupported for Unix domain sockets")
+		}
+		return nil, errors.New("proxyProtocolMode trusted-sources requires a TCP listener")
+	}
+
+	dedicatedPort := len(socketConfig.ProxyProtocolListenPorts) > 0
+	if dedicatedPort && tcpListener.Port == 0 {
+		return nil, errors.New("proxyProtocolListenPorts cannot be selected before binding TCP port 0")
+	}
+	if dedicatedPort && !containsProxyProtocolPort(socketConfig.ProxyProtocolListenPorts, uint32(tcpListener.Port)) {
+		return nil, nil
+	}
+
+	trustedPrefixes, err := parseProxyProtocolTrustedSources(socketConfig.ProxyProtocolTrustedSources)
+	if err != nil {
+		return nil, err
+	}
+
+	return &proxyProtocolListenerConfig{
+		policy: func(connOpts proxyproto.ConnPolicyOptions) (proxyproto.Policy, error) {
+			upstream, ok := connOpts.Upstream.(*stdnet.TCPAddr)
+			if ok && upstream.IP != nil && upstream.Zone == "" {
+				if upstreamAddr, valid := netip.AddrFromSlice(upstream.IP); valid {
+					upstreamAddr = upstreamAddr.Unmap()
+					for _, prefix := range trustedPrefixes {
+						if prefix.Contains(upstreamAddr) {
+							return proxyproto.REQUIRE, nil
+						}
+					}
+				}
+			}
+			if dedicatedPort {
+				return proxyproto.SKIP, proxyproto.ErrInvalidUpstream
+			}
+			return proxyproto.SKIP, nil
+		},
+		validator: validateSourceAwareProxyHeader,
+	}, nil
+}
+
+func containsProxyProtocolPort(ports []uint32, port uint32) bool {
+	for _, allowed := range ports {
+		if allowed == port {
+			return true
+		}
+	}
+	return false
+}
+
+func validateSourceAwareProxyHeader(header *proxyproto.Header) error {
+	if header == nil {
+		return errors.New("missing PROXY protocol header")
+	}
+	if header.Version != 2 {
+		return errors.New("PROXY protocol v2 is required")
+	}
+	if _, err := header.TLVs(); err != nil {
+		return errors.New("invalid PROXY protocol v2 TLVs").Base(err)
+	}
+	if header.Command != proxyproto.PROXY {
+		return errors.New("PROXY command is required")
+	}
+	if header.TransportProtocol != proxyproto.TCPv4 && header.TransportProtocol != proxyproto.TCPv6 {
+		return errors.New("TCPv4 or TCPv6 PROXY transport is required")
+	}
+	source, destination, ok := header.TCPAddrs()
+	if !ok || source == nil || destination == nil {
+		return errors.New("TCP source and destination addresses are required")
+	}
+	if source.IP == nil || source.IP.IsUnspecified() || source.IP.IsMulticast() || isIPv4LimitedBroadcast(source.IP) || source.Port <= 0 || source.Port > 65535 {
+		return errors.New("a valid client source address is required")
+	}
+	if destination.IP == nil || destination.IP.IsUnspecified() || destination.IP.IsMulticast() || isIPv4LimitedBroadcast(destination.IP) || destination.Port <= 0 || destination.Port > 65535 {
+		return errors.New("a valid destination address is required")
+	}
+	return nil
+}
+
+func isIPv4LimitedBroadcast(ip stdnet.IP) bool {
+	ipv4 := ip.To4()
+	return ipv4 != nil && ipv4.Equal(stdnet.IPv4bcast)
+}

--- a/transport/internet/proxy_protocol_policy_test.go
+++ b/transport/internet/proxy_protocol_policy_test.go
@@ -1,0 +1,964 @@
+package internet
+
+import (
+	"context"
+	stderrors "errors"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pires/go-proxyproto"
+	xnet "github.com/xtls/xray-core/common/net"
+)
+
+func TestValidateProxyProtocolConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *SocketConfig
+		wantErr bool
+	}{
+		{name: "nil config"},
+		{name: "disabled", config: &SocketConfig{}},
+		{name: "legacy require all", config: &SocketConfig{AcceptProxyProtocol: true}},
+		{
+			name: "trusted exact addresses and canonical CIDR",
+			config: &SocketConfig{
+				ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+				ProxyProtocolTrustedSources: []string{"192.0.2.10", "2001:db8::/32"},
+				ProxyProtocolListenPorts:    []uint32{18443},
+			},
+		},
+		{
+			name: "CIDR blocks remain supported",
+			config: &SocketConfig{
+				ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+				ProxyProtocolTrustedSources: []string{"198.51.100.0/24", "0.0.0.0/0"},
+			},
+		},
+		{
+			name: "sources without explicit mode",
+			config: &SocketConfig{
+				AcceptProxyProtocol:         true,
+				ProxyProtocolTrustedSources: []string{"192.0.2.10"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "ports without explicit mode",
+			config: &SocketConfig{
+				ProxyProtocolListenPorts: []uint32{18443},
+			},
+			wantErr: true,
+		},
+		{
+			name: "trusted mode requires sources",
+			config: &SocketConfig{
+				ProxyProtocolMode: SocketConfig_ProxyProtocolTrustedSources,
+			},
+			wantErr: true,
+		},
+		{
+			name: "trusted mode rejects legacy accept flag",
+			config: &SocketConfig{
+				AcceptProxyProtocol:         true,
+				ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+				ProxyProtocolTrustedSources: []string{"192.0.2.10"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid source",
+			config: &SocketConfig{
+				ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+				ProxyProtocolTrustedSources: []string{"not-an-address"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-canonical CIDR",
+			config: &SocketConfig{
+				ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+				ProxyProtocolTrustedSources: []string{"192.0.2.10/24"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "IPv4-mapped CIDR",
+			config: &SocketConfig{
+				ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+				ProxyProtocolTrustedSources: []string{"::ffff:192.0.2.0/120"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "IPv6 link-local address",
+			config: &SocketConfig{
+				ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+				ProxyProtocolTrustedSources: []string{"fe80::1"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "IPv6 link-local prefix",
+			config: &SocketConfig{
+				ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+				ProxyProtocolTrustedSources: []string{"fe80::/10"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "IPv6 prefix overlapping link-local space",
+			config: &SocketConfig{
+				ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+				ProxyProtocolTrustedSources: []string{"fe00::/8"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid port zero",
+			config: &SocketConfig{
+				ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+				ProxyProtocolTrustedSources: []string{"192.0.2.10"},
+				ProxyProtocolListenPorts:    []uint32{0},
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicate port",
+			config: &SocketConfig{
+				ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+				ProxyProtocolTrustedSources: []string{"192.0.2.10"},
+				ProxyProtocolListenPorts:    []uint32{18443, 18443},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown programmatic mode",
+			config: &SocketConfig{
+				ProxyProtocolMode: SocketConfig_ProxyProtocolMode(99),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateProxyProtocolConfig(test.config)
+			if test.wantErr && err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !test.wantErr && err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestValidateProxyProtocolTransportConfigRejectsLegacyFlag(t *testing.T) {
+	config := &SocketConfig{
+		ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+		ProxyProtocolTrustedSources: []string{"192.0.2.10"},
+	}
+	if err := ValidateProxyProtocolTransportConfig(config, legacyProxyProtocolTransport{accept: false}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateProxyProtocolTransportConfig(config, legacyProxyProtocolTransport{accept: true}); err == nil {
+		t.Fatal("source-aware mode accepted a programmatic legacy transport flag")
+	}
+}
+
+func TestValidateProxyProtocolListenerSet(t *testing.T) {
+	ports := func(values ...uint32) *xnet.PortList {
+		list := &xnet.PortList{}
+		for _, value := range values {
+			list.Range = append(list.Range, xnet.SinglePortRange(xnet.Port(value)))
+		}
+		return list
+	}
+
+	for _, test := range []struct {
+		name          string
+		listenerPorts *xnet.PortList
+		proxyPorts    []uint32
+		wantErr       bool
+	}{
+		{name: "same-port TCP", listenerPorts: ports(443)},
+		{name: "dedicated port intersects", listenerPorts: ports(443, 18443), proxyPorts: []uint32{18443}},
+		{name: "one of several dedicated ports is missing", listenerPorts: ports(443, 18443), proxyPorts: []uint32{18443, 28443}, wantErr: true},
+		{name: "dedicated ports miss all listeners", listenerPorts: ports(443), proxyPorts: []uint32{18443}, wantErr: true},
+		{name: "Unix listener", listenerPorts: nil, wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			config := &SocketConfig{
+				ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+				ProxyProtocolTrustedSources: []string{"192.0.2.10"},
+				ProxyProtocolListenPorts:    test.proxyPorts,
+			}
+			err := ValidateProxyProtocolListenerSet(config, test.listenerPorts)
+			if test.wantErr && err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !test.wantErr && err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestValidateProxyProtocolInboundConfigRejectsUDPBeforeWorkers(t *testing.T) {
+	config := &SocketConfig{
+		ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+		ProxyProtocolTrustedSources: []string{"192.0.2.10"},
+	}
+	ports := &xnet.PortList{Range: []*xnet.PortRange{xnet.SinglePortRange(443)}}
+	stream := &MemoryStreamConfig{ProtocolName: "tcp"}
+	if err := ValidateProxyProtocolInboundConfig(config, ports, []xnet.Network{xnet.Network_TCP}, stream); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateProxyProtocolInboundConfig(config, ports, []xnet.Network{xnet.Network_UDP}, stream); err == nil {
+		t.Fatal("source-aware UDP inbound passed validation")
+	}
+	if err := ValidateProxyProtocolInboundConfig(config, ports, []xnet.Network{xnet.Network_TCP, xnet.Network_UDP}, stream); err == nil {
+		t.Fatal("source-aware mixed TCP/UDP inbound passed validation")
+	}
+}
+
+func TestValidateProxyProtocolInboundConfigRejectsPacketTransports(t *testing.T) {
+	config := &SocketConfig{
+		ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+		ProxyProtocolTrustedSources: []string{"192.0.2.10"},
+	}
+	ports := &xnet.PortList{Range: []*xnet.PortRange{xnet.SinglePortRange(443)}}
+	tests := []struct {
+		name     string
+		protocol string
+		security interface{}
+		wantErr  bool
+	}{
+		{name: "default TCP"},
+		{name: "RAW TCP", protocol: "tcp"},
+		{name: "WebSocket", protocol: "websocket"},
+		{name: "HTTPUpgrade", protocol: "httpupgrade"},
+		{name: "gRPC", protocol: "grpc"},
+		{name: "XHTTP H2", protocol: "splithttp", security: nextProtocolSettings{next: []string{"h2"}}},
+		{name: "mKCP", protocol: "mkcp", wantErr: true},
+		{name: "Hysteria", protocol: "hysteria", wantErr: true},
+		{name: "XHTTP H3", protocol: "splithttp", security: nextProtocolSettings{next: []string{"h3"}}, wantErr: true},
+		{name: "unknown transport", protocol: "custom-packet", wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateProxyProtocolInboundConfig(config, ports, []xnet.Network{xnet.Network_TCP}, &MemoryStreamConfig{
+				ProtocolName:     test.protocol,
+				SecuritySettings: test.security,
+			})
+			if test.wantErr && err == nil {
+				t.Fatal("expected effective transport validation error")
+			}
+			if !test.wantErr && err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestProxyProtocolTrustedSourcesRejectsPacketListener(t *testing.T) {
+	packet, err := (&DefaultListener{}).ListenPacket(context.Background(), &net.UDPAddr{IP: net.IPv4zero, Port: 0}, &SocketConfig{
+		ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+		ProxyProtocolTrustedSources: []string{"127.0.0.1"},
+	})
+	if packet != nil {
+		_ = packet.Close()
+		t.Fatal("unexpected packet listener")
+	}
+	if err == nil {
+		t.Fatal("expected trusted-sources packet listener error")
+	}
+}
+
+func TestCanUseXForwardedFor(t *testing.T) {
+	if !CanUseXForwardedFor(nil, 443) || !CanUseXForwardedFor(&SocketConfig{}, 443) {
+		t.Fatal("legacy HTTP transport behavior changed")
+	}
+	if CanUseXForwardedFor(&SocketConfig{ProxyProtocolMode: SocketConfig_ProxyProtocolTrustedSources}, 443) {
+		t.Fatal("X-Forwarded-For can override a same-port source-aware PROXY address")
+	}
+	dedicated := &SocketConfig{
+		ProxyProtocolMode:        SocketConfig_ProxyProtocolTrustedSources,
+		ProxyProtocolListenPorts: []uint32{18443},
+	}
+	if !CanUseXForwardedFor(dedicated, 443) {
+		t.Fatal("dedicated direct listener lost legacy X-Forwarded-For behavior")
+	}
+	if CanUseXForwardedFor(dedicated, 18443) {
+		t.Fatal("X-Forwarded-For can override a dedicated source-aware PROXY address")
+	}
+}
+
+func TestProxyProtocolListenerPolicy(t *testing.T) {
+	samePortConfig := &SocketConfig{
+		ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+		ProxyProtocolTrustedSources: []string{"192.0.2.10", "2001:db8::/32"},
+	}
+	listenerConfig, err := newProxyProtocolListenerConfig(&net.TCPAddr{IP: net.IPv4zero, Port: 443}, samePortConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if listenerConfig == nil {
+		t.Fatal("source-aware listener config is missing")
+	}
+
+	for _, test := range []struct {
+		address string
+		want    proxyproto.Policy
+	}{
+		{address: "192.0.2.10", want: proxyproto.REQUIRE},
+		{address: "::ffff:192.0.2.10", want: proxyproto.REQUIRE},
+		{address: "192.0.2.11", want: proxyproto.SKIP},
+		{address: "2001:db8::10", want: proxyproto.REQUIRE},
+		{address: "2001:db9::10", want: proxyproto.SKIP},
+	} {
+		got, err := listenerConfig.policy(proxyproto.ConnPolicyOptions{
+			Upstream: &net.TCPAddr{IP: net.ParseIP(test.address), Port: 1234},
+		})
+		if err != nil {
+			t.Fatalf("policy(%s): %v", test.address, err)
+		}
+		if got != test.want {
+			t.Fatalf("policy(%s) = %v, want %v", test.address, got, test.want)
+		}
+	}
+	if policy, err := listenerConfig.policy(proxyproto.ConnPolicyOptions{
+		Upstream: &net.TCPAddr{IP: net.ParseIP("2001:db8::10"), Port: 1234, Zone: "en0"},
+	}); err != nil || policy != proxyproto.SKIP {
+		t.Fatalf("scoped IPv6 peer policy = %v, %v; want SKIP", policy, err)
+	}
+
+	dedicatedConfig := &SocketConfig{
+		ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+		ProxyProtocolTrustedSources: []string{"192.0.2.10"},
+		ProxyProtocolListenPorts:    []uint32{18443},
+	}
+	directListener, err := newProxyProtocolListenerConfig(&net.TCPAddr{IP: net.IPv4zero, Port: 443}, dedicatedConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if directListener != nil {
+		t.Fatal("direct port unexpectedly enabled PROXY protocol")
+	}
+
+	gatewayListener, err := newProxyProtocolListenerConfig(&net.TCPAddr{IP: net.IPv4zero, Port: 18443}, dedicatedConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gatewayListener == nil {
+		t.Fatal("gateway port did not enable PROXY protocol")
+	}
+	if _, err := gatewayListener.policy(proxyproto.ConnPolicyOptions{
+		Upstream: &net.TCPAddr{IP: net.ParseIP("192.0.2.11"), Port: 1234},
+	}); !stderrors.Is(err, proxyproto.ErrInvalidUpstream) {
+		t.Fatalf("untrusted gateway-port peer error = %v, want ErrInvalidUpstream", err)
+	}
+	if _, err := gatewayListener.policy(proxyproto.ConnPolicyOptions{
+		Upstream: &net.TCPAddr{IP: net.ParseIP("192.0.2.10"), Port: 1234, Zone: "en0"},
+	}); !stderrors.Is(err, proxyproto.ErrInvalidUpstream) {
+		t.Fatalf("scoped gateway-port peer error = %v, want ErrInvalidUpstream", err)
+	}
+	if _, err := newProxyProtocolListenerConfig(&net.TCPAddr{IP: net.IPv4zero, Port: 0}, dedicatedConfig); err == nil {
+		t.Fatal("dedicated source-aware selection accepted TCP port 0")
+	}
+}
+
+func TestValidateSourceAwareProxyHeader(t *testing.T) {
+	validV4 := proxyproto.HeaderProxyFromAddrs(2,
+		&net.TCPAddr{IP: net.ParseIP("203.0.113.7"), Port: 12345},
+		&net.TCPAddr{IP: net.ParseIP("192.0.2.20"), Port: 443},
+	)
+	validV6 := proxyproto.HeaderProxyFromAddrs(2,
+		&net.TCPAddr{IP: net.ParseIP("2001:db8::10"), Port: 12345},
+		&net.TCPAddr{IP: net.ParseIP("2001:db8::20"), Port: 443},
+	)
+	validV4WithTLV := proxyproto.HeaderProxyFromAddrs(2,
+		&net.TCPAddr{IP: net.ParseIP("203.0.113.7"), Port: 12345},
+		&net.TCPAddr{IP: net.ParseIP("192.0.2.20"), Port: 443},
+	)
+	if err := validV4WithTLV.SetTLVs([]proxyproto.TLV{{
+		Type:  proxyproto.PP2_TYPE_ALPN,
+		Value: []byte("h2"),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		header  *proxyproto.Header
+		wantErr bool
+	}{
+		{name: "valid TCPv4", header: validV4},
+		{name: "valid TCPv6", header: validV6},
+		{name: "valid TCPv4 with TLV", header: validV4WithTLV},
+		{name: "missing", wantErr: true},
+		{
+			name: "version one is unsupported",
+			header: proxyproto.HeaderProxyFromAddrs(1,
+				&net.TCPAddr{IP: net.ParseIP("203.0.113.7"), Port: 12345},
+				&net.TCPAddr{IP: net.ParseIP("192.0.2.20"), Port: 443},
+			),
+			wantErr: true,
+		},
+		{
+			name: "LOCAL command",
+			header: &proxyproto.Header{
+				Version:           2,
+				Command:           proxyproto.LOCAL,
+				TransportProtocol: proxyproto.UNSPEC,
+			},
+			wantErr: true,
+		},
+		{
+			name: "UDP transport",
+			header: proxyproto.HeaderProxyFromAddrs(2,
+				&net.UDPAddr{IP: net.ParseIP("203.0.113.7"), Port: 12345},
+				&net.UDPAddr{IP: net.ParseIP("192.0.2.20"), Port: 443},
+			),
+			wantErr: true,
+		},
+		{
+			name: "zero source port",
+			header: proxyproto.HeaderProxyFromAddrs(2,
+				&net.TCPAddr{IP: net.ParseIP("203.0.113.7"), Port: 0},
+				&net.TCPAddr{IP: net.ParseIP("192.0.2.20"), Port: 443},
+			),
+			wantErr: true,
+		},
+		{
+			name: "unspecified source IP",
+			header: proxyproto.HeaderProxyFromAddrs(2,
+				&net.TCPAddr{IP: net.IPv4zero, Port: 12345},
+				&net.TCPAddr{IP: net.ParseIP("192.0.2.20"), Port: 443},
+			),
+			wantErr: true,
+		},
+		{
+			name: "multicast source IPv4",
+			header: proxyproto.HeaderProxyFromAddrs(2,
+				&net.TCPAddr{IP: net.ParseIP("224.0.0.1"), Port: 12345},
+				&net.TCPAddr{IP: net.ParseIP("192.0.2.20"), Port: 443},
+			),
+			wantErr: true,
+		},
+		{
+			name: "multicast source IPv6",
+			header: proxyproto.HeaderProxyFromAddrs(2,
+				&net.TCPAddr{IP: net.ParseIP("ff02::1"), Port: 12345},
+				&net.TCPAddr{IP: net.ParseIP("2001:db8::20"), Port: 443},
+			),
+			wantErr: true,
+		},
+		{
+			name: "limited broadcast source IPv4",
+			header: proxyproto.HeaderProxyFromAddrs(2,
+				&net.TCPAddr{IP: net.IPv4bcast, Port: 12345},
+				&net.TCPAddr{IP: net.ParseIP("192.0.2.20"), Port: 443},
+			),
+			wantErr: true,
+		},
+		{
+			name: "unspecified destination IPv4",
+			header: proxyproto.HeaderProxyFromAddrs(2,
+				&net.TCPAddr{IP: net.ParseIP("203.0.113.7"), Port: 12345},
+				&net.TCPAddr{IP: net.IPv4zero, Port: 443},
+			),
+			wantErr: true,
+		},
+		{
+			name: "unspecified destination IPv6",
+			header: proxyproto.HeaderProxyFromAddrs(2,
+				&net.TCPAddr{IP: net.ParseIP("2001:db8::10"), Port: 12345},
+				&net.TCPAddr{IP: net.IPv6unspecified, Port: 443},
+			),
+			wantErr: true,
+		},
+		{
+			name: "multicast destination IPv4",
+			header: proxyproto.HeaderProxyFromAddrs(2,
+				&net.TCPAddr{IP: net.ParseIP("203.0.113.7"), Port: 12345},
+				&net.TCPAddr{IP: net.ParseIP("224.0.0.1"), Port: 443},
+			),
+			wantErr: true,
+		},
+		{
+			name: "multicast destination IPv6",
+			header: proxyproto.HeaderProxyFromAddrs(2,
+				&net.TCPAddr{IP: net.ParseIP("2001:db8::10"), Port: 12345},
+				&net.TCPAddr{IP: net.ParseIP("ff02::1"), Port: 443},
+			),
+			wantErr: true,
+		},
+		{
+			name: "limited broadcast destination IPv4",
+			header: proxyproto.HeaderProxyFromAddrs(2,
+				&net.TCPAddr{IP: net.ParseIP("203.0.113.7"), Port: 12345},
+				&net.TCPAddr{IP: net.IPv4bcast, Port: 443},
+			),
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateSourceAwareProxyHeader(test.header)
+			if test.wantErr && err == nil {
+				t.Fatal("expected header validation error")
+			}
+			if !test.wantErr && err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestProxyProtocolSourceAwareDataPlane(t *testing.T) {
+	const payload = "VLESS-client-hello"
+	validHeader := formatProxyHeader(t, proxyproto.HeaderProxyFromAddrs(2,
+		&net.TCPAddr{IP: net.ParseIP("203.0.113.7"), Port: 12345},
+		&net.TCPAddr{IP: net.ParseIP("192.0.2.20"), Port: 443},
+	))
+	malformedTLVHeader := append([]byte{}, validHeader...)
+	malformedTLVHeader[15]++ // Extend the PPv2 payload by one truncated TLV byte.
+	malformedTLVHeader = append(malformedTLVHeader, byte(proxyproto.PP2_TYPE_ALPN))
+	v1Header := []byte("PROXY TCP4 203.0.113.7 192.0.2.20 12345 443\r\n")
+	v1HeaderWithExtraField := []byte("PROXY TCP4 203.0.113.7 192.0.2.20 12345 443 ignored\r\n")
+	unknownHeader := []byte("PROXY UNKNOWN\r\n")
+	localHeader := formatProxyHeader(t, &proxyproto.Header{
+		Version:           2,
+		Command:           proxyproto.LOCAL,
+		TransportProtocol: proxyproto.UNSPEC,
+	})
+
+	tests := []struct {
+		name         string
+		peerIP       string
+		wire         []byte
+		wantPayload  []byte
+		wantError    bool
+		wantRawConn  bool
+		wantRemoteIP string
+	}{
+		{
+			name:         "trusted gateway with strict PPv2 header",
+			peerIP:       "192.0.2.10",
+			wire:         append(append([]byte{}, validHeader...), payload...),
+			wantPayload:  []byte(payload),
+			wantRemoteIP: "203.0.113.7",
+		},
+		{
+			name:      "trusted gateway without header",
+			peerIP:    "192.0.2.10",
+			wire:      []byte(payload),
+			wantError: true,
+		},
+		{
+			name:      "trusted gateway with v1 header",
+			peerIP:    "192.0.2.10",
+			wire:      append(append([]byte{}, v1Header...), payload...),
+			wantError: true,
+		},
+		{
+			name:      "trusted gateway with v1 extra field",
+			peerIP:    "192.0.2.10",
+			wire:      append(append([]byte{}, v1HeaderWithExtraField...), payload...),
+			wantError: true,
+		},
+		{
+			name:      "trusted gateway with UNKNOWN header",
+			peerIP:    "192.0.2.10",
+			wire:      append(append([]byte{}, unknownHeader...), payload...),
+			wantError: true,
+		},
+		{
+			name:      "trusted gateway with LOCAL header",
+			peerIP:    "192.0.2.10",
+			wire:      append(append([]byte{}, localHeader...), payload...),
+			wantError: true,
+		},
+		{
+			name:      "trusted gateway with truncated PPv2 TLV",
+			peerIP:    "192.0.2.10",
+			wire:      append(append([]byte{}, malformedTLVHeader...), payload...),
+			wantError: true,
+		},
+		{
+			name:        "direct client without header",
+			peerIP:      "192.0.2.11",
+			wire:        []byte(payload),
+			wantPayload: []byte(payload),
+			wantRawConn: true,
+		},
+		{
+			name:        "direct client PROXY bytes remain unparsed",
+			peerIP:      "192.0.2.11",
+			wire:        append(append([]byte{}, validHeader...), payload...),
+			wantPayload: append(append([]byte{}, validHeader...), payload...),
+			wantRawConn: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			listenerConfig, err := newProxyProtocolListenerConfig(&net.TCPAddr{IP: net.IPv4zero, Port: 443}, &SocketConfig{
+				ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+				ProxyProtocolTrustedSources: []string{"192.0.2.10"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rawServer, client := net.Pipe()
+			server := &addressedConn{
+				Conn:   rawServer,
+				remote: &net.TCPAddr{IP: net.ParseIP(test.peerIP), Port: 1234},
+				local:  &net.TCPAddr{IP: net.ParseIP("192.0.2.20"), Port: 443},
+			}
+			t.Cleanup(func() {
+				_ = server.Close()
+				_ = client.Close()
+			})
+
+			writeDone := make(chan error, 1)
+			go func() {
+				_, err := client.Write(test.wire)
+				writeDone <- err
+			}()
+
+			listener := &proxyproto.Listener{
+				Listener:          &singleConnListener{conn: server},
+				ConnPolicy:        listenerConfig.policy,
+				ValidateHeader:    listenerConfig.validator,
+				ReadHeaderTimeout: time.Second,
+			}
+			conn, err := listener.Accept()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.wantRawConn && conn != server {
+				t.Fatalf("SKIP returned wrapped connection %T", conn)
+			}
+			readSize := len(test.wantPayload)
+			if readSize == 0 {
+				readSize = len(payload)
+			}
+			buf := make([]byte, readSize)
+			n, err := io.ReadFull(conn, buf)
+			if test.wantError {
+				if err == nil {
+					t.Fatalf("expected connection rejection, got %q", buf[:n])
+				}
+				_ = conn.Close()
+				<-writeDone
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := string(buf[:n]); got != string(test.wantPayload) {
+				t.Fatalf("payload = %q, want %q", got, test.wantPayload)
+			}
+			if test.wantRemoteIP != "" && !strings.HasPrefix(conn.RemoteAddr().String(), test.wantRemoteIP+":") {
+				t.Fatalf("remote address = %q, want IP %s", conn.RemoteAddr(), test.wantRemoteIP)
+			}
+			_ = conn.Close()
+			if err := <-writeDone; err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestProxyProtocolSourceAwareRejectsFragmentedV1(t *testing.T) {
+	listenerConfig, err := newProxyProtocolListenerConfig(&net.TCPAddr{IP: net.IPv4zero, Port: 443}, &SocketConfig{
+		ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+		ProxyProtocolTrustedSources: []string{"192.0.2.10"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rawServer, client := net.Pipe()
+	server := &addressedConn{
+		Conn:   rawServer,
+		remote: &net.TCPAddr{IP: net.ParseIP("192.0.2.10"), Port: 1234},
+		local:  &net.TCPAddr{IP: net.ParseIP("192.0.2.20"), Port: 443},
+	}
+	t.Cleanup(func() {
+		_ = server.Close()
+		_ = client.Close()
+	})
+	_ = server.SetDeadline(time.Now().Add(5 * time.Second))
+	_ = client.SetDeadline(time.Now().Add(5 * time.Second))
+
+	writeDone := make(chan error, 1)
+	go func() {
+		if _, err := client.Write([]byte("PROXY TCP4 203.0.113.7")); err != nil {
+			writeDone <- err
+			return
+		}
+		_, err := client.Write([]byte(" 192.0.2.20 12345 443\r\n"))
+		writeDone <- err
+	}()
+
+	listener := &proxyproto.Listener{
+		Listener:          &singleConnListener{conn: server},
+		ConnPolicy:        listenerConfig.policy,
+		ValidateHeader:    listenerConfig.validator,
+		ReadHeaderTimeout: time.Second,
+	}
+	conn, err := listener.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf [1]byte
+	if _, err := conn.Read(buf[:]); err == nil {
+		t.Fatal("fragmented PROXY v1 header was accepted")
+	}
+	_ = conn.Close()
+	<-writeDone
+}
+
+func TestProxyProtocolSourceAwareTCPListener(t *testing.T) {
+	listener, err := (&DefaultListener{}).Listen(context.Background(), &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0}, &SocketConfig{
+		ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+		ProxyProtocolTrustedSources: []string{"127.0.0.1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	client, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	_ = client.SetDeadline(time.Now().Add(5 * time.Second))
+
+	const payload = "listener-payload"
+	header := formatProxyHeader(t, proxyproto.HeaderProxyFromAddrs(2,
+		&net.TCPAddr{IP: net.ParseIP("203.0.113.7"), Port: 12345},
+		&net.TCPAddr{IP: net.ParseIP("192.0.2.20"), Port: 443},
+	))
+	if _, err := client.Write(append(header, payload...)); err != nil {
+		t.Fatal(err)
+	}
+
+	conn, err := listener.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+	buf := make([]byte, len(payload))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatal(err)
+	}
+	if string(buf) != payload {
+		t.Fatalf("payload = %q, want %q", buf, payload)
+	}
+	if !strings.HasPrefix(conn.RemoteAddr().String(), "203.0.113.7:") {
+		t.Fatalf("remote address = %q, want claimed client IP", conn.RemoteAddr())
+	}
+}
+
+func TestProxyProtocolDedicatedPortDropsUntrustedBeforeRead(t *testing.T) {
+	listenerConfig, err := newProxyProtocolListenerConfig(&net.TCPAddr{IP: net.IPv4zero, Port: 18443}, &SocketConfig{
+		ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+		ProxyProtocolTrustedSources: []string{"192.0.2.10"},
+		ProxyProtocolListenPorts:    []uint32{18443},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rawServer, client := net.Pipe()
+	server := &addressedConn{
+		Conn:   rawServer,
+		remote: &net.TCPAddr{IP: net.ParseIP("192.0.2.11"), Port: 1234},
+		local:  &net.TCPAddr{IP: net.ParseIP("192.0.2.20"), Port: 18443},
+	}
+	t.Cleanup(func() {
+		_ = server.Close()
+		_ = client.Close()
+	})
+
+	listener := &proxyproto.Listener{
+		Listener:   &singleConnListener{conn: server},
+		ConnPolicy: listenerConfig.policy,
+	}
+	if _, err := listener.Accept(); !stderrors.Is(err, io.EOF) {
+		t.Fatalf("Accept error = %v, want EOF after dropping the only untrusted connection", err)
+	}
+	if _, err := client.Write([]byte("PROXY-looking bytes")); err == nil {
+		t.Fatal("untrusted connection remained writable after policy drop")
+	}
+}
+
+func TestProxyProtocolDedicatedModeLeavesDirectListenerUnwrapped(t *testing.T) {
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	directPort := probe.Addr().(*net.TCPAddr).Port
+	_ = probe.Close()
+	proxyPort := uint32(18443)
+	if uint32(directPort) == proxyPort {
+		proxyPort++
+	}
+	listener, err := (&DefaultListener{}).Listen(context.Background(), &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: directPort}, &SocketConfig{
+		ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+		ProxyProtocolTrustedSources: []string{"127.0.0.1"},
+		ProxyProtocolListenPorts:    []uint32{proxyPort},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	if _, wrapped := listener.(*proxyproto.Listener); wrapped {
+		t.Fatal("direct listener was unexpectedly wrapped with PROXY protocol")
+	}
+}
+
+func TestProxyProtocolTrustedSourcesRejectsUDSBeforeCreate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "xray.sock")
+	listener, err := (&DefaultListener{}).Listen(context.Background(), &net.UnixAddr{Name: path, Net: "unix"}, &SocketConfig{
+		ProxyProtocolMode:           SocketConfig_ProxyProtocolTrustedSources,
+		ProxyProtocolTrustedSources: []string{"127.0.0.1"},
+	})
+	if listener != nil {
+		_ = listener.Close()
+		t.Fatal("unexpected UDS listener")
+	}
+	if err == nil {
+		t.Fatal("expected source-aware UDS configuration error")
+	}
+	for _, candidate := range []string{path, path + ".lock"} {
+		if _, statErr := os.Stat(candidate); !os.IsNotExist(statErr) {
+			t.Fatalf("source-aware UDS validation left %s behind: %v", candidate, statErr)
+		}
+	}
+}
+
+func TestProxyProtocolLegacyFilesystemUDS(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix domain sockets are unavailable")
+	}
+	tempDir, err := os.MkdirTemp("/tmp", "xray-uds-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+	path := filepath.Join(tempDir, "xray.sock")
+	listener, err := (&DefaultListener{}).Listen(context.Background(), &net.UnixAddr{Name: path, Net: "unix"}, &SocketConfig{
+		AcceptProxyProtocol: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	client, err := net.Dial("unix", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	_ = client.SetDeadline(time.Now().Add(5 * time.Second))
+
+	const payload = "uds-payload"
+	header := formatProxyHeader(t, proxyproto.HeaderProxyFromAddrs(2,
+		&net.TCPAddr{IP: net.ParseIP("203.0.113.7"), Port: 12345},
+		&net.TCPAddr{IP: net.ParseIP("192.0.2.20"), Port: 443},
+	))
+	if _, err := client.Write(append(header, payload...)); err != nil {
+		t.Fatal(err)
+	}
+
+	conn, err := listener.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+	buf := make([]byte, len(payload))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatal(err)
+	}
+	if string(buf) != payload {
+		t.Fatalf("payload = %q, want %q", buf, payload)
+	}
+	if !strings.HasPrefix(conn.RemoteAddr().String(), "203.0.113.7:") {
+		t.Fatalf("remote address = %q, want claimed client IP", conn.RemoteAddr())
+	}
+}
+
+func formatProxyHeader(t *testing.T, header *proxyproto.Header) []byte {
+	t.Helper()
+	formatted, err := header.Format()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return formatted
+}
+
+type addressedConn struct {
+	net.Conn
+	remote net.Addr
+	local  net.Addr
+}
+
+func (conn *addressedConn) RemoteAddr() net.Addr { return conn.remote }
+func (conn *addressedConn) LocalAddr() net.Addr  { return conn.local }
+
+type singleConnListener struct {
+	conn net.Conn
+}
+
+type legacyProxyProtocolTransport struct {
+	accept bool
+}
+
+type nextProtocolSettings struct {
+	next []string
+}
+
+func (settings nextProtocolSettings) GetNextProtocol() []string {
+	return settings.next
+}
+
+func (transport legacyProxyProtocolTransport) GetAcceptProxyProtocol() bool {
+	return transport.accept
+}
+
+func (l *singleConnListener) Accept() (net.Conn, error) {
+	if l.conn == nil {
+		return nil, io.EOF
+	}
+	conn := l.conn
+	l.conn = nil
+	return conn, nil
+}
+
+func (l *singleConnListener) Close() error {
+	if l.conn != nil {
+		return l.conn.Close()
+	}
+	return nil
+}
+
+func (*singleConnListener) Addr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4zero}
+}

--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -33,14 +33,15 @@ import (
 )
 
 type requestHandler struct {
-	config         *Config
-	host           string
-	path           string
-	ln             *Listener
-	sessionMu      *sync.Mutex
-	sessions       sync.Map
-	localAddr      net.Addr
-	socketSettings *internet.SocketConfig
+	config              *Config
+	host                string
+	path                string
+	ln                  *Listener
+	sessionMu           *sync.Mutex
+	sessions            sync.Map
+	localAddr           net.Addr
+	socketSettings      *internet.SocketConfig
+	canUseXForwardedFor bool
 }
 
 type httpSession struct {
@@ -171,11 +172,13 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 			Port: remoteAddr.(*net.TCPAddr).Port,
 		}
 	}
-	var trustedXFF []string
-	if h.socketSettings != nil {
-		trustedXFF = h.socketSettings.TrustedXForwardedFor
+	if h.canUseXForwardedFor {
+		var trustedXFF []string
+		if h.socketSettings != nil {
+			trustedXFF = h.socketSettings.TrustedXForwardedFor
+		}
+		remoteAddr = http_proto.ApplyTrustedXForwardedFor(request.Header, trustedXFF, remoteAddr)
 	}
-	remoteAddr = http_proto.ApplyTrustedXForwardedFor(request.Header, trustedXFF, remoteAddr)
 
 	var currentSession *httpSession
 	if sessionId != "" {
@@ -450,13 +453,14 @@ func ListenXH(ctx context.Context, address net.Address, port net.Port, streamSet
 		}
 	}
 	handler := &requestHandler{
-		config:         l.config,
-		host:           l.config.Host,
-		path:           l.config.GetNormalizedPath(),
-		ln:             l,
-		sessionMu:      &sync.Mutex{},
-		sessions:       sync.Map{},
-		socketSettings: streamSettings.SocketSettings,
+		config:              l.config,
+		host:                l.config.Host,
+		path:                l.config.GetNormalizedPath(),
+		ln:                  l,
+		sessionMu:           &sync.Mutex{},
+		sessions:            sync.Map{},
+		socketSettings:      streamSettings.SocketSettings,
+		canUseXForwardedFor: internet.CanUseXForwardedFor(streamSettings.SocketSettings, uint32(port)),
 	}
 	tlsConfig := getTLSConfig(streamSettings)
 	l.isH3 = len(tlsConfig.NextProtos) == 1 && tlsConfig.NextProtos[0] == "h3"

--- a/transport/internet/splithttp/splithttp_test.go
+++ b/transport/internet/splithttp/splithttp_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -82,48 +83,66 @@ func Test_ListenXHAndDial(t *testing.T) {
 }
 
 func TestDialWithRemoteAddr(t *testing.T) {
-	listenPort := tcp.PickPort()
-	listen, err := ListenXH(context.Background(), net.LocalHostIP, listenPort, &internet.MemoryStreamConfig{
-		ProtocolName: "splithttp",
-		ProtocolSettings: &Config{
-			Path: "sh",
-		},
-		SocketSettings: &internet.SocketConfig{
-			TrustedXForwardedFor: []string{"X-Forwarded-For"},
-		},
-	}, func(conn stat.Connection) {
-		go func(c stat.Connection) {
-			defer c.Close()
+	for _, test := range []struct {
+		name       string
+		mode       string
+		want       string
+		wantPrefix string
+	}{
+		{name: "legacy X-Forwarded-For", want: "1.1.1.1:0"},
+		{name: "dedicated direct listener keeps X-Forwarded-For", mode: "dedicated-direct", want: "1.1.1.1:0"},
+		{name: "same-port source-aware listener ignores X-Forwarded-For", mode: "same-port", wantPrefix: "127.0.0.1:"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			listenPort := tcp.PickPort()
+			socketSettings := &internet.SocketConfig{TrustedXForwardedFor: []string{"X-Forwarded-For"}}
+			if test.mode != "" {
+				socketSettings.ProxyProtocolMode = internet.SocketConfig_ProxyProtocolTrustedSources
+				socketSettings.ProxyProtocolTrustedSources = []string{"192.0.2.10"}
+				if test.mode == "dedicated-direct" {
+					proxyPort := tcp.PickPort()
+					for proxyPort == listenPort {
+						proxyPort = tcp.PickPort()
+					}
+					socketSettings.ProxyProtocolListenPorts = []uint32{uint32(proxyPort)}
+				}
+			}
+			listen, err := ListenXH(context.Background(), net.LocalHostIP, listenPort, &internet.MemoryStreamConfig{
+				ProtocolName:     "splithttp",
+				ProtocolSettings: &Config{Path: "sh"},
+				SocketSettings:   socketSettings,
+			}, func(conn stat.Connection) {
+				go func(c stat.Connection) {
+					defer c.Close()
+					var b [1024]byte
+					if _, err := c.Read(b[:]); err == nil {
+						_, _ = c.Write([]byte(c.RemoteAddr().String()))
+					}
+				}(conn)
+			})
+			common.Must(err)
+			defer listen.Close()
+
+			conn, err := Dial(context.Background(), net.TCPDestination(net.DomainAddress("localhost"), listenPort), &internet.MemoryStreamConfig{
+				ProtocolName:     "splithttp",
+				ProtocolSettings: &Config{Path: "sh", Headers: map[string]string{"X-Forwarded-For": "1.1.1.1"}},
+			})
+			common.Must(err)
+			defer conn.Close()
+			_, err = conn.Write([]byte("Test connection 1"))
+			common.Must(err)
 
 			var b [1024]byte
-			_, err := c.Read(b[:])
-			// common.Must(err)
-			if err != nil {
-				return
+			n, _ := io.ReadFull(conn, b[:])
+			got := string(b[:n])
+			if test.want != "" && got != test.want {
+				t.Fatalf("response = %q, want %q", got, test.want)
 			}
-
-			_, err = c.Write([]byte(c.RemoteAddr().String()))
-			common.Must(err)
-		}(conn)
-	})
-	common.Must(err)
-
-	conn, err := Dial(context.Background(), net.TCPDestination(net.DomainAddress("localhost"), listenPort), &internet.MemoryStreamConfig{
-		ProtocolName:     "splithttp",
-		ProtocolSettings: &Config{Path: "sh", Headers: map[string]string{"X-Forwarded-For": "1.1.1.1"}},
-	})
-
-	common.Must(err)
-	_, err = conn.Write([]byte("Test connection 1"))
-	common.Must(err)
-
-	var b [1024]byte
-	n, _ := io.ReadFull(conn, b[:])
-	if string(b[:n]) != "1.1.1.1:0" {
-		t.Error("response: ", string(b[:n]))
+			if test.wantPrefix != "" && !strings.HasPrefix(got, test.wantPrefix) {
+				t.Fatalf("response = %q, want prefix %q", got, test.wantPrefix)
+			}
+		})
 	}
-
-	common.Must(listen.Close())
 }
 
 func Test_ListenXHAndDial_TLS(t *testing.T) {

--- a/transport/internet/system_listener.go
+++ b/transport/internet/system_listener.go
@@ -75,6 +75,11 @@ func (conn *UnixConnWrapper) RemoteAddr() net.Addr {
 }
 
 func (dl *DefaultListener) Listen(ctx context.Context, addr net.Addr, sockopt *SocketConfig) (l net.Listener, err error) {
+	proxyProtocolConfig, err := newProxyProtocolListenerConfig(addr, sockopt)
+	if err != nil {
+		return nil, err
+	}
+
 	var lc net.ListenConfig
 	var network, address string
 	// callback is called after the Listen function returns
@@ -166,14 +171,25 @@ func (dl *DefaultListener) Listen(ctx context.Context, addr net.Addr, sockopt *S
 	}
 
 	l, err = callback(lc.Listen(ctx, network, address))
-	if err == nil && sockopt != nil && sockopt.AcceptProxyProtocol {
-		policyFunc := func(upstream net.Addr) (proxyproto.Policy, error) { return proxyproto.REQUIRE, nil }
-		l = &proxyproto.Listener{Listener: l, Policy: policyFunc}
+	if err == nil && proxyProtocolConfig != nil {
+		errors.LogWarning(ctx, "accepting PROXY protocol")
+		l = &proxyproto.Listener{
+			Listener:       l,
+			ConnPolicy:     proxyProtocolConfig.policy,
+			ValidateHeader: proxyProtocolConfig.validator,
+		}
 	}
 	return l, err
 }
 
 func (dl *DefaultListener) ListenPacket(ctx context.Context, addr net.Addr, sockopt *SocketConfig) (net.PacketConn, error) {
+	if err := ValidateProxyProtocolConfig(sockopt); err != nil {
+		return nil, err
+	}
+	if sockopt != nil && sockopt.ProxyProtocolMode == SocketConfig_ProxyProtocolTrustedSources {
+		return nil, errors.New("proxyProtocolMode trusted-sources is unsupported for packet listeners")
+	}
+
 	var lc net.ListenConfig
 
 	lc.Control = getControlFunc(ctx, sockopt, dl.controllers)

--- a/transport/internet/tcp/hub.go
+++ b/transport/internet/tcp/hub.go
@@ -33,6 +33,9 @@ func ListenTCP(ctx context.Context, address net.Address, port net.Port, streamSe
 	}
 	tcpSettings := streamSettings.ProtocolSettings.(*Config)
 	l.config = tcpSettings
+	if err := internet.ValidateProxyProtocolTransportConfig(streamSettings.SocketSettings, tcpSettings); err != nil {
+		return nil, errors.New("invalid PROXY protocol transport configuration").Base(err)
+	}
 	if l.config != nil {
 		if streamSettings.SocketSettings == nil {
 			streamSettings.SocketSettings = &internet.SocketConfig{}
@@ -66,10 +69,6 @@ func ListenTCP(ctx context.Context, address net.Address, port net.Port, streamSe
 
 	if streamSettings.TcpmaskManager != nil {
 		listener, _ = streamSettings.TcpmaskManager.WrapListener(listener)
-	}
-
-	if streamSettings.SocketSettings != nil && streamSettings.SocketSettings.AcceptProxyProtocol {
-		errors.LogWarning(ctx, "accepting PROXY protocol")
 	}
 
 	l.listener = listener

--- a/transport/internet/websocket/hub.go
+++ b/transport/internet/websocket/hub.go
@@ -21,10 +21,11 @@ import (
 )
 
 type requestHandler struct {
-	host           string
-	path           string
-	ln             *Listener
-	socketSettings *internet.SocketConfig
+	host                string
+	path                string
+	ln                  *Listener
+	socketSettings      *internet.SocketConfig
+	canUseXForwardedFor bool
 }
 
 var replacer = strings.NewReplacer("+", "-", "/", "_", "=", "")
@@ -66,11 +67,13 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 	}
 
 	remoteAddr := conn.RemoteAddr()
-	var trustedXFF []string
-	if h.socketSettings != nil {
-		trustedXFF = h.socketSettings.TrustedXForwardedFor
+	if h.canUseXForwardedFor {
+		var trustedXFF []string
+		if h.socketSettings != nil {
+			trustedXFF = h.socketSettings.TrustedXForwardedFor
+		}
+		remoteAddr = http_proto.ApplyTrustedXForwardedFor(request.Header, trustedXFF, remoteAddr)
 	}
-	remoteAddr = http_proto.ApplyTrustedXForwardedFor(request.Header, trustedXFF, remoteAddr)
 
 	h.ln.addConn(NewConnection(conn, remoteAddr, extraReader, h.ln.config.HeartbeatPeriod))
 }
@@ -89,6 +92,9 @@ func ListenWS(ctx context.Context, address net.Address, port net.Port, streamSet
 	}
 	wsSettings := streamSettings.ProtocolSettings.(*Config)
 	l.config = wsSettings
+	if err := internet.ValidateProxyProtocolTransportConfig(streamSettings.SocketSettings, wsSettings); err != nil {
+		return nil, errors.New("invalid PROXY protocol transport configuration").Base(err)
+	}
 	if l.config != nil {
 		if streamSettings.SocketSettings == nil {
 			streamSettings.SocketSettings = &internet.SocketConfig{}
@@ -121,10 +127,6 @@ func ListenWS(ctx context.Context, address net.Address, port net.Port, streamSet
 		listener, _ = streamSettings.TcpmaskManager.WrapListener(listener)
 	}
 
-	if streamSettings.SocketSettings != nil && streamSettings.SocketSettings.AcceptProxyProtocol {
-		errors.LogWarning(ctx, "accepting PROXY protocol")
-	}
-
 	if config := v2tls.ConfigFromStreamSettings(streamSettings); config != nil {
 		if tlsConfig := config.GetTLSConfig(); tlsConfig != nil {
 			listener = tls.NewListener(listener, tlsConfig)
@@ -135,10 +137,11 @@ func ListenWS(ctx context.Context, address net.Address, port net.Port, streamSet
 
 	l.server = http.Server{
 		Handler: &requestHandler{
-			host:           wsSettings.Host,
-			path:           wsSettings.GetNormalizedPath(),
-			ln:             l,
-			socketSettings: streamSettings.SocketSettings,
+			host:                wsSettings.Host,
+			path:                wsSettings.GetNormalizedPath(),
+			ln:                  l,
+			socketSettings:      streamSettings.SocketSettings,
+			canUseXForwardedFor: internet.CanUseXForwardedFor(streamSettings.SocketSettings, uint32(port)),
 		},
 		ReadHeaderTimeout: time.Second * 4,
 		MaxHeaderBytes:    8192,

--- a/transport/internet/websocket/proxy_protocol_test.go
+++ b/transport/internet/websocket/proxy_protocol_test.go
@@ -1,0 +1,113 @@
+package websocket_test
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/pires/go-proxyproto"
+	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/testing/servers/tcp"
+	"github.com/xtls/xray-core/transport/internet"
+	"github.com/xtls/xray-core/transport/internet/stat"
+	. "github.com/xtls/xray-core/transport/internet/websocket"
+)
+
+func TestSourceAwareProxyAddressOverridesXForwardedFor(t *testing.T) {
+	listenPort := tcp.PickPort()
+	listen, err := ListenWS(context.Background(), net.LocalHostIP, listenPort, &internet.MemoryStreamConfig{
+		ProtocolName:     "websocket",
+		ProtocolSettings: &Config{Path: "ws"},
+		SocketSettings: &internet.SocketConfig{
+			ProxyProtocolMode:           internet.SocketConfig_ProxyProtocolTrustedSources,
+			ProxyProtocolTrustedSources: []string{"127.0.0.1"},
+			ProxyProtocolListenPorts:    []uint32{uint32(listenPort)},
+			TrustedXForwardedFor:        []string{"X-Forwarded-For"},
+		},
+	}, func(conn stat.Connection) {
+		go func(c stat.Connection) {
+			defer c.Close()
+			_ = c.SetDeadline(time.Now().Add(5 * time.Second))
+			var b [1024]byte
+			if _, err := c.Read(b[:]); err == nil {
+				_, _ = c.Write([]byte(c.RemoteAddr().String()))
+			}
+		}(conn)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listen.Close() })
+
+	header, err := proxyproto.HeaderProxyFromAddrs(2,
+		&net.TCPAddr{IP: net.ParseIP("203.0.113.7"), Port: 12345},
+		&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: int(listenPort)},
+	).Format()
+	if err != nil {
+		t.Fatal(err)
+	}
+	forwardPort := startProxyProtocolV2Forwarder(t, listenPort, header)
+
+	conn, err := Dial(context.Background(), net.TCPDestination(net.DomainAddress("localhost"), forwardPort), &internet.MemoryStreamConfig{
+		ProtocolName:     "websocket",
+		ProtocolSettings: &Config{Path: "ws", Header: map[string]string{"X-Forwarded-For": "1.1.1.1"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+	if _, err := conn.Write([]byte("source-aware XFF precedence")); err != nil {
+		t.Fatal(err)
+	}
+
+	var b [128]byte
+	n, err := conn.Read(b[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(b[:n]); got != "203.0.113.7:12345" {
+		t.Fatalf("remote address = %q, want validated PROXY address", got)
+	}
+}
+
+func startProxyProtocolV2Forwarder(t *testing.T, targetPort net.Port, prefix []byte) net.Port {
+	t.Helper()
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		for {
+			downstream, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer downstream.Close()
+				upstream, err := net.Dial("tcp4", net.JoinHostPort("127.0.0.1", targetPort.String()))
+				if err != nil {
+					return
+				}
+				defer upstream.Close()
+				_ = downstream.SetDeadline(time.Now().Add(10 * time.Second))
+				_ = upstream.SetDeadline(time.Now().Add(10 * time.Second))
+				if _, err := upstream.Write(prefix); err != nil {
+					return
+				}
+				copyDone := make(chan struct{})
+				go func() {
+					_, _ = io.Copy(upstream, downstream)
+					close(copyDone)
+				}()
+				_, _ = io.Copy(downstream, upstream)
+				<-copyDone
+			}()
+		}
+	}()
+
+	return net.Port(listener.Addr().(*net.TCPAddr).Port)
+}


### PR DESCRIPTION
## Summary

- add a source-aware PROXY protocol v2 mode with explicit trusted IP/CIDR prefixes
- optionally restrict PROXY protocol handling to selected inbound listener ports
- reject PROXY v1, LOCAL/UNKNOWN commands, datagram headers, malformed TLVs and invalid endpoints
- preserve PROXY-derived peer addresses over X-Forwarded-For
- reject incompatible transports and legacy acceptProxyProtocol combinations at startup

## Behavior

When `proxyProtocolListenPorts` is empty:

- trusted physical sources must send a valid PROXY protocol v2 header
- untrusted sources bypass PROXY parsing and their bytes remain untouched

When `proxyProtocolListenPorts` is configured:

- selected ports require a trusted physical source and valid PROXY protocol v2
- untrusted connections to selected ports are dropped before application data is read
- other inbound ports remain ordinary direct listeners

## Tests

Added coverage for:

- trusted and untrusted IPv4/IPv6 sources
- same-port and dedicated-port policies
- malformed and fragmented headers
- PROXY v1 rejection
- command, transport, endpoint and TLV validation
- listener accept-loop liveness
- WebSocket, HTTP Upgrade, XHTTP and gRPC address precedence
- unsupported transports and hot-added inbound validation