### PR TITLE
XHTTP: Add configurable response prelude

### DIFF
--- a/infra/conf/transport_method.go
+++ b/infra/conf/transport_method.go
@@ -255,36 +255,44 @@ func (c *TCPConfig) Build() (proto.Message, error) {
 }
 
 type SplitHTTPConfig struct {
-	Host                 string            `json:"host"`
-	Path                 string            `json:"path"`
-	Mode                 string            `json:"mode"`
-	Headers              map[string]string `json:"headers"`
-	XPaddingBytes        Int32Range        `json:"xPaddingBytes"`
-	XPaddingObfsMode     bool              `json:"xPaddingObfsMode"`
-	XPaddingKey          string            `json:"xPaddingKey"`
-	XPaddingHeader       string            `json:"xPaddingHeader"`
-	XPaddingPlacement    string            `json:"xPaddingPlacement"`
-	XPaddingMethod       string            `json:"xPaddingMethod"`
-	UplinkHTTPMethod     string            `json:"uplinkHTTPMethod"`
-	SessionIDPlacement   string            `json:"sessionIDPlacement"`
-	SessionIDKey         string            `json:"sessionIDKey"`
-	SessionIDTable       string            `json:"sessionIDTable"`
-	SessionIDLength      Int32Range        `json:"sessionIDLength"`
-	SeqPlacement         string            `json:"seqPlacement"`
-	SeqKey               string            `json:"seqKey"`
-	UplinkDataPlacement  string            `json:"uplinkDataPlacement"`
-	UplinkDataKey        string            `json:"uplinkDataKey"`
-	UplinkChunkSize      Int32Range        `json:"uplinkChunkSize"`
-	NoGRPCHeader         bool              `json:"noGRPCHeader"`
-	NoSSEHeader          bool              `json:"noSSEHeader"`
-	ScMaxEachPostBytes   Int32Range        `json:"scMaxEachPostBytes"`
-	ScMinPostsIntervalMs Int32Range        `json:"scMinPostsIntervalMs"`
-	ScMaxBufferedPosts   int64             `json:"scMaxBufferedPosts"`
-	ScStreamUpServerSecs Int32Range        `json:"scStreamUpServerSecs"`
-	ServerMaxHeaderBytes int32             `json:"serverMaxHeaderBytes"`
-	Xmux                 XmuxConfig        `json:"xmux"`
-	DownloadSettings     *StreamConfig     `json:"downloadSettings"`
-	Extra                json.RawMessage   `json:"extra"`
+	Host                 string                 `json:"host"`
+	Path                 string                 `json:"path"`
+	Mode                 string                 `json:"mode"`
+	Headers              map[string]string      `json:"headers"`
+	XPaddingBytes        Int32Range             `json:"xPaddingBytes"`
+	XPaddingObfsMode     bool                   `json:"xPaddingObfsMode"`
+	XPaddingKey          string                 `json:"xPaddingKey"`
+	XPaddingHeader       string                 `json:"xPaddingHeader"`
+	XPaddingPlacement    string                 `json:"xPaddingPlacement"`
+	XPaddingMethod       string                 `json:"xPaddingMethod"`
+	UplinkHTTPMethod     string                 `json:"uplinkHTTPMethod"`
+	SessionIDPlacement   string                 `json:"sessionIDPlacement"`
+	SessionIDKey         string                 `json:"sessionIDKey"`
+	SessionIDTable       string                 `json:"sessionIDTable"`
+	SessionIDLength      Int32Range             `json:"sessionIDLength"`
+	ResponsePrelude      *ResponsePreludeConfig `json:"responsePrelude"`
+	SeqPlacement         string                 `json:"seqPlacement"`
+	SeqKey               string                 `json:"seqKey"`
+	UplinkDataPlacement  string                 `json:"uplinkDataPlacement"`
+	UplinkDataKey        string                 `json:"uplinkDataKey"`
+	UplinkChunkSize      Int32Range             `json:"uplinkChunkSize"`
+	NoGRPCHeader         bool                   `json:"noGRPCHeader"`
+	NoSSEHeader          bool                   `json:"noSSEHeader"`
+	ScMaxEachPostBytes   Int32Range             `json:"scMaxEachPostBytes"`
+	ScMinPostsIntervalMs Int32Range             `json:"scMinPostsIntervalMs"`
+	ScMaxBufferedPosts   int64                  `json:"scMaxBufferedPosts"`
+	ScStreamUpServerSecs Int32Range             `json:"scStreamUpServerSecs"`
+	ServerMaxHeaderBytes int32                  `json:"serverMaxHeaderBytes"`
+	Xmux                 XmuxConfig             `json:"xmux"`
+	DownloadSettings     *StreamConfig          `json:"downloadSettings"`
+	Extra                json.RawMessage        `json:"extra"`
+}
+
+type ResponsePreludeConfig struct {
+	Placement string     `json:"placement"`
+	Key       string     `json:"key"`
+	Table     string     `json:"table"`
+	Length    Int32Range `json:"length"`
 }
 
 type XmuxConfig struct {
@@ -424,6 +432,52 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 		}
 	}
 
