### PR TITLE
Transport: Bind the UDP outbound socket in the destination family

### DIFF
--- a/transport/internet/system_dialer.go
+++ b/transport/internet/system_dialer.go
@@ -50,18 +50,26 @@ func (d *DefaultSystemDialer) Dial(ctx context.Context, src net.Address, dest ne
 	errors.LogDebug(ctx, "dialing to "+dest.String())
 
 	if dest.Network == net.Network_UDP {
-		srcAddr := resolveSrcAddr(net.Network_UDP, src)
-		if srcAddr == nil {
-			srcAddr = &net.UDPAddr{
-				IP:   []byte{0, 0, 0, 0},
-				Port: 0,
-			}
-		}
-		var lc net.ListenConfig
 		destAddr, err := net.ResolveUDPAddr("udp", dest.NetAddr())
 		if err != nil {
 			return nil, err
 		}
+		srcAddr := resolveSrcAddr(net.Network_UDP, src)
+		if srcAddr == nil {
+			// Bind the wildcard of the destination's own address family.
+			// Where IPv4-mapped IPv6 addresses are unavailable, OpenBSD among
+			// them, binding 0.0.0.0 gives an AF_INET socket that cannot reach
+			// an IPv6 peer.
+			wildcard := net.AnyIP.IP()
+			if destAddr.IP.To4() == nil {
+				wildcard = net.AnyIPv6.IP()
+			}
+			srcAddr = &net.UDPAddr{
+				IP:   wildcard,
+				Port: 0,
+			}
+		}
+		var lc net.ListenConfig
 		lc.Control = func(network, address string, c syscall.RawConn) error {
 			for _, ctl := range Controllers {
 				if err := ctl(network, address, c); err != nil {

--- a/transport/internet/system_dialer.go
+++ b/transport/internet/system_dialer.go
@@ -56,10 +56,8 @@ func (d *DefaultSystemDialer) Dial(ctx context.Context, src net.Address, dest ne
 		}
 		srcAddr := resolveSrcAddr(net.Network_UDP, src)
 		if srcAddr == nil {
-			// Bind the wildcard of the destination's own address family.
-			// Where IPv4-mapped IPv6 addresses are unavailable, OpenBSD among
-			// them, binding 0.0.0.0 gives an AF_INET socket that cannot reach
-			// an IPv6 peer.
+			// some OS don't support mapped IPv4 dual stack
+			// and need to select 0.0.0.0 or [::] manually based on the destination
 			wildcard := net.AnyIP.IP()
 			if destAddr.IP.To4() == nil {
 				wildcard = net.AnyIPv6.IP()


### PR DESCRIPTION
The generic half I mentioned in #6624.

An outbound UDP socket with no sendThrough address is bound to the 0.0.0.0
wildcard. On most platforms that's fine: the runtime turns it into a
dual-stack socket on [::] (see ipToSockaddrInet6 in net/ipsock_posix.go), so
IPv6 destinations work anyway. OpenBSD and DragonFly have no IPv4-mapped
addresses at all, there the socket stays AF_INET and a send to an IPv6 peer
fails with "non-IPv4 address".

So bind the wildcard of the destination's own family instead: 0.0.0.0 for a
v4 destination, :: for a v6 one. On platforms with the mapping both wildcards
produce exactly the same dual-stack socket as before, nothing changes there.
The network string passed to ListenPacket is untouched too, so sockopt
controllers keep getting the same arguments.

Tested on OpenBSD 7.7/7.8/7.9 amd64: with this and #6624 the transparent
proxy handles IPv6 UDP (DNS, QUIC) end to end on a live router.