### PR TITLE
Burst observatory: add option to limit number of outbounds during init check

### DIFF
--- a/app/observatory/burst/config.pb.go
+++ b/app/observatory/burst/config.pb.go
@@ -88,7 +88,9 @@ type HealthPingConfig struct {
 	// ping timeout, int64 values of time.Duration
 	Timeout int64 `protobuf:"varint,5,opt,name=timeout,proto3" json:"timeout,omitempty"`
 	// http method to make request
-	HttpMethod    string `protobuf:"bytes,6,opt,name=httpMethod,proto3" json:"httpMethod,omitempty"`
+	HttpMethod string `protobuf:"bytes,6,opt,name=httpMethod,proto3" json:"httpMethod,omitempty"`
+	// limits how many matched outbounds are health-checked at startup
+	StartupChecks int32 `protobuf:"varint,7,opt,name=startupChecks,proto3" json:"startupChecks,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -165,6 +167,13 @@ func (x *HealthPingConfig) GetHttpMethod() string {
 	return ""
 }
 
+func (x *HealthPingConfig) GetStartupChecks() int32 {
+	if x != nil {
+		return x.StartupChecks
+	}
+	return 0
+}
+
 var File_app_observatory_burst_config_proto protoreflect.FileDescriptor
 
 const file_app_observatory_burst_config_proto_rawDesc = "" +
@@ -173,7 +182,7 @@ const file_app_observatory_burst_config_proto_rawDesc = "" +
 	"\x06Config\x12)\n" +
 	"\x10subject_selector\x18\x02 \x03(\tR\x0fsubjectSelector\x12R\n" +
 	"\vping_config\x18\x03 \x01(\v21.xray.core.app.observatory.burst.HealthPingConfigR\n" +
-	"pingConfig\"\xd4\x01\n" +
+	"pingConfig\"\xfa\x01\n" +
 	"\x10HealthPingConfig\x12 \n" +
 	"\vdestination\x18\x01 \x01(\tR\vdestination\x12\"\n" +
 	"\fconnectivity\x18\x02 \x01(\tR\fconnectivity\x12\x1a\n" +
@@ -182,7 +191,8 @@ const file_app_observatory_burst_config_proto_rawDesc = "" +
 	"\atimeout\x18\x05 \x01(\x03R\atimeout\x12\x1e\n" +
 	"\n" +
 	"httpMethod\x18\x06 \x01(\tR\n" +
-	"httpMethodBp\n" +
+	"httpMethod\x12$\n" +
+	"\rstartupChecks\x18\a \x01(\x05R\rstartupChecksBp\n" +
 	"\x1ecom.xray.app.observatory.burstP\x01Z/github.com/xtls/xray-core/app/observatory/burst\xaa\x02\x1aXray.App.Observatory.Burstb\x06proto3"
 
 var (

--- a/app/observatory/burst/config.proto
+++ b/app/observatory/burst/config.proto
@@ -28,5 +28,7 @@ message HealthPingConfig {
   int64 timeout = 5;
   // http method to make request
   string httpMethod = 6;
+  // limits how many matched outbounds are health-checked at startup.
+  int32 startupChecks = 7;
 
 }

--- a/app/observatory/burst/healthping.go
+++ b/app/observatory/burst/healthping.go
@@ -21,6 +21,7 @@ type HealthPingSettings struct {
 	SamplingCount int           `json:"sampling"`
 	Timeout       time.Duration `json:"timeout"`
 	HttpMethod    string        `json:"httpMethod"`
+	StartupChecks int           `json:"startupChecks"`
 }
 
 // HealthPing is the health checker for balancers
@@ -55,6 +56,7 @@ func NewHealthPing(ctx context.Context, dispatcher routing.Dispatcher, config *H
 			SamplingCount: int(config.SamplingCount),
 			Timeout:       time.Duration(config.Timeout),
 			HttpMethod:    httpMethod,
+			StartupChecks: int(config.StartupChecks),
 		}
 	}
 	if settings.Destination == "" {
@@ -102,6 +104,10 @@ func (h *HealthPing) StartScheduler(selector func() ([]string, error)) {
 		if err != nil {
 			errors.LogWarning(h.ctx, "error select outbounds for initial health check: ", err)
 			return
+		}
+		if n := h.Settings.StartupChecks; n > 0 && n < len(tags) {
+			errors.LogInfo(h.ctx, "initial health check limited to ", n, " of ", len(tags), " matched outbounds, picked at random")
+			tags = pickRandomTags(tags, n)
 		}
 		h.Check(tags)
 	}()
@@ -152,6 +158,18 @@ func (h *HealthPing) Check(tags []string) error {
 	errors.LogInfo(h.ctx, "perform one-time health check for tags ", tags)
 	h.doCheck(h.ctx, tags, 0, 1)
 	return nil
+}
+
+// Pick n random elements from tags
+// n must be > 0 and <= len(tags)
+func pickRandomTags(tags []string, n int) []string {
+	shuffled := make([]string, len(tags))
+	copy(shuffled, tags)
+	for i := len(shuffled) - 1; i > 0; i-- {
+		j := dice.Roll(i + 1)
+		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+	}
+	return shuffled[:n]
 }
 
 type rtt struct {

--- a/infra/conf/router_strategy.go
+++ b/infra/conf/router_strategy.go
@@ -51,6 +51,7 @@ type HealthCheckSettings struct {
 	SamplingCount int               `json:"sampling"`
 	Timeout       duration.Duration `json:"timeout"`
 	HttpMethod    string            `json:"httpMethod"`
+	StartupChecks int               `json:"startupChecks,omitempty"`
 }
 
 func (h HealthCheckSettings) Build() (proto.Message, error) {
@@ -67,6 +68,7 @@ func (h HealthCheckSettings) Build() (proto.Message, error) {
 		Timeout:       int64(h.Timeout),
 		SamplingCount: int32(h.SamplingCount),
 		HttpMethod:    httpMethod,
+		StartupChecks: int32(h.StartupChecks),
 	}, nil
 }
 


### PR DESCRIPTION
BurstObservatory pings all matched outbounds simultaneously during the initial check. With small number of outbounds that's ok, but if we have a lot of them, a large burst of connections at startup may look unusual. Also this create a high load and affect the initial check results.

This adds the optional startupChecks field to pingConfig, which allows limiting the number of outbounds checked during the initial health check. The selected outbounds are picked randomly:

```json
"pingConfig": {
  "interval": "60m",
  "sampling": 4,
  "startupChecks": 8
}
```

startupChecks = 0 (default) - unchanged behavior (all matched outbounds are checked at startup as before)
startupChecks < 0 - unchanged behavior
startupChecks >= len(matched outbounds) - unchanged behavior
startupChecks: N (N > 0, N < number of matched outbounds) - only N randomly chosen outbounds are checked at startup