### PR TITLE
HTTP outbound: Fix `headers` for requests without an inbound

### DIFF
--- a/proxy/http/client.go
+++ b/proxy/http/client.go
@@ -169,19 +169,22 @@ func fillRequestHeader(ctx context.Context, header []*Header) ([]*Header, error)
 		return header, nil
 	}
 
-	inbound := session.InboundFromContext(ctx)
 	outbounds := session.OutboundsFromContext(ctx)
 	ob := outbounds[len(outbounds)-1]
 
-	if inbound == nil || ob == nil {
-		return nil, errors.New("missing inbound or outbound metadata from context")
+	// A request can reach here without an inbound, for example a health check
+	// dispatched through tagged.Dialer. Fall back to an unspecified source
+	// rather than refusing to build the headers.
+	source := net.TCPDestination(net.AnyIP, 0)
+	if inbound := session.InboundFromContext(ctx); inbound != nil {
+		source = inbound.Source
 	}
 
 	data := struct {
 		Source net.Destination
 		Target net.Destination
 	}{
-		Source: inbound.Source,
+		Source: source,
 		Target: ob.Target,
 	}
 

--- a/proxy/http/client_test.go
+++ b/proxy/http/client_test.go
@@ -1,0 +1,70 @@
+package http
+
+import (
+	"context"
+	"testing"
+
+	"github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/session"
+)
+
+func outboundContext(ctx context.Context) context.Context {
+	return session.ContextWithOutbounds(ctx, []*session.Outbound{{
+		Target: net.TCPDestination(net.ParseAddress("203.0.113.7"), 443),
+	}})
+}
+
+func filled(t *testing.T, ctx context.Context, header []*Header) map[string]string {
+	t.Helper()
+	out, err := fillRequestHeader(ctx, header)
+	if err != nil {
+		t.Fatalf("fillRequestHeader: %v", err)
+	}
+	values := make(map[string]string, len(out))
+	for _, h := range out {
+		values[h.Key] = h.Value
+	}
+	return values
+}
+
+// A health check dispatched through tagged.Dialer carries no inbound, which
+// used to make every outbound with a configured "headers" map fail to build
+// its request.
+func TestFillRequestHeaderWithoutInbound(t *testing.T) {
+	values := filled(t, outboundContext(context.Background()), []*Header{
+		{Key: "Host", Value: "front.example.com:443"},
+		{Key: "X-Source", Value: "{{.Source}}"},
+		{Key: "X-Target", Value: "{{.Target}}"},
+	})
+
+	if values["Host"] != "front.example.com:443" {
+		t.Errorf("Host = %q", values["Host"])
+	}
+	if values["X-Source"] != "tcp:0.0.0.0:0" {
+		t.Errorf("X-Source = %q, want an unspecified source", values["X-Source"])
+	}
+	if values["X-Target"] != "tcp:203.0.113.7:443" {
+		t.Errorf("X-Target = %q", values["X-Target"])
+	}
+}
+
+func TestFillRequestHeaderWithInbound(t *testing.T) {
+	ctx := session.ContextWithInbound(outboundContext(context.Background()), &session.Inbound{
+		Source: net.TCPDestination(net.ParseAddress("192.0.2.9"), 1234),
+	})
+
+	values := filled(t, ctx, []*Header{{Key: "X-Source", Value: "{{.Source}}"}})
+	if values["X-Source"] != "tcp:192.0.2.9:1234" {
+		t.Errorf("X-Source = %q", values["X-Source"])
+	}
+}
+
+func TestFillRequestHeaderWithoutHeaders(t *testing.T) {
+	out, err := fillRequestHeader(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("fillRequestHeader: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("got %v, want nothing", out)
+	}
+}


### PR DESCRIPTION
## Summary

- fall back to an unspecified source when the context carries no inbound, instead of refusing to build the headers

## Root cause

`fillRequestHeader` returns an error when there is no inbound in the context.
`burstObservatory` dispatches its health checks through `tagged.Dialer`, which
carries no inbound, so an HTTP outbound with a configured `headers` map fails
every probe. Because it fails during dispatch, a balancer never collects a
sample for that outbound at all — with `leastPing` it keeps using
`fallbackTag`, and the outbound is never actually rated. Every probe reports
`io: read/write on closed pipe`, including probes of outbounds that are
perfectly healthy.

## Note on an earlier version of this PR

This originally also guarded `outbounds[len(outbounds)-1]` and claimed it could
panic. That was wrong: `Process` already indexes the same expression before
this is reached, so outbounds is never empty here. The panic was only reachable
by calling the unexported function directly from a test, which is not a real
code path. That part has been dropped, along with the conditional that only
demanded metadata for templated values — falling back to `0.0.0.0:0` is
simpler and covers the case that actually occurs.

## Tests

`TestFillRequestHeaderWithoutInbound` fails on `main` with
`missing inbound or outbound metadata from context`. The others cover that a
present inbound is still used, and that an empty header list is a no-op.
