### PR TITLE
Routing: Export HealthCheckSettings

### DIFF
--- a/infra/conf/observatory.go
+++ b/infra/conf/observatory.go
@@ -23,7 +23,7 @@ func (o *ObservatoryConfig) Build() (proto.Message, error) {
 type BurstObservatoryConfig struct {
 	SubjectSelector []string `json:"subjectSelector"`
 	// health check settings
-	HealthCheck *healthCheckSettings `json:"pingConfig,omitempty"`
+	HealthCheck *HealthCheckSettings `json:"pingConfig,omitempty"`
 }
 
 func (b BurstObservatoryConfig) Build() (proto.Message, error) {

--- a/infra/conf/router_strategy.go
+++ b/infra/conf/router_strategy.go
@@ -43,8 +43,8 @@ type strategyLeastLoadConfig struct {
 	Tolerance float64 `json:"tolerance,omitempty"`
 }
 
-// healthCheckSettings holds settings for health Checker
-type healthCheckSettings struct {
+// HealthCheckSettings holds settings for health Checker
+type HealthCheckSettings struct {
 	Destination   string            `json:"destination"`
 	Connectivity  string            `json:"connectivity"`
 	Interval      duration.Duration `json:"interval"`
@@ -53,7 +53,7 @@ type healthCheckSettings struct {
 	HttpMethod    string            `json:"httpMethod"`
 }
 
-func (h healthCheckSettings) Build() (proto.Message, error) {
+func (h HealthCheckSettings) Build() (proto.Message, error) {
 	var httpMethod string
 	if h.HttpMethod == "" {
 		httpMethod = "HEAD"


### PR DESCRIPTION
Currently, trying to build a `BurstObservatory` config from `conf.BurstObservatoryConfig`:
```go
config.BurstObservatory = &conf.BurstObservatoryConfig{
	SubjectSelector: []string{"out"},
	HealthCheck: &conf.healthCheckSettings{},
}
```
Results in a compiler error:
```
1. name healthCheckSettings not exported by package conf [UnexportedName]
```
`conf.BurstObservatoryConfig` is public, but uses `conf.healthCheckSettings` (a private struct), which prevents creating a `conf.Config` with a burst observatory from an outside package.
Making `healthCheckSettings` public should allow building of a config with a burst observatory. 