### PR TITLE
XHTTP server: Add IdleTimeout to close abandoned carrier connections

### DIFF
--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -572,6 +572,7 @@ func ListenXH(ctx context.Context, address net.Address, port net.Port, streamSet
 		l.server = http.Server{
 			Handler:           handler,
 			ReadHeaderTimeout: time.Second * 4,
+			IdleTimeout:       time.Minute * 5,
 			MaxHeaderBytes:    l.config.GetNormalizedServerMaxHeaderBytes(),
 			Protocols:         protocols,
 		}


### PR DESCRIPTION
The XHTTP http.Server only sets ReadHeaderTimeout, so carrier connections whose streams have ended are kept open forever. Since ListenSystem disables TCP keepalive by default, a peer that vanishes without FIN/RST never triggers a read error and the connection stays ESTABLISHED, leaking fds and memory.

connIdle already closes the dead stream; IdleTimeout closes the then-empty connection. Clients handle this transparently, same as behind nginx/CDN. h3 unaffected.

Closes #6684.