### PR TITLE
docs: remove dead WireGuard tutorial link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@
   - [REALITY (English)](https://cscot.pages.dev/2023/03/02/Xray-REALITY-tutorial/)
   - [XTLS-Iran-Reality (English)](https://github.com/SasukeFreestyle/XTLS-Iran-Reality)
   - [Xray REALITY with 'steal oneself' (English)](https://computerscot.github.io/vless-xtls-utls-reality-steal-oneself.html)
-  - [Xray with WireGuard inbound (English)](https://g800.pages.dev/wireguard)
 
 ## GUI Clients
 


### PR DESCRIPTION
Removes a dead tutorial link from the README:

- `https://g800.pages.dev/wireguard` ("Xray with WireGuard inbound (English)") → **HTTP 404**

The pages.dev site is gone, the GitHub account that added it (in c590163f) has been deleted, the Wayback Machine has no capture, and no relocated copy of the tutorial could be found — the document is unrecoverable.
