### PR TITLE
Hysteria server: Fix Unix masquerade socket path

### DIFF
--- a/transport/internet/hysteria/hub.go
+++ b/transport/internet/hysteria/hub.go
@@ -231,8 +231,8 @@ func Listen(ctx context.Context, address net.Address, port net.Port, streamSetti
 				transport.TLSClientConfig.InsecureSkipVerify = true
 			}
 		case "", "unix":
-			u = &url.URL{Scheme: "http", Host: "localhost"}
 			path := u.Path
+			u = &url.URL{Scheme: "http", Host: "localhost"}
 			dialer := &net.Dialer{Timeout: 30 * time.Second}
 			transport = transport.Clone()
 			transport.Proxy = nil


### PR DESCRIPTION
## Problem

The current Xray code handles Unix-socket targets in the following order:

```go
case "", "unix":
    u = &url.URL{Scheme: "http", Host: "localhost"}
    path := u.Path

    dialer := &net.Dialer{Timeout: 30 * time.Second}
    transport = transport.Clone()
    transport.Proxy = nil
    transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
        return dialer.DialContext(ctx, "unix", path)
    }
```

The original parsed URL is overwritten before its path is saved:

```go
u = &url.URL{Scheme: "http", Host: "localhost"}
```

The replacement URL has an empty `Path`, so the next assignment always produces:

```go
path == ""
```

Consequently, the custom transport effectively attempts:

```go
dialer.DialContext(ctx, "unix", "")
```

On Linux, this fails with an error similar to:

```text
dial unix: missing address
```

The Hysteria masquerade handler then returns `502 Bad Gateway`, while Xray logs:

```text
HTTP reverse proxy error
```

This affects all supported Unix-socket target formats, not just one particular URL form, because the parsed socket path is discarded in every case.

## Upstream behavior

In the [upstream Hysteria implementation](https://github.com/HyNetworks/hysteria/commit/f06fda470922d69bcd176c74bfe12f7f380c595a), the socket path is saved before constructing the synthetic HTTP target:

```go
socketPath := parsedURL.Path
```

Only after that does it return the target used by `httputil.ReverseProxy`:

```go
return &url.URL{
    Scheme: "http",
    Host:   "localhost",
}, transport, nil
```

The custom transport therefore captures the original socket path:

```go
transport.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
    return dialer.DialContext(ctx, "unix", socketPath)
}
```

The incorrect ordering was introduced while adapting this logic in #6565 it is not caused by the upstream Hysteria implementation.

## Fix

Save `u.Path` before replacing `u` with the synthetic `http://localhost` target:

```go
case "", "unix":
    path := u.Path
    u = &url.URL{Scheme: "http", Host: "localhost"}
```

This preserves the original Unix socket address while leaving HTTP and HTTPS masquerade behavior unchanged.