### PR TITLE
sniffer: fix a uTP false positive and detect DHT and UDP tracker traffic

### DIFF
--- a/app/dispatcher/sniffer.go
+++ b/app/dispatcher/sniffer.go
@@ -41,6 +41,8 @@ func NewSniffer(ctx context.Context) *Sniffer {
 			{func(c context.Context, b []byte) (SniffResult, error) { return bittorrent.SniffBittorrent(b) }, false, net.Network_TCP},
 			{func(c context.Context, b []byte) (SniffResult, error) { return quic.SniffQUIC(b) }, false, net.Network_UDP},
 			{func(c context.Context, b []byte) (SniffResult, error) { return bittorrent.SniffUTP(b) }, false, net.Network_UDP},
+			{func(c context.Context, b []byte) (SniffResult, error) { return bittorrent.SniffUDPTracker(b) }, false, net.Network_UDP},
+			{func(c context.Context, b []byte) (SniffResult, error) { return bittorrent.SniffDHT(b) }, false, net.Network_UDP},
 		},
 	}
 	if sniffer, err := newFakeDNSSniffer(ctx); err == nil {

--- a/common/protocol/bittorrent/bittorrent.go
+++ b/common/protocol/bittorrent/bittorrent.go
@@ -46,6 +46,12 @@ func SniffUTP(b []byte) (*SniffHeader, error) {
 		return nil, errNotBittorrent
 	}
 
+	// ack_nr carries no meaning until the peer replies, and implementations send
+	// a zeroed one. Requiring it rules out DNS queries, whose qclass sits here
+	if binary.BigEndian.Uint16(b[18:20]) != 0 {
+		return nil, errNotBittorrent
+	}
+
 	// Walk the extension chain. Selective ack (1) and extension bits (2)
 	extension, offset := b[1], 20
 	for extension != 0 {
@@ -74,6 +80,33 @@ func SniffUTP(b []byte) (*SniffHeader, error) {
 
 	// extensions should consume all ST_SYN payload
 	if len(b) != offset {
+		return nil, errNotBittorrent
+	}
+
+	return &SniffHeader{}, nil
+}
+
+// udpTrackerMagic opens every BEP 15 connect request.
+const udpTrackerMagic = 0x41727101980
+
+// SniffUDPTracker matches the connect request that opens a session with a UDP
+// tracker (BEP 15). It is the only packet a client sends first, and it is
+// exactly 16 bytes: the magic, action 0, and a transaction id.
+func SniffUDPTracker(b []byte) (*SniffHeader, error) {
+	if len(b) < 16 {
+		return nil, common.ErrNoClue
+	}
+
+	if len(b) != 16 {
+		return nil, errNotBittorrent
+	}
+
+	if binary.BigEndian.Uint64(b[0:8]) != udpTrackerMagic {
+		return nil, errNotBittorrent
+	}
+
+	// action 0 is connect
+	if binary.BigEndian.Uint32(b[8:12]) != 0 {
 		return nil, errNotBittorrent
 	}
 

--- a/common/protocol/bittorrent/bittorrent_test.go
+++ b/common/protocol/bittorrent/bittorrent_test.go
@@ -42,6 +42,12 @@ func TestSniffUTP(t *testing.T) {
 			0x41, 0x00, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 			0x01, 'a', 0x02, 'c', 'o', 0x00, 0x00, 0x01, 0x00, 0x01,
 		}, errNotBittorrent},
+		// the same collision at exactly 20 bytes, where the extension chain check
+		// cannot help: QNAME is 2 characters, so qclass lands on ack_nr
+		{"dns query the size of a bare header", []byte{
+			0x41, 0x00, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x02, 'a', 'b', 0x00, 0x00, 0x01, 0x00, 0x01,
+		}, errNotBittorrent},
 		{"established connection packets", utpPacket(0, 0, 0x5678, 'x', 'y', 'z'), errNotBittorrent},
 		{"state", utpPacket(2, 0, 0x5678), errNotBittorrent},
 		{"fin", utpPacket(1, 0, 0x5678), errNotBittorrent},
@@ -56,6 +62,94 @@ func TestSniffUTP(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			h, err := SniffUTP(c.payload)
+			if err != c.err {
+				t.Fatalf("expected error %v, got %v", c.err, err)
+			}
+			if err == nil && h == nil {
+				t.Fatal("expected a sniff header, got nil")
+			}
+		})
+	}
+}
+
+// btHandshake builds the fixed 68 byte handshake defined by BEP 3.
+func btHandshake() []byte {
+	b := make([]byte, 0, 68)
+	b = append(b, 19)
+	b = append(b, "BitTorrent protocol"...)
+	b = append(b, make([]byte, 8)...) // reserved
+	ids := make([]byte, 40)           // info_hash and peer_id, arbitrary
+	for i := range ids {
+		ids[i] = byte(i)
+	}
+	return append(b, ids...)
+}
+
+func TestSniffBittorrent(t *testing.T) {
+	wrongLength := btHandshake()
+	wrongLength[0] = 20
+
+	wrongProtocol := btHandshake()
+	copy(wrongProtocol[1:20], "bitTorrent protocol")
+
+	cases := []struct {
+		name    string
+		payload []byte
+		err     error
+	}{
+		{"handshake", btHandshake(), nil},
+		{"handshake cut to the matched prefix", btHandshake()[:20], nil},
+		{"wrong pstrlen", wrongLength, errNotBittorrent},
+		{"wrong protocol string", wrongProtocol, errNotBittorrent},
+		{"tls client hello", []byte{
+			0x16, 0x03, 0x01, 0x02, 0x00, 0x01, 0x00, 0x01, 0xfc, 0x03, 0x03,
+			0x9b, 0x1e, 0x4c, 0x7a, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66,
+		}, errNotBittorrent},
+		// an HTTP tracker announce is BitTorrent, but not this handshake
+		{"http tracker announce", []byte("GET /announce?info_hash=aaaaaaaaaaaaaaaaaaaa HTTP/1.1\r\n"), errNotBittorrent},
+		{"shorter than the matched prefix", btHandshake()[:19], common.ErrNoClue},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h, err := SniffBittorrent(c.payload)
+			if err != c.err {
+				t.Fatalf("expected error %v, got %v", c.err, err)
+			}
+			if err == nil && h == nil {
+				t.Fatal("expected a sniff header, got nil")
+			}
+		})
+	}
+}
+
+// udpTrackerConnect builds the 16 byte connect request defined by BEP 15.
+func udpTrackerConnect(magic uint64, action uint32) []byte {
+	b := make([]byte, 16)
+	binary.BigEndian.PutUint64(b[0:8], magic)
+	binary.BigEndian.PutUint32(b[8:12], action)
+	binary.BigEndian.PutUint32(b[12:16], 0x2b8c41f7) // transaction_id, random
+	return b
+}
+
+func TestSniffUDPTracker(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload []byte
+		err     error
+	}{
+		{"connect request", udpTrackerConnect(udpTrackerMagic, 0), nil},
+		{"wrong magic", udpTrackerConnect(udpTrackerMagic+1, 0), errNotBittorrent},
+		{"announce rather than connect", udpTrackerConnect(udpTrackerMagic, 1), errNotBittorrent},
+		{"connect request with trailing bytes", append(udpTrackerConnect(udpTrackerMagic, 0), 'x'), errNotBittorrent},
+		{"utp syn", utpPacket(4, 0, 0), errNotBittorrent},
+		{"zeroed datagram", make([]byte, 16), errNotBittorrent},
+		{"shorter than a connect request", udpTrackerConnect(udpTrackerMagic, 0)[:15], common.ErrNoClue},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h, err := SniffUDPTracker(c.payload)
 			if err != c.err {
 				t.Fatalf("expected error %v, got %v", c.err, err)
 			}

--- a/common/protocol/bittorrent/dht.go
+++ b/common/protocol/bittorrent/dht.go
@@ -1,0 +1,203 @@
+package bittorrent
+
+import (
+	"github.com/xtls/xray-core/common"
+)
+
+// The DHT speaks KRPC (BEP 5): bencoded dictionaries, one per UDP datagram.
+// Only as much of bencode as it takes to validate the shape of a message is
+// implemented here, since a sniffer cares about the framing, not the contents.
+
+// bencodeMaxDepth bounds recursion on hostile input. Real KRPC messages nest
+// three levels at most.
+const bencodeMaxDepth = 8
+
+// readString reads the bencode byte string at i, returning its content and the
+// offset just past it.
+func readString(b []byte, i int) ([]byte, int, bool) {
+	colon := -1
+	// a length of more than seven digits cannot describe a datagram
+	for j := i; j < len(b) && j < i+8; j++ {
+		if b[j] == ':' {
+			colon = j
+			break
+		}
+		if b[j] < '0' || b[j] > '9' {
+			return nil, 0, false
+		}
+	}
+	if colon <= i {
+		return nil, 0, false
+	}
+
+	length := 0
+	for _, d := range b[i:colon] {
+		length = length*10 + int(d-'0')
+	}
+
+	end := colon + 1 + length
+	if end > len(b) {
+		return nil, 0, false
+	}
+	return b[colon+1 : end], end, true
+}
+
+// skipValue validates the bencode value at i and returns the offset just past it.
+func skipValue(b []byte, i, depth int) (int, bool) {
+	if depth > bencodeMaxDepth || i >= len(b) {
+		return 0, false
+	}
+
+	switch c := b[i]; c {
+	case 'i':
+		j := i + 1
+		if j < len(b) && b[j] == '-' {
+			j++
+		}
+		digits := j
+		for j < len(b) && b[j] >= '0' && b[j] <= '9' {
+			j++
+		}
+		if j == digits || j >= len(b) || b[j] != 'e' {
+			return 0, false
+		}
+		return j + 1, true
+	case 'l':
+		j := i + 1
+		for j < len(b) && b[j] != 'e' {
+			next, ok := skipValue(b, j, depth+1)
+			if !ok {
+				return 0, false
+			}
+			j = next
+		}
+		if j >= len(b) {
+			return 0, false
+		}
+		return j + 1, true
+	case 'd':
+		j := i + 1
+		for j < len(b) && b[j] != 'e' {
+			// keys are always byte strings
+			_, valueStart, ok := readString(b, j)
+			if !ok {
+				return 0, false
+			}
+			next, ok := skipValue(b, valueStart, depth+1)
+			if !ok {
+				return 0, false
+			}
+			j = next
+		}
+		if j >= len(b) {
+			return 0, false
+		}
+		return j + 1, true
+	default:
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		_, end, ok := readString(b, i)
+		return end, ok
+	}
+}
+
+// hasNodeID reports whether a bencoded dictionary carries the 20 byte "id" that
+// every KRPC query and response has to name.
+func hasNodeID(d []byte) bool {
+	if len(d) == 0 || d[0] != 'd' {
+		return false
+	}
+
+	i := 1
+	for i < len(d) && d[i] != 'e' {
+		key, valueStart, ok := readString(d, i)
+		if !ok {
+			return false
+		}
+		valueEnd, ok := skipValue(d, valueStart, 1)
+		if !ok {
+			return false
+		}
+		if string(key) == "id" {
+			id, _, ok := readString(d, valueStart)
+			return ok && len(id) == 20
+		}
+		i = valueEnd
+	}
+
+	return false
+}
+
+// SniffDHT matches a KRPC message of the BitTorrent DHT (BEP 5).
+func SniffDHT(b []byte) (*SniffHeader, error) {
+	if len(b) < 20 {
+		return nil, common.ErrNoClue
+	}
+
+	// every KRPC message is a bencoded dictionary
+	if b[0] != 'd' {
+		return nil, errNotBittorrent
+	}
+
+	var msgType, txID, method, args, resp, errList []byte
+
+	i := 1
+	for i < len(b) && b[i] != 'e' {
+		key, valueStart, ok := readString(b, i)
+		if !ok {
+			return nil, errNotBittorrent
+		}
+		valueEnd, ok := skipValue(b, valueStart, 1)
+		if !ok {
+			return nil, errNotBittorrent
+		}
+		if len(key) == 1 {
+			switch key[0] {
+			// a value of the wrong kind leaves the field empty, which the
+			// checks below reject
+			case 'y':
+				msgType, _, _ = readString(b, valueStart)
+			case 't':
+				txID, _, _ = readString(b, valueStart)
+			case 'q':
+				method, _, _ = readString(b, valueStart)
+			case 'a':
+				args = b[valueStart:valueEnd]
+			case 'r':
+				resp = b[valueStart:valueEnd]
+			case 'e':
+				errList = b[valueStart:valueEnd]
+			}
+		}
+		i = valueEnd
+	}
+
+	// the loop stops on the closing 'e', which has to be the last byte
+	if i+1 != len(b) {
+		return nil, errNotBittorrent
+	}
+
+	if len(msgType) != 1 || len(txID) == 0 {
+		return nil, errNotBittorrent
+	}
+
+	switch msgType[0] {
+	case 'q': // query: a method name, and arguments naming the sender
+		if len(method) == 0 || !hasNodeID(args) {
+			return nil, errNotBittorrent
+		}
+	case 'r': // response: the answering node names itself
+		if !hasNodeID(resp) {
+			return nil, errNotBittorrent
+		}
+	case 'e': // error: a list holding a code and a message
+		if len(errList) == 0 || errList[0] != 'l' {
+			return nil, errNotBittorrent
+		}
+	default:
+		return nil, errNotBittorrent
+	}
+
+	return &SniffHeader{}, nil
+}

--- a/common/protocol/bittorrent/dht_test.go
+++ b/common/protocol/bittorrent/dht_test.go
@@ -1,0 +1,65 @@
+package bittorrent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/xtls/xray-core/common"
+)
+
+// nodeID stands in for the 20 byte identifier every KRPC message carries.
+var nodeID = strings.Repeat("A", 20)
+
+func TestSniffDHT(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload []byte
+		err     error
+	}{
+		{"ping query", []byte("d1:ad2:id20:" + nodeID + "e1:q4:ping1:t2:aa1:y1:qe"), nil},
+		{"get_peers query", []byte("d1:ad2:id20:" + nodeID + "9:info_hash20:" + nodeID + "e1:q9:get_peers1:t2:aa1:y1:qe"), nil},
+		{"ping response", []byte("d1:rd2:id20:" + nodeID + "e1:t2:aa1:y1:re"), nil},
+		{"response with an ip key ahead of r", []byte("d2:ip6:abcdef1:rd2:id20:" + nodeID + "e1:t2:aa1:y1:re"), nil},
+		{"error", []byte("d1:eli201e23:A Generic Error Ocurrede1:t2:aa1:y1:ee"), nil},
+		{"query without a node id", []byte("d1:ad4:porti6881ee1:q4:ping1:t2:aa1:y1:qe"), errNotBittorrent},
+		{"node id of the wrong length", []byte("d1:ad2:id19:" + nodeID[:19] + "e1:q4:ping1:t2:aa1:y1:qe"), errNotBittorrent},
+		{"query without a method name", []byte("d1:ad2:id20:" + nodeID + "e1:t2:aa1:y1:qe"), errNotBittorrent},
+		{"message without a transaction id", []byte("d1:ad2:id20:" + nodeID + "e1:q4:ping1:y1:qe"), errNotBittorrent},
+		{"unknown message type", []byte("d1:ad2:id20:" + nodeID + "e1:q4:ping1:t2:aa1:y1:ze"), errNotBittorrent},
+		{"message type that is not a string", []byte("d1:ad2:id20:" + nodeID + "e1:q4:ping1:t2:aa1:yi1ee"), errNotBittorrent},
+		{"trailing byte past the dictionary", []byte("d1:ad2:id20:" + nodeID + "e1:q4:ping1:t2:aa1:y1:qex"), errNotBittorrent},
+		{"dictionary left open", []byte("d1:ad2:id20:" + nodeID + "e1:q4:ping1:t2:aa1:y1:q"), errNotBittorrent},
+		{"string longer than the datagram", []byte("d1:ad2:id99:" + nodeID + "e1:q4:ping1:t2:aa1:y1:qe"), errNotBittorrent},
+		// guards the recursion bound rather than the protocol
+		{"nested lists", []byte("d1:a" + strings.Repeat("l", 64) + strings.Repeat("e", 64) + "1:q4:ping1:t2:aa1:y1:qe"), errNotBittorrent},
+		// datagrams the UDP sniffers see alongside the DHT
+		{"dns query", []byte{
+			0x41, 0x00, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x02, 'a', 'b', 0x00, 0x00, 0x01, 0x00, 0x01,
+		}, errNotBittorrent},
+		{"utp syn", utpPacket(4, 0, 0), errNotBittorrent},
+		{"udp tracker connect", udpTrackerConnect(udpTrackerMagic, 0), common.ErrNoClue},
+		{"stun binding request", []byte{
+			0x00, 0x01, 0x00, 0x00, 0x21, 0x12, 0xa4, 0x42, 0x00, 0x11, 0x22, 0x33,
+			0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
+		}, errNotBittorrent},
+		{"wireguard handshake initiation", []byte{
+			0x01, 0x00, 0x00, 0x00, 0x3f, 0x2a, 0x91, 0xc4, 0x00, 0x11, 0x22, 0x33,
+			0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd,
+		}, errNotBittorrent},
+		{"plain text", []byte("this is not a bencoded dictionary"), errNotBittorrent},
+		{"shorter than any message", []byte("d1:y1:qe"), common.ErrNoClue},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h, err := SniffDHT(c.payload)
+			if err != c.err {
+				t.Fatalf("expected error %v, got %v", c.err, err)
+			}
+			if err == nil && h == nil {
+				t.Fatal("expected a sniff header, got nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two things:

1. **Fixes a false positive** in `SniffUTP`, where an ordinary DNS query is classified as BitTorrent.
2. **Extends detection** to the two UDP protocols a BitTorrent client actually speaks first and which were not recognised at all: the DHT (BEP 5) and UDP trackers (BEP 15).

`Protocol()` still returns exactly `"bittorrent"`, `app/dispatcher/default.go` is untouched, and the existing sniffer order is unchanged.

## The false positive

`SniffUTP` accepts a standard DNS query as a uTP `ST_SYN`. Every field lines up:

| Bytes | uTP field | What a DNS query has there | Result |
|---|---|---|---|
| `b[0]` | `0x41` — ST_SYN, version 1 | high byte of the transaction id | passes when the id starts with `0x41` |
| `b[1]` | extension list head | low byte of the transaction id | `0x00` means "no extensions", so the chain walk is skipped |
| `b[8:12]` | `timestamp_difference` | `nscount` + `arcount` | **always zero for a query without EDNS0** |
| `len == 20` | a bare header with no payload | 12 byte header + 8 byte question | a two character name fits exactly |

The existing `"dns query"` case in `bittorrent_test.go` aims at this collision but uses a 22 byte packet, which the "extensions consume all payload" check rejects. Shortening the queried name to two characters produces exactly 20 bytes and slips through.


### Fix

Require `ack_nr` to be zero. In a DNS query that offset holds `qclass`, which is `0x0001` for the internet class, so the whole collision class disappears. The check adds 16 bits of strictness and only narrows the set of accepted packets, so it cannot introduce new false positives.

BEP 29 describes `ack_nr` as meaningless in `ST_SYN`, so this was checked against implementations rather than the specification:

- **libutp** — `utp_connect` does `memset(p1, 0, header_size)` and then assigns `version`, `type`, `ext`, `connid`, `windowsize` and `seq_nr`. `ack_nr` is never assigned and stays zero.
- **libtorrent** — `send_syn()` sets `m_ack_nr = 0`, and `send_pkt` writes `h->ack_nr = m_ack_nr`.

## New sniffers

### UDP tracker, BEP 15

The connect request is the only packet a client sends first, and it is exactly 16 bytes: the magic `0x41727101980`, `action == 0`, and a transaction id. 64 bits of constant leave no room for accidental matches.

It has to be a separate function rather than a branch inside `SniffUTP`, because 16 bytes is below that function's `len(b) < 20` floor and would be discarded as `ErrNoClue` before any check runs.

### DHT, BEP 5

KRPC messages are bencoded dictionaries, one per datagram. Rather than scanning for substrings, this validates the structure with a minimal bencode reader. A datagram is accepted only when:

- it parses as a bencoded dictionary that **ends exactly on the last byte** of the datagram — the same trick the extension chain walk already uses;
- it carries `y` with a value of `q`, `r` or `e`, and a transaction id `t`;
- a query also carries a method name and arguments holding a **20 byte** node id; a response carries the same id; an error carries a list.

Parsing is bounded at depth 8, so nested lists such as `llllll…` cannot exhaust the stack. There is a test for that.

Only the parts of bencode needed to validate a message are implemented — a sniffer needs the framing, not the contents.

## False positive testing

Three million random datagrams of 16 to 215 bytes were run through all three UDP sniffers:

```
rounds=3000000  utp=0  tracker=0  dht=0
```

That check was scratch work and is not part of the diff. What is committed are explicit negative cases for the protocols that share UDP with BitTorrent — DNS (including the 20 byte collision above), STUN binding requests, WireGuard handshake initiations, uTP SYN packets and tracker connect requests — each cross-checked against every sniffer.

`SniffBittorrent` had no tests at all; it now has a table covering the handshake, truncation, a wrong `pstrlen`, a wrong protocol string, a TLS ClientHello and an HTTP tracker announce.

## Behaviour change

**DHT and UDP tracker traffic now matches `protocol: bittorrent` routing rules.** Traffic that previously fell through will now be matched — users with a `bittorrent` block rule will start blocking it. That is the point of the change, but it is worth knowing before upgrading.

HTTP tracker announces are still classified as `http`, since `SniffHTTP` runs first and wins on them. Changing that would alter existing behaviour, so it is out of scope here.