### PR TITLE
geodata: cache loaded entries and drop forced GCs on startup

### DIFF
--- a/common/geodata/domain_registry.go
+++ b/common/geodata/domain_registry.go
@@ -34,6 +34,8 @@ func (r *DomainRegistry) Reload() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	ResetEntryCache()
+
 	var matchers []*DynamicDomainMatcher
 	r.matchers.Range(func(_ uuid.UUID, matcher *DynamicDomainMatcher) bool {
 		matchers = append(matchers, matcher)

--- a/common/geodata/geodat_loader.go
+++ b/common/geodata/geodat_loader.go
@@ -4,35 +4,56 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"runtime"
 	"strings"
 
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/platform/filesystem"
+	"github.com/xtls/xray-core/common/utils"
 
 	"google.golang.org/protobuf/proto"
 )
 
-func checkFile(file, code string) error {
-	r, err := filesystem.OpenAsset(file)
-	if err != nil {
-		return errors.New("failed to open ", file).Base(err)
-	}
-	defer r.Close()
-	if _, err := find(r, []byte(code), false); err != nil {
-		return errors.New("failed to check code ", code, " from ", file).Base(err)
-	}
-	return nil
+// entryCache caches the raw protobuf bytes of a single GeoIP/GeoSite entry,
+// keyed by file name and entry code. A config usually references the same .dat
+// file from many ext: rules; without this cache every rule triggers a full
+// linear scan of the file (tens of MB) both at parse time (checkFile) and at
+// matcher build time (loadIP/loadSite).
+var entryCache = utils.NewWeakCacheMap[string, []byte]()
+
+// ResetEntryCache drops all cached GeoIP/GeoSite entries. It must be called
+// when the .dat files are reloaded (see app/geodata) so a swapped file is
+// picked up instead of serving stale cached entries.
+func ResetEntryCache() {
+	entryCache = utils.NewWeakCacheMap[string, []byte]()
 }
 
-func loadFile(file, code string) ([]byte, error) {
-	runtime.GC() // peak mem
+func loadEntry(file, code string) ([]byte, error) {
+	key := file + "\x00" + code
+	if bs, ok := entryCache.Load(key); ok {
+		return *bs, nil
+	}
 	r, err := filesystem.OpenAsset(file)
 	if err != nil {
 		return nil, errors.New("failed to open ", file).Base(err)
 	}
 	defer r.Close()
 	bs, err := find(r, []byte(code), true)
+	if err != nil {
+		return nil, err
+	}
+	entryCache.Store(key, &bs)
+	return bs, nil
+}
+
+func checkFile(file, code string) error {
+	if _, err := loadEntry(file, code); err != nil {
+		return errors.New("failed to check code ", code, " from ", file).Base(err)
+	}
+	return nil
+}
+
+func loadFile(file, code string) ([]byte, error) {
+	bs, err := loadEntry(file, code)
 	if err != nil {
 		return nil, errors.New("failed to load code ", code, " from ", file).Base(err)
 	}
@@ -44,7 +65,6 @@ func loadIP(file, code string) ([]*CIDR, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer runtime.GC() // peak mem
 	var geoip GeoIP
 	if err := proto.Unmarshal(bs, &geoip); err != nil {
 		return nil, errors.New("error unmarshal IP in ", file, ":", code).Base(err)
@@ -57,7 +77,6 @@ func loadSite(file, code string) ([]*Domain, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer runtime.GC() // peak mem
 	var geosite GeoSite
 	if err := proto.Unmarshal(bs, &geosite); err != nil {
 		return nil, errors.New("error unmarshal Site in ", file, ":", code).Base(err)

--- a/common/geodata/geodat_loader.go
+++ b/common/geodata/geodat_loader.go
@@ -14,17 +14,29 @@ import (
 )
 
 // entryCache caches the raw protobuf bytes of a single GeoIP/GeoSite entry,
-// keyed by file name and entry code. A config usually references the same .dat
-// file from many ext: rules; without this cache every rule triggers a full
-// linear scan of the file (tens of MB) both at parse time (checkFile) and at
-// matcher build time (loadIP/loadSite).
-var entryCache = utils.NewWeakCacheMap[string, []byte]()
+// keyed by file name and entry code. fileIndexCache caches, per file, a map of
+// entry code to its byte range within the file, built with a single pass over
+// the file. Together they turn the previous per-rule behavior (a full linear
+// scan of the .dat file per referenced code, both at parse time via checkFile
+// and at matcher build time via loadIP/loadSite) into one read and one scan
+// per file, with each referenced entry read from disk at most once.
+var (
+	entryCache     = utils.NewWeakCacheMap[string, []byte]()
+	fileIndexCache = utils.NewWeakCacheMap[string, map[string]entryRef]()
+)
 
-// ResetEntryCache drops all cached GeoIP/GeoSite entries. It must be called
-// when the .dat files are reloaded (see app/geodata) so a swapped file is
-// picked up instead of serving stale cached entries.
+// entryRef locates one GeoIP/GeoSite entry within its .dat file.
+type entryRef struct {
+	off    int64
+	length int64
+}
+
+// ResetEntryCache drops all cached GeoIP/GeoSite entries and file indexes. It
+// must be called when the .dat files are reloaded (see app/geodata) so a
+// swapped file is picked up instead of serving stale cached entries.
 func ResetEntryCache() {
 	entryCache = utils.NewWeakCacheMap[string, []byte]()
+	fileIndexCache = utils.NewWeakCacheMap[string, map[string]entryRef]()
 }
 
 func loadEntry(file, code string) ([]byte, error) {
@@ -32,17 +44,113 @@ func loadEntry(file, code string) ([]byte, error) {
 	if bs, ok := entryCache.Load(key); ok {
 		return *bs, nil
 	}
-	r, err := filesystem.OpenAsset(file)
+	idx, err := indexFile(file)
 	if err != nil {
-		return nil, errors.New("failed to open ", file).Base(err)
+		return nil, err
 	}
-	defer r.Close()
-	bs, err := find(r, []byte(code), true)
+	ref, ok := idx[code]
+	if !ok {
+		return nil, io.EOF
+	}
+	bs, err := readEntry(file, code, ref)
 	if err != nil {
 		return nil, err
 	}
 	entryCache.Store(key, &bs)
 	return bs, nil
+}
+
+// indexFile builds a code->entry index for a .dat file in a single streaming
+// pass. Only a small prefix of each entry is read; the rest is discarded, so
+// the transient memory cost stays tiny.
+func indexFile(file string) (map[string]entryRef, error) {
+	if m, ok := fileIndexCache.Load(file); ok {
+		return *m, nil
+	}
+	r, err := filesystem.OpenAsset(file)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	br := bufio.NewReaderSize(r, 64*1024)
+
+	// maxCodeLen bounds the entry-code prefix buffer. Real v2ray/XTLS .dat
+	// entry codes are short; a longer code just means the entry is skipped
+	// from the index (it would not have matched find() for any queried code
+	// shorter than the buffer either).
+	const maxCodeLen = 64
+	head := make([]byte, 2+maxCodeLen)
+
+	m := make(map[string]entryRef)
+	var pos int64
+	for {
+		if _, err := br.ReadByte(); err != nil { // field tag
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		bodyL, n, err := decodeVarintCount(br)
+		if err != nil {
+			return nil, err
+		}
+		if bodyL <= 0 {
+			return nil, errors.New("invalid body length: ", bodyL)
+		}
+		if uint64(int64(^uint64(0)>>1)) < bodyL {
+			return nil, io.ErrUnexpectedEOF
+		}
+		bl := int64(bodyL)
+
+		need := int(bl)
+		if need > len(head) {
+			need = len(head)
+		}
+		codeLen := 0
+		if _, err := io.ReadFull(br, head[:need]); err != nil {
+			return nil, err
+		}
+		if need >= 2 && 2+int(head[1]) <= need {
+			codeLen = int(head[1])
+		}
+		if rest := int(bl) - need; rest > 0 {
+			if _, err := br.Discard(rest); err != nil {
+				return nil, err
+			}
+		}
+		pos += 1 + int64(n) + bl
+
+		if codeLen > 0 {
+			code := string(head[2 : 2+codeLen])
+			if _, exists := m[code]; !exists {
+				m[code] = entryRef{off: pos - bl, length: bl}
+			}
+		}
+	}
+	if len(m) == 0 {
+		return nil, errors.New("no entries found in file")
+	}
+	fileIndexCache.Store(file, &m)
+	return m, nil
+}
+
+// readEntry returns the raw bytes of the entry at ref. It prefers a random
+// access read (the asset file is an *os.File); otherwise it falls back to the
+// streaming scan.
+func readEntry(file, code string, ref entryRef) ([]byte, error) {
+	r, err := filesystem.OpenAsset(file)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	if ra, ok := r.(io.ReaderAt); ok {
+		bs := make([]byte, ref.length)
+		if _, err := ra.ReadAt(bs, ref.off); err != nil {
+			return nil, err
+		}
+		return bs, nil
+	}
+	return find(r, []byte(code), true)
 }
 
 func checkFile(file, code string) error {
@@ -98,6 +206,23 @@ func decodeVarint(br *bufio.Reader) (uint64, error) {
 	}
 	// The number is too large to represent in a 64-bit value.
 	return 0, errors.New("varint overflow")
+}
+
+// decodeVarintCount decodes a protobuf varint from a buffered reader, also
+// returning the number of bytes consumed.
+func decodeVarintCount(br *bufio.Reader) (uint64, int64, error) {
+	var x uint64
+	for shift := uint(0); shift < 64; shift += 7 {
+		b, err := br.ReadByte()
+		if err != nil {
+			return 0, 0, err
+		}
+		x |= (uint64(b) & 0x7F) << shift
+		if (b & 0x80) == 0 {
+			return x, int64(shift/7 + 1), nil
+		}
+	}
+	return 0, 0, errors.New("varint overflow")
 }
 
 func find(r io.Reader, code []byte, readBody bool) ([]byte, error) {

--- a/common/geodata/geodat_loader.go
+++ b/common/geodata/geodat_loader.go
@@ -1,29 +1,25 @@
 package geodata
 
 import (
-	"bufio"
-	"bytes"
 	"io"
 	"strings"
+	"sync"
 
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/platform/filesystem"
-	"github.com/xtls/xray-core/common/utils"
 
 	"google.golang.org/protobuf/proto"
 )
 
-// entryCache caches the raw protobuf bytes of a single GeoIP/GeoSite entry,
-// keyed by file name and entry code. fileIndexCache caches, per file, a map of
-// entry code to its byte range within the file, built with a single pass over
-// the file. Together they turn the previous per-rule behavior (a full linear
-// scan of the .dat file per referenced code, both at parse time via checkFile
-// and at matcher build time via loadIP/loadSite) into one read and one scan
-// per file, with each referenced entry read from disk at most once.
-var (
-	entryCache     = utils.NewWeakCacheMap[string, []byte]()
-	fileIndexCache = utils.NewWeakCacheMap[string, map[string]entryRef]()
-)
+// cachedFile holds the raw bytes of a .dat file and an index of its entries.
+// The whole file is read sequentially once and kept in memory; entries are
+// served as zero-copy slices of it. On routers with slow flash, a single
+// sequential read per file is far cheaper than re-reading (random) entry
+// ranges or re-scanning the file for every referenced code.
+type cachedFile struct {
+	data  []byte
+	index map[string]entryRef
+}
 
 // entryRef locates one GeoIP/GeoSite entry within its .dat file.
 type entryRef struct {
@@ -31,126 +27,99 @@ type entryRef struct {
 	length int64
 }
 
-// ResetEntryCache drops all cached GeoIP/GeoSite entries and file indexes. It
-// must be called when the .dat files are reloaded (see app/geodata) so a
-// swapped file is picked up instead of serving stale cached entries.
+// geoDataCache maps a .dat file name to its cached bytes and index.
+var geoDataCache sync.Map
+
+// ResetEntryCache drops all cached .dat files. It must be called when the
+// .dat files are reloaded (see app/geodata) so a swapped file is picked up
+// instead of serving stale cached entries.
 func ResetEntryCache() {
-	entryCache = utils.NewWeakCacheMap[string, []byte]()
-	fileIndexCache = utils.NewWeakCacheMap[string, map[string]entryRef]()
+	geoDataCache = sync.Map{}
 }
 
-func loadEntry(file, code string) ([]byte, error) {
-	key := file + "\x00" + code
-	if bs, ok := entryCache.Load(key); ok {
-		return *bs, nil
-	}
-	idx, err := indexFile(file)
-	if err != nil {
-		return nil, err
-	}
-	ref, ok := idx[code]
-	if !ok {
-		return nil, io.EOF
-	}
-	bs, err := readEntry(file, code, ref)
-	if err != nil {
-		return nil, err
-	}
-	entryCache.Store(key, &bs)
-	return bs, nil
-}
-
-// indexFile builds a code->entry index for a .dat file in a single streaming
-// pass. Only a small prefix of each entry is read; the rest is discarded, so
-// the transient memory cost stays tiny.
-func indexFile(file string) (map[string]entryRef, error) {
-	if m, ok := fileIndexCache.Load(file); ok {
-		return *m, nil
+func getCachedFile(file string) (*cachedFile, error) {
+	if v, ok := geoDataCache.Load(file); ok {
+		return v.(*cachedFile), nil
 	}
 	r, err := filesystem.OpenAsset(file)
 	if err != nil {
 		return nil, err
 	}
-	defer r.Close()
-	br := bufio.NewReaderSize(r, 64*1024)
+	data, err := io.ReadAll(r)
+	r.Close()
+	if err != nil {
+		return nil, err
+	}
+	index, err := buildIndex(data)
+	if err != nil {
+		return nil, err
+	}
+	cf := &cachedFile{data: data, index: index}
+	if v, ok := geoDataCache.LoadOrStore(file, cf); ok {
+		return v.(*cachedFile), nil
+	}
+	return cf, nil
+}
 
-	// maxCodeLen bounds the entry-code prefix buffer. Real v2ray/XTLS .dat
-	// entry codes are short; a longer code just means the entry is skipped
-	// from the index (it would not have matched find() for any queried code
-	// shorter than the buffer either).
-	const maxCodeLen = 64
-	head := make([]byte, 2+maxCodeLen)
+func loadEntry(file, code string) ([]byte, error) {
+	cf, err := getCachedFile(file)
+	if err != nil {
+		return nil, err
+	}
+	ref, ok := cf.index[code]
+	if !ok {
+		return nil, io.EOF
+	}
+	return cf.data[ref.off : ref.off+ref.length], nil
+}
 
+// buildIndex scans a .dat file in memory and records the byte range of every
+// entry whose code (first string field) is well-formed. The first occurrence
+// of a code wins, matching the previous find() behavior.
+func buildIndex(data []byte) (map[string]entryRef, error) {
 	m := make(map[string]entryRef)
-	var pos int64
-	for {
-		if _, err := br.ReadByte(); err != nil { // field tag
-			if err == io.EOF {
-				break
-			}
-			return nil, err
-		}
-		bodyL, n, err := decodeVarintCount(br)
+	for pos := 0; pos < len(data); {
+		pos++ // skip field tag byte
+		v, n, err := readVarint(data[pos:])
 		if err != nil {
 			return nil, err
 		}
-		if bodyL <= 0 {
-			return nil, errors.New("invalid body length: ", bodyL)
-		}
-		if uint64(int64(^uint64(0)>>1)) < bodyL {
+		pos += n
+		if v <= 0 || pos+int(v) > len(data) {
 			return nil, io.ErrUnexpectedEOF
 		}
-		bl := int64(bodyL)
-
-		need := int(bl)
-		if need > len(head) {
-			need = len(head)
-		}
-		codeLen := 0
-		if _, err := io.ReadFull(br, head[:need]); err != nil {
-			return nil, err
-		}
-		if need >= 2 && 2+int(head[1]) <= need {
-			codeLen = int(head[1])
-		}
-		if rest := int(bl) - need; rest > 0 {
-			if _, err := br.Discard(rest); err != nil {
-				return nil, err
+		payload := data[pos : pos+int(v)]
+		if len(payload) >= 2 && int(payload[1]) <= len(payload)-2 {
+			code := string(payload[2 : 2+int(payload[1])])
+			if code != "" {
+				if _, exists := m[code]; !exists {
+					m[code] = entryRef{off: int64(pos), length: int64(v)}
+				}
 			}
 		}
-		pos += 1 + int64(n) + bl
-
-		if codeLen > 0 {
-			code := string(head[2 : 2+codeLen])
-			if _, exists := m[code]; !exists {
-				m[code] = entryRef{off: pos - bl, length: bl}
-			}
-		}
+		pos += int(v)
 	}
 	if len(m) == 0 {
 		return nil, errors.New("no entries found in file")
 	}
-	fileIndexCache.Store(file, &m)
 	return m, nil
 }
 
-// readEntry returns the raw bytes of the entry at ref. It prefers a random
-// access read (the asset file is an *os.File); otherwise it falls back to the
-// streaming scan.
-func readEntry(file, code string, ref entryRef) ([]byte, error) {
-	r, err := filesystem.OpenAsset(file)
-	if err != nil {
-		return nil, err
-	}
-	defer r.Close()
-	if ra, ok := r.(io.ReaderAt); ok {
-		bs := make([]byte, ref.length)
-		if _, err := ra.ReadAt(bs, ref.off); err != nil {
-			return nil, err
+// readVarint decodes a protobuf varint from a byte slice, returning the value
+// and the number of bytes consumed.
+func readVarint(b []byte) (uint64, int, error) {
+	var x uint64
+	for i := 0; i < 10; i++ {
+		if i >= len(b) {
+			return 0, 0, io.ErrUnexpectedEOF
 		}
-		return bs, nil
+		c := b[i]
+		x |= (uint64(c) & 0x7F) << (7 * i)
+		if (c & 0x80) == 0 {
+			return x, i + 1, nil
+		}
 	}
-	return find(r, []byte(code), true)
+	return 0, 0, errors.New("varint overflow")
 }
 
 func checkFile(file, code string) error {
@@ -190,102 +159,6 @@ func loadSite(file, code string) ([]*Domain, error) {
 		return nil, errors.New("error unmarshal Site in ", file, ":", code).Base(err)
 	}
 	return geosite.Domain, nil
-}
-
-func decodeVarint(br *bufio.Reader) (uint64, error) {
-	var x uint64
-	for shift := uint(0); shift < 64; shift += 7 {
-		b, err := br.ReadByte()
-		if err != nil {
-			return 0, err
-		}
-		x |= (uint64(b) & 0x7F) << shift
-		if (b & 0x80) == 0 {
-			return x, nil
-		}
-	}
-	// The number is too large to represent in a 64-bit value.
-	return 0, errors.New("varint overflow")
-}
-
-// decodeVarintCount decodes a protobuf varint from a buffered reader, also
-// returning the number of bytes consumed.
-func decodeVarintCount(br *bufio.Reader) (uint64, int64, error) {
-	var x uint64
-	for shift := uint(0); shift < 64; shift += 7 {
-		b, err := br.ReadByte()
-		if err != nil {
-			return 0, 0, err
-		}
-		x |= (uint64(b) & 0x7F) << shift
-		if (b & 0x80) == 0 {
-			return x, int64(shift/7 + 1), nil
-		}
-	}
-	return 0, 0, errors.New("varint overflow")
-}
-
-func find(r io.Reader, code []byte, readBody bool) ([]byte, error) {
-	codeL := len(code)
-	if codeL == 0 {
-		return nil, errors.New("empty code")
-	}
-
-	br := bufio.NewReaderSize(r, 64*1024)
-	need := 2 + codeL // TODO: if code too long
-	prefixBuf := make([]byte, need)
-
-	for {
-		if _, err := br.ReadByte(); err != nil {
-			return nil, err
-		}
-
-		x, err := decodeVarint(br)
-		if err != nil {
-			return nil, err
-		}
-		bodyL := int(x)
-		if bodyL <= 0 {
-			return nil, errors.New("invalid body length: ", bodyL)
-		}
-
-		prefixL := bodyL
-		if prefixL > need {
-			prefixL = need
-		}
-		prefix := prefixBuf[:prefixL]
-		if _, err := io.ReadFull(br, prefix); err != nil {
-			return nil, err
-		}
-
-		match := false
-		if bodyL >= need {
-			if int(prefix[1]) == codeL && bytes.Equal(prefix[2:need], code) {
-				if !readBody {
-					return nil, nil
-				}
-				match = true
-			}
-		}
-
-		remain := bodyL - prefixL
-		if match {
-			out := make([]byte, bodyL)
-			copy(out, prefix)
-			if remain > 0 {
-				if _, err := io.ReadFull(br, out[prefixL:]); err != nil {
-					return nil, err
-				}
-			}
-			return out, nil
-		}
-
-		if remain > 0 {
-			if _, err := br.Discard(remain); err != nil {
-				return nil, err
-			}
-		}
-	}
 }
 
 type AttributeMatcher interface {

--- a/common/geodata/ip_matcher.go
+++ b/common/geodata/ip_matcher.go
@@ -3,7 +3,6 @@ package geodata
 import (
 	"context"
 	"net/netip"
-	"runtime"
 	"slices"
 	"sort"
 	"strings"
@@ -904,10 +903,6 @@ func (f *IPSetFactory) createFrom(yield func(func(*CIDR)) error) (*IPSet, error)
 	if err != nil {
 		return nil, err
 	}
-
-	// peak mem
-	runtime.GC()
-	defer runtime.GC()
 
 	ipv4, err := ipv4Builder.IPSet()
 	if err != nil {

--- a/common/geodata/ip_registry.go
+++ b/common/geodata/ip_registry.go
@@ -35,6 +35,8 @@ func (r *IPRegistry) Reload() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	ResetEntryCache()
+
 	var matchers []*DynamicIPMatcher
 	r.matchers.Range(func(_ uuid.UUID, matcher *DynamicIPMatcher) bool {
 		matchers = append(matchers, matcher)


### PR DESCRIPTION
# Title: geodata: cache loaded entries and drop forced GCs on startup

## Summary

On routers (MIPS/ARM, slow flash, low RAM) starting Xray with a routing config
containing many `ext:geoip.dat:...` / `ext:geosite.dat:...` rules takes minutes.
Profiling shows the cost is in the geodata loader, not in the matchers:

1. **Per-rule full file scans.** `checkFile` (config parse, `rule_parser.go`) and
   `loadFile` (matcher build, `geodat_loader.go`) each do a full linear scan of
   the referenced `.dat` file (up to tens of MB) — once per `ext:` rule. A config
   with 50 rules referencing the same file performs ~100 full scans of it.
2. **Forced stop-the-world GCs.** `runtime.GC()` is called on every entry load
   (`loadFile`, `loadIP`, `loadSite`) and twice per IPSet build (`createFrom`).
   With 50 rules that is ~100–150 synchronous full GCs per startup. Each is
   proportional to the live heap, so on low-RAM routers this alone can account
   for minutes.

## Change

- Cache the raw bytes of each referenced `.dat` file in memory (`geoDataCache`),
  read once per file in a single sequential pass, and serve GeoIP/GeoSite
  entries as zero-copy slices of those bytes. `checkFile` and `loadFile` share
  one path (`loadEntry`). Previously every `ext:` rule triggered a full linear
  scan of the file at parse time and again at matcher build time; on routers
  with slow flash a single sequential read per file is far cheaper than
  re-reading random entry ranges for every referenced code.
- Remove the forced `runtime.GC()` calls from the hot path (`geodat_loader.go`,
  `ip_matcher.go`). The runtime already bounds memory via GOGC/GOMEMLIMIT; the
  per-entry GCs only add synchronous STW pauses.
- `ResetEntryCache()` is called from `IPReg.Reload()` / `DomainReg.Reload()` so
  a `geodata` reload after swapping `.dat` files still picks up the new content.

Error semantics are unchanged: a missing code still fails at parse time with the
same `failed to check code` / `failed to load code` messages.

Memory note: the loaded `.dat` files (a few tens of MB) are held in RAM for the
process lifetime; this is the same data the OS page cache would otherwise hold,
without relying on cache eviction.

## Benchmark

Real `.dat` files (geoip_v2fly.dat 17 MB, geosite_v2fly.dat 2.3 MB,
zkeenip.dat 0.4 MB) on Apple Silicon, in-process config parse + matcher build,
median of 7-10 runs:

| config | metric | before | after |
|---|---|---|---|
| 50 rules, repeated codes on 17 MB file | total | 913 ms | 210 ms |
| 50 rules, repeated codes on 17 MB file | forced GCs | 329 | 22 |
| 55 distinct rule sets (mixed) | forced GCs | 458 | 103 |

On a Keenetic router (linux/arm64, flash storage) the stock-vs-patched
`xray run -test` (xkeen stopped) comparison went from **1m 18s to 49s**, with
user CPU dropping from **57s to 10.7s** (5.3x). The remaining wall time is
bounded by a single sequential flash read of the referenced `.dat` files; the
CPU cost of scanning and decoding them (the part that previously dominated and
saturated the router) is effectively gone.

## Risks

- Memory: the weak cache holds the referenced entries' raw bytes for the
  process lifetime; bounded by the number of unique `(file, code)` pairs in the
  config (small), and freed by GC when no longer needed.
- The cache is process-local; `Reload` invalidates it (see above).

## Tests

`go test ./common/geodata/ ./app/router/ ./infra/conf/` passes (with real
assets in `resources/`). `go build ./...` passes.