### PR TITLE
Fix outbound tags cache data race

### DIFF
--- a/app/proxyman/outbound/handler_test.go
+++ b/app/proxyman/outbound/handler_test.go
@@ -107,11 +107,11 @@ func TestTagsCache(t *testing.T) {
 	v.AddFeature(ohm)
 	ctx := context.WithValue(context.Background(), xrayKey, v)
 
-	stop_add_rm := false
+	stop_add_rm := atomic.Bool{}
 	wg_add_rm := sync.WaitGroup{}
 	addHandlers := func() {
 		defer wg_add_rm.Done()
-		for !stop_add_rm {
+		for !stop_add_rm.Load() {
 			time.Sleep(delay)
 			idx := counter.Add(1)
 			tag := fmt.Sprintf("%s%d", tags_prefix, idx)
@@ -134,7 +134,7 @@ func TestTagsCache(t *testing.T) {
 
 	rmHandlers := func() {
 		defer wg_add_rm.Done()
-		for !stop_add_rm {
+		for !stop_add_rm.Load() {
 			time.Sleep(delay)
 			tags.Range(func(key interface{}, value interface{}) bool {
 				if _, ok := tags.LoadAndDelete(key); ok {
@@ -149,10 +149,10 @@ func TestTagsCache(t *testing.T) {
 
 	selectors := []string{tags_prefix}
 	wg_get := sync.WaitGroup{}
-	stop_get := false
+	stop_get := atomic.Bool{}
 	getTags := func() {
 		defer wg_get.Done()
-		for !stop_get {
+		for !stop_get.Load() {
 			time.Sleep(delay)
 			_ = ohm.Select(selectors)
 			// t.Logf("get tags: %v", tag)
@@ -168,8 +168,8 @@ func TestTagsCache(t *testing.T) {
 	}
 
 	time.Sleep(test_duration)
-	stop_add_rm = true
+	stop_add_rm.Store(true)
 	wg_add_rm.Wait()
-	stop_get = true
+	stop_get.Store(true)
 	wg_get.Wait()
 }

--- a/app/proxyman/outbound/outbound.go
+++ b/app/proxyman/outbound/outbound.go
@@ -104,7 +104,7 @@ func (m *Manager) AddHandler(ctx context.Context, handler outbound.Handler) erro
 	m.access.Lock()
 	defer m.access.Unlock()
 
-	m.tagsCache = &sync.Map{}
+	m.tagsCache.Clear()
 
 	if m.defaultHandler == nil {
 		m.defaultHandler = handler
@@ -135,7 +135,7 @@ func (m *Manager) RemoveHandler(ctx context.Context, tag string) error {
 	m.access.Lock()
 	defer m.access.Unlock()
 
-	m.tagsCache = &sync.Map{}
+	m.tagsCache.Clear()
 
 	delete(m.taggedHandler, tag)
 	if m.defaultHandler != nil && m.defaultHandler.Tag() == tag {


### PR DESCRIPTION
## Summary

- clear the existing outbound tags cache when handlers change instead of
  replacing its pointer
- synchronize the stop flags in "TestTagsCache"

## Problem

"Manager.Select" reads "m.tagsCache" on its cache-hit path without acquiring
"Manager.access". "AddHandler" and "RemoveHandler" replaced that pointer while
holding "access", but that lock did not synchronize with the unlocked read.

This is reproducible with:

    go test -race ./app/proxyman/outbound -run '^TestTagsCache$' -count=1

The test also contained two independent races in its stop flags, which obscured
the production regression result.

Dynamic handler mutation is used by the handler service and runtime features.
A selection overlapping removal may transiently retain an old candidate. If
that tag is no longer registered when dispatch resolves it, the new link is
closed. Existing flows that already hold a handler are unaffected.

## Fix

Keep the initialized "sync.Map" and call "Clear" under the existing manager
write lock.

This removes the unsafe pointer publication while preserving cache
invalidation and the cache-hit fast path. The module targets Go 1.27;
"sync.Map.Clear" has been available since Go 1.23.

The test stop flags now use "atomic.Bool", without reducing the concurrent
"AddHandler", "RemoveHandler" and "Select" workload.

## Scope

This fix removes unsafe "tagsCache" pointer publication and preserves the
cache-hit fast path. It does not change balancer or selector policy and does
not make handler selection linearizable with concurrent handler mutation.

Unrelated observatory scheduling behavior is not claimed fixed.

## Validation

- "go test ./app/proxyman/outbound -run '^TestTagsCache$' -count=3"
- "go test -race ./app/proxyman/outbound -run '^TestTagsCache$' -count=3"
- "go test -race ./app/proxyman/outbound -count=1"
- relevant router and observatory tests
- "go vet" for affected packages
- "git diff --check"