### PR TITLE
fix(proxy): synchronize Vision TLS classification

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -13,6 +13,8 @@ import (
 	"math/big"
 	"runtime"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pires/go-proxyproto"
@@ -102,6 +104,11 @@ type GetOutbound interface {
 // TrafficState is used to track uplink and downlink of one connection
 // It is used by XTLS to determine if switch to raw copy mode, It is used by Vision to calculate padding
 type TrafficState struct {
+	// TLS classification is shared by the concurrent Vision reader and writer.
+	// Keep the mutable phase serialized and publish an immutable final snapshot
+	// so established connections avoid a mutex on the data path.
+	filterAccess           sync.Mutex
+	finalTLSState          atomic.Pointer[trafficStateSnapshot]
 	UserUUID               []byte
 	NumberOfPacketToFilter int
 	EnableXtls             bool
@@ -111,6 +118,55 @@ type TrafficState struct {
 	RemainingServerHello   int32
 	Inbound                InboundState
 	Outbound               OutboundState
+}
+
+type trafficStateSnapshot struct {
+	numberOfPacketToFilter int
+	enableXtls             bool
+	isTLS12orAbove         bool
+	isTLS                  bool
+}
+
+func (s *TrafficState) snapshotLocked() trafficStateSnapshot {
+	return trafficStateSnapshot{
+		numberOfPacketToFilter: s.NumberOfPacketToFilter,
+		enableXtls:             s.EnableXtls,
+		isTLS12orAbove:         s.IsTLS12orAbove,
+		isTLS:                  s.IsTLS,
+	}
+}
+
+func (s *TrafficState) publishFinalTLSStateLocked(snapshot trafficStateSnapshot) {
+	if snapshot.numberOfPacketToFilter <= 0 {
+		s.finalTLSState.Store(&snapshot)
+	} else {
+		s.finalTLSState.Store(nil)
+	}
+}
+
+func (s *TrafficState) isFilteringTLS() bool {
+	if s.finalTLSState.Load() != nil {
+		return false
+	}
+	s.filterAccess.Lock()
+	defer s.filterAccess.Unlock()
+	snapshot := s.snapshotLocked()
+	s.publishFinalTLSStateLocked(snapshot)
+	return snapshot.numberOfPacketToFilter > 0
+}
+
+func (s *TrafficState) filterTLSIfNeeded(buffer buf.MultiBuffer, ctx context.Context) trafficStateSnapshot {
+	if snapshot := s.finalTLSState.Load(); snapshot != nil {
+		return *snapshot
+	}
+	s.filterAccess.Lock()
+	defer s.filterAccess.Unlock()
+	if s.NumberOfPacketToFilter > 0 {
+		xtlsFilterTLS(buffer, s, ctx)
+	}
+	snapshot := s.snapshotLocked()
+	s.publishFinalTLSStateLocked(snapshot)
+	return snapshot
 }
 
 type InboundState struct {
@@ -232,7 +288,7 @@ func (w *VisionReader) ReadMultiBuffer() (buf.MultiBuffer, error) {
 		return buffer, err
 	}
 
-	if *withinPaddingBuffers || w.trafficState.NumberOfPacketToFilter > 0 {
+	if *withinPaddingBuffers || w.trafficState.isFilteringTLS() {
 		mb2 := make(buf.MultiBuffer, 0, len(buffer))
 		for _, b := range buffer {
 			newbuffer := XtlsUnpadding(b, w.trafficState, w.isUplink, w.ctx)
@@ -252,9 +308,7 @@ func (w *VisionReader) ReadMultiBuffer() (buf.MultiBuffer, error) {
 			errors.LogDebug(w.ctx, "XtlsRead unknown command ", *currentCommand, buffer.Len())
 		}
 	}
-	if w.trafficState.NumberOfPacketToFilter > 0 {
-		XtlsFilterTls(buffer, w.trafficState, w.ctx)
-	}
+	w.trafficState.filterTLSIfNeeded(buffer, w.ctx)
 
 	if *switchToDirectCopy {
 		// XTLS Vision processes TLS-like conn's input and rawInput
@@ -349,9 +403,7 @@ func (w *VisionWriter) WriteMultiBuffer(mb buf.MultiBuffer) error {
 		w.directWriteCounter.Add(int64(mb.Len()))
 	}
 
-	if w.trafficState.NumberOfPacketToFilter > 0 {
-		XtlsFilterTls(mb, w.trafficState, w.ctx)
-	}
+	tlsState := w.trafficState.filterTLSIfNeeded(mb, w.ctx)
 
 	if *isPadding {
 		if len(mb) == 1 && mb[0] == nil {
@@ -359,16 +411,16 @@ func (w *VisionWriter) WriteMultiBuffer(mb buf.MultiBuffer) error {
 		} else {
 			isComplete := IsCompleteRecord(mb)
 			mb = ReshapeMultiBuffer(w.ctx, mb)
-			longPadding := w.trafficState.IsTLS
+			longPadding := tlsState.isTLS
 			for i, b := range mb {
-				if w.trafficState.IsTLS && b.Len() >= 6 && bytes.Equal(TlsApplicationDataStart, b.BytesTo(3)) && isComplete {
-					if w.trafficState.EnableXtls {
+				if tlsState.isTLS && b.Len() >= 6 && bytes.Equal(TlsApplicationDataStart, b.BytesTo(3)) && isComplete {
+					if tlsState.enableXtls {
 						*switchToDirectCopy = true
 					}
 					var command byte = CommandPaddingContinue
 					if i == len(mb)-1 {
 						command = CommandPaddingEnd
-						if w.trafficState.EnableXtls {
+						if tlsState.enableXtls {
 							command = CommandPaddingDirect
 						}
 					}
@@ -376,7 +428,7 @@ func (w *VisionWriter) WriteMultiBuffer(mb buf.MultiBuffer) error {
 					*isPadding = false // padding going to end
 					longPadding = false
 					continue
-				} else if !w.trafficState.IsTLS12orAbove && w.trafficState.NumberOfPacketToFilter <= 1 { // For compatibility with earlier vision receiver, we finish padding 1 packet early
+				} else if !tlsState.isTLS12orAbove && tlsState.numberOfPacketToFilter <= 1 { // For compatibility with earlier vision receiver, we finish padding 1 packet early
 					*isPadding = false
 					mb[i] = XtlsPadding(b, CommandPaddingEnd, &w.writeOnceUserUUID, longPadding, w.ctx, w.testseed)
 					break
@@ -384,7 +436,7 @@ func (w *VisionWriter) WriteMultiBuffer(mb buf.MultiBuffer) error {
 				var command byte = CommandPaddingContinue
 				if i == len(mb)-1 && !*isPadding {
 					command = CommandPaddingEnd
-					if w.trafficState.EnableXtls {
+					if tlsState.enableXtls {
 						command = CommandPaddingDirect
 					}
 				}
@@ -617,6 +669,13 @@ func XtlsUnpadding(b *buf.Buffer, s *TrafficState, isUplink bool, ctx context.Co
 
 // XtlsFilterTls filter and recognize tls 1.3 and other info
 func XtlsFilterTls(buffer buf.MultiBuffer, trafficState *TrafficState, ctx context.Context) {
+	trafficState.filterAccess.Lock()
+	defer trafficState.filterAccess.Unlock()
+	xtlsFilterTLS(buffer, trafficState, ctx)
+	trafficState.publishFinalTLSStateLocked(trafficState.snapshotLocked())
+}
+
+func xtlsFilterTLS(buffer buf.MultiBuffer, trafficState *TrafficState, ctx context.Context) {
 	for _, b := range buffer {
 		if b == nil {
 			continue

--- a/proxy/vision_concurrency_test.go
+++ b/proxy/vision_concurrency_test.go
@@ -1,0 +1,89 @@
+package proxy
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/xtls/xray-core/common/buf"
+)
+
+func TestVisionTrafficStateConcurrentPacketFiltering(t *testing.T) {
+	state := NewTrafficState(make([]byte, 16))
+	state.NumberOfPacketToFilter = 1 << 30
+	state.Outbound.IsPadding = false
+	writer := NewVisionWriter(buf.NewWriter(io.Discard), state, true, context.Background(), nil, nil, nil)
+
+	start := make(chan struct{})
+	var workers sync.WaitGroup
+	workers.Add(2)
+	go func() {
+		defer workers.Done()
+		<-start
+		for range 10_000 {
+			buffer := buf.New()
+			_, _ = buffer.Write([]byte{0})
+			if err := writer.WriteMultiBuffer(buf.MultiBuffer{buffer}); err != nil {
+				t.Errorf("Vision writer: %v", err)
+				return
+			}
+		}
+	}()
+	go func() {
+		defer workers.Done()
+		<-start
+		for range 10_000 {
+			buffer := buf.New()
+			_, _ = buffer.Write([]byte{0})
+			multiBuffer := buf.MultiBuffer{buffer}
+			XtlsFilterTls(multiBuffer, state, context.Background())
+			buf.ReleaseMulti(multiBuffer)
+		}
+	}()
+	close(start)
+	workers.Wait()
+	if got, want := state.NumberOfPacketToFilter, (1<<30)-20_000; got != want {
+		t.Fatalf("NumberOfPacketToFilter = %d, want %d", got, want)
+	}
+}
+
+func TestVisionTrafficStateConcurrentTLSClassification(t *testing.T) {
+	state := NewTrafficState(make([]byte, 16))
+	serverHello := make([]byte, 90)
+	copy(serverHello, TlsServerHandShakeStart)
+	serverHello[4] = 85
+	serverHello[5] = TlsHandshakeTypeServerHello
+	serverHello[43] = 0
+	serverHello[44] = 0x13
+	serverHello[45] = 0x01
+	copy(serverHello[50:], Tls13SupportedVersions)
+
+	start := make(chan struct{})
+	var workers sync.WaitGroup
+	for range 2 {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			<-start
+			for range 100 {
+				buffer := buf.New()
+				_, _ = buffer.Write(serverHello)
+				multiBuffer := buf.MultiBuffer{buffer}
+				XtlsFilterTls(multiBuffer, state, context.Background())
+				buf.ReleaseMulti(multiBuffer)
+			}
+		}()
+	}
+	close(start)
+	workers.Wait()
+	if !state.IsTLS || !state.IsTLS12orAbove || !state.EnableXtls {
+		t.Fatalf("unexpected TLS classification: IsTLS=%t IsTLS12orAbove=%t EnableXtls=%t", state.IsTLS, state.IsTLS12orAbove, state.EnableXtls)
+	}
+	if got, want := state.Cipher, uint16(0x1301); got != want {
+		t.Fatalf("Cipher = %#x, want %#x", got, want)
+	}
+	if got := state.RemainingServerHello; got != 0 {
+		t.Fatalf("RemainingServerHello = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
## Summary

- serialize mutable TLS classification shared by the concurrent Vision reader and writer
- publish an immutable final snapshot for the established data path
- add concurrent packet-filtering and TLS-classification regression tests

## Problem

`VisionReader` and `VisionWriter` operate concurrently on the same `TrafficState`. Both paths read and update the packet counter and TLS classification fields without synchronization. The race detector reports conflicting accesses, and the writer can observe a mixture of classifier states while deciding padding and direct-copy behavior.

## Implementation

The mutable classification phase is protected by a mutex. Once classification finishes, a coherent immutable snapshot is published atomically, so established connections do not take the mutex on the data path. The exported `XtlsFilterTls` entry point uses the same synchronization.

## Validation

- `go vet ./proxy`
- `go test ./proxy/... -count=1`
- `go test -race ./proxy -run '^TestVisionTrafficStateConcurrent' -count=100`
- `go test -race ./testing/scenarios -run '^TestVlessXtlsVision$' -count=1`
- `go test -race ./testing/scenarios -run '^TestVlessXtlsVisionReality$' -count=1`