### PR TITLE
HTTP outbound: Fix `Host` header on CONNECT

### DIFF
--- a/proxy/http/client.go
+++ b/proxy/http/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"text/template"
 
@@ -202,6 +203,27 @@ func fillRequestHeader(ctx context.Context, header []*Header) ([]*Header, error)
 	return filled, nil
 }
 
+// applyRequestHeaders copies the configured headers onto the CONNECT request.
+//
+// Host needs care. Request.Write ignores Header["Host"] and writes req.Host
+// instead, so a configured Host never reaches the wire on its own. Moving it to
+// req.Host is not enough either: for CONNECT, Request.Write also derives the
+// request-URI from req.Host, so setting it would rewrite the tunnel authority
+// as well. Pinning the real target in URL.Opaque keeps the request-URI intact
+// while letting the configured value appear as the Host header.
+func applyRequestHeaders(req *http.Request, target string, header []*Header) {
+	for _, h := range header {
+		if strings.EqualFold(h.Key, "Host") {
+			if req.URL.Opaque == "" {
+				req.URL.Opaque = target
+			}
+			req.Host = h.Value
+			continue
+		}
+		req.Header.Set(h.Key, h.Value)
+	}
+}
+
 // setUpHTTPTunnel will create a socket tunnel via HTTP CONNECT method
 func setUpHTTPTunnel(ctx context.Context, dest net.Destination, target string, user *protocol.MemoryUser, dialer internet.Dialer, header []*Header, firstPayload []byte) (net.Conn, error) {
 	req := &http.Request{
@@ -217,9 +239,7 @@ func setUpHTTPTunnel(ctx context.Context, dest net.Destination, target string, u
 		req.Header.Set("Proxy-Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(auth)))
 	}
 
-	for _, h := range header {
-		req.Header.Set(h.Key, h.Value)
-	}
+	applyRequestHeaders(req, target, header)
 	utils.TryDefaultHeadersWith(req.Header, "nav")
 
 	connectHTTP1 := func(rawConn net.Conn) (net.Conn, error) {

--- a/proxy/http/client_test.go
+++ b/proxy/http/client_test.go
@@ -1,0 +1,93 @@
+package http
+
+import (
+	"bufio"
+	"bytes"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// connectRequest builds the request setUpHTTPTunnel starts from.
+func connectRequest(target string) *http.Request {
+	return &http.Request{
+		Method: http.MethodConnect,
+		URL:    &url.URL{Host: target},
+		Header: make(http.Header),
+		Host:   target,
+	}
+}
+
+func writeRequest(t *testing.T, req *http.Request) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := req.Write(&buf); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	return buf.String()
+}
+
+func requestLine(t *testing.T, raw string) string {
+	t.Helper()
+	line, err := bufio.NewReader(strings.NewReader(raw)).ReadString('\n')
+	if err != nil {
+		t.Fatalf("read request line: %v", err)
+	}
+	return strings.TrimSpace(line)
+}
+
+// A configured Host must reach the wire. Request.Write ignores Header["Host"],
+// so setting it there alone leaves the header at the tunnel target.
+func TestApplyRequestHeadersSendsConfiguredHost(t *testing.T) {
+	const target = "203.0.113.7:443"
+	req := connectRequest(target)
+	applyRequestHeaders(req, target, []*Header{
+		{Key: "Host", Value: "front.example.com:443"},
+		{Key: "X-Token", Value: "abc"},
+	})
+
+	raw := writeRequest(t, req)
+	if !strings.Contains(raw, "Host: front.example.com:443\r\n") {
+		t.Errorf("configured Host missing from request:\n%s", raw)
+	}
+	if !strings.Contains(raw, "X-Token: abc\r\n") {
+		t.Errorf("other headers should still be applied:\n%s", raw)
+	}
+}
+
+// For CONNECT, Request.Write derives the request-URI from req.Host, so a Host
+// override must not drag the tunnel authority along with it.
+func TestApplyRequestHeadersKeepsTheTunnelAuthority(t *testing.T) {
+	const target = "203.0.113.7:443"
+	req := connectRequest(target)
+	applyRequestHeaders(req, target, []*Header{{Key: "Host", Value: "front.example.com:443"}})
+
+	if got, want := requestLine(t, writeRequest(t, req)), "CONNECT "+target+" HTTP/1.1"; got != want {
+		t.Errorf("request line = %q, want %q", got, want)
+	}
+}
+
+func TestApplyRequestHeadersMatchesHostCaseInsensitively(t *testing.T) {
+	const target = "203.0.113.7:443"
+	req := connectRequest(target)
+	applyRequestHeaders(req, target, []*Header{{Key: "host", Value: "front.example.com:443"}})
+
+	if req.Host != "front.example.com:443" {
+		t.Errorf("req.Host = %q, want the configured value", req.Host)
+	}
+}
+
+func TestApplyRequestHeadersLeavesTheDefaultHostAlone(t *testing.T) {
+	const target = "203.0.113.7:443"
+	req := connectRequest(target)
+	applyRequestHeaders(req, target, []*Header{{Key: "X-Token", Value: "abc"}})
+
+	raw := writeRequest(t, req)
+	if !strings.Contains(raw, "Host: "+target+"\r\n") {
+		t.Errorf("without an override the Host should stay the target:\n%s", raw)
+	}
+	if got, want := requestLine(t, raw), "CONNECT "+target+" HTTP/1.1"; got != want {
+		t.Errorf("request line = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- send a `Host` configured in the outbound's `headers` map on the CONNECT request
- keep the CONNECT request-URI pointing at the tunnel target when that happens
- move header application into `applyRequestHeaders` and cover both with tests

## Root cause

`Request.Write` excludes `Header["Host"]` and emits `req.Host` instead, so a
`Host` placed in the `headers` map is silently dropped. An upstream proxy that
authenticates on a `Host` different from the tunnel target cannot be used at
all.

Assigning `req.Host` alone is not a fix either. For CONNECT, `Request.Write`
also derives the request-URI from `req.Host`:

```go
ruri := r.URL.RequestURI()
if r.Method == "CONNECT" && r.URL.Path == "" {
    ruri = host          // host is r.Host when set
    if r.URL.Opaque != "" {
        ruri = r.URL.Opaque
    }
}
```

so the request becomes `CONNECT front.example.com:443` and the tunnel is opened
to the wrong host. That failure is quiet at the HTTP layer — the proxy answers
`200 Connection established` — and only surfaces later as a TLS handshake
landing on the proxy's own certificate. Pinning the real target in `URL.Opaque`
keeps the request-URI intact while the configured value goes out as the `Host`
header.

## Tests

`TestApplyRequestHeadersSendsConfiguredHost` and
`TestApplyRequestHeadersMatchesHostCaseInsensitively` fail without the change.
`TestApplyRequestHeadersKeepsTheTunnelAuthority` additionally fails against the
naive version that only assigns `req.Host`:

```
request line = "CONNECT front.example.com:443 HTTP/1.1", want "CONNECT 203.0.113.7:443 HTTP/1.1"
```
