### PR TITLE
SS2022 outbound: Close connection to server on early returns

### DIFF
--- a/proxy/shadowsocks_2022/outbound.go
+++ b/proxy/shadowsocks_2022/outbound.go
@@ -82,6 +82,7 @@ func (o *Outbound) Process(ctx context.Context, link *transport.Link, dialer int
 	if err != nil {
 		return errors.New("failed to connect to server").Base(err)
 	}
+	defer connection.Close()
 
 	if session.TimeoutOnlyFromContext(ctx) {
 		ctx, _ = context.WithCancel(context.Background())


### PR DESCRIPTION
Process dials server but never closes connection. On normal path sing's
CopyConn cleanup handles it, but three returns before that (read payload,
write payload, client handshake) leave it open. First one only needs client
to hang up inside 100ms ReadMultiBufferTimeout, which returns io.EOF.

Every other outbound does defer conn.Close() right after dialing.