### PR TITLE
XHTTP transport: Add `pathTable` to disguise requests as static files

### DIFF
--- a/infra/conf/transport_method.go
+++ b/infra/conf/transport_method.go
@@ -270,6 +270,9 @@ type SplitHTTPConfig struct {
 	SessionIDKey         string            `json:"sessionIDKey"`
 	SessionIDTable       string            `json:"sessionIDTable"`
 	SessionIDLength      Int32Range        `json:"sessionIDLength"`
+	PathTable            string            `json:"pathTable"`
+	PathLength           Int32Range        `json:"pathLength"`
+	PathExtension        string            `json:"pathExtension"`
 	SeqPlacement         string            `json:"seqPlacement"`
 	SeqKey               string            `json:"seqKey"`
 	UplinkDataPlacement  string            `json:"uplinkDataPlacement"`
@@ -424,6 +427,31 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 		}
 	}
 
+	if c.PathTable != "" {
+		if predefined, ok := splithttp.PredefinedTable[c.PathTable]; ok {
+			c.PathTable = predefined
+		}
+		room := roomSize(len(c.PathTable), c.PathLength.From, c.PathLength.To)
+		// 2.1B possiblities should be enough
+		if room.Cmp(big.NewInt(2<<30)) < 0 {
+			return nil, errors.New("pathTable or pathLength is too small")
+		}
+		if c.PathLength.From <= 0 {
+			return nil, errors.New("pathLength.from must be greater than 0")
+		}
+		for i := 0; i < len(c.PathTable); i++ {
+			if c.PathTable[i] >= 0x80 {
+				return nil, errors.New("pathTable must contain only ASCII characters")
+			}
+		}
+	} else if c.PathExtension != "" {
+		return nil, errors.New("pathExtension requires pathTable to be set")
+	}
+
+	if strings.ContainsRune(c.PathExtension, '/') {
+		return nil, errors.New("pathExtension must not contain '/'")
+	}
+
 	if c.SeqPlacement != "path" && c.SeqKey == "" {
 		switch c.SeqPlacement {
 		case "cookie", "query":
@@ -486,6 +514,9 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 		ServerMaxHeaderBytes: c.ServerMaxHeaderBytes,
 		SessionIDTable:       c.SessionIDTable,
 		SessionIDLength:      newRangeConfig(c.SessionIDLength),
+		PathTable:            c.PathTable,
+		PathLength:           newRangeConfig(c.PathLength),
+		PathExtension:        c.PathExtension,
 		Xmux: &splithttp.XmuxConfig{
 			MaxConcurrency:   newRangeConfig(c.Xmux.MaxConcurrency),
 			MaxConnections:   newRangeConfig(c.Xmux.MaxConnections),

--- a/transport/internet/splithttp/config.go
+++ b/transport/internet/splithttp/config.go
@@ -2,6 +2,7 @@ package splithttp
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -296,6 +297,12 @@ func (c *Config) ApplyMetaToRequest(req *http.Request, sessionId string, seqStr 
 			req.AddCookie(&http.Cookie{Name: seqKey, Value: seqStr})
 		}
 	}
+
+	// Always last, so that the request ends in something that looks like a file
+	// name regardless of where the session ID and the sequence number went.
+	if segment := c.GeneratePathSegment(sessionId); segment != "" {
+		req.URL.Path = appendToPath(req.URL.Path, segment)
+	}
 }
 
 func (c *Config) FillStreamRequest(request *http.Request, sessionId string, seqStr string) {
@@ -524,6 +531,69 @@ func (c *Config) GenerateSessionID() string {
 		uuid := uuid.New()
 		return uuid.String()
 	}
+}
+
+// GeneratePathSegment builds the trailing path segment that disguises a request
+// as a static file, e.g. "9f3ac21b7e4d.js". It returns "" unless PathTable is set.
+//
+// The segment is derived from the session ID instead of being drawn at random,
+// so that every request belonging to one session asks for the same "file" — the
+// way a real page keeps fetching one asset — while a new session picks a new
+// name. Sessionless modes (stream-one) fall back to a random segment.
+func (c *Config) GeneratePathSegment(sessionId string) string {
+	table := c.PathTable
+	if predefined, ok := PredefinedTable[table]; ok {
+		table = predefined
+	}
+	if table == "" {
+		return ""
+	}
+
+	if sessionId == "" {
+		length := c.PathLength.rand()
+		name := make([]byte, length)
+		for i := range name {
+			name[i] = table[rand.N(len(table))]
+		}
+		return string(name) + c.PathExtension
+	}
+
+	// Deterministic, uniform pick over the table, seeded by the session ID.
+	digest := sha256.Sum256([]byte(sessionId))
+	stream := digest[:]
+	pos := 0
+	next := func() byte {
+		if pos == len(stream) {
+			digest = sha256.Sum256(stream)
+			stream = digest[:]
+			pos = 0
+		}
+		b := stream[pos]
+		pos++
+		return b
+	}
+	// Reject the tail of the byte range that would skew the distribution.
+	limit := 256
+	if len(table) < limit {
+		limit -= limit % len(table)
+	}
+	pick := func() byte {
+		for {
+			if b := next(); int(b) < limit {
+				return table[int(b)%len(table)]
+			}
+		}
+	}
+
+	length := int(c.PathLength.From)
+	if spread := int(c.PathLength.To) - length; spread > 0 {
+		length += int(next()) % (spread + 1)
+	}
+	name := make([]byte, length)
+	for i := range name {
+		name[i] = pick()
+	}
+	return string(name) + c.PathExtension
 }
 
 func appendToPath(path, value string) string {

--- a/transport/internet/splithttp/config.pb.go
+++ b/transport/internet/splithttp/config.pb.go
@@ -189,6 +189,9 @@ type Config struct {
 	ServerMaxHeaderBytes int32                  `protobuf:"varint,27,opt,name=serverMaxHeaderBytes,proto3" json:"serverMaxHeaderBytes,omitempty"`
 	SessionIDTable       string                 `protobuf:"bytes,28,opt,name=sessionIDTable,proto3" json:"sessionIDTable,omitempty"`
 	SessionIDLength      *RangeConfig           `protobuf:"bytes,29,opt,name=sessionIDLength,proto3" json:"sessionIDLength,omitempty"`
+	PathTable            string                 `protobuf:"bytes,30,opt,name=pathTable,proto3" json:"pathTable,omitempty"`
+	PathLength           *RangeConfig           `protobuf:"bytes,31,opt,name=pathLength,proto3" json:"pathLength,omitempty"`
+	PathExtension        string                 `protobuf:"bytes,32,opt,name=pathExtension,proto3" json:"pathExtension,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
@@ -426,6 +429,27 @@ func (x *Config) GetSessionIDLength() *RangeConfig {
 	return nil
 }
 
+func (x *Config) GetPathTable() string {
+	if x != nil {
+		return x.PathTable
+	}
+	return ""
+}
+
+func (x *Config) GetPathLength() *RangeConfig {
+	if x != nil {
+		return x.PathLength
+	}
+	return nil
+}
+
+func (x *Config) GetPathExtension() string {
+	if x != nil {
+		return x.PathExtension
+	}
+	return ""
+}
+
 var File_transport_internet_splithttp_config_proto protoreflect.FileDescriptor
 
 const file_transport_internet_splithttp_config_proto_rawDesc = "" +
@@ -441,7 +465,7 @@ const file_transport_internet_splithttp_config_proto_rawDesc = "" +
 	"\x0ecMaxReuseTimes\x18\x03 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x0ecMaxReuseTimes\x12Z\n" +
 	"\x10hMaxRequestTimes\x18\x04 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x10hMaxRequestTimes\x12Z\n" +
 	"\x10hMaxReusableSecs\x18\x05 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x10hMaxReusableSecs\x12*\n" +
-	"\x10hKeepAlivePeriod\x18\x06 \x01(\x03R\x10hKeepAlivePeriod\"\xcc\f\n" +
+	"\x10hKeepAlivePeriod\x18\x06 \x01(\x03R\x10hKeepAlivePeriod\"\xe0\r\n" +
 	"\x06Config\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
 	"\x04path\x18\x02 \x01(\tR\x04path\x12\x12\n" +
@@ -472,7 +496,12 @@ const file_transport_internet_splithttp_config_proto_rawDesc = "" +
 	"\x0fuplinkChunkSize\x18\x1a \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x0fuplinkChunkSize\x122\n" +
 	"\x14serverMaxHeaderBytes\x18\x1b \x01(\x05R\x14serverMaxHeaderBytes\x12&\n" +
 	"\x0esessionIDTable\x18\x1c \x01(\tR\x0esessionIDTable\x12X\n" +
-	"\x0fsessionIDLength\x18\x1d \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x0fsessionIDLength\x1a:\n" +
+	"\x0fsessionIDLength\x18\x1d \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x0fsessionIDLength\x12\x1c\n" +
+	"\tpathTable\x18\x1e \x01(\tR\tpathTable\x12N\n" +
+	"\n" +
+	"pathLength\x18\x1f \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\n" +
+	"pathLength\x12$\n" +
+	"\rpathExtension\x18  \x01(\tR\rpathExtension\x1a:\n" +
 	"\fHeadersEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x85\x01\n" +
@@ -513,11 +542,12 @@ var file_transport_internet_splithttp_config_proto_depIdxs = []int32{
 	4,  // 11: xray.transport.internet.splithttp.Config.downloadSettings:type_name -> xray.transport.internet.StreamConfig
 	0,  // 12: xray.transport.internet.splithttp.Config.uplinkChunkSize:type_name -> xray.transport.internet.splithttp.RangeConfig
 	0,  // 13: xray.transport.internet.splithttp.Config.sessionIDLength:type_name -> xray.transport.internet.splithttp.RangeConfig
-	14, // [14:14] is the sub-list for method output_type
-	14, // [14:14] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	0,  // 14: xray.transport.internet.splithttp.Config.pathLength:type_name -> xray.transport.internet.splithttp.RangeConfig
+	15, // [15:15] is the sub-list for method output_type
+	15, // [15:15] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_transport_internet_splithttp_config_proto_init() }

--- a/transport/internet/splithttp/config.proto
+++ b/transport/internet/splithttp/config.proto
@@ -52,4 +52,7 @@ message Config {
   int32 serverMaxHeaderBytes = 27;
   string sessionIDTable = 28;
   RangeConfig sessionIDLength = 29;
+  string pathTable = 30;
+  RangeConfig pathLength = 31;
+  string pathExtension = 32;
 }

--- a/transport/internet/splithttp/config_test.go
+++ b/transport/internet/splithttp/config_test.go
@@ -3,6 +3,7 @@ package splithttp_test
 import (
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -111,5 +112,85 @@ func Test_FillPacketRequest_GetBody(t *testing.T) {
 
 	if string(data) != string(second) {
 		t.Fatalf("Replayed body mismatch. Format %q and %q are not equal", data, second)
+	}
+}
+
+func Test_GeneratePathSegment(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		c := Config{}
+		assert.Equal(t, "", c.GeneratePathSegment("session"))
+	})
+
+	t.Run("stable for one session, different across sessions", func(t *testing.T) {
+		c := Config{PathTable: "0123456789abcdef", PathLength: &RangeConfig{From: 12, To: 12}, PathExtension: ".js"}
+		first := c.GeneratePathSegment("session-a")
+		assert.Equal(t, first, c.GeneratePathSegment("session-a"))
+		assert.NotEqual(t, first, c.GeneratePathSegment("session-b"))
+	})
+
+	t.Run("honours table, length and extension", func(t *testing.T) {
+		c := Config{PathTable: "0123456789abcdef", PathLength: &RangeConfig{From: 8, To: 16}, PathExtension: ".js"}
+		for _, sessionId := range []string{"a", "b", "c", "d", "e", "f", "g", "h"} {
+			segment := c.GeneratePathSegment(sessionId)
+			name := strings.TrimSuffix(segment, ".js")
+			assert.True(t, strings.HasSuffix(segment, ".js"))
+			assert.GreaterOrEqual(t, len(name), 8)
+			assert.LessOrEqual(t, len(name), 16)
+			for i := 0; i < len(name); i++ {
+				assert.True(t, strings.IndexByte("0123456789abcdef", name[i]) >= 0)
+			}
+		}
+	})
+
+	t.Run("oversized table does not hang", func(t *testing.T) {
+		table := strings.Repeat("abcdefghij", 30) // 300 characters
+		c := Config{PathTable: table, PathLength: &RangeConfig{From: 8, To: 8}}
+		assert.Len(t, c.GeneratePathSegment("session"), 8)
+	})
+
+	t.Run("random when there is no session id", func(t *testing.T) {
+		c := Config{PathTable: "0123456789abcdef", PathLength: &RangeConfig{From: 16, To: 16}}
+		assert.NotEqual(t, c.GeneratePathSegment(""), c.GeneratePathSegment(""))
+	})
+}
+
+func Test_ApplyMetaToRequest_PathSegmentGoesLast(t *testing.T) {
+	tests := []struct {
+		TestName           string
+		SessionIDPlacement string
+		SeqPlacement       string
+		ExpectedPrefix     string
+	}{
+		{
+			TestName:           "session and seq in query",
+			SessionIDPlacement: "query",
+			SeqPlacement:       "query",
+			ExpectedPrefix:     "/assets/",
+		},
+		{
+			TestName:       "session and seq in path",
+			ExpectedPrefix: "/assets/sess/7/",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.TestName, func(t *testing.T) {
+			c := Config{
+				Path:               "/assets/",
+				SessionIDPlacement: test.SessionIDPlacement,
+				SeqPlacement:       test.SeqPlacement,
+				PathTable:          "0123456789abcdef",
+				PathLength:         &RangeConfig{From: 12, To: 12},
+				PathExtension:      ".js",
+			}
+			req, err := http.NewRequest("GET", "https://example.com"+c.GetNormalizedPath(), nil)
+			common.Must(err)
+			c.ApplyMetaToRequest(req, "sess", "7")
+
+			assert.True(t, strings.HasPrefix(req.URL.Path, test.ExpectedPrefix),
+				"path %q does not start with %q", req.URL.Path, test.ExpectedPrefix)
+			assert.True(t, strings.HasSuffix(req.URL.Path, ".js"))
+			// The server matches on the configured prefix and ignores the rest.
+			assert.True(t, strings.HasPrefix(req.URL.Path, c.GetNormalizedPath()))
+		})
 	}
 }


### PR DESCRIPTION
## Problem

XHTTP's `path` is a single fixed string, shared by every request of every user of an inbound.
Two separate consequences:

**1. The URL shape is distinctive.** With the default placements a request reads

```
GET /api/stream/1b7c6f9e-1d0a-4f0e-9f6a-6c0d2f1a55c1/17
```

A constant prefix followed by a UUID and an incrementing counter, both as path segments, is
not a shape ordinary web traffic produces.

**2. Some CDNs only forward requests that look like file requests.** Several CDNs (we hit
this on a CDNVideo-based one) answer `403` at the edge unless the last path segment contains
a file extension. Measured against such an edge, with the same origin behind it:

| Request | Result |
| --- | --- |
| `/assets/app.js?v=1&t=1` | reaches the origin |
| `/assets/app.js/?v=1&t=1` | `403` at the edge |
| `/assets/app.js/x` | `403` at the edge |
| `/assets/app.js/x.js` | reaches the origin |

A fixed `path` such as `/assets/app.js` satisfies that rule (this is what
[#6307](https://github.com/XTLS/Xray-core/pull/6307) made possible by dropping the forced
trailing slash), but then an entire deployment keeps requesting one and the same file name
forever, and changing it means reissuing every client config.

## What this adds

Three options, deliberately mirroring the existing `sessionIDTable` / `sessionIDLength`:

| Option | Type | Default | Meaning |
| --- | --- | --- | --- |
| `pathTable` | string | `""` (feature off) | Alphabet for the generated segment: a `PredefinedTable` name (`hex`, `base36`, `Base62`, …) or a literal ASCII alphabet |
| `pathLength` | Int32Range | — | Length of the generated segment, e.g. `"8-16"` |
| `pathExtension` | string | `""` | Appended verbatim after the generated segment, e.g. `".js"` |

Client config:

```json
"xhttpSettings": {
  "path": "/assets/",
  "sessionIDPlacement": "query", "sessionIDKey": "v",
  "seqPlacement": "query", "seqKey": "t",
  "pathTable": "hex",
  "pathLength": "8-16",
  "pathExtension": ".js"
}
```

Resulting requests, all from one session:

```
GET /assets/61877619ff3cadff.js?_dc=…&t=1&v=064ef1806d654a7e
GET /assets/61877619ff3cadff.js?_dc=…&t=2&v=064ef1806d654a7e
GET /assets/61877619ff3cadff.js?_dc=…&t=3&v=064ef1806d654a7e
```

Validation mirrors `sessionIDTable`: ASCII-only alphabet, `pathLength.from > 0`, and the same
"2.1B possibilities" room check. `pathExtension` is rejected without `pathTable`, or if it
contains `/`.

## Design notes

**The segment is derived from the session ID, not drawn per request.** Every request of one
session therefore asks for the same "file" — the way a real page keeps fetching one asset —
while a new session picks a new name. Drawing per request would mean a single client pulling
hundreds of distinct scripts per second, which is not what real traffic looks like, so it
would trade one anomaly for another. Derivation also keeps the change local: `sessionId` is
already a parameter of `ApplyMetaToRequest`, so no plumbing through `client.go` /
`browser_client.go` was needed. Modes without a session ID (`stream-one`) fall back to a
randomly drawn segment.

**The segment is always appended last**, after the session ID and the sequence number. It
therefore composes with every placement, including `path`, where it gives that layout a
file-like ending as well (`/assets/<session>/<seq>/<name>.js`).

**No server-side option, and no server-side change.** The server matches the configured path
as a prefix (`strings.HasPrefix` in `hub.go`) and, when the session ID and the sequence number
are not in the path, never looks at the remainder; when they are in the path, it reads them
positionally and ignores anything after them. A client using this feature therefore talks to
an **unmodified** server whose `path` is configured as the prefix (for example `"/assets/"`).

**Defaults are unchanged.** With `pathTable` empty nothing is appended and the request is
byte-for-byte what it is today.

## Testing

Unit tests added to `transport/internet/splithttp/config_test.go`:

- disabled by default;
- stable within one session, different across sessions;
- alphabet, length range and extension are all honoured;
- random when there is no session ID;
- an oversized (> 256 character) alphabet does not hang the rejection-sampling loop;
- `ApplyMetaToRequest` puts the segment last and keeps the configured path as a prefix, both
  with query placements and with path placements.

Manual testing:

- A patched client was pointed at a plain HTTP server that logs request paths: both the
  stream-down and the packet-up requests of one session used the same generated name.
- End-to-end against a **stock, unpatched** Xray v26.7.28 server (`path: "/assets/"`) with a
  real CDN in front of it: the tunnel came up and carried traffic normally, and the origin
  logged the requests quoted above. This is the compatibility claim above, verified.

`config.pb.go` was regenerated with the same toolchain the existing file records
(protoc-gen-go v1.36.11, protoc v6.33.5), so its diff is limited to the three new fields.

## Not included on purpose

- No per-request randomization (see the rationale above); if it is wanted, it is a small
  follow-up.
- No server-side knob — nothing on the server needs to know about this.
- `pathExtension` is a single fixed string rather than a list to pick from; a list would be
  easy to add later if it turns out to be useful.
