### PR TITLE
Sniffer: refactor HTTP

### DIFF
--- a/common/protocol/http/headers.go
+++ b/common/protocol/http/headers.go
@@ -65,13 +65,13 @@ func RemoveHopByHopHeaders(header http.Header) {
 // ParseHost splits host and port from a raw string. Default port is used when raw string doesn't contain port.
 func ParseHost(rawHost string, defaultPort net.Port) (net.Destination, error) {
 	port := defaultPort
+
 	host, rawPort, err := net.SplitHostPort(rawHost)
 	if err != nil {
-		if addrError, ok := err.(*net.AddrError); ok && strings.Contains(addrError.Err, "missing port") {
-			host = rawHost
-		} else {
+		if addrError, ok := err.(*net.AddrError); !ok || !strings.Contains(addrError.Err, "missing port") {
 			return net.Destination{}, err
 		}
+		host = rawHost
 	} else if len(rawPort) > 0 {
 		intPort, err := strconv.Atoi(rawPort)
 		if err != nil {
@@ -79,6 +79,8 @@ func ParseHost(rawHost string, defaultPort net.Port) (net.Destination, error) {
 		}
 		port = net.Port(intPort)
 	}
+
+	host = strings.ToLower(strings.TrimRight(host, "."))
 
 	return net.TCPDestination(net.ParseAddress(host), port), nil
 }

--- a/common/protocol/http/sniff.go
+++ b/common/protocol/http/sniff.go
@@ -39,79 +39,145 @@ func (h *SniffHeader) Domain() string {
 }
 
 var (
-	methods = [...]string{"get", "post", "head", "put", "delete", "options", "connect"}
-
-	errNotHTTPMethod = errors.New("not an HTTP method")
-)
-
-func beginWithHTTPMethod(b []byte) error {
-	for _, m := range &methods {
-		if len(b) >= len(m) && strings.EqualFold(string(b[:len(m)]), m) {
-			return nil
-		}
-
-		if len(b) < len(m) {
-			return common.ErrNoClue
-		}
+	methods = [...][]byte{
+		[]byte("GET"), []byte("POST"), []byte("HEAD"), []byte("PUT"),
+		[]byte("DELETE"), []byte("OPTIONS"), []byte("CONNECT"), []byte("PATCH"), []byte("TRACE"),
 	}
 
-	return errNotHTTPMethod
+	spaceByte     = []byte(" ")
+	newlineByte   = []byte("\n")
+	schemeSepByte = []byte("://")
+	crByte        = []byte("\r")
+	colonByte     = []byte(":")
+	hostKeyByte   = []byte("host")
+
+	errNotHTTP = errors.New("not an HTTP")
+)
+
+func isHTTPMethodPrefix(prefix []byte) bool {
+	for _, m := range methods {
+		if bytes.HasPrefix(m, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func isHTTPMethod(method []byte) bool {
+	for _, m := range methods {
+		if bytes.Equal(method, m) {
+			return true
+		}
+	}
+	return false
 }
 
 func SniffHTTP(b []byte, c context.Context) (*SniffHeader, error) {
 	content := session.ContentFromContext(c)
-	ShouldSniffAttr := true
 	// If content.Attributes have information, that means it comes from HTTP inbound PlainHTTP mode.
 	// It will set attributes, so skip it.
-	if content == nil || len(content.Attributes) != 0 {
-		ShouldSniffAttr = false
+	shouldSniffAttr := content != nil && len(content.Attributes) == 0
+
+	method, _, found := bytes.Cut(b, spaceByte)
+	switch {
+	case !found && isHTTPMethodPrefix(b):
+		return nil, common.ErrNoClue
+	case !found || !isHTTPMethod(method):
+		return nil, errNotHTTP
 	}
-	if err := beginWithHTTPMethod(b); err != nil {
-		return nil, err
+
+	req, afterReqLine, found := bytes.Cut(b, newlineByte)
+	if !found || len(req) < 14 {
+		return nil, common.ErrNoClue
+	}
+
+	_, rest, ok1 := bytes.Cut(req, spaceByte)
+	uri, _, ok2 := bytes.Cut(rest, spaceByte)
+	if !ok1 || !ok2 {
+		return nil, common.ErrNoClue
+	}
+	if len(uri) == 0 {
+		return nil, common.ErrNoClue
 	}
 
 	sh := &SniffHeader{
 		version: HTTP1,
 	}
 
-	headers := bytes.Split(b, []byte{'\n'})
-	for i := 1; i < len(headers); i++ {
-		header := headers[i]
-		if len(header) == 0 {
-			break
-		}
-		parts := bytes.SplitN(header, []byte{':'}, 2)
-		if len(parts) != 2 {
-			continue
-		}
-		key := strings.ToLower(string(parts[0]))
-		value := string(bytes.TrimSpace(parts[1]))
-		if ShouldSniffAttr {
-			content.SetAttribute(key, value) // Put header in attribute
-		}
-		if key == "host" {
-			rawHost := strings.ToLower(value)
-			dest, err := ParseHost(rawHost, net.Port(80))
-			if err != nil {
-				return nil, err
-			}
-			sh.host = dest.Address.String()
-		}
-	}
 	// Parse request line
 	// Request line is like this
 	// "GET /homo/114514 HTTP/1.1"
-	if len(headers) > 0 && ShouldSniffAttr {
-		RequestLineParts := bytes.Split(headers[0], []byte{' '})
-		if len(RequestLineParts) == 3 {
-			content.SetAttribute(":method", string(RequestLineParts[0]))
-			content.SetAttribute(":path", string(RequestLineParts[1]))
+	if shouldSniffAttr {
+		content.SetAttribute(":method", string(method))
+		if uri[0] == '/' {
+			content.SetAttribute(":path", string(uri))
 		}
 	}
 
-	if len(sh.host) > 0 {
-		return sh, nil
+	if uri[0] != '/' && uri[0] != '*' {
+		if _, afterScheme, found := bytes.Cut(uri, schemeSepByte); found {
+			uri = afterScheme
+		}
+
+		var path string
+		if i := bytes.IndexAny(uri, "/?#"); i >= 0 {
+			path = string(uri[i:])
+			if path[0] != '/' {
+				path = "/" + path
+			}
+			uri = uri[:i]
+		} else {
+			path = "/"
+		}
+		if shouldSniffAttr {
+			content.SetAttribute(":path", path)
+		}
+
+		if i := bytes.LastIndexByte(uri, '@'); i >= 0 {
+			uri = uri[i+1:]
+		}
+
+		if host, ok := sniffHost(uri); ok {
+			sh.host = host
+		}
 	}
 
-	return nil, common.ErrNoClue
+	rest = afterReqLine
+	for {
+		line, tail, found := bytes.Cut(rest, newlineByte)
+		line = bytes.TrimSuffix(line, crByte)
+		if !found || len(line) == 0 {
+			break
+		}
+		rest = tail
+
+		key, value, found := bytes.Cut(line, colonByte)
+		if !found {
+			continue
+		}
+
+		value = bytes.TrimSpace(value)
+		if sh.host == "" && bytes.EqualFold(key, hostKeyByte) {
+			if host, ok := sniffHost(value); ok {
+				sh.host = host
+			}
+		}
+		if shouldSniffAttr {
+			content.SetAttribute(strings.ToLower(string(key)), string(value)) // Put header in attribute
+		}
+	}
+
+	if sh.host == "" {
+		return nil, common.ErrNoClue
+	}
+
+	return sh, nil
+}
+
+func sniffHost(raw []byte) (string, bool) {
+	dest, err := ParseHost(string(raw), net.Port(80))
+	if err != nil {
+		return "", false
+	}
+	return dest.Address.String(), true
 }

--- a/common/protocol/http/sniff_test.go
+++ b/common/protocol/http/sniff_test.go
@@ -86,6 +86,51 @@ first_name=John&last_name=Doe&action=Submit`,
 			domain: "",
 			err:    true,
 		},
+		{
+			input:  "GET http://example.com HTTP/1.1\r\nHost: test.example.com\r\n\r\n",
+			domain: "example.com",
+		},
+		{
+			input:  "GET http://example.com/some/path HTTP/1.1\r\nHost: test.example.com\r\n\r\n",
+			domain: "example.com",
+		},
+		{
+			input:  "GET http://example.com?x=1 HTTP/1.1\r\nHost: test.example.com\r\n\r\n",
+			domain: "example.com",
+		},
+		{
+			input:  "GET http://example.com#frag HTTP/1.1\r\nHost: test.example.com\r\n\r\n",
+			domain: "example.com",
+		},
+		{
+			input:  "GET http://example.com:443/path HTTP/1.1\r\nContent-Type: text/html\r\n\r\n",
+			domain: "example.com",
+		},
+		{
+			input:  "CONNECT example.com:443 HTTP/1.1\r\nHost: test.example.com\r\n\r\n",
+			domain: "example.com",
+		},
+		{
+			input:  "OPTIONS * HTTP/1.1\r\nHost: test.example.com\r\n\r\n",
+			domain: "test.example.com",
+		},
+		{
+			input:  "get /path HTTP/1.1\r\nHost: test.example.com\r\n\r\n",
+			domain: "",
+			err:    true,
+		},
+		{
+			input:  "GET / HTTP/1.1\r\nHost: [1EeT:S2:A2:tTt::1]:8080\r\n\r\n",
+			domain: "1eet:s2:a2:ttt::1",
+		},
+		{
+			input:  "GET / HTTP/1.1\r\nHost: example.com.\r\n\r\n",
+			domain: "example.com",
+		},
+		{
+			input:  "GET http://chicken:leg@example.com/path HTTP/1.1\r\nHost: test.example.com\r\n\r\n",
+			domain: "example.com",
+		},
 	}
 
 	for _, test := range cases {
@@ -97,6 +142,7 @@ first_name=John&last_name=Doe&action=Submit`,
 		} else {
 			if err != nil {
 				t.Errorf("Expect no error but actually %s in test %v", err.Error(), test)
+				continue
 			}
 			if header.Domain() != test.domain {
 				t.Error("expected domain ", test.domain, " but got ", header.Domain())


### PR DESCRIPTION
### Changes:
- If the request line uses `absolute-form` or `authority-form`, the sniffer now attempts to extract the Host from the URI. Fallback to the Host header otherwise..
- `PATCH` and `TRACE` methods are now recognized.
- The `:path` attribute can now be populated from more sources. I also considered stripping `?` and `#`, but it turns out attribute value matching in routing rules uses regexp, so users can already configure this flexibly on their own.
- A few minor fixes for more correct sniffing overall.

Tests were added for the new changes. Existing tests were left untouched, even though they use `\n` instead of `\r\n`. There was also a bug in the test file where, on failure, it would call a method on a variable that was nil