### PR TITLE
proxy/tun: improve Windows outbound interface selection

### DIFF
--- a/proxy/tun/README.md
+++ b/proxy/tun/README.md
@@ -42,6 +42,15 @@ Here is simple Xray config snippet to enable the inbound:
 `desc` sets the Windows Wintun adapter tunnel type and defaults to `Wintun`.
 It is ignored on other platforms.
 
+When `autoOutboundsInterface` is set to `auto`, Xray automatically selects an
+active non-loopback interface with an address for its outbound connections.
+On Windows, the selection is heuristic: known virtual adapter descriptions
+are deprioritized, while WiFi and common physical Ethernet descriptions may
+be preferred. This does not inspect or reproduce the Windows routing table.
+For environments with enterprise VPNs, ZeroTier, Hyper-V, or other virtual
+adapters, configure `autoOutboundsInterface` with the exact interface name
+when a specific outbound interface is required.
+
 ## SUPPORTED FEATURES
 
 - IPv4 and IPv6

--- a/proxy/tun/tun_windows.go
+++ b/proxy/tun/tun_windows.go
@@ -325,6 +325,16 @@ func findOutboundInterface(tunIndex int, fixedName string) (*net.Interface, erro
 		return nil, nil
 	}
 
+	// Adapter descriptions are driver-provided and generally survive friendly
+	// name changes. Keep this best-effort so lookup failures do not drop candidates.
+	var descriptions map[int]string
+	if rows, err := winipcfg.GetIfTable2Ex(winipcfg.MibIfEntryNormalWithoutStatistics); err == nil {
+		descriptions = make(map[int]string, len(rows))
+		for i := range rows {
+			descriptions[int(rows[i].InterfaceIndex)] = rows[i].Description()
+		}
+	}
+
 	var candidates []struct {
 		index int
 		score int
@@ -333,7 +343,7 @@ func findOutboundInterface(tunIndex int, fixedName string) (*net.Interface, erro
 		if iface.Index == tunIndex {
 			continue
 		}
-		if strings.Contains(iface.Name, "vEthernet") {
+		if strings.Contains(strings.ToLower(iface.Name), "vethernet") {
 			continue
 		}
 		if iface.Flags&net.FlagUp == 0 {
@@ -349,7 +359,7 @@ func findOutboundInterface(tunIndex int, fixedName string) (*net.Interface, erro
 		candidates = append(candidates, struct {
 			index int
 			score int
-		}{i, scoreWindowsInterface(&iface, addrs)})
+		}{i, scoreWindowsInterface(&iface, descriptions[iface.Index])})
 	}
 
 	sort.Slice(candidates, func(i, j int) bool {
@@ -366,20 +376,42 @@ func findOutboundInterface(tunIndex int, fixedName string) (*net.Interface, erro
 	return &iface, nil
 }
 
-func scoreWindowsInterface(iface *net.Interface, addrs []net.Addr) int {
-	score := 0
-
+func scoreWindowsInterface(iface *net.Interface, description string) int {
 	name := strings.ToLower(iface.Name)
-	if strings.Contains(name, "wlan") || strings.Contains(name, "wi-fi") {
-		score += 2
+	description = strings.ToLower(description)
+
+	// De-prioritize driver-provided descriptions associated with virtual adapters.
+	if strings.Contains(description, "virtual") ||
+		strings.Contains(description, "zerotier") ||
+		strings.Contains(description, "hyper-v") ||
+		strings.Contains(description, "vmware") ||
+		strings.Contains(description, "virtualbox") ||
+		strings.Contains(description, "tailscale") ||
+		strings.Contains(description, "wireguard") ||
+		strings.Contains(description, "vpn") ||
+		strings.Contains(description, "wintun") {
+		return -1
 	}
 
-	for _, addr := range addrs {
-		if strings.HasPrefix(addr.String(), "192.168.") {
-			score++
-			break
-		}
+	// WiFi adapters.
+	if strings.Contains(name, "wifi") ||
+		strings.Contains(name, "wi-fi") ||
+		strings.Contains(name, "wlan") ||
+		strings.Contains(description, "wifi") ||
+		strings.Contains(description, "wi-fi") ||
+		strings.Contains(description, "wireless") ||
+		strings.Contains(description, "wlan") ||
+		strings.Contains(description, "802.11") {
+		return 1
 	}
 
-	return score
+	// Wired adapters.
+	if strings.Contains(name, "ethernet") ||
+		strings.Contains(description, "gbe") ||
+		strings.Contains(description, "gigabit") ||
+		strings.Contains(description, "fast ethernet") {
+		return 1
+	}
+
+	return 0
 }

--- a/proxy/tun/tun_windows_test.go
+++ b/proxy/tun/tun_windows_test.go
@@ -1,0 +1,56 @@
+//go:build windows
+
+package tun
+
+import (
+	"net"
+	"testing"
+)
+
+func TestScoreWindowsInterface(t *testing.T) {
+	tests := []struct {
+		name        string
+		ifaceName   string
+		description string
+		want        int
+	}{
+		{name: "pppoe", ifaceName: "PPPoE 2", want: 0},
+		{name: "generic vpn description", ifaceName: "Ethernet 2", description: "Corporate VPN Adapter", want: -1},
+		{name: "virtual product in friendly name only", ifaceName: "ZeroTier One", want: 0},
+
+		{name: "wifi name", ifaceName: "WiFi 2", want: 1},
+		{name: "wi-fi name", ifaceName: "Wi-Fi", want: 1},
+		{name: "wlan name", ifaceName: "WLAN3", want: 1},
+		{name: "wifi description", ifaceName: "Wireless", description: "Intel(R) WiFi 6 AX200 160MHz", want: 1},
+		{name: "wireless description", ifaceName: "Network 2", description: "Qualcomm Wireless Adapter", want: 1},
+		{name: "wlan description", ifaceName: "Network 3", description: "802.11 WLAN Adapter", want: 1},
+		{name: "802.11 description", ifaceName: "Network 4", description: "802.11ax Adapter", want: 1},
+		{name: "gbe description", ifaceName: "Ethernet 5", description: "Realtek PCIe GbE Family Controller", want: 1},
+		{name: "2.5gbe description", ifaceName: "Ethernet 1", description: "Realtek Gaming USB 2.5GbE Family Controller", want: 1},
+		{name: "gigabit description", ifaceName: "Ethernet 4", description: "Intel(R) Gigabit Network Connection", want: 1},
+		{name: "fast ethernet description", ifaceName: "Ethernet 8", description: "USB Fast Ethernet Adapter", want: 1},
+		{name: "ethernet name", ifaceName: "Ethernet 6", description: "PCIe Network Adapter", want: 1},
+		{name: "ethernet without description", ifaceName: "Ethernet 3", want: 1},
+
+		{name: "zerotier description", ifaceName: "Ethernet 2", description: "ZeroTier Port", want: -1},
+		{name: "hyper-v description", ifaceName: "Ethernet 3", description: "Hyper-V Network Adapter", want: -1},
+		{name: "vmware description", ifaceName: "Ethernet 4", description: "VMware Network Adapter VMnet8", want: -1},
+		{name: "virtualbox description", ifaceName: "Ethernet 5", description: "VirtualBox Host-Only Ethernet Adapter", want: -1},
+		{name: "tailscale description", ifaceName: "Ethernet 6", description: "Tailscale Tunnel", want: -1},
+		{name: "wireguard description", ifaceName: "Ethernet 7", description: "WireGuard Tunnel", want: -1},
+		{name: "vpn client description", ifaceName: "Ethernet 8", description: "Corporate VPN Client Adapter", want: -1},
+		{name: "wintun description", ifaceName: "Ethernet 9", description: "Wintun Tunnel", want: -1},
+
+		{name: "virtual takes precedence over wifi", ifaceName: "WiFi", description: "Microsoft Wi-Fi Direct Virtual Adapter", want: -1},
+		{name: "vpn client takes precedence over wired", ifaceName: "Ethernet", description: "Gigabit VPN Client Adapter", want: -1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			iface := &net.Interface{Name: test.ifaceName}
+			if got := scoreWindowsInterface(iface, test.description); got != test.want {
+				t.Fatalf("scoreWindowsInterface(%q, %q) = %d, want %d", test.ifaceName, test.description, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The previous Windows heuristic primarily relied on interface names and whether an interface had a `192.168.x.x` address. This could miss physical interfaces using other private address ranges, such as `10.x.x.x` or `172.16.x.x` through `172.31.x.x`, and could incorrectly select virtual or VPN interfaces when their names did not match the limited filters or when they also used a `192.168.x.x` address.

This change:

- Uses driver-provided adapter descriptions from `GetIfTable2Ex`.
- Deprioritizes known virtual and VPN adapters, including ZeroTier, Tailscale, and WireGuard.
- Recognizes Wi-Fi indicators such as `WiFi`, `WLAN`, and `802.11`.
- Recognizes wired adapters through `Ethernet`, `GbE`, `Gigabit`, and related identifiers.
- Makes `vEthernet` filtering case-insensitive.

原有的 Windows 启发式主要依赖网卡名称，以及网卡是否使用 `192.168.x.x` 地址。这可能导致使用其他私有地址段（例如 `10.x.x.x` 或 `172.16.x.x` 至 `172.31.x.x`）的物理网卡无法被优先识别；当虚拟网卡或 VPN 网卡的名称不符合有限的过滤规则，或它们同样使用 `192.168.x.x` 地址时，也可能被错误选中。

本次改动：

- 通过 `GetIfTable2Ex` 获取网卡驱动提供的描述信息。
- 降低已知虚拟网卡和 VPN 网卡的优先级，包括 ZeroTier、Tailscale 和 WireGuard。
- 增加对 `WiFi`、`WLAN` 和 `802.11` 等无线网卡标识的识别。
- 增加对 `Ethernet`、`GbE`、`Gigabit` 等有线网卡标识的识别。
- 将 `vEthernet` 过滤改为大小写不敏感。