### PR TITLE
TLS: synchronize certificate publication during reload

### DIFF
--- a/transport/internet/tls/certificate_race_test.go
+++ b/transport/internet/tls/certificate_race_test.go
@@ -1,0 +1,32 @@
+package tls_test
+
+import (
+	gotls "crypto/tls"
+	"runtime"
+	"testing"
+
+	"github.com/xtls/xray-core/common/protocol/tls/cert"
+	. "github.com/xtls/xray-core/transport/internet/tls"
+)
+
+// The reload ticker invokes its first callback immediately, even without file
+// paths or OCSP. Concurrent certificate selection must see immutable snapshots.
+func TestCertificateSelectionDuringInitialReload(t *testing.T) {
+	generated, err := cert.Generate(nil, cert.CommonName("example.com"), cert.DNSNames("example.com"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	certificate := ParseCertificate(generated)
+	config := &Config{Certificate: []*Certificate{certificate}}
+	for i := 0; i < 100; i++ {
+		tlsConfig := config.GetTLSConfig()
+		for j := 0; j < 50; j++ {
+			selected, err := tlsConfig.GetCertificate(&gotls.ClientHelloInfo{ServerName: "example.com"})
+			if err != nil || selected == nil {
+				t.Fatalf("certificate selection failed: %v", err)
+			}
+			_ = selected.Certificate[0]
+			runtime.Gosched()
+		}
+	}
+}

--- a/transport/internet/tls/config.go
+++ b/transport/internet/tls/config.go
@@ -19,7 +19,11 @@ import (
 	"github.com/xtls/xray-core/common/platform/filesystem"
 	"github.com/xtls/xray-core/common/protocol/tls/cert"
 	"github.com/xtls/xray-core/transport/internet"
+	"google.golang.org/protobuf/proto"
 )
+
+// certificateAccess protects publication; published certificate values are immutable.
+var certificateAccess sync.RWMutex
 
 var globalSessionCache = tls.NewLRUClientSessionCache(128)
 
@@ -47,8 +51,11 @@ func (c *Config) loadSelfCertPool() (*x509.CertPool, error) {
 
 // BuildCertificates builds a list of TLS certificates from proto definition.
 func (c *Config) BuildCertificates() []*tls.Certificate {
+	certificateAccess.Lock()
+	defer certificateAccess.Unlock()
 	certs := make([]*tls.Certificate, 0, len(c.Certificate))
 	for _, entry := range c.Certificate {
+		entry = proto.Clone(entry).(*Certificate)
 		if entry.Usage != Certificate_ENCIPHERMENT {
 			continue
 		}
@@ -72,7 +79,10 @@ func (c *Config) BuildCertificates() []*tls.Certificate {
 		}
 		index := len(certs) - 1
 		setupOcspTicker(entry, func(isReloaded, isOcspstapling bool) {
-			cert := certs[index]
+			certificateAccess.RLock()
+			snapshot := *certs[index]
+			certificateAccess.RUnlock()
+			cert := &snapshot
 			if isReloaded {
 				if newKeyPair := getX509KeyPair(); newKeyPair != nil {
 					cert = newKeyPair
@@ -87,7 +97,9 @@ func (c *Config) BuildCertificates() []*tls.Certificate {
 					cert.OCSPStaple = newOCSPData
 				}
 			}
+			certificateAccess.Lock()
 			certs[index] = cert
+			certificateAccess.Unlock()
 		})
 	}
 	return certs
@@ -245,6 +257,8 @@ func getGetCertificateFunc(c *tls.Config, ca []*Certificate) func(hello *tls.Cli
 
 func getNewGetCertificateFunc(certs []*tls.Certificate, rejectUnknownSNI bool) func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	return func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		certificateAccess.RLock()
+		defer certificateAccess.RUnlock()
 		if len(certs) == 0 {
 			return nil, errNoCertificates
 		}


### PR DESCRIPTION
## Problem

`BuildCertificates` starts a background certificate/OCSP ticker for every encipherment certificate. The first callback runs immediately, before the first ticker wait. That callback reads and replaces an element of the certificate slice while `GetCertificate` may read it during a TLS handshake. The callback can also overlap with the initial slice construction. This happens even when certificate paths and OCSP are not configured.

When OCSP is enabled, mutating `OCSPStaple` on an already published `tls.Certificate` additionally allows a handshake to observe a concurrent mutation. Reloading file contents also mutates the protobuf certificate entry shared with the caller.

## Change

- Synchronize certificate slice construction, publication and selection with an RW mutex.
- Publish a fresh certificate snapshot instead of mutating the object already returned to a handshake. Network OCSP fetches happen outside the lock.
- Clone each protobuf certificate entry before handing it to the background loader, so loader updates do not mutate the caller's configuration.
- Add a regression test exercising certificate selection while the initial reload callback runs.

This deliberately keeps the existing ticker lifecycle and reload timing unchanged. The package-level mutex is a conservative implementation; a per-loader store could avoid contention between independent TLS configurations, but would require a larger API change. Exported direct consumers of `BuildCertificates` that retain/read its returned slice are not made safe by this patch; this draft addresses the normal `GetTLSConfig` / `GetCertificate` path and invites review of that API boundary.

## Reproduction and validation

Base: `eef6e63bc16d6e97fd98178556d49aad7978809a`.
Environment: Go 1.26.2, darwin/arm64.

With only the new test applied to the base:

```sh
go test -race ./transport/internet/tls -run TestCertificateSelectionDuringInitialReload -count=1
```

Result: `WARNING: DATA RACE`; the test fails with `race detected during execution of test`. The reported accesses are the callback in `BuildCertificates` and certificate selection in `getNewGetCertificateFunc`.

With the patch:

```sh
go test -race ./transport/internet/tls -run TestCertificateSelectionDuringInitialReload -count=3
go test -race ./transport/internet/tls
```

Both pass. The full repository suite and an OCSP network integration test have not been run. The regression covers initial publication; OCSP snapshot handling also needs maintainer review.

The separate XHTTP `WaitReadCloser` issue is already addressed by #6694 and is not included here. This contribution was prepared with AI assistance. The consuming application continues to use an official release and does not depend on this fork.