+	if c.ResponsePrelude != nil {
+		switch c.ResponsePrelude.Placement {
+		case "":
+			c.ResponsePrelude.Placement = splithttp.PlacementCookie
+		case splithttp.PlacementPath, splithttp.PlacementCookie, splithttp.PlacementHeader, splithttp.PlacementQuery:
+		default:
+			return nil, errors.New("unsupported responsePrelude placement: " + c.ResponsePrelude.Placement)
+		}
+
+		if c.ResponsePrelude.Placement == splithttp.PlacementPath && (c.SessionIDPlacement == splithttp.PlacementPath || c.SeqPlacement == splithttp.PlacementPath) {
+			return nil, errors.New("responsePrelude placement path cannot be combined with sessionIDPlacement or seqPlacement path")
+		}
+
+		if c.ResponsePrelude.Key == "" {
+			switch c.ResponsePrelude.Placement {
+			case splithttp.PlacementCookie, splithttp.PlacementQuery:
+				c.ResponsePrelude.Key = "sample_id"
+			case splithttp.PlacementHeader:
+				c.ResponsePrelude.Key = "X-Sample-ID"
+			}
+		}
+
+		if c.ResponsePrelude.Table == "" {
+			c.ResponsePrelude.Table = "Base62"
+		}
+		if predefined, ok := splithttp.PredefinedTable[c.ResponsePrelude.Table]; ok {
+			c.ResponsePrelude.Table = predefined
+		}
+		if len(c.ResponsePrelude.Table) < 2 {
+			return nil, errors.New("responsePrelude.table must contain at least 2 characters")
+		}
+		for i := 0; i < len(c.ResponsePrelude.Table); i++ {
+			ch := c.ResponsePrelude.Table[i]
+			if !((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '-' || ch == '.' || ch == '_' || ch == '~') {
+				return nil, errors.New("responsePrelude.table must contain only URL-safe ASCII characters")
+			}
+		}
+
+		if c.ResponsePrelude.Length == (Int32Range{}) {
+			c.ResponsePrelude.Length = Int32Range{From: 16, To: 32}
+		}
+		if c.ResponsePrelude.Length.From <= 0 || c.ResponsePrelude.Length.To < c.ResponsePrelude.Length.From || c.ResponsePrelude.Length.To > splithttp.MaxResponsePreludeLength {
+			return nil, errors.New("responsePrelude.length must be within 1..4096 and from <= to")
+		}
+	}
+
 	if c.SeqPlacement != "path" && c.SeqKey == "" {
 		switch c.SeqPlacement {
 		case "cookie", "query":
@@ -494,6 +548,15 @@ func (c *SplitHTTPConfig) Build() (proto.Message, error) {
 			HMaxReusableSecs: newRangeConfig(c.Xmux.HMaxReusableSecs),
 			HKeepAlivePeriod: c.Xmux.HKeepAlivePeriod,
 		},
+	}
+
+	if c.ResponsePrelude != nil {
+		config.ResponsePrelude = &splithttp.ResponsePreludeConfig{
+			Placement: c.ResponsePrelude.Placement,
+			Key:       c.ResponsePrelude.Key,
+			Table:     c.ResponsePrelude.Table,
+			Length:    newRangeConfig(c.ResponsePrelude.Length),
+		}
 	}
 
 	if c.DownloadSettings != nil {

--- a/infra/conf/transport_method_response_prelude_test.go
+++ b/infra/conf/transport_method_response_prelude_test.go
@@ -1,0 +1,176 @@
+package conf
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/xtls/xray-core/transport/internet/splithttp"
+)
+
+func baseResponsePreludeConfig() SplitHTTPConfig {
+	return SplitHTTPConfig{
+		Mode:               "packet-up",
+		Path:               "/test",
+		SessionIDPlacement: splithttp.PlacementCookie,
+		SeqPlacement:       splithttp.PlacementQuery,
+		ResponsePrelude: &ResponsePreludeConfig{
+			Placement: splithttp.PlacementCookie,
+			Key:       "sample_id",
+			Table:     "Base62",
+			Length:    Int32Range{From: 16, To: 32},
+		},
+	}
+}
+
+func TestResponsePreludeConfigBuildDefaults(t *testing.T) {
+	cfg := SplitHTTPConfig{
+		Mode:               "packet-up",
+		Path:               "/test",
+		SessionIDPlacement: splithttp.PlacementCookie,
+		SeqPlacement:       splithttp.PlacementQuery,
+		ResponsePrelude:    &ResponsePreludeConfig{},
+	}
+
+	built, err := cfg.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := built.(*splithttp.Config).ResponsePrelude
+	if got == nil {
+		t.Fatal("internal response prelude config is nil")
+	}
+	if got.Placement != splithttp.PlacementCookie {
+		t.Fatalf("placement: got %q", got.Placement)
+	}
+	if got.Key != "sample_id" {
+		t.Fatalf("cookie key: got %q", got.Key)
+	}
+	if got.Table != splithttp.PredefinedTable["Base62"] {
+		t.Fatal("table was not normalized to Base62")
+	}
+	if got.Length == nil || got.Length.From != 16 || got.Length.To != 32 {
+		t.Fatalf("length: %#v", got.Length)
+	}
+
+	headerCfg := SplitHTTPConfig{
+		Mode:               "packet-up",
+		Path:               "/test",
+		SessionIDPlacement: splithttp.PlacementCookie,
+		SeqPlacement:       splithttp.PlacementQuery,
+		ResponsePrelude: &ResponsePreludeConfig{
+			Placement: splithttp.PlacementHeader,
+		},
+	}
+	headerBuilt, err := headerCfg.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	headerGot := headerBuilt.(*splithttp.Config).ResponsePrelude
+	if headerGot.Key != "X-Sample-ID" {
+		t.Fatalf("header key: got %q", headerGot.Key)
+	}
+}
+
+func TestResponsePreludeConfigBuildAllPlacements(t *testing.T) {
+	tests := []struct {
+		placement string
+		key       string
+	}{
+		{splithttp.PlacementCookie, "pref_cookie"},
+		{splithttp.PlacementHeader, "X-Pref"},
+		{splithttp.PlacementQuery, "pref_query"},
+		{splithttp.PlacementPath, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.placement, func(t *testing.T) {
+			cfg := baseResponsePreludeConfig()
+			cfg.ResponsePrelude.Placement = tt.placement
+			cfg.ResponsePrelude.Key = tt.key
+			built, err := cfg.Build()
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := built.(*splithttp.Config).ResponsePrelude
+			if got == nil || got.Placement != tt.placement {
+				t.Fatalf("placement: %#v", got)
+			}
+		})
+	}
+}
+
+func TestResponsePreludeConfigCustomTableAndFixedLength(t *testing.T) {
+	cfg := baseResponsePreludeConfig()
+	cfg.ResponsePrelude.Table = "abCD09-_"
+	cfg.ResponsePrelude.Length = Int32Range{From: 24, To: 24}
+
+	built, err := cfg.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := built.(*splithttp.Config).ResponsePrelude
+	if got.Table != "abCD09-_" || got.Length.From != 24 || got.Length.To != 24 {
+		t.Fatalf("unexpected config: %#v", got)
+	}
+}
+
+func TestResponsePreludeConfigRejectsInvalidPlacement(t *testing.T) {
+	cfg := baseResponsePreludeConfig()
+	cfg.ResponsePrelude.Placement = "body"
+
+	_, err := cfg.Build()
+	if err == nil || !strings.Contains(err.Error(), "unsupported responsePrelude placement") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResponsePreludeConfigRejectsPathConflicts(t *testing.T) {
+	tests := []struct {
+		name     string
+		session  string
+		sequence string
+	}{
+		{"session-path", splithttp.PlacementPath, splithttp.PlacementQuery},
+		{"sequence-path", splithttp.PlacementCookie, splithttp.PlacementPath},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := baseResponsePreludeConfig()
+			cfg.ResponsePrelude.Placement = splithttp.PlacementPath
+			cfg.SessionIDPlacement = tt.session
+			cfg.SeqPlacement = tt.sequence
+
+			_, err := cfg.Build()
+			if err == nil || !strings.Contains(err.Error(), "responsePrelude placement path") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestResponsePreludeConfigRejectsInvalidTables(t *testing.T) {
+	for _, table := range []string{"a", "ab/c", "ab c", "аб"} {
+		t.Run(table, func(t *testing.T) {
+			cfg := baseResponsePreludeConfig()
+			cfg.ResponsePrelude.Table = table
+			if _, err := cfg.Build(); err == nil {
+				t.Fatalf("table %q unexpectedly accepted", table)
+			}
+		})
+	}
+}
+
+func TestResponsePreludeConfigRejectsInvalidLengths(t *testing.T) {
+	for _, length := range []Int32Range{
+		{From: 0, To: 16},
+		{From: 32, To: 16},
+		{From: 1, To: splithttp.MaxResponsePreludeLength + 1},
+	} {
+		cfg := baseResponsePreludeConfig()
+		cfg.ResponsePrelude.Length = length
+		if _, err := cfg.Build(); err == nil {
+			t.Fatalf("length %#v unexpectedly accepted", length)
+		}
+	}
+}

--- a/transport/internet/splithttp/browser_client.go
+++ b/transport/internet/splithttp/browser_client.go
@@ -33,13 +33,20 @@ func (c *BrowserDialerClient) OpenStream(ctx context.Context, url string, sessio
 
 	c.transportConfig.FillStreamRequest(request, sessionId, "")
 
+	responsePrelude := ""
+	if shouldApplyResponsePrelude(c.transportConfig, body, uploadOnly) {
+		responsePrelude = c.transportConfig.GenerateResponsePrelude()
+		c.transportConfig.ApplyResponsePreludeToRequest(request, responsePrelude)
+	}
+
 	conn, err := browser_dialer.DialGet(request.URL.String(), request.Header, request.Cookies())
 	dummyAddr := &net.IPAddr{}
 	if err != nil {
 		return nil, dummyAddr, dummyAddr, err
 	}
 
-	return websocket.NewConnection(conn, dummyAddr, nil, 0), conn.RemoteAddr(), conn.LocalAddr(), nil
+	response := websocket.NewConnection(conn, dummyAddr, nil, 0)
+	return newResponsePreludeReadCloser(response, responsePrelude), conn.RemoteAddr(), conn.LocalAddr(), nil
 }
 
 func (c *BrowserDialerClient) PostPacket(ctx context.Context, url string, sessionId string, seqStr string, payload buf.MultiBuffer) error {

--- a/transport/internet/splithttp/client.go
+++ b/transport/internet/splithttp/client.go
@@ -68,6 +68,12 @@ func (c *DefaultDialerClient) OpenStream(ctx context.Context, url string, sessio
 	}
 	c.transportConfig.FillStreamRequest(req, sessionId, "")
 
+	responsePrelude := ""
+	if shouldApplyResponsePrelude(c.transportConfig, body, uploadOnly) {
+		responsePrelude = c.transportConfig.GenerateResponsePrelude()
+		c.transportConfig.ApplyResponsePreludeToRequest(req, responsePrelude)
+	}
+
 	wrc = &WaitReadCloser{Wait: make(chan struct{})}
 	go func() {
 		resp, err := c.client.Do(req)
@@ -91,7 +97,7 @@ func (c *DefaultDialerClient) OpenStream(ctx context.Context, url string, sessio
 			wrc.Close()
 			return
 		}
-		wrc.(*WaitReadCloser).Set(resp.Body)
+		wrc.(*WaitReadCloser).Set(newResponsePreludeReadCloser(resp.Body, responsePrelude))
 	}()
 
 	<-gotConn.Wait()

--- a/transport/internet/splithttp/config.go
+++ b/transport/internet/splithttp/config.go
@@ -108,7 +108,8 @@ func (c *Config) WriteResponseHeader(writer http.ResponseWriter, requestMethod s
 	if c.GetNormalizedSessionPlacement() == PlacementCookie ||
 		c.GetNormalizedSeqPlacement() == PlacementCookie ||
 		c.XPaddingPlacement == PlacementCookie ||
-		c.GetNormalizedUplinkDataPlacement() == PlacementCookie {
+		c.GetNormalizedUplinkDataPlacement() == PlacementCookie ||
+		c.GetNormalizedResponsePreludePlacement() == PlacementCookie {
 		writer.Header().Set("Access-Control-Allow-Credentials", "true")
 	}
 

--- a/transport/internet/splithttp/config.pb.go
+++ b/transport/internet/splithttp/config.pb.go
@@ -189,6 +189,7 @@ type Config struct {
 	ServerMaxHeaderBytes int32                  `protobuf:"varint,27,opt,name=serverMaxHeaderBytes,proto3" json:"serverMaxHeaderBytes,omitempty"`
 	SessionIDTable       string                 `protobuf:"bytes,28,opt,name=sessionIDTable,proto3" json:"sessionIDTable,omitempty"`
 	SessionIDLength      *RangeConfig           `protobuf:"bytes,29,opt,name=sessionIDLength,proto3" json:"sessionIDLength,omitempty"`
+	ResponsePrelude      *ResponsePreludeConfig `protobuf:"bytes,30,opt,name=responsePrelude,proto3" json:"responsePrelude,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
@@ -426,6 +427,81 @@ func (x *Config) GetSessionIDLength() *RangeConfig {
 	return nil
 }
 
+func (x *Config) GetResponsePrelude() *ResponsePreludeConfig {
+	if x != nil {
+		return x.ResponsePrelude
+	}
+	return nil
+}
+
+type ResponsePreludeConfig struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Placement     string                 `protobuf:"bytes,1,opt,name=placement,proto3" json:"placement,omitempty"`
+	Key           string                 `protobuf:"bytes,2,opt,name=key,proto3" json:"key,omitempty"`
+	Table         string                 `protobuf:"bytes,3,opt,name=table,proto3" json:"table,omitempty"`
+	Length        *RangeConfig           `protobuf:"bytes,4,opt,name=length,proto3" json:"length,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResponsePreludeConfig) Reset() {
+	*x = ResponsePreludeConfig{}
+	mi := &file_transport_internet_splithttp_config_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResponsePreludeConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResponsePreludeConfig) ProtoMessage() {}
+
+func (x *ResponsePreludeConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_transport_internet_splithttp_config_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResponsePreludeConfig.ProtoReflect.Descriptor instead.
+func (*ResponsePreludeConfig) Descriptor() ([]byte, []int) {
+	return file_transport_internet_splithttp_config_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *ResponsePreludeConfig) GetPlacement() string {
+	if x != nil {
+		return x.Placement
+	}
+	return ""
+}
+
+func (x *ResponsePreludeConfig) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+func (x *ResponsePreludeConfig) GetTable() string {
+	if x != nil {
+		return x.Table
+	}
+	return ""
+}
+
+func (x *ResponsePreludeConfig) GetLength() *RangeConfig {
+	if x != nil {
+		return x.Length
+	}
+	return nil
+}
+
 var File_transport_internet_splithttp_config_proto protoreflect.FileDescriptor
 
 const file_transport_internet_splithttp_config_proto_rawDesc = "" +
@@ -441,7 +517,7 @@ const file_transport_internet_splithttp_config_proto_rawDesc = "" +
 	"\x0ecMaxReuseTimes\x18\x03 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x0ecMaxReuseTimes\x12Z\n" +
 	"\x10hMaxRequestTimes\x18\x04 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x10hMaxRequestTimes\x12Z\n" +
 	"\x10hMaxReusableSecs\x18\x05 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x10hMaxReusableSecs\x12*\n" +
-	"\x10hKeepAlivePeriod\x18\x06 \x01(\x03R\x10hKeepAlivePeriod\"\xcc\f\n" +
+	"\x10hKeepAlivePeriod\x18\x06 \x01(\x03R\x10hKeepAlivePeriod\"\xb0\r\n" +
 	"\x06Config\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
 	"\x04path\x18\x02 \x01(\tR\x04path\x12\x12\n" +
@@ -472,10 +548,16 @@ const file_transport_internet_splithttp_config_proto_rawDesc = "" +
 	"\x0fuplinkChunkSize\x18\x1a \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x0fuplinkChunkSize\x122\n" +
 	"\x14serverMaxHeaderBytes\x18\x1b \x01(\x05R\x14serverMaxHeaderBytes\x12&\n" +
 	"\x0esessionIDTable\x18\x1c \x01(\tR\x0esessionIDTable\x12X\n" +
-	"\x0fsessionIDLength\x18\x1d \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x0fsessionIDLength\x1a:\n" +
+	"\x0fsessionIDLength\x18\x1d \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x0fsessionIDLength\x12b\n" +
+	"\x0fresponsePrelude\x18\x1e \x01(\v28.xray.transport.internet.splithttp.ResponsePreludeConfigR\x0fresponsePrelude\x1a:\n" +
 	"\fHeadersEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x85\x01\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xa5\x01\n" +
+	"\x15ResponsePreludeConfig\x12\x1c\n" +
+	"\tplacement\x18\x01 \x01(\tR\tplacement\x12\x10\n" +
+	"\x03key\x18\x02 \x01(\tR\x03key\x12\x14\n" +
+	"\x05table\x18\x03 \x01(\tR\x05table\x12F\n" +
+	"\x06length\x18\x04 \x01(\v2..xray.transport.internet.splithttp.RangeConfigR\x06lengthB\x85\x01\n" +
 	"%com.xray.transport.internet.splithttpP\x01Z6github.com/xtls/xray-core/transport/internet/splithttp\xaa\x02!Xray.Transport.Internet.SplitHttpb\x06proto3"
 
 var (
@@ -490,13 +572,14 @@ func file_transport_internet_splithttp_config_proto_rawDescGZIP() []byte {
 	return file_transport_internet_splithttp_config_proto_rawDescData
 }
 
-var file_transport_internet_splithttp_config_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_transport_internet_splithttp_config_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_transport_internet_splithttp_config_proto_goTypes = []any{
 	(*RangeConfig)(nil),           // 0: xray.transport.internet.splithttp.RangeConfig
 	(*XmuxConfig)(nil),            // 1: xray.transport.internet.splithttp.XmuxConfig
 	(*Config)(nil),                // 2: xray.transport.internet.splithttp.Config
-	nil,                           // 3: xray.transport.internet.splithttp.Config.HeadersEntry
-	(*internet.StreamConfig)(nil), // 4: xray.transport.internet.StreamConfig
+	(*ResponsePreludeConfig)(nil), // 3: xray.transport.internet.splithttp.ResponsePreludeConfig
+	nil,                           // 4: xray.transport.internet.splithttp.Config.HeadersEntry
+	(*internet.StreamConfig)(nil), // 5: xray.transport.internet.StreamConfig
 }
 var file_transport_internet_splithttp_config_proto_depIdxs = []int32{
 	0,  // 0: xray.transport.internet.splithttp.XmuxConfig.maxConcurrency:type_name -> xray.transport.internet.splithttp.RangeConfig
@@ -504,20 +587,22 @@ var file_transport_internet_splithttp_config_proto_depIdxs = []int32{
 	0,  // 2: xray.transport.internet.splithttp.XmuxConfig.cMaxReuseTimes:type_name -> xray.transport.internet.splithttp.RangeConfig
 	0,  // 3: xray.transport.internet.splithttp.XmuxConfig.hMaxRequestTimes:type_name -> xray.transport.internet.splithttp.RangeConfig
 	0,  // 4: xray.transport.internet.splithttp.XmuxConfig.hMaxReusableSecs:type_name -> xray.transport.internet.splithttp.RangeConfig
-	3,  // 5: xray.transport.internet.splithttp.Config.headers:type_name -> xray.transport.internet.splithttp.Config.HeadersEntry
+	4,  // 5: xray.transport.internet.splithttp.Config.headers:type_name -> xray.transport.internet.splithttp.Config.HeadersEntry
 	0,  // 6: xray.transport.internet.splithttp.Config.xPaddingBytes:type_name -> xray.transport.internet.splithttp.RangeConfig
 	0,  // 7: xray.transport.internet.splithttp.Config.scMaxEachPostBytes:type_name -> xray.transport.internet.splithttp.RangeConfig
 	0,  // 8: xray.transport.internet.splithttp.Config.scMinPostsIntervalMs:type_name -> xray.transport.internet.splithttp.RangeConfig
 	0,  // 9: xray.transport.internet.splithttp.Config.scStreamUpServerSecs:type_name -> xray.transport.internet.splithttp.RangeConfig
 	1,  // 10: xray.transport.internet.splithttp.Config.xmux:type_name -> xray.transport.internet.splithttp.XmuxConfig
-	4,  // 11: xray.transport.internet.splithttp.Config.downloadSettings:type_name -> xray.transport.internet.StreamConfig
+	5,  // 11: xray.transport.internet.splithttp.Config.downloadSettings:type_name -> xray.transport.internet.StreamConfig
 	0,  // 12: xray.transport.internet.splithttp.Config.uplinkChunkSize:type_name -> xray.transport.internet.splithttp.RangeConfig
 	0,  // 13: xray.transport.internet.splithttp.Config.sessionIDLength:type_name -> xray.transport.internet.splithttp.RangeConfig
-	14, // [14:14] is the sub-list for method output_type
-	14, // [14:14] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	3,  // 14: xray.transport.internet.splithttp.Config.responsePrelude:type_name -> xray.transport.internet.splithttp.ResponsePreludeConfig
+	0,  // 15: xray.transport.internet.splithttp.ResponsePreludeConfig.length:type_name -> xray.transport.internet.splithttp.RangeConfig
+	16, // [16:16] is the sub-list for method output_type
+	16, // [16:16] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_transport_internet_splithttp_config_proto_init() }
@@ -531,7 +616,7 @@ func file_transport_internet_splithttp_config_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_transport_internet_splithttp_config_proto_rawDesc), len(file_transport_internet_splithttp_config_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/transport/internet/splithttp/config.proto
+++ b/transport/internet/splithttp/config.proto
@@ -52,4 +52,12 @@ message Config {
   int32 serverMaxHeaderBytes = 27;
   string sessionIDTable = 28;
   RangeConfig sessionIDLength = 29;
+  ResponsePreludeConfig responsePrelude = 30;
+}
+
+message ResponsePreludeConfig {
+  string placement = 1;
+  string key = 2;
+  string table = 3;
+  RangeConfig length = 4;
 }

--- a/transport/internet/splithttp/hub.go
+++ b/transport/internet/splithttp/hub.go
@@ -347,6 +347,13 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 
 		writer.WriteHeader(http.StatusOK)
 	} else if request.Method == "GET" || sessionId == "" { // stream-down, stream-one
+		responsePrelude := h.config.ExtractResponsePreludeFromRequest(request, h.path)
+		if responsePrelude != "" && !h.config.IsResponsePreludeValid(responsePrelude) {
+			errors.LogInfo(context.Background(), "invalid response prelude")
+			writer.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
 		if sessionId != "" {
 			// after GET is done, the connection is finished. disable automatic
 			// session reaping, and handle it in defer
@@ -367,6 +374,12 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		}
 
 		writer.WriteHeader(http.StatusOK)
+		if responsePrelude != "" {
+			if _, err := writer.Write([]byte(responsePrelude)); err != nil {
+				errors.LogInfoInner(context.Background(), err, "failed to write response prelude")
+				return
+			}
+		}
 		writer.(http.Flusher).Flush()
 
 		httpSC := &httpServerConn{

--- a/transport/internet/splithttp/response_prelude.go
+++ b/transport/internet/splithttp/response_prelude.go
@@ -1,0 +1,184 @@
+package splithttp
+
+import (
+	"bytes"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"strings"
+)
+
+const MaxResponsePreludeLength int32 = 4096
+
+func (c *Config) GetNormalizedResponsePreludePlacement() string {
+	if c.ResponsePrelude == nil {
+		return ""
+	}
+	if c.ResponsePrelude.Placement == "" {
+		return PlacementCookie
+	}
+	return c.ResponsePrelude.Placement
+}
+
+func (c *Config) GetNormalizedResponsePreludeKey() string {
+	if c.ResponsePrelude == nil {
+		return ""
+	}
+	if c.ResponsePrelude.Key != "" {
+		return c.ResponsePrelude.Key
+	}
+	switch c.GetNormalizedResponsePreludePlacement() {
+	case PlacementHeader:
+		return "X-Sample-ID"
+	case PlacementCookie, PlacementQuery:
+		return "sample_id"
+	default:
+		return ""
+	}
+}
+
+func (c *Config) GetNormalizedResponsePreludeTable() string {
+	if c.ResponsePrelude == nil {
+		return ""
+	}
+	table := c.ResponsePrelude.Table
+	if table == "" {
+		table = "Base62"
+	}
+	if predefined, ok := PredefinedTable[table]; ok {
+		return predefined
+	}
+	return table
+}
+
+func (c *Config) GetNormalizedResponsePreludeLength() *RangeConfig {
+	if c.ResponsePrelude == nil {
+		return nil
+	}
+	if c.ResponsePrelude.Length == nil || c.ResponsePrelude.Length.From <= 0 || c.ResponsePrelude.Length.To <= 0 {
+		return &RangeConfig{From: 16, To: 32}
+	}
+	return c.ResponsePrelude.Length
+}
+
+func (c *Config) GenerateResponsePrelude() string {
+	if c.ResponsePrelude == nil {
+		return ""
+	}
+	lengthConfig := c.GetNormalizedResponsePreludeLength()
+	table := c.GetNormalizedResponsePreludeTable()
+	if lengthConfig == nil || table == "" {
+		return ""
+	}
+	length := lengthConfig.rand()
+	if length <= 0 {
+		return ""
+	}
+	value := make([]byte, length)
+	for i := range value {
+		value[i] = table[rand.N(len(table))]
+	}
+	return string(value)
+}
+
+func (c *Config) ApplyResponsePreludeToRequest(req *http.Request, value string) {
+	if c.ResponsePrelude == nil || value == "" {
+		return
+	}
+	placement := c.GetNormalizedResponsePreludePlacement()
+	key := c.GetNormalizedResponsePreludeKey()
+	switch placement {
+	case PlacementPath:
+		req.URL.Path = appendToPath(req.URL.Path, value)
+	case PlacementQuery:
+		q := req.URL.Query()
+		q.Set(key, value)
+		req.URL.RawQuery = q.Encode()
+	case PlacementHeader:
+		req.Header.Set(key, value)
+	case PlacementCookie:
+		req.AddCookie(&http.Cookie{Name: key, Value: value})
+	}
+}
+
+func (c *Config) ExtractResponsePreludeFromRequest(req *http.Request, basePath string) string {
+	if c.ResponsePrelude == nil {
+		return ""
+	}
+	placement := c.GetNormalizedResponsePreludePlacement()
+	key := c.GetNormalizedResponsePreludeKey()
+	switch placement {
+	case PlacementPath:
+		remainder := strings.TrimPrefix(req.URL.Path, basePath)
+		remainder = strings.TrimPrefix(remainder, "/")
+		if remainder == "" || strings.Contains(remainder, "/") {
+			return ""
+		}
+		return remainder
+	case PlacementQuery:
+		return req.URL.Query().Get(key)
+	case PlacementHeader:
+		return req.Header.Get(key)
+	case PlacementCookie:
+		if cookie, err := req.Cookie(key); err == nil {
+			return cookie.Value
+		}
+	}
+	return ""
+}
+
+func (c *Config) IsResponsePreludeValid(value string) bool {
+	if c.ResponsePrelude == nil || value == "" {
+		return false
+	}
+	lengthConfig := c.GetNormalizedResponsePreludeLength()
+	if lengthConfig == nil || int32(len(value)) < lengthConfig.From || int32(len(value)) > lengthConfig.To {
+		return false
+	}
+	table := c.GetNormalizedResponsePreludeTable()
+	if table == "" {
+		return false
+	}
+	for i := 0; i < len(value); i++ {
+		if !strings.ContainsRune(table, rune(value[i])) {
+			return false
+		}
+	}
+	return true
+}
+
+type responsePreludeReadCloser struct {
+	source   io.ReadCloser
+	expected []byte
+	reader   io.Reader
+	checked  bool
+}
+
+func newResponsePreludeReadCloser(source io.ReadCloser, expected string) io.ReadCloser {
+	if source == nil || expected == "" {
+		return source
+	}
+	return &responsePreludeReadCloser{source: source, expected: []byte(expected)}
+}
+
+func (r *responsePreludeReadCloser) Read(p []byte) (int, error) {
+	if !r.checked {
+		r.checked = true
+		got := make([]byte, len(r.expected))
+		n, err := io.ReadFull(r.source, got)
+		if err == nil && bytes.Equal(got, r.expected) {
+			r.reader = r.source
+		} else {
+			r.reader = io.MultiReader(bytes.NewReader(got[:n]), r.source)
+		}
+	}
+	return r.reader.Read(p)
+}
+
+func (r *responsePreludeReadCloser) Close() error {
+	return r.source.Close()
+}
+
+func shouldApplyResponsePrelude(c *Config, body io.Reader, uploadOnly bool) bool {
+	return c != nil && c.ResponsePrelude != nil && body == nil && !uploadOnly
+}

--- a/transport/internet/splithttp/response_prelude_integration_test.go
+++ b/transport/internet/splithttp/response_prelude_integration_test.go
@@ -1,0 +1,193 @@
+package splithttp_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	stdnet "net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/xtls/xray-core/common"
+	xraynet "github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/testing/servers/tcp"
+	"github.com/xtls/xray-core/transport/internet"
+	. "github.com/xtls/xray-core/transport/internet/splithttp"
+	"github.com/xtls/xray-core/transport/internet/stat"
+)
+
+func TestResponsePreludeEndToEndThroughBufferingProxy(t *testing.T) {
+	backendPort := tcp.PickPort()
+	proxyPort := tcp.PickPort()
+
+	responsePrelude := &ResponsePreludeConfig{
+		Placement: PlacementCookie,
+		Key:       "sample_id",
+		Table:     PredefinedTable["Base62"],
+		Length:    &RangeConfig{From: 16, To: 32},
+	}
+
+	// Application payload is deliberately blocked until the intermediary
+	// has observed the response prelude. Without the prelude this creates
+	// the same headers-only buffering deadlock seen with some CDNs.
+	preludeSeen := make(chan struct{})
+	var preludeSeenOnce sync.Once
+
+	backendSettings := &internet.MemoryStreamConfig{
+		ProtocolName: "splithttp",
+		ProtocolSettings: &Config{
+			Path:            "/sh",
+			Mode:            "packet-up",
+			ResponsePrelude: responsePrelude,
+		},
+	}
+
+	listen, err := ListenXH(
+		context.Background(),
+		xraynet.LocalHostIP,
+		backendPort,
+		backendSettings,
+		func(conn stat.Connection) {
+			go func(c stat.Connection) {
+				defer c.Close()
+
+				select {
+				case <-preludeSeen:
+				case <-time.After(2 * time.Second):
+					return
+				}
+
+				common.Must2(c.Write([]byte("PAYLOAD")))
+			}(conn)
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listen.Close()
+
+	target, err := url.Parse("http://127.0.0.1:" + backendPort.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		cookie, err := resp.Request.Cookie("sample_id")
+		if err != nil {
+			return fmt.Errorf("stream-down request has no sample_id cookie: %w", err)
+		}
+		if cookie.Value == "" {
+			return fmt.Errorf("empty sample_id")
+		}
+
+		first := make([]byte, len(cookie.Value))
+		if _, err := io.ReadFull(resp.Body, first); err != nil {
+			return fmt.Errorf("failed to read initial response bytes: %w", err)
+		}
+		if !bytes.Equal(first, []byte(cookie.Value)) {
+			return fmt.Errorf("first response bytes %q do not match response prelude %q", first, cookie.Value)
+		}
+
+		// Replay the bytes so the real XHTTP client receives them and proves
+		// that its responsePrelude reader strips them before exposing payload.
+		resp.Body = io.NopCloser(io.MultiReader(bytes.NewReader(first), resp.Body))
+		preludeSeenOnce.Do(func() { close(preludeSeen) })
+		return nil
+	}
+
+	proxyListener, err := stdnet.Listen("tcp", "127.0.0.1:"+proxyPort.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxyServer := &http.Server{Handler: proxy}
+	go func() {
+		_ = proxyServer.Serve(proxyListener)
+	}()
+	defer proxyServer.Close()
+
+	clientSettings := &internet.MemoryStreamConfig{
+		ProtocolName: "splithttp",
+		ProtocolSettings: &Config{
+			Path:            "/sh",
+			Mode:            "packet-up",
+			ResponsePrelude: responsePrelude,
+		},
+	}
+
+	conn, err := Dial(
+		context.Background(),
+		xraynet.TCPDestination(xraynet.DomainAddress("localhost"), proxyPort),
+		clientSettings,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	got := make([]byte, len("PAYLOAD"))
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "PAYLOAD" {
+		t.Fatalf("upper layer received %q, want PAYLOAD", got)
+	}
+
+	select {
+	case <-preludeSeen:
+	default:
+		t.Fatal("intermediary never observed response prelude")
+	}
+}
+
+func TestResponsePreludeDisabledPreservesLegacyEndToEnd(t *testing.T) {
+	listenPort := tcp.PickPort()
+
+	settings := &internet.MemoryStreamConfig{
+		ProtocolName: "splithttp",
+		ProtocolSettings: &Config{
+			Path: "/sh",
+			Mode: "packet-up",
+		},
+	}
+
+	listen, err := ListenXH(
+		context.Background(),
+		xraynet.LocalHostIP,
+		listenPort,
+		settings,
+		func(conn stat.Connection) {
+			go func(c stat.Connection) {
+				defer c.Close()
+				common.Must2(c.Write([]byte("PAYLOAD")))
+			}(conn)
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listen.Close()
+
+	conn, err := Dial(
+		context.Background(),
+		xraynet.TCPDestination(xraynet.DomainAddress("localhost"), listenPort),
+		settings,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	got := make([]byte, len("PAYLOAD"))
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "PAYLOAD" {
+		t.Fatalf("legacy upper layer received %q, want PAYLOAD", got)
+	}
+}

--- a/transport/internet/splithttp/response_prelude_test.go
+++ b/transport/internet/splithttp/response_prelude_test.go
@@ -1,0 +1,437 @@
+package splithttp
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/xtls/xray-core/transport/internet/stat"
+)
+
+func testResponsePreludeConfig(placement string, table string, from, to int32) *Config {
+	return &Config{
+		SessionIDPlacement: PlacementCookie,
+		SeqPlacement:       PlacementQuery,
+		ResponsePrelude: &ResponsePreludeConfig{
+			Placement: placement,
+			Key:       "pref",
+			Table:     table,
+			Length:    &RangeConfig{From: from, To: to},
+		},
+	}
+}
+
+func TestResponsePreludeRequestRoundTripAllPlacements(t *testing.T) {
+	for _, placement := range []string{PlacementCookie, PlacementHeader, PlacementQuery, PlacementPath} {
+		t.Run(placement, func(t *testing.T) {
+			cfg := testResponsePreludeConfig(placement, PredefinedTable["Base62"], 16, 16)
+			req, err := http.NewRequest(http.MethodGet, "https://example.com/stream", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			value := cfg.GenerateResponsePrelude()
+			if len(value) != 16 {
+				t.Fatalf("unexpected response prelude length: %d", len(value))
+			}
+
+			cfg.ApplyResponsePreludeToRequest(req, value)
+			got := cfg.ExtractResponsePreludeFromRequest(req, "/stream")
+			if got != value {
+				t.Fatalf("round trip mismatch: got %q want %q", got, value)
+			}
+			if !cfg.IsResponsePreludeValid(got) {
+				t.Fatal("generated response prelude rejected")
+			}
+		})
+	}
+}
+
+func TestResponsePreludeGenerationMatrix(t *testing.T) {
+	tests := []struct {
+		name  string
+		table string
+		from  int32
+		to    int32
+	}{
+		{"base62-fixed", PredefinedTable["Base62"], 24, 24},
+		{"base62-range", PredefinedTable["Base62"], 16, 32},
+		{"custom-fixed", "abCD09-_", 8, 8},
+		{"custom-range", "xyz789.~", 7, 19},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testResponsePreludeConfig(PlacementCookie, tt.table, tt.from, tt.to)
+			seen := map[string]struct{}{}
+			for i := 0; i < 256; i++ {
+				value := cfg.GenerateResponsePrelude()
+				if int32(len(value)) < tt.from || int32(len(value)) > tt.to {
+					t.Fatalf("length %d outside %d..%d", len(value), tt.from, tt.to)
+				}
+				for _, ch := range value {
+					if !strings.ContainsRune(tt.table, ch) {
+						t.Fatalf("generated character %q outside table %q", ch, tt.table)
+					}
+				}
+				if !cfg.IsResponsePreludeValid(value) {
+					t.Fatalf("generated value rejected: %q", value)
+				}
+				seen[value] = struct{}{}
+			}
+			if len(seen) < 2 {
+				t.Fatal("generator returned a constant value")
+			}
+		})
+	}
+}
+
+func TestResponsePreludeDefaults(t *testing.T) {
+	cfg := &Config{ResponsePrelude: &ResponsePreludeConfig{}}
+
+	if got := cfg.GetNormalizedResponsePreludePlacement(); got != PlacementCookie {
+		t.Fatalf("default placement: got %q want %q", got, PlacementCookie)
+	}
+	if got := cfg.GetNormalizedResponsePreludeKey(); got != "sample_id" {
+		t.Fatalf("default cookie key: got %q", got)
+	}
+	if got := cfg.GetNormalizedResponsePreludeTable(); got != PredefinedTable["Base62"] {
+		t.Fatal("default table is not Base62")
+	}
+	length := cfg.GetNormalizedResponsePreludeLength()
+	if length == nil || length.From != 16 || length.To != 32 {
+		t.Fatalf("default length: %#v", length)
+	}
+
+	cfg.ResponsePrelude.Placement = PlacementHeader
+	cfg.ResponsePrelude.Key = ""
+	if got := cfg.GetNormalizedResponsePreludeKey(); got != "X-Sample-ID" {
+		t.Fatalf("default header key: got %q", got)
+	}
+
+	cfg.ResponsePrelude.Placement = PlacementQuery
+	cfg.ResponsePrelude.Key = ""
+	if got := cfg.GetNormalizedResponsePreludeKey(); got != "sample_id" {
+		t.Fatalf("default query key: got %q", got)
+	}
+}
+
+func TestResponsePreludeValidationRejectsBadValues(t *testing.T) {
+	cfg := testResponsePreludeConfig(PlacementCookie, "abc", 3, 5)
+
+	for _, value := range []string{"", "ab", "abcabc", "abZ"} {
+		if cfg.IsResponsePreludeValid(value) {
+			t.Fatalf("unexpected valid response prelude: %q", value)
+		}
+	}
+
+	for _, value := range []string{"abc", "abcab", "caba"} {
+		if !cfg.IsResponsePreludeValid(value) {
+			t.Fatalf("unexpected invalid response prelude: %q", value)
+		}
+	}
+}
+
+func TestResponsePreludeDecisionMatrix(t *testing.T) {
+	cfg := testResponsePreludeConfig(PlacementCookie, "abc", 3, 3)
+
+	tests := []struct {
+		name       string
+		body       io.Reader
+		uploadOnly bool
+		want       bool
+	}{
+		{"stream-down", nil, false, true},
+		{"stream-up-body", strings.NewReader("payload"), false, false},
+		{"upload-only", nil, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldApplyResponsePrelude(cfg, tt.body, tt.uploadOnly); got != tt.want {
+				t.Fatalf("got %v want %v", got, tt.want)
+			}
+		})
+	}
+
+	if shouldApplyResponsePrelude(&Config{}, nil, false) {
+		t.Fatal("response prelude enabled without configuration")
+	}
+}
+
+func TestResponsePreludeNeverAddedToPacketRequests(t *testing.T) {
+	for _, method := range []string{http.MethodGet, http.MethodPost} {
+		for _, placement := range []string{PlacementCookie, PlacementHeader, PlacementQuery, PlacementPath} {
+			t.Run(method+"-"+placement, func(t *testing.T) {
+				cfg := testResponsePreludeConfig(placement, PredefinedTable["Base62"], 16, 32)
+				cfg.UplinkHTTPMethod = method
+				cfg.UplinkDataPlacement = PlacementBody
+				cfg.XPaddingBytes = &RangeConfig{From: 1, To: 1}
+
+				req, err := http.NewRequest(method, "https://example.com/upload", nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if err := cfg.FillPacketRequest(req, "session123", "7", nil); err != nil {
+					t.Fatal(err)
+				}
+
+				switch placement {
+				case PlacementCookie:
+					if cookie, err := req.Cookie("pref"); err == nil && cookie != nil {
+						t.Fatalf("packet request unexpectedly has response prelude cookie: %q", cookie.Value)
+					}
+				case PlacementHeader:
+					if got := req.Header.Get("pref"); got != "" {
+						t.Fatalf("packet request unexpectedly has response prelude header: %q", got)
+					}
+				case PlacementQuery:
+					if got := req.URL.Query().Get("pref"); got != "" {
+						t.Fatalf("packet request unexpectedly has response prelude query: %q", got)
+					}
+				case PlacementPath:
+					if strings.Contains(req.URL.Path, "/pref") {
+						t.Fatalf("unexpected response prelude path: %q", req.URL.Path)
+					}
+					if req.URL.Path != "/upload" {
+						t.Fatalf("packet request path changed unexpectedly: %q", req.URL.Path)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestResponsePreludeReaderStripsMatch(t *testing.T) {
+	reader := newResponsePreludeReadCloser(io.NopCloser(strings.NewReader("ABCpayload")), "ABC")
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "payload" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestResponsePreludeReaderReplaysMismatch(t *testing.T) {
+	reader := newResponsePreludeReadCloser(io.NopCloser(strings.NewReader("XYZpayload")), "ABC")
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "XYZpayload" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestResponsePreludeReaderReplaysShortSource(t *testing.T) {
+	reader := newResponsePreludeReadCloser(io.NopCloser(strings.NewReader("AB")), "ABCD")
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "AB" {
+		t.Fatalf("short source was not replayed: got %q", got)
+	}
+}
+
+func TestResponsePreludeHandlerWritesPreludeBeforePayload(t *testing.T) {
+	cfg := &Config{
+		Mode: "stream-one",
+		ResponsePrelude: &ResponsePreludeConfig{
+			Placement: PlacementCookie,
+			Key:       "pref",
+			Table:     PredefinedTable["Base62"],
+			Length:    &RangeConfig{From: 16, To: 16},
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.com/stream", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.FillStreamRequest(req, "", "")
+	prelude := cfg.GenerateResponsePrelude()
+	cfg.ApplyResponsePreludeToRequest(req, prelude)
+
+	h := &requestHandler{
+		config: cfg,
+		path:   "/stream",
+		ln: &Listener{
+			config: cfg,
+			addConn: func(conn stat.Connection) {
+				_ = conn.Close()
+			},
+		},
+	}
+
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	resp := recorder.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status: %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != prelude {
+		t.Fatalf("response body: got %q want %q", body, prelude)
+	}
+
+	reader := newResponsePreludeReadCloser(io.NopCloser(strings.NewReader(string(body)+"payload")), prelude)
+	stripped, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(stripped) != "payload" {
+		t.Fatalf("response prelude was not stripped: got %q", stripped)
+	}
+}
+
+func TestResponsePreludeHandlerRejectsInvalidValue(t *testing.T) {
+	cfg := &Config{
+		Mode: "stream-one",
+		ResponsePrelude: &ResponsePreludeConfig{
+			Placement: PlacementHeader,
+			Key:       "X-Test-Prelude",
+			Table:     "abc",
+			Length:    &RangeConfig{From: 3, To: 3},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/stream", nil)
+	cfg.FillStreamRequest(req, "", "")
+	req.Header.Set("X-Test-Prelude", "abZ")
+
+	h := &requestHandler{
+		config: cfg,
+		path:   "/stream",
+		ln: &Listener{
+			config: cfg,
+			addConn: func(conn stat.Connection) {
+				_ = conn.Close()
+			},
+		},
+	}
+
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("got status %d want %d", recorder.Code, http.StatusBadRequest)
+	}
+}
+
+func TestResponsePreludeAbsentPreservesLegacyBehavior(t *testing.T) {
+	cfg := &Config{
+		Mode: "stream-one",
+		ResponsePrelude: &ResponsePreludeConfig{
+			Placement: PlacementCookie,
+			Key:       "pref",
+			Table:     PredefinedTable["Base62"],
+			Length:    &RangeConfig{From: 16, To: 16},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/stream", nil)
+	cfg.FillStreamRequest(req, "", "")
+
+	h := &requestHandler{
+		config: cfg,
+		path:   "/stream",
+		ln: &Listener{
+			config: cfg,
+			addConn: func(conn stat.Connection) {
+				_ = conn.Close()
+			},
+		},
+	}
+
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("got status %d want %d", recorder.Code, http.StatusOK)
+	}
+	if recorder.Body.Len() != 0 {
+		t.Fatalf("legacy request unexpectedly received response prelude: %q", recorder.Body.String())
+	}
+}
+
+func TestResponsePreludeCookieEnablesCORSCredentials(t *testing.T) {
+	cfg := &Config{
+		SessionIDPlacement:  PlacementPath,
+		SeqPlacement:        PlacementPath,
+		UplinkDataPlacement: PlacementBody,
+		ResponsePrelude:     &ResponsePreludeConfig{Placement: PlacementCookie},
+	}
+	recorder := httptest.NewRecorder()
+	cfg.WriteResponseHeader(recorder, http.MethodGet, http.Header{"Origin": []string{"https://example.com"}})
+	if got := recorder.Header().Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Fatalf("Access-Control-Allow-Credentials: got %q want true", got)
+	}
+}
+
+func TestResponsePreludeNonCookieDoesNotForceCORSCredentials(t *testing.T) {
+	cfg := &Config{
+		SessionIDPlacement:  PlacementPath,
+		SeqPlacement:        PlacementPath,
+		UplinkDataPlacement: PlacementBody,
+		ResponsePrelude:     &ResponsePreludeConfig{Placement: PlacementHeader},
+	}
+	recorder := httptest.NewRecorder()
+	cfg.WriteResponseHeader(recorder, http.MethodGet, http.Header{"Origin": []string{"https://example.com"}})
+	if got := recorder.Header().Get("Access-Control-Allow-Credentials"); got != "" {
+		t.Fatalf("unexpected Access-Control-Allow-Credentials: %q", got)
+	}
+}
+
+func TestResponsePreludeInvalidMetadataIgnoredOnPacketUplink(t *testing.T) {
+	cfg := &Config{
+		Mode:                "packet-up",
+		SessionIDPlacement:  PlacementCookie,
+		SessionIDKey:        "x_session",
+		SeqPlacement:        PlacementQuery,
+		SeqKey:              "chunk_id",
+		UplinkDataPlacement: PlacementBody,
+		XPaddingBytes:       &RangeConfig{From: 1, To: 1},
+		ResponsePrelude: &ResponsePreludeConfig{
+			Placement: PlacementHeader,
+			Key:       "X-Test-Prelude",
+			Table:     "abc",
+			Length:    &RangeConfig{From: 3, To: 3},
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.com/stream", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.FillPacketRequest(req, "session123", "0", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Deliberately invalid for responsePrelude. Packet uplink must ignore it.
+	req.Header.Set("X-Test-Prelude", "ZZZ")
+
+	h := &requestHandler{
+		config:    cfg,
+		path:      "/stream",
+		sessionMu: &sync.Mutex{},
+		ln: &Listener{
+			config: cfg,
+		},
+	}
+
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("packet uplink unexpectedly rejected: got %d want %d", recorder.Code, http.StatusOK)
+	}
+}


### PR DESCRIPTION
Some CDN configurations may wait for response body data before they start forwarding a streaming response. With XHTTP this can sometimes make the downlink stream fail to start or behave inconsistently.

This adds an optional `responsePrelude` setting. The client sends a small value with the downlink request, the server writes the same value at the beginning of the response and flushes it, and the client removes it before passing the actual stream data further.

The intention is just to make the response start earlier for CDN setups where headers alone are not enough.

It is optional and does not change the normal XHTTP behavior when it is not configured. A client without `responsePrelude` continues to use the existing path.

I tested the main request placements, packet-up/downlink behavior, compatibility without the option, and added an end-to-end test with a buffering HTTP intermediary. It was also tested with a real CDN setup where this helped the stream start.

The current default names are `sample_id` for cookie/query and `X-Sample-ID` for header. I tried to keep them generic, but I can change the naming if something else fits XHTTP better.