### PR TITLE
README: add Caspian-BYOC under Others

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@
 - Xray Tools
   - [xray-knife](https://github.com/lilendian0x00/xray-knife)
   - [xray-checker](https://github.com/kutovoys/xray-checker)
+- Xray Gateways
+  - [Caspian-BYOC](https://github.com/Iman/caspian)
 - Xray Wrapper
   - [XTLS/libXray](https://github.com/XTLS/libXray)
   - [xtls-sdk](https://github.com/remnawave/xtls-sdk)


### PR DESCRIPTION
Adds Caspian-BYOC: https://github.com/Iman/caspian

Caspian-BYOC turns a Windows PC, a Mac, a Linux box or a Raspberry Pi into a WiFi hotspot. The user pastes one VLESS, VMess, Trojan, Shadowsocks, SOCKS or Hysteria2 share link (or Clash YAML, raw Xray JSON, or a base64 subscription) into a local web panel, and every device that joins the hotspot goes through the Xray tunnel with no client app installed on the phones. Fail-closed: if the tunnel drops, traffic is blocked rather than leaked.

Written in Go, AGPL-3.0-or-later, no telemetry, panel in English and Persian. Tagged releases with builds for Windows 10 version 2004 or later and Windows 11 (x64, arm64), macOS 13+ (Intel and Apple Silicon), Linux (x86_64, arm64, armv7, armv6) and Raspberry Pi.
