### PR TITLE
Config(reality): Interpret null value of dest and target as no value

### DIFF
--- a/infra/conf/transport_security.go
+++ b/infra/conf/transport_security.go
@@ -1,6 +1,7 @@
 package conf
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/hex"
@@ -59,7 +60,7 @@ func (c *REALITYConfig) Build() (proto.Message, error) {
 	if c.Target != nil {
 		c.Dest = c.Target
 	}
-	if c.Dest != nil {
+	if c.Dest != nil && !bytes.Equal(c.Dest, []byte("null")){
 		var i uint16
 		var s string
 		if err = json.Unmarshal(c.Dest, &i); err == nil {


### PR DESCRIPTION
Having no `target` value in `realitySettings` causes Xray to interpret the settings as client-side. Example config without `target`:
```json
{"outbounds": [
	{
		"protocol": "blackhole",
		"streamSettings": {
			"security": "reality",
			"realitySettings": {
				"password": "JqmkP6Fys7jN2Fu1iDJuWKVNPhlgHfy_pj1DHFVKVhw"
			}
		}
	}
]}
```
Works fine:
```
Xray 26.7.28 (Xray, Penetrates Everything.) Custom (go1.27.0-X:nodwarf5 linux/amd64)
A unified platform for anti-censorship.
2026/08/29 20:41:36.847225 [Info] infra/conf/serial: Reading config: &{Name:config.json Format:json}
2026/08/29 20:41:36.847766 [Warning] core: Xray 26.7.28 started
```
Setting `target` to `null` should have the same behaviour, but `null` is unmarshalled as bytes "null" instead of `nil` when parsing the JSON configuration, causing Xray core to interpret the settings as server-side and require parameters not used on the client:
```json
{"outbounds": [
	{
		"protocol": "blackhole",
		"streamSettings": {
			"security": "reality",
			"realitySettings": {
				"target": null,
				"password": "JqmkP6Fys7jN2Fu1iDJuWKVNPhlgHfy_pj1DHFVKVhw"
			}
		}
	}
]}
```
```
Xray 26.7.28 (Xray, Penetrates Everything.) Custom (go1.27.0-X:nodwarf5 linux/amd64)
A unified platform for anti-censorship.
2026/08/29 20:39:29.621612 [Info] infra/conf/serial: Reading config: &{Name:config.json Format:json}
Failed to start: main: failed to load config files: [config.json] > infra/conf: failed to build outbound config with tag  > infra/conf: failed to build stream settings for outbound detour > infra/conf: Failed to build REALITY config. > infra/conf: empty "serverNames"
exit status 23
```
All of the above applies to both `target` and `dest`, and this PR fixes the behaviour for both.